### PR TITLE
feat: bind open intent to exact content

### DIFF
--- a/docs/architecture/project-session.md
+++ b/docs/architecture/project-session.md
@@ -4,10 +4,11 @@ Status: accepted
 
 Implementation status: synchronous Qt-free ownership, editable/degraded/preserved-read-only state,
 immutable document access, command forwarding, clean revision, dirty state, application-owned
-runtime session identity, checked Open/path generations, sealed Save/Save-As path authority, and
-generation-scoped publication-intent-ordered savepoint acceptance are implemented. Save-As path
-authority is exclusive and supports typed abandonment. Asynchronous Open/Save, atomic content
-installation, round-trip state, unsaved continuations, and complete result handling remain pending.
+runtime session identity, checked content-bound Open/path generations, sealed Save/Save-As path
+authority, and generation-scoped publication-intent-ordered savepoint acceptance are implemented.
+Save-As path authority is exclusive and supports typed abandonment. Asynchronous Open/Save, atomic
+content installation, round-trip state, unsaved continuations, and complete result handling remain
+pending.
 
 Updated: 2026-08-25
 
@@ -142,8 +143,9 @@ files. Admission performs these steps:
 
 1. resolve any current unsaved-change intent
 2. increment the desired `OpenIntentGeneration`
-3. capture `ProjectSessionId` and `SessionResultAcceptanceGeneration`, plus document revision for
-   decoded content or the immutable content token for preserved read-only content
+3. capture `ProjectSessionId`, `SessionResultAcceptanceGeneration`, installed content kind, and the
+   command stack's exact tracked revision for decoded content; preserved read-only content carries
+   no fabricated document revision
 4. submit a task containing only the chosen path, limits, cancellation/progress channels, and
    captured value identities
 
@@ -152,14 +154,18 @@ successful worker result installs only when all of these remain true:
 
 - its `OpenIntentGeneration` is still desired
 - the captured `ProjectSessionId` and `SessionResultAcceptanceGeneration` still match
-- decoded current content still has the revision captured after unsaved resolution, or preserved
-  read-only content still has the captured immutable token
+- the installed content kind still matches, and decoded current content still has the exact command
+  stack revision captured after unsaved resolution; preserved read-only content remains bound by
+  its runtime session and acceptance generation without a decoded revision
 - the result is fully validated and has a supported editable or preserved-read-only outcome
 - the application is not already in final runtime shutdown
 
 Editing the current project while Open runs is allowed. Such an edit makes the revision check fail;
 Bloom keeps the current project and reports that Open was not installed because the current project
 changed. It never silently discards the edit and never freezes the authoring UI for background I/O.
+No-op and rejected commands retain the revision and therefore do not spuriously invalidate Open.
+Undo and redo issue newer monotonic revisions, so returning to artistically identical content never
+revives an intent captured against an older state.
 
 Failure, cancellation, supersession, malformed input, unavailable memory, or an unsupported major
 version leaves the active document, command history, path, selection, time, preview, and dirty state
@@ -376,6 +382,9 @@ current time remain UI/session concerns. They consume project-session state but 
 ## Required Verification
 
 - Open A then Open B with reverse completion installs only B
+- successful, no-op, rejected, undo, and redo command outcomes preserve or invalidate a decoded
+  Open intent solely according to its exact tracked revision; preserved read-only intent carries no
+  decoded revision
 - edit during Open, failed Open, cancelled Open, and malformed Open leave all active state unchanged
 - successful Open rebinds every projection coherently and clears history, selection, time, and old
   preview publication

--- a/src/host/include/bloom/host/project_session.hpp
+++ b/src/host/include/bloom/host/project_session.hpp
@@ -35,6 +35,11 @@ using SessionPathIntentGeneration = core::Id<SessionPathIntentGenerationTag>;
 class ProjectSession;
 class ProjectSessionTestAccess;
 
