### PR TITLE
ci: validate every push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,14 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Closes #10.

CI previously ran only on `pull_request` and `workflow_dispatch`, so commits landing on `main` (squash merges and direct pushes) were never validated. This change:

- adds a `push` trigger restricted to `main`
- makes `cancel-in-progress` conditional so pull request runs keep superseding each other while `main` runs are never cancelled
- groups non-PR runs by commit SHA so rapid consecutive merges each get their own completed run instead of replacing one another in a shared queue

No job, step, permission, or pinned action changes.

## Validation

- Pull request behavior unchanged: grouped by PR number, superseded runs cancelled.
- After merge, this squash commit itself should trigger the first push-driven run on `main` — verifying the fix live.

## Provenance

Implemented by Ox Alpha (`opencode/x-preview-f-free` via OpenCode) from a bounded task specification; reviewed, committed, and shepherded by Claude as supervising agent.