+enum class ProjectSessionContentKind : std::uint8_t {
+    DecodedDocument,
+    PreservedReadOnly,
+};
+
 struct ProjectSessionIdentitySourceSnapshot final {
     ProjectSessionId lastIssuedSessionId;
     bool identityExhausted = false;
@@ -99,8 +104,15 @@ class OpenIntentCapture final {
         return resultAcceptance_;
     }
     [[nodiscard]] constexpr OpenIntentGeneration generation() const noexcept { return generation_; }
+    [[nodiscard]] constexpr ProjectSessionContentKind contentKind() const noexcept {
+        return contentKind_;
+    }
+    [[nodiscard]] constexpr std::optional<document::Revision> decodedRevision() const noexcept {
+        return decodedRevision_;
+    }
     [[nodiscard]] constexpr bool isValid() const noexcept {
-        return resultAcceptance_.isValid() && generation_.isValid();
+        return resultAcceptance_.isValid() && generation_.isValid() &&
+               hasValidContentBinding(contentKind_, decodedRevision_);
     }
 
     friend constexpr bool operator==(const OpenIntentCapture&,
@@ -110,11 +122,28 @@ class OpenIntentCapture final {
     friend class ProjectSession;
 
     constexpr OpenIntentCapture(const SessionResultAcceptanceCapture resultAcceptance,
-                                const OpenIntentGeneration generation) noexcept
-        : resultAcceptance_(resultAcceptance), generation_(generation) {}
+                                const OpenIntentGeneration generation,
+                                const ProjectSessionContentKind contentKind,
+                                const std::optional<document::Revision> decodedRevision) noexcept
+        : resultAcceptance_(resultAcceptance), generation_(generation), contentKind_(contentKind),
+          decodedRevision_(decodedRevision) {}
+
+    [[nodiscard]] static constexpr bool
+    hasValidContentBinding(const ProjectSessionContentKind contentKind,
+                           const std::optional<document::Revision> decodedRevision) noexcept {
+        switch (contentKind) {
+        case ProjectSessionContentKind::DecodedDocument:
+            return decodedRevision.has_value();
+        case ProjectSessionContentKind::PreservedReadOnly:
+            return !decodedRevision.has_value();
+        }
+        return false;
+    }
 
     SessionResultAcceptanceCapture resultAcceptance_;
     OpenIntentGeneration generation_;
+    ProjectSessionContentKind contentKind_ = ProjectSessionContentKind::PreservedReadOnly;
+    std::optional<document::Revision> decodedRevision_;
 };
 
 enum class SessionPathIntentKind : std::uint8_t {
@@ -230,11 +259,6 @@ enum class SessionResultAcceptanceAdvanceStatus : std::uint8_t {
     Advanced,
     InvalidSession,
     RuntimeIdentityExhausted,
-};
-
-enum class ProjectSessionContentKind : std::uint8_t {
-    DecodedDocument,
-    PreservedReadOnly,
 };
 
 enum class DecodedProjectEditability : std::uint8_t {

--- a/src/host/project_session.cpp
+++ b/src/host/project_session.cpp
@@ -259,8 +259,12 @@ OpenIntentAdmissionResult ProjectSession::admitOpenIntent() noexcept {
         return OpenIntentAdmissionResult(OpenIntentAdmissionStatus::RuntimeIdentityExhausted);
     }
     openIntentGeneration_ = OpenIntentGeneration::fromRaw(openIntentGeneration_.value() + 1);
-    return OpenIntentAdmissionResult(
-        OpenIntentCapture(captureResultAcceptance(), openIntentGeneration_));
+    const auto decodedRevision =
+        contentKind_ == ProjectSessionContentKind::DecodedDocument
+            ? std::optional<document::Revision>{commandStack_->trackedRevision()}
+            : std::nullopt;
+    return OpenIntentAdmissionResult(OpenIntentCapture(
+        captureResultAcceptance(), openIntentGeneration_, contentKind_, decodedRevision));
 }
 
 SessionPathIntentAdvanceResult ProjectSession::advancePathIntentForSaveAs() noexcept {
@@ -302,9 +306,15 @@ bool ProjectSession::matchesResultAcceptance(
 }
 
 bool ProjectSession::isDesiredOpenIntent(const OpenIntentCapture capture) const noexcept {
-    return isValid() && capture.isValid() &&
-           capture.resultAcceptance() == captureResultAcceptance() &&
-           capture.generation() == openIntentGeneration_;
+    if (!isValid() || !capture.isValid() ||
+        capture.resultAcceptance() != captureResultAcceptance() ||
+        capture.generation() != openIntentGeneration_ || capture.contentKind() != contentKind_) {
+        return false;
+    }
+    if (contentKind_ == ProjectSessionContentKind::PreservedReadOnly) {
+        return true;
+    }
+    return capture.decodedRevision() == commandStack_->trackedRevision();
 }
 
 bool ProjectSession::matchesPathIntent(const SessionPathIntentCapture capture) const noexcept {

--- a/src/host/tests/project_session_tests.cpp
+++ b/src/host/tests/project_session_tests.cpp
@@ -70,6 +70,7 @@ using bloom::host::DecodedProjectSessionRequest;
 using bloom::host::DecodedProjectSnapshotStatus;
 using bloom::host::NewProjectSessionRequest;
 using bloom::host::OpenIntentAdmissionStatus;
+using bloom::host::OpenIntentCapture;
 using bloom::host::ProjectDisplayPath;
 using bloom::host::ProjectSession;
 using bloom::host::ProjectSessionCommandStatus;
@@ -85,6 +86,14 @@ using bloom::host::SessionResultAcceptanceAdvanceStatus;
 
 static_assert(!std::is_copy_constructible_v<ProjectSessionIdentitySource>);
 static_assert(!std::is_move_constructible_v<ProjectSessionIdentitySource>);
+static_assert(std::is_nothrow_default_constructible_v<OpenIntentCapture>);
+static_assert(!OpenIntentCapture{}.isValid());
+static_assert(noexcept(std::declval<const OpenIntentCapture&>().contentKind()));
+static_assert(noexcept(std::declval<const OpenIntentCapture&>().decodedRevision()));
+static_assert(
+    !std::is_constructible_v<OpenIntentCapture, bloom::host::SessionResultAcceptanceCapture,
+                             bloom::host::OpenIntentGeneration, ProjectSessionContentKind,
+                             std::optional<bloom::document::Revision>>);
 
 [[nodiscard]] CommandStatus commandStatus(const bloom::host::ProjectSessionCommandResult& result) {
     if (!result.command.has_value()) {
@@ -276,6 +285,8 @@ void testGenerationCapturesAndSubsetPredicates(Expectations& expectations) {
         resultCapture.isValid() && plainSave.isValid() &&
             plainSave.kind() == SessionPathIntentKind::ExistingPath && firstOpen && firstSaveAs &&
             firstOpen.capture().generation().value() == 2 &&
+            firstOpen.capture().contentKind() == ProjectSessionContentKind::DecodedDocument &&
+            firstOpen.capture().decodedRevision() == currentRevision(session) &&
             firstSaveAs.capture().generation().value() == 2 &&
             firstSaveAs.capture().kind() == SessionPathIntentKind::ReplacementPath &&
             !plainWhileReplacementPending.isValid() &&
@@ -332,6 +343,81 @@ void testGenerationCapturesAndSubsetPredicates(Expectations& expectations) {
             session.capturePlainSavePathIntent().isValid(),
         "installed-content replacement cancels pending path authority and invalidates old "
         "captures");
+}
+
+void testOpenIntentBindsExactContent(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = newSession(expectations, identitySource);
+    const auto initialAdmission = session.admitOpenIntent();
+    if (!initialAdmission) {
+        expectations.expect(false, "the decoded Open binding fixture admits its initial intent");
+        return;
+    }
+    const auto initial = initialAdmission.capture();
+    expectations.expect(initial.contentKind() == ProjectSessionContentKind::DecodedDocument &&
+                            initial.decodedRevision() == currentRevision(session) &&
+                            session.isDesiredOpenIntent(initial),
+                        "a decoded Open intent captures its exact command-stack revision");
+
+    Transaction noChange("No-op while Open", currentRevision(session));
+    noChange.emplace<SetProjectName>("Project");
+    const auto noChangeResult = session.execute(std::move(noChange));
+    expectations.expect(noChangeResult.completed() &&
+                            commandStatus(noChangeResult) == CommandStatus::NoChange &&
+                            session.isDesiredOpenIntent(initial) &&
+                            initial.decodedRevision() == currentRevision(session),
+                        "an idempotent edit leaves the exact decoded Open binding desired");
+
+    Transaction rejected("Rejected while Open", currentRevision(session));
+    rejected.emplace<SetCompositionName>(bloom::document::CompositionId::fromRaw(999), "Missing");
+    const auto rejectedResult = session.execute(std::move(rejected));
+    expectations.expect(rejectedResult.completed() &&
+                            commandStatus(rejectedResult) == CommandStatus::Rejected &&
+                            session.isDesiredOpenIntent(initial) &&
+                            initial.decodedRevision() == currentRevision(session),
+                        "a rejected edit leaves the exact decoded Open binding desired");
+
+    const auto successful = session.execute(rename("Changed while Open", session));
+    expectations.expect(successful.changed() && !session.isDesiredOpenIntent(initial) &&
+                            initial.decodedRevision().has_value() &&
+                            *initial.decodedRevision() < currentRevision(session),
+                        "a successful edit invalidates the captured decoded Open content");
+
+    const auto editedAdmission = session.admitOpenIntent();
+    if (!editedAdmission) {
+        expectations.expect(false, "the edited Open binding fixture admits a new intent");
+        return;
+    }
+    const auto edited = editedAdmission.capture();
+    const auto editedRevision = currentRevision(session);
+    expectations.expect(edited.decodedRevision() == editedRevision &&
+                            session.isDesiredOpenIntent(edited),
+                        "a newer Open binds to the newly edited revision");
+
+    const auto undoResult = session.undo();
+    const auto undoRevision = currentRevision(session);
+    expectations.expect(
+        undoResult.changed() && projectName(session) == "Project" &&
+            undoRevision > editedRevision && !session.isDesiredOpenIntent(edited),
+        "undo restores artist content with a newer revision and cannot revive an older Open");
+
+    const auto undoneAdmission = session.admitOpenIntent();
+    if (!undoneAdmission) {
+        expectations.expect(false, "the undone Open binding fixture admits a new intent");
+        return;
+    }
+    const auto undone = undoneAdmission.capture();
+    const auto redoResult = session.redo();
+    expectations.expect(
+        undone.decodedRevision() == undoRevision && redoResult.changed() &&
+            currentRevision(session) > undoRevision && !session.isDesiredOpenIntent(undone),
+        "redo advances monotonically and invalidates an intent captured after undo");
+
+    auto other = newSession(expectations, identitySource);
+    const auto otherOpen = other.admitOpenIntent();
+    expectations.expect(otherOpen && !session.isDesiredOpenIntent(otherOpen.capture()) &&
+                            !other.isDesiredOpenIntent(undone),
+                        "content bindings never cross runtime project sessions");
 }
 
 void testGenerationExhaustionBoundaries(Expectations& expectations) {
@@ -396,7 +482,10 @@ void testGenerationExhaustionBoundaries(Expectations& expectations) {
     const auto afterOpenExhaustion = openSession.stateSnapshot();
     expectations.expect(
         finalOpen && finalOpen.capture().generation().value() == maximum &&
+            finalOpen.capture().contentKind() == ProjectSessionContentKind::DecodedDocument &&
+            finalOpen.capture().decodedRevision() == currentRevision(openSession) &&
             exhaustedOpen.status() == OpenIntentAdmissionStatus::RuntimeIdentityExhausted &&
+            openSession.isDesiredOpenIntent(finalOpen.capture()) &&
             afterOpenExhaustion.resultAcceptanceGeneration ==
                 beforeOpenExhaustion.resultAcceptanceGeneration &&
             afterOpenExhaustion.openIntentGeneration == beforeOpenExhaustion.openIntentGeneration &&
@@ -843,6 +932,18 @@ void testPreservedReadOnlyState(Expectations& expectations,
                                 SessionPathIntentAbandonStatus::ReadOnly,
                         "preserved content cannot manufacture a native Save or Save As intent");
 
+    const auto firstOpen = session.admitOpenIntent();
+    const auto secondOpen = session.admitOpenIntent();
+    expectations.expect(
+        firstOpen && secondOpen &&
+            firstOpen.capture().contentKind() == ProjectSessionContentKind::PreservedReadOnly &&
+            !firstOpen.capture().decodedRevision().has_value() &&
+            secondOpen.capture().contentKind() == ProjectSessionContentKind::PreservedReadOnly &&
+            !secondOpen.capture().decodedRevision().has_value() &&
+            !session.isDesiredOpenIntent(firstOpen.capture()) &&
+            session.isDesiredOpenIntent(secondOpen.capture()),
+        "preserved Open intent binds to read-only content without fabricating a revision");
+
     Transaction blocked("Blocked edit");
     blocked.emplace<SetProjectName>("Must not apply");
     expectations.expect(session.execute(std::move(blocked)).status ==
@@ -964,16 +1065,18 @@ void testMoveAndLifetimeSafety(Expectations& expectations,
             !original.matchesPathIntent(
                 pathCapture), // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
         "a moved-from session exposes only invalid captures and cannot accept prior work");
-    expectations.expect(moved.isValid() && projectName(moved) == "Before move" &&
-                            moved.stateSnapshot().undoLabel == "Owned label" &&
-                            beforeMove.undoLabel == "Owned label" &&
-                            moved.stateSnapshot().projectSessionId == beforeMove.projectSessionId &&
-                            moved.stateSnapshot().newestAcceptedPublicationIntent ==
-                                beforeMove.newestAcceptedPublicationIntent &&
-                            moved.matchesResultAcceptance(acceptanceCapture) &&
-                            moved.isDesiredOpenIntent(openCapture) &&
-                            moved.matchesPathIntent(pathCapture),
-                        "moving preserves identity, generations, history, and captured authority");
+    expectations.expect(
+        moved.isValid() && projectName(moved) == "Before move" &&
+            moved.stateSnapshot().undoLabel == "Owned label" &&
+            beforeMove.undoLabel == "Owned label" &&
+            moved.stateSnapshot().projectSessionId == beforeMove.projectSessionId &&
+            moved.stateSnapshot().newestAcceptedPublicationIntent ==
+                beforeMove.newestAcceptedPublicationIntent &&
+            openCapture.contentKind() == ProjectSessionContentKind::DecodedDocument &&
+            openCapture.decodedRevision() == beforeMove.currentRevision &&
+            moved.matchesResultAcceptance(acceptanceCapture) &&
+            moved.isDesiredOpenIntent(openCapture) && moved.matchesPathIntent(pathCapture),
+        "moving preserves identity, generations, history, and captured authority");
     expectations.expect(moved.undo().changed() && projectName(moved) == "Project",
                         "the moved command stack remains bound to its heap-owned document");
 }
@@ -986,6 +1089,7 @@ int main() {
     try {
         testIdentitySourceAndExactExhaustion(expectations);
         testGenerationCapturesAndSubsetPredicates(expectations);
+        testOpenIntentBindsExactContent(expectations);
         testGenerationExhaustionBoundaries(expectations);
         testNewProjectBaselineAndSnapshots(expectations, identitySource);
         testDirtySavepointBranching(expectations, identitySource);


### PR DESCRIPTION
## Summary

Closes #12.

Binds each admitted Open intent to the exact installed content, as `docs/architecture/project-session.md` requires:

- `OpenIntentCapture` now records the installed content kind and, for decoded documents, the command stack's exact tracked revision; preserved read-only content carries no fabricated revision
- `ProjectSession::isDesiredOpenIntent` rejects a result when the content kind or exact revision no longer matches, in addition to the existing session identity, acceptance, and generation checks
- no-op and rejected commands retain the binding; undo and redo issue newer monotonic revisions, so returning to artistically identical content never revives an older intent
- the capture stays validity-checked: a decoded binding without a revision, or a preserved binding with one, is invalid

The architecture document's admission steps, installation conditions, and required verification list are updated in the same change.

## Testing

- New `testOpenIntentBindsExactContent` covers successful/no-op/rejected/undo/redo outcomes against a captured intent, rebinding after edits, and cross-session rejection
- Preserved read-only, generation-exhaustion, subset-predicate, and move-safety tests extended with content-kind and revision assertions
- Full `ci-linux-native` configure, build, and CTest suite pass locally
