### PR TITLE
feat: encode canonical project documents

### DIFF
--- a/docs/architecture/project-format.md
+++ b/docs/architecture/project-format.md
@@ -6,9 +6,10 @@ Implementation status: bounded reservations and PMR allocation, canonical intege
 Base64, UTF-8 string, and shared count/write JSON-layout primitives, canonical manifest encoding
 and schema checks, the normative document `1.0` schema artifact and checks, manifest requirement
 validation, durable allocator high-water state, opaque extension envelopes, and the Linux
-staged-artifact close/reopen verification foundation are implemented. Complete JSON
-parsing/document encoding, ZIP, migration, unknown-member overlay, format-specific semantic
-verification, and cross-platform publication parity remain pending.
+staged-artifact close/reopen verification foundation, and the version 1 canonical document
+writer over immutable snapshots with explicitly supplied color settings are implemented. Complete
+JSON parsing, ZIP, migration, unknown-member overlay, format-specific semantic verification, and
+cross-platform publication parity remain pending.
 
 Updated: 2026-08-25
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -367,8 +367,9 @@ manifest encoding, its Draft 2020-12 schema artifact, and manifest requirement s
 exact project coverage validation are also implemented. The complete writable document `1.0`
 Draft 2020-12 schema artifact, strict artifact checker, exact canonical Float64 codec, finite
 known-field Float64 normalization, and the lossless editable unknown-number subset are implemented.
-DOM integration, the document writer, instance validation, and golden document fixtures remain
-pending.
+The version 1 canonical document writer and its golden document fixtures are implemented; the
+writer takes color settings as an explicit caller value until Project owns durable color identity.
+DOM integration, the document reader, and instance validation remain pending.
 
 - implement the accepted complete `manifest.json` and `document.json` shapes and JSON Schema
   dialect without reopening their wire semantics

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(
     PRIVATE
         canonical_base64.cpp
         canonical_decimal.cpp
+        canonical_document.cpp
         canonical_json_string.cpp
         canonical_json_string_detail.hpp
         canonical_json_writer.cpp
@@ -21,6 +22,7 @@ target_sources(
         FILES
             include/bloom/project/canonical_base64.hpp
             include/bloom/project/canonical_decimal.hpp
+            include/bloom/project/canonical_document.hpp
             include/bloom/project/canonical_json_string.hpp
             include/bloom/project/canonical_json_writer.hpp
             include/bloom/project/canonical_manifest.hpp
@@ -57,6 +59,15 @@ if(BUILD_TESTING)
         NAME bloom.project.canonical_manifest
         COMMAND bloom_project_canonical_manifest_test
         LABELS unit project persistence manifest
+    )
+
+    add_executable(bloom_project_canonical_document_test tests/canonical_document_tests.cpp)
+    target_link_libraries(bloom_project_canonical_document_test PRIVATE bloom_project)
+    bloom_enable_warnings(bloom_project_canonical_document_test)
+    bloom_add_test(
+        NAME bloom.project.canonical_document
+        COMMAND bloom_project_canonical_document_test
+        LABELS unit project persistence document
     )
 
     add_executable(bloom_project_canonical_json_writer_test tests/canonical_json_writer_tests.cpp)

--- a/src/project/canonical_document.cpp
+++ b/src/project/canonical_document.cpp
@@ -61,8 +61,7 @@ struct SortWindows final {
     plan.window0 = project.compositions().size();
     for (const auto& composition : project.compositions()) {
         plan.window1 = maximumOf(plan.window1, composition.parameters().records().size());
-        plan.window1 =
-            maximumOf(plan.window1, composition.animationCurves().records().size());
+        plan.window1 = maximumOf(plan.window1, composition.animationCurves().records().size());
         plan.window1 = maximumOf(plan.window1, composition.graph().nodes().size());
         plan.window1 = maximumOf(plan.window1, composition.graph().edges().size());
         plan.window1 = maximumOf(plan.window1, composition.graph().layerOutputs().size());
@@ -70,8 +69,7 @@ struct SortWindows final {
             plan.window2 = maximumOf(plan.window2, node.parameters.size());
         }
         for (const auto& record : composition.animationCurves().records()) {
-            if (const auto* scalar =
-                    std::get_if<bloom::document::ScalarAnimationCurve>(&record)) {
+            if (const auto* scalar = std::get_if<bloom::document::ScalarAnimationCurve>(&record)) {
                 plan.window2 = maximumOf(plan.window2, scalar->keyframes.size());
             } else if (const auto* vector =
                            std::get_if<bloom::document::Vec2AnimationCurve>(&record)) {
@@ -122,10 +120,9 @@ struct WalkState final {
     std::size_t compositionIndex = kCanonicalDocumentNoIndex;
     std::size_t elementIndex = kCanonicalDocumentNoIndex;
 
-    void
-    fail(const CanonicalDocumentError failure,
-         const std::size_t failedCompositionIndex = kCanonicalDocumentNoIndex,
-         const std::size_t failedElementIndex = kCanonicalDocumentNoIndex) noexcept {
+    void fail(const CanonicalDocumentError failure,
+              const std::size_t failedCompositionIndex = kCanonicalDocumentNoIndex,
+              const std::size_t failedElementIndex = kCanonicalDocumentNoIndex) noexcept {
         if (error == CanonicalDocumentError::None) {
             error = failure;
             compositionIndex = failedCompositionIndex;
@@ -170,12 +167,10 @@ struct EmitState final {
     if (!state.ok(writer.beginObject())) {
         return false;
     }
-    if (!state.ok(writer.memberName("major")) ||
-        !state.ok(writer.integerValue(version.major))) {
+    if (!state.ok(writer.memberName("major")) || !state.ok(writer.integerValue(version.major))) {
         return false;
     }
-    if (!state.ok(writer.memberName("minor")) ||
-        !state.ok(writer.integerValue(version.minor))) {
+    if (!state.ok(writer.memberName("minor")) || !state.ok(writer.integerValue(version.minor))) {
         return false;
     }
     return state.ok(writer.endObject());
@@ -224,8 +219,8 @@ struct EmitState final {
     return state.ok(state.writer.endObject());
 }
 
-[[nodiscard]] std::string_view extensionTargetKind(
-    const bloom::document::ExtensionTarget& target) noexcept {
+[[nodiscard]] std::string_view
+extensionTargetKind(const bloom::document::ExtensionTarget& target) noexcept {
     using namespace bloom::document;
     if (std::holds_alternative<ProjectId>(target)) {
         return "project";
@@ -254,8 +249,8 @@ struct EmitState final {
     return "keyframe";
 }
 
-[[nodiscard]] std::uint64_t extensionTargetValue(
-    const bloom::document::ExtensionTarget& target) noexcept {
+[[nodiscard]] std::uint64_t
+extensionTargetValue(const bloom::document::ExtensionTarget& target) noexcept {
     if (const auto* projectId = std::get_if<bloom::document::ProjectId>(&target)) {
         return projectId->value();
     }
@@ -330,10 +325,8 @@ struct EmitState final {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("color4")) &&
                state.ok(writer.memberName("red")) && state.ok(writer.float64Value(color->red)) &&
                state.ok(writer.memberName("green")) &&
-               state.ok(writer.float64Value(color->green)) &&
-               state.ok(writer.memberName("blue")) &&
-               state.ok(writer.float64Value(color->blue)) &&
-               state.ok(writer.memberName("alpha")) &&
+               state.ok(writer.float64Value(color->green)) && state.ok(writer.memberName("blue")) &&
+               state.ok(writer.float64Value(color->blue)) && state.ok(writer.memberName("alpha")) &&
                state.ok(writer.float64Value(color->alpha)) && state.ok(writer.endObject());
     }
     if (const auto* text = std::get_if<std::string>(&value)) {
@@ -375,8 +368,11 @@ struct EmitState final {
             return false;
         }
         if (!emitConstantValue(state, constant->value)) {
-            { state.walk.fail(CanonicalDocumentError::InvalidParameter,
-                                   state.walk.compositionIndex, parameterRank); return false; }
+            {
+                state.walk.fail(CanonicalDocumentError::InvalidParameter,
+                                state.walk.compositionIndex, parameterRank);
+                return false;
+            }
         }
     } else if (const auto* curve = std::get_if<AnimationCurveSource>(&record.source)) {
         if (!state.ok(writer.memberName("kind")) ||
@@ -389,14 +385,18 @@ struct EmitState final {
     } else {
         // Admission rejected live driver sources before staging; reaching this path means the
         // caller bypassed canonicalDocumentSize.
-        { state.walk.fail(CanonicalDocumentError::UnsupportedDriverBindingSource,
-                               state.walk.compositionIndex, parameterRank); return false; }
+        {
+            state.walk.fail(CanonicalDocumentError::UnsupportedDriverBindingSource,
+                            state.walk.compositionIndex, parameterRank);
+            return false;
+        }
     }
     return state.ok(writer.endObject()) && state.ok(writer.endObject());
 }
 
-[[nodiscard]] bool emitInterpolation(
-    EmitState& state, const bloom::document::KeyframeInterpolation interpolation) noexcept {
+[[nodiscard]] bool
+emitInterpolation(EmitState& state,
+                  const bloom::document::KeyframeInterpolation interpolation) noexcept {
     switch (interpolation) {
     case bloom::document::KeyframeInterpolation::Hold:
         return state.ok(state.writer.stringValue("hold"));
@@ -481,13 +481,16 @@ struct EmitState final {
     }
     const auto& records = composition.animationCurves().records();
     std::span<const std::size_t> order;
-    if (!makeOrder(records,
-                   [](const AnimationCurveRecord& record) noexcept {
-                       return animationCurveId(record).value();
-                   },
-                   state.sort.window1, order, state.walk.error)) {
-        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                               compositionIndex); return false; }
+    if (!makeOrder(
+            records,
+            [](const AnimationCurveRecord& record) noexcept {
+                return animationCurveId(record).value();
+            },
+            state.sort.window1, order, state.walk.error)) {
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity, compositionIndex);
+            return false;
+        }
     }
     for (const auto recordIndex : order) {
         const auto& record = records[recordIndex];
@@ -503,16 +506,22 @@ struct EmitState final {
                 return false;
             }
             std::span<const std::size_t> keyOrder;
-            if (!makeOrder(scalar->keyframes,
-                           [](const ScalarKeyframe& key) noexcept { return key.time; },
-                           state.sort.window2, keyOrder, state.walk.error)) {
-                { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                                       compositionIndex); return false; }
+            if (!makeOrder(
+                    scalar->keyframes, [](const ScalarKeyframe& key) noexcept { return key.time; },
+                    state.sort.window2, keyOrder, state.walk.error)) {
+                {
+                    state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                                    compositionIndex);
+                    return false;
+                }
             }
             for (const auto keyIndex : keyOrder) {
                 if (!emitScalarKeyframe(state, scalar->keyframes[keyIndex])) {
-                    { state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
-                                           compositionIndex); return false; }
+                    {
+                        state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
+                                        compositionIndex);
+                        return false;
+                    }
                 }
             }
         } else if (const auto* vector = std::get_if<Vec2AnimationCurve>(&record)) {
@@ -521,21 +530,29 @@ struct EmitState final {
                 return false;
             }
             std::span<const std::size_t> keyOrder;
-            if (!makeOrder(vector->keyframes,
-                           [](const Vec2Keyframe& key) noexcept { return key.time; },
-                           state.sort.window2, keyOrder, state.walk.error)) {
-                { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                                       compositionIndex); return false; }
+            if (!makeOrder(
+                    vector->keyframes, [](const Vec2Keyframe& key) noexcept { return key.time; },
+                    state.sort.window2, keyOrder, state.walk.error)) {
+                {
+                    state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                                    compositionIndex);
+                    return false;
+                }
             }
             for (const auto keyIndex : keyOrder) {
                 if (!emitVec2Keyframe(state, vector->keyframes[keyIndex])) {
-                    { state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
-                                           compositionIndex); return false; }
+                    {
+                        state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
+                                        compositionIndex);
+                        return false;
+                    }
                 }
             }
         } else {
-            { state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
-                                   compositionIndex); return false; }
+            {
+                state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve, compositionIndex);
+                return false;
+            }
         }
         if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
             return false;
@@ -553,11 +570,13 @@ struct EmitState final {
     }
     const auto& records = composition.parameters().records();
     std::span<const std::size_t> order;
-    if (!makeOrder(records,
-                   [](const ParameterRecord& record) noexcept { return record.id.value(); },
-                   state.sort.window1, order, state.walk.error)) {
-        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                               compositionIndex); return false; }
+    if (!makeOrder(
+            records, [](const ParameterRecord& record) noexcept { return record.id.value(); },
+            state.sort.window1, order, state.walk.error)) {
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity, compositionIndex);
+            return false;
+        }
     }
     for (const auto index : order) {
         if (!emitParameter(state, records[index], index)) {
@@ -580,10 +599,13 @@ struct EmitState final {
         return false;
     }
     std::span<const std::size_t> nodeOrder;
-    if (!makeOrder(graph.nodes(), [](const NodeRecord& node) noexcept { return node.id.value(); },
-                   state.sort.window1, nodeOrder, state.walk.error)) {
-        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                               compositionIndex); return false; }
+    if (!makeOrder(
+            graph.nodes(), [](const NodeRecord& node) noexcept { return node.id.value(); },
+            state.sort.window1, nodeOrder, state.walk.error)) {
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity, compositionIndex);
+            return false;
+        }
     }
     for (const auto nodeIndex : nodeOrder) {
         const auto& node = graph.nodes()[nodeIndex];
@@ -604,14 +626,18 @@ struct EmitState final {
             return false;
         }
         std::span<const std::size_t> bindingOrder;
-        if (!makeOrder(node.parameters,
-                       [](const ParameterBinding& binding) noexcept
-                           -> std::pair<std::string_view, std::uint64_t> {
-                           return {binding.role, binding.parameterId.value()};
-                       },
-                       state.sort.window2, bindingOrder, state.walk.error)) {
-            { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                                   compositionIndex); return false; }
+        if (!makeOrder(
+                node.parameters,
+                [](const ParameterBinding& binding) noexcept
+                    -> std::pair<std::string_view, std::uint64_t> {
+                    return {binding.role, binding.parameterId.value()};
+                },
+                state.sort.window2, bindingOrder, state.walk.error)) {
+            {
+                state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                                compositionIndex);
+                return false;
+            }
         }
         for (const auto bindingIndex : bindingOrder) {
             const auto& binding = node.parameters[bindingIndex];
@@ -641,10 +667,13 @@ struct EmitState final {
         return false;
     }
     std::span<const std::size_t> edgeOrder;
-    if (!makeOrder(graph.edges(), [](const EdgeRecord& edge) noexcept { return edge.id.value(); },
-                   state.sort.window1, edgeOrder, state.walk.error)) {
-        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                               compositionIndex); return false; }
+    if (!makeOrder(
+            graph.edges(), [](const EdgeRecord& edge) noexcept { return edge.id.value(); },
+            state.sort.window1, edgeOrder, state.walk.error)) {
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity, compositionIndex);
+            return false;
+        }
     }
     for (const auto edgeIndex : edgeOrder) {
         const auto& edge = graph.edges()[edgeIndex];
@@ -688,7 +717,10 @@ struct EmitState final {
                 return false;
             }
         } else {
-            { state.walk.fail(CanonicalDocumentError::InvalidGraph, compositionIndex); return false; }
+            {
+                state.walk.fail(CanonicalDocumentError::InvalidGraph, compositionIndex);
+                return false;
+            }
         }
         if (!state.ok(writer.endObject()) || !state.ok(writer.endObject())) {
             return false;
@@ -702,14 +734,17 @@ struct EmitState final {
         return false;
     }
     std::span<const std::size_t> boundaryOrder;
-    if (!makeOrder(graph.layerOutputs(),
-                   [](const LayerOutputBoundary& boundary) noexcept
-                       -> std::pair<std::uint64_t, std::uint64_t> {
-                       return {boundary.layerId.value(), boundary.nodeId.value()};
-                   },
-                   state.sort.window1, boundaryOrder, state.walk.error)) {
-        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
-                               compositionIndex); return false; }
+    if (!makeOrder(
+            graph.layerOutputs(),
+            [](const LayerOutputBoundary& boundary) noexcept
+                -> std::pair<std::uint64_t, std::uint64_t> {
+                return {boundary.layerId.value(), boundary.nodeId.value()};
+            },
+            state.sort.window1, boundaryOrder, state.walk.error)) {
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity, compositionIndex);
+            return false;
+        }
     }
     for (const auto boundaryIndex : boundaryOrder) {
         const auto& boundary = graph.layerOutputs()[boundaryIndex];
@@ -765,7 +800,10 @@ struct EmitState final {
     }
 
     if (!graph.compositionOutput().has_value()) {
-        { state.walk.fail(CanonicalDocumentError::InvalidGraph, compositionIndex); return false; }
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidGraph, compositionIndex);
+            return false;
+        }
     }
     if (!state.ok(writer.memberName("compositionOutput"))) {
         return false;
@@ -787,8 +825,7 @@ struct EmitState final {
     if (!emitNamedId(state, "id", composition.id().value())) {
         return false;
     }
-    if (!state.ok(writer.memberName("name")) ||
-        !state.ok(writer.stringValue(composition.name()))) {
+    if (!state.ok(writer.memberName("name")) || !state.ok(writer.stringValue(composition.name()))) {
         return false;
     }
     if (!state.ok(writer.memberName("duration"))) {
@@ -802,12 +839,10 @@ struct EmitState final {
         return false;
     }
     const auto format = composition.format();
-    if (!state.ok(writer.memberName("width")) ||
-        !state.ok(writer.integerValue(format.width()))) {
+    if (!state.ok(writer.memberName("width")) || !state.ok(writer.integerValue(format.width()))) {
         return false;
     }
-    if (!state.ok(writer.memberName("height")) ||
-        !state.ok(writer.integerValue(format.height()))) {
+    if (!state.ok(writer.memberName("height")) || !state.ok(writer.integerValue(format.height()))) {
         return false;
     }
     if (!state.ok(writer.memberName("pixelAspect"))) {
@@ -847,20 +882,17 @@ struct EmitState final {
     }
     bool emitted = false;
     if (const auto* builtIn = std::get_if<BuiltInOcioConfigLocator>(&locator)) {
-        emitted = state.ok(writer.memberName("kind")) &&
-                  state.ok(writer.stringValue("builtin")) &&
+        emitted = state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("builtin")) &&
                   state.ok(writer.memberName("uri")) && state.ok(writer.stringValue(builtIn->uri));
-    } else if (const auto* projectRelative =
-                   std::get_if<ProjectRelativeOciozLocator>(&locator)) {
+    } else if (const auto* projectRelative = std::get_if<ProjectRelativeOciozLocator>(&locator)) {
         emitted = state.ok(writer.memberName("kind")) &&
                   state.ok(writer.stringValue("project-relative-ocioz")) &&
                   state.ok(writer.memberName("path")) &&
                   state.ok(writer.stringValue(projectRelative->path));
     } else if (const auto* externalOcioz = std::get_if<ExternalOciozLocator>(&locator)) {
-        emitted = state.ok(writer.memberName("kind")) &&
-                  state.ok(writer.stringValue("external-ocioz")) &&
-                  state.ok(writer.memberName("uri")) &&
-                  state.ok(writer.stringValue(externalOcioz->uri));
+        emitted =
+            state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("external-ocioz")) &&
+            state.ok(writer.memberName("uri")) && state.ok(writer.stringValue(externalOcioz->uri));
     } else if (const auto* externalConfig = std::get_if<ExternalOcioConfigLocator>(&locator)) {
         emitted = state.ok(writer.memberName("kind")) &&
                   state.ok(writer.stringValue("external-config")) &&
@@ -930,11 +962,12 @@ struct EmitState final {
     case OcioConfigPortability::External:
         portability = "external";
         break;
-    default:
-        { state.walk.fail(CanonicalDocumentError::OcioPortabilityMismatch); return false; }
+    default: {
+        state.walk.fail(CanonicalDocumentError::OcioPortabilityMismatch);
+        return false;
     }
-    if (!state.ok(writer.memberName("portability")) ||
-        !state.ok(writer.stringValue(portability))) {
+    }
+    if (!state.ok(writer.memberName("portability")) || !state.ok(writer.stringValue(portability))) {
         return false;
     }
     if (!state.ok(writer.memberName("contextVariables")) || !state.ok(writer.beginArray())) {
@@ -944,8 +977,7 @@ struct EmitState final {
         if (!state.ok(writer.beginObject())) {
             return false;
         }
-        if (!state.ok(writer.memberName("name")) ||
-            !state.ok(writer.stringValue(variable.name))) {
+        if (!state.ok(writer.memberName("name")) || !state.ok(writer.stringValue(variable.name))) {
             return false;
         }
         if (!state.ok(writer.memberName("value")) ||
@@ -966,12 +998,18 @@ struct EmitState final {
                                const bloom::document::OpaqueExtensionPayload& payload) noexcept {
     const auto encodedSize = bloom::project::canonicalBase64EncodedSize(payload.size());
     if (!encodedSize.hasValue() || *encodedSize.value() > state.payloadScratch.size()) {
-        { state.walk.fail(CanonicalDocumentError::PayloadBufferTooSmall); return false; }
+        {
+            state.walk.fail(CanonicalDocumentError::PayloadBufferTooSmall);
+            return false;
+        }
     }
     const auto encoded = bloom::project::encodeCanonicalBase64(
         payload.bytes(), state.payloadScratch.first(*encodedSize.value()));
     if (!encoded) {
-        { state.walk.fail(CanonicalDocumentError::PayloadBufferTooSmall); return false; }
+        {
+            state.walk.fail(CanonicalDocumentError::PayloadBufferTooSmall);
+            return false;
+        }
     }
     return state.ok(state.writer.stringValue(
         std::string_view(state.payloadScratch.data(), *encodedSize.value())));
@@ -1020,8 +1058,7 @@ struct EmitState final {
         }
     } else if (const auto* table =
                    std::get_if<ExtensionHostReferenceTable>(&record.referencePolicy)) {
-        if (!state.ok(writer.memberName("kind")) ||
-            !state.ok(writer.stringValue("host-table"))) {
+        if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("host-table"))) {
             return false;
         }
         if (!state.ok(writer.memberName("references")) || !state.ok(writer.beginArray())) {
@@ -1065,7 +1102,10 @@ struct EmitState final {
             return false;
         }
     } else {
-        { state.walk.fail(CanonicalDocumentError::InvalidExtensionRecord); return false; }
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidExtensionRecord);
+            return false;
+        }
     }
     if (!state.ok(writer.endObject())) {
         return false;
@@ -1114,12 +1154,14 @@ struct EmitState final {
         return false;
     }
     std::span<const std::size_t> compositionOrder;
-    if (!makeOrder(state.project.compositions(),
-                   [](const Composition& composition) noexcept {
-                       return composition.id().value();
-                   },
-                   state.sort.window0, compositionOrder, state.walk.error)) {
-        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity); return false; }
+    if (!makeOrder(
+            state.project.compositions(),
+            [](const Composition& composition) noexcept { return composition.id().value(); },
+            state.sort.window0, compositionOrder, state.walk.error)) {
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity);
+            return false;
+        }
     }
     for (const auto compositionIndex : compositionOrder) {
         if (!emitComposition(state, state.project.compositions()[compositionIndex],
@@ -1158,10 +1200,14 @@ struct EmitState final {
         return false;
     }
     std::span<const std::size_t> recordOrder;
-    if (!makeOrder(state.project.extensionRecords(),
-                   [](const ExtensionRecord& record) noexcept { return record.id.value(); },
-                   state.sort.window1, recordOrder, state.walk.error)) {
-        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity); return false; }
+    if (!makeOrder(
+            state.project.extensionRecords(),
+            [](const ExtensionRecord& record) noexcept { return record.id.value(); },
+            state.sort.window1, recordOrder, state.walk.error)) {
+        {
+            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity);
+            return false;
+        }
     }
     for (const auto recordIndex : recordOrder) {
         if (!emitExtensionRecord(state, state.project.extensionRecords()[recordIndex])) {
@@ -1212,8 +1258,7 @@ locatorPortability(const bloom::document::OcioConfigLocator& locator) noexcept {
         return walk;
     }
     if (limits.maximumValues > bloom::project::kCanonicalJsonMaximumValues ||
-        limits.maximumContainerEntries >
-            bloom::project::kCanonicalJsonMaximumContainerEntries ||
+        limits.maximumContainerEntries > bloom::project::kCanonicalJsonMaximumContainerEntries ||
         limits.maximumOutputBytes > bloom::project::kCanonicalDocumentMaximumBytes) {
         walk.fail(CanonicalDocumentError::InvalidLimits);
         return walk;
@@ -1255,11 +1300,10 @@ locatorPortability(const bloom::document::OcioConfigLocator& locator) noexcept {
          ++compositionIndex) {
         const auto& composition = project.compositions()[compositionIndex];
         const auto& parameters = composition.parameters().records();
-        for (std::size_t parameterIndex = 0; parameterIndex < parameters.size();
-             ++parameterIndex) {
+        for (std::size_t parameterIndex = 0; parameterIndex < parameters.size(); ++parameterIndex) {
             if (std::holds_alternative<DriverBindingSource>(parameters[parameterIndex].source)) {
-                walk.fail(CanonicalDocumentError::UnsupportedDriverBindingSource,
-                          compositionIndex, parameterIndex);
+                walk.fail(CanonicalDocumentError::UnsupportedDriverBindingSource, compositionIndex,
+                          parameterIndex);
                 return walk;
             }
         }
@@ -1291,8 +1335,7 @@ locatorPortability(const bloom::document::OcioConfigLocator& locator) noexcept {
         return walk;
     }
     for (const auto& record : project.extensionRecords()) {
-        const auto encodedSize =
-            bloom::project::canonicalBase64EncodedSize(record.payload.size());
+        const auto encodedSize = bloom::project::canonicalBase64EncodedSize(record.payload.size());
         if (!encodedSize.hasValue() || *encodedSize.value() > document.payloadScratch.size()) {
             walk.fail(CanonicalDocumentError::PayloadBufferTooSmall);
             return walk;
@@ -1337,9 +1380,9 @@ CanonicalDocumentSizeResult canonicalDocumentSize(const CanonicalDocumentV1& doc
     return CanonicalDocumentSizeResult::success(requiredSize);
 }
 
-CanonicalDocumentWriteResult encodeCanonicalDocument(const CanonicalDocumentV1& document,
-                                                     const std::span<char> output,
-                                                     const CanonicalDocumentLimits limits) noexcept {
+CanonicalDocumentWriteResult
+encodeCanonicalDocument(const CanonicalDocumentV1& document, const std::span<char> output,
+                        const CanonicalDocumentLimits limits) noexcept {
     const auto sizeResult = canonicalDocumentSize(document, limits);
     if (!sizeResult) {
         return CanonicalDocumentWriteResult::failure(sizeResult.error(), std::nullopt,
@@ -1361,8 +1404,7 @@ CanonicalDocumentWriteResult encodeCanonicalDocument(const CanonicalDocumentV1& 
                     snapshot.project(),
                     snapshot.ids().highWater(),
                     *document.colorSettings,
-                    splitSortScratch(document.sortScratch,
-                                     measureSortPlan(snapshot.project())),
+                    splitSortScratch(document.sortScratch, measureSortPlan(snapshot.project())),
                     document.payloadScratch,
                     {}};
     if (!emitDocumentRoot(state) || writer.bytesWritten() != requiredSize) {

--- a/src/project/canonical_document.cpp
+++ b/src/project/canonical_document.cpp
@@ -1,0 +1,1374 @@
+#include <bloom/project/canonical_document.hpp>
+
+#include <algorithm>
+#include <bloom/core/utf8.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/persisted_text.hpp>
+#include <bloom/project/canonical_base64.hpp>
+#include <bloom/project/canonical_decimal.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+namespace {
+
+using bloom::document::AnimationCurveRecord;
+using bloom::document::Composition;
+using bloom::document::ExtensionRecord;
+using bloom::project::CanonicalDecimalText;
+using bloom::project::CanonicalDocumentError;
+using bloom::project::CanonicalDocumentLimits;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::CanonicalJsonWriter;
+using bloom::project::CanonicalJsonWriterError;
+using bloom::project::CanonicalJsonWriterResult;
+using bloom::project::kCanonicalDocumentNoIndex;
+
+constexpr auto kV1SchemaVersion = bloom::project::kCanonicalDocumentSchemaVersionV1;
+
+// One canonical emission walk. Every collection ordered by a semantic value is materialized as an
+// index order inside one of three disjoint scratch windows so nested orders never overlap: window
+// zero holds the composition order, window one holds one composition-scoped collection at a time
+// (parameters, curves, nodes, edges, boundaries) plus extension records, and window two holds one
+// nested sub-order at a time (node bindings, curve keyframes).
+struct SortPlan final {
+    std::size_t window0 = 0;
+    std::size_t window1 = 0;
+    std::size_t window2 = 0;
+
+    [[nodiscard]] std::size_t total() const noexcept { return window0 + window1 + window2; }
+};
+
+struct SortWindows final {
+    std::span<std::size_t> window0{};
+    std::span<std::size_t> window1{};
+    std::span<std::size_t> window2{};
+};
+
+[[nodiscard]] std::size_t maximumOf(const std::size_t left, const std::size_t right) noexcept {
+    return left > right ? left : right;
+}
+
+[[nodiscard]] SortPlan measureSortPlan(const bloom::document::Project& project) noexcept {
+    SortPlan plan;
+    plan.window0 = project.compositions().size();
+    for (const auto& composition : project.compositions()) {
+        plan.window1 = maximumOf(plan.window1, composition.parameters().records().size());
+        plan.window1 =
+            maximumOf(plan.window1, composition.animationCurves().records().size());
+        plan.window1 = maximumOf(plan.window1, composition.graph().nodes().size());
+        plan.window1 = maximumOf(plan.window1, composition.graph().edges().size());
+        plan.window1 = maximumOf(plan.window1, composition.graph().layerOutputs().size());
+        for (const auto& node : composition.graph().nodes()) {
+            plan.window2 = maximumOf(plan.window2, node.parameters.size());
+        }
+        for (const auto& record : composition.animationCurves().records()) {
+            if (const auto* scalar =
+                    std::get_if<bloom::document::ScalarAnimationCurve>(&record)) {
+                plan.window2 = maximumOf(plan.window2, scalar->keyframes.size());
+            } else if (const auto* vector =
+                           std::get_if<bloom::document::Vec2AnimationCurve>(&record)) {
+                plan.window2 = maximumOf(plan.window2, vector->keyframes.size());
+            }
+        }
+    }
+    plan.window1 = maximumOf(plan.window1, project.extensionRecords().size());
+    return plan;
+}
+
+[[nodiscard]] SortWindows splitSortScratch(const std::span<std::size_t> scratch,
+                                           const SortPlan& plan) noexcept {
+    return {scratch.first(plan.window0), scratch.subspan(plan.window0, plan.window1),
+            scratch.subspan(plan.window0 + plan.window1, plan.window2)};
+}
+
+// Fills the leading range.size() entries of window with the ascending index order of range by key.
+// Duplicate keys are rejected because canonical collections are identity-unique.
+template <typename Range, typename KeyOf>
+[[nodiscard]] bool makeOrder(const Range& range, KeyOf key, const std::span<std::size_t> window,
+                             std::span<const std::size_t>& order,
+                             CanonicalDocumentError& error) noexcept {
+    const auto count = range.size();
+    if (count > window.size()) {
+        error = CanonicalDocumentError::SortBufferTooSmall;
+        return false;
+    }
+    for (std::size_t index = 0; index < count; ++index) {
+        window[index] = index;
+    }
+    const auto byKey = [&range, &key](const std::size_t left, const std::size_t right) noexcept {
+        return key(range[left]) < key(range[right]);
+    };
+    std::sort(window.begin(), window.begin() + static_cast<std::ptrdiff_t>(count), byKey);
+    for (std::size_t index = 1; index < count; ++index) {
+        if (!byKey(window[index - 1], window[index])) {
+            error = CanonicalDocumentError::InvalidCollectionIdentity;
+            return false;
+        }
+    }
+    order = window.first(count);
+    return true;
+}
+
+struct WalkState final {
+    CanonicalDocumentError error = CanonicalDocumentError::None;
+    std::size_t compositionIndex = kCanonicalDocumentNoIndex;
+    std::size_t elementIndex = kCanonicalDocumentNoIndex;
+
+    void
+    fail(const CanonicalDocumentError failure,
+         const std::size_t failedCompositionIndex = kCanonicalDocumentNoIndex,
+         const std::size_t failedElementIndex = kCanonicalDocumentNoIndex) noexcept {
+        if (error == CanonicalDocumentError::None) {
+            error = failure;
+            compositionIndex = failedCompositionIndex;
+            elementIndex = failedElementIndex;
+        }
+    }
+};
+
+struct EmitState final {
+    CanonicalJsonWriter& writer;
+    const bloom::document::Project& project;
+    const bloom::document::IdAllocatorHighWater highWater;
+    const bloom::document::ColorSettings& colorSettings;
+    SortWindows sort;
+    std::span<char> payloadScratch;
+    WalkState walk{};
+
+    [[nodiscard]] bool ok(const CanonicalJsonWriterResult result) noexcept {
+        if (result) {
+            return true;
+        }
+        if (walk.error == CanonicalDocumentError::None) {
+            switch (result.error()) {
+            case CanonicalJsonWriterError::ValueLimitExceeded:
+                walk.error = CanonicalDocumentError::ValueCountExceeded;
+                break;
+            case CanonicalJsonWriterError::ContainerLimitExceeded:
+                walk.error = CanonicalDocumentError::ContainerEntryCountExceeded;
+                break;
+            default:
+                // Validation proved every other writer failure impossible for trusted snapshots.
+                std::terminate();
+            }
+        }
+        return false;
+    }
+};
+
+[[nodiscard]] bool emitVersion(EmitState& state,
+                               const bloom::document::SchemaVersion version) noexcept {
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("major")) ||
+        !state.ok(writer.integerValue(version.major))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("minor")) ||
+        !state.ok(writer.integerValue(version.minor))) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitNamedId(EmitState& state, const std::string_view name,
+                               const std::uint64_t value) noexcept {
+    const auto text = bloom::project::formatCanonicalUInt64(value);
+    return state.ok(state.writer.memberName(name)) &&
+           state.ok(state.writer.stringValue(text.view()));
+}
+
+[[nodiscard]] bool emitNamedSigned(EmitState& state, const std::string_view name,
+                                   const std::int64_t value) noexcept {
+    const auto text = bloom::project::formatCanonicalInt64(value);
+    return state.ok(state.writer.memberName(name)) &&
+           state.ok(state.writer.stringValue(text.view()));
+}
+
+[[nodiscard]] bool emitRational(EmitState& state, const std::int64_t numerator,
+                                const std::int64_t denominator) noexcept {
+    if (!state.ok(state.writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedSigned(state, "numerator", numerator)) {
+        return false;
+    }
+    if (!emitNamedSigned(state, "denominator", denominator)) {
+        return false;
+    }
+    return state.ok(state.writer.endObject());
+}
+
+[[nodiscard]] bool emitOutputPortRef(EmitState& state,
+                                     const bloom::document::OutputPortRef& reference) noexcept {
+    if (!state.ok(state.writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "nodeId", reference.nodeId.value())) {
+        return false;
+    }
+    if (!state.ok(state.writer.memberName("port")) ||
+        !state.ok(state.writer.stringValue(reference.port))) {
+        return false;
+    }
+    return state.ok(state.writer.endObject());
+}
+
+[[nodiscard]] std::string_view extensionTargetKind(
+    const bloom::document::ExtensionTarget& target) noexcept {
+    using namespace bloom::document;
+    if (std::holds_alternative<ProjectId>(target)) {
+        return "project";
+    }
+    if (std::holds_alternative<CompositionId>(target)) {
+        return "composition";
+    }
+    if (std::holds_alternative<NodeId>(target)) {
+        return "node";
+    }
+    if (std::holds_alternative<EdgeId>(target)) {
+        return "edge";
+    }
+    if (std::holds_alternative<LayerId>(target)) {
+        return "layer";
+    }
+    if (std::holds_alternative<LayerSlotId>(target)) {
+        return "layer-slot";
+    }
+    if (std::holds_alternative<ParameterId>(target)) {
+        return "parameter";
+    }
+    if (std::holds_alternative<AnimationCurveId>(target)) {
+        return "animation-curve";
+    }
+    return "keyframe";
+}
+
+[[nodiscard]] std::uint64_t extensionTargetValue(
+    const bloom::document::ExtensionTarget& target) noexcept {
+    if (const auto* projectId = std::get_if<bloom::document::ProjectId>(&target)) {
+        return projectId->value();
+    }
+    if (const auto* compositionId = std::get_if<bloom::document::CompositionId>(&target)) {
+        return compositionId->value();
+    }
+    if (const auto* nodeId = std::get_if<bloom::document::NodeId>(&target)) {
+        return nodeId->value();
+    }
+    if (const auto* edgeId = std::get_if<bloom::document::EdgeId>(&target)) {
+        return edgeId->value();
+    }
+    if (const auto* layerId = std::get_if<bloom::document::LayerId>(&target)) {
+        return layerId->value();
+    }
+    if (const auto* layerSlotId = std::get_if<bloom::document::LayerSlotId>(&target)) {
+        return layerSlotId->value();
+    }
+    if (const auto* parameterId = std::get_if<bloom::document::ParameterId>(&target)) {
+        return parameterId->value();
+    }
+    if (const auto* curveId = std::get_if<bloom::document::AnimationCurveId>(&target)) {
+        return curveId->value();
+    }
+    const auto* keyframeId = std::get_if<bloom::document::KeyframeId>(&target);
+    return keyframeId == nullptr ? 0 : keyframeId->value();
+}
+
+[[nodiscard]] bool emitTypedTarget(EmitState& state,
+                                   const bloom::document::ExtensionTarget& target) noexcept {
+    if (!state.ok(state.writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(state.writer.memberName("kind")) ||
+        !state.ok(state.writer.stringValue(extensionTargetKind(target)))) {
+        return false;
+    }
+    if (!emitNamedId(state, "id", extensionTargetValue(target))) {
+        return false;
+    }
+    return state.ok(state.writer.endObject());
+}
+
+[[nodiscard]] bool emitConstantValue(EmitState& state,
+                                     const bloom::document::ParameterValue& value) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (const auto* boolean = std::get_if<bool>(&value)) {
+        return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("bool")) &&
+               state.ok(writer.memberName("value")) && state.ok(writer.booleanValue(*boolean)) &&
+               state.ok(writer.endObject());
+    }
+    if (const auto* integer = std::get_if<std::int64_t>(&value)) {
+        return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("int64")) &&
+               emitNamedSigned(state, "value", *integer) && state.ok(writer.endObject());
+    }
+    if (const auto* floating = std::get_if<double>(&value)) {
+        return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("float64")) &&
+               state.ok(writer.memberName("value")) && state.ok(writer.float64Value(*floating)) &&
+               state.ok(writer.endObject());
+    }
+    if (const auto* vector = std::get_if<Vec2d>(&value)) {
+        return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("vec2")) &&
+               state.ok(writer.memberName("x")) && state.ok(writer.float64Value(vector->x)) &&
+               state.ok(writer.memberName("y")) && state.ok(writer.float64Value(vector->y)) &&
+               state.ok(writer.endObject());
+    }
+    if (const auto* color = std::get_if<bloom::core::Color4d>(&value)) {
+        return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("color4")) &&
+               state.ok(writer.memberName("red")) && state.ok(writer.float64Value(color->red)) &&
+               state.ok(writer.memberName("green")) &&
+               state.ok(writer.float64Value(color->green)) &&
+               state.ok(writer.memberName("blue")) &&
+               state.ok(writer.float64Value(color->blue)) &&
+               state.ok(writer.memberName("alpha")) &&
+               state.ok(writer.float64Value(color->alpha)) && state.ok(writer.endObject());
+    }
+    if (const auto* text = std::get_if<std::string>(&value)) {
+        return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("string")) &&
+               state.ok(writer.memberName("value")) && state.ok(writer.stringValue(*text)) &&
+               state.ok(writer.endObject());
+    }
+    if (const auto* rational = std::get_if<bloom::core::RationalTime>(&value)) {
+        return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("rational")) &&
+               emitNamedSigned(state, "numerator", rational->numerator()) &&
+               emitNamedSigned(state, "denominator", rational->denominator()) &&
+               state.ok(writer.endObject());
+    }
+    return false;
+}
+
+[[nodiscard]] bool emitParameter(EmitState& state, const bloom::document::ParameterRecord& record,
+                                 const std::size_t parameterRank) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "id", record.id.value())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("schemaKey")) ||
+        !state.ok(writer.stringValue(record.schemaKey))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("source")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (const auto* constant = std::get_if<ConstantValueSource>(&record.source)) {
+        if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("constant"))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("value"))) {
+            return false;
+        }
+        if (!emitConstantValue(state, constant->value)) {
+            { state.walk.fail(CanonicalDocumentError::InvalidParameter,
+                                   state.walk.compositionIndex, parameterRank); return false; }
+        }
+    } else if (const auto* curve = std::get_if<AnimationCurveSource>(&record.source)) {
+        if (!state.ok(writer.memberName("kind")) ||
+            !state.ok(writer.stringValue("animation-curve"))) {
+            return false;
+        }
+        if (!emitNamedId(state, "curveId", curve->curveId.value())) {
+            return false;
+        }
+    } else {
+        // Admission rejected live driver sources before staging; reaching this path means the
+        // caller bypassed canonicalDocumentSize.
+        { state.walk.fail(CanonicalDocumentError::UnsupportedDriverBindingSource,
+                               state.walk.compositionIndex, parameterRank); return false; }
+    }
+    return state.ok(writer.endObject()) && state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitInterpolation(
+    EmitState& state, const bloom::document::KeyframeInterpolation interpolation) noexcept {
+    switch (interpolation) {
+    case bloom::document::KeyframeInterpolation::Hold:
+        return state.ok(state.writer.stringValue("hold"));
+    case bloom::document::KeyframeInterpolation::Linear:
+        return state.ok(state.writer.stringValue("linear"));
+    }
+    return false;
+}
+
+[[nodiscard]] bool emitScalarKeyframe(EmitState& state,
+                                      const bloom::document::ScalarKeyframe& key) noexcept {
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "id", key.id.value())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("time"))) {
+        return false;
+    }
+    if (!emitRational(state, key.time.numerator(), key.time.denominator())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("value"))) {
+        return false;
+    }
+    if (!state.ok(writer.float64Value(key.value))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("outgoingInterpolation"))) {
+        return false;
+    }
+    if (!emitInterpolation(state, key.outgoingInterpolation)) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitVec2Keyframe(EmitState& state,
+                                    const bloom::document::Vec2Keyframe& key) noexcept {
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "id", key.id.value())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("time"))) {
+        return false;
+    }
+    if (!emitRational(state, key.time.numerator(), key.time.denominator())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("value")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("x")) || !state.ok(writer.float64Value(key.value.x))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("y")) || !state.ok(writer.float64Value(key.value.y))) {
+        return false;
+    }
+    if (!state.ok(writer.endObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("outgoingInterpolation"))) {
+        return false;
+    }
+    if (!emitInterpolation(state, key.outgoingInterpolation)) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitAnimationCurves(EmitState& state, const Composition& composition,
+                                       const std::size_t compositionIndex) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    if (!state.ok(writer.memberName("animationCurves")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    const auto& records = composition.animationCurves().records();
+    std::span<const std::size_t> order;
+    if (!makeOrder(records,
+                   [](const AnimationCurveRecord& record) noexcept {
+                       return animationCurveId(record).value();
+                   },
+                   state.sort.window1, order, state.walk.error)) {
+        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                               compositionIndex); return false; }
+    }
+    for (const auto recordIndex : order) {
+        const auto& record = records[recordIndex];
+        if (!state.ok(writer.beginObject())) {
+            return false;
+        }
+        if (!emitNamedId(state, "id", animationCurveId(record).value())) {
+            return false;
+        }
+        if (const auto* scalar = std::get_if<ScalarAnimationCurve>(&record)) {
+            if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("scalar")) ||
+                !state.ok(writer.memberName("keyframes")) || !state.ok(writer.beginArray())) {
+                return false;
+            }
+            std::span<const std::size_t> keyOrder;
+            if (!makeOrder(scalar->keyframes,
+                           [](const ScalarKeyframe& key) noexcept { return key.time; },
+                           state.sort.window2, keyOrder, state.walk.error)) {
+                { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                                       compositionIndex); return false; }
+            }
+            for (const auto keyIndex : keyOrder) {
+                if (!emitScalarKeyframe(state, scalar->keyframes[keyIndex])) {
+                    { state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
+                                           compositionIndex); return false; }
+                }
+            }
+        } else if (const auto* vector = std::get_if<Vec2AnimationCurve>(&record)) {
+            if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("vec2")) ||
+                !state.ok(writer.memberName("keyframes")) || !state.ok(writer.beginArray())) {
+                return false;
+            }
+            std::span<const std::size_t> keyOrder;
+            if (!makeOrder(vector->keyframes,
+                           [](const Vec2Keyframe& key) noexcept { return key.time; },
+                           state.sort.window2, keyOrder, state.walk.error)) {
+                { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                                       compositionIndex); return false; }
+            }
+            for (const auto keyIndex : keyOrder) {
+                if (!emitVec2Keyframe(state, vector->keyframes[keyIndex])) {
+                    { state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
+                                           compositionIndex); return false; }
+                }
+            }
+        } else {
+            { state.walk.fail(CanonicalDocumentError::InvalidAnimationCurve,
+                                   compositionIndex); return false; }
+        }
+        if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+            return false;
+        }
+    }
+    return state.ok(writer.endArray());
+}
+
+[[nodiscard]] bool emitParameters(EmitState& state, const Composition& composition,
+                                  const std::size_t compositionIndex) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    if (!state.ok(writer.memberName("parameters")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    const auto& records = composition.parameters().records();
+    std::span<const std::size_t> order;
+    if (!makeOrder(records,
+                   [](const ParameterRecord& record) noexcept { return record.id.value(); },
+                   state.sort.window1, order, state.walk.error)) {
+        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                               compositionIndex); return false; }
+    }
+    for (const auto index : order) {
+        if (!emitParameter(state, records[index], index)) {
+            return false;
+        }
+    }
+    return state.ok(writer.endArray());
+}
+
+[[nodiscard]] bool emitGraph(EmitState& state, const Composition& composition,
+                             const std::size_t compositionIndex) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    const auto& graph = composition.graph();
+    if (!state.ok(writer.memberName("graph")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+
+    if (!state.ok(writer.memberName("nodes")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    std::span<const std::size_t> nodeOrder;
+    if (!makeOrder(graph.nodes(), [](const NodeRecord& node) noexcept { return node.id.value(); },
+                   state.sort.window1, nodeOrder, state.walk.error)) {
+        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                               compositionIndex); return false; }
+    }
+    for (const auto nodeIndex : nodeOrder) {
+        const auto& node = graph.nodes()[nodeIndex];
+        if (!state.ok(writer.beginObject())) {
+            return false;
+        }
+        if (!emitNamedId(state, "id", node.id.value())) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("typeId")) || !state.ok(writer.stringValue(node.typeId))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("schemaVersion")) ||
+            !state.ok(writer.integerValue(node.schemaVersion))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("parameters")) || !state.ok(writer.beginArray())) {
+            return false;
+        }
+        std::span<const std::size_t> bindingOrder;
+        if (!makeOrder(node.parameters,
+                       [](const ParameterBinding& binding) noexcept
+                           -> std::pair<std::string_view, std::uint64_t> {
+                           return {binding.role, binding.parameterId.value()};
+                       },
+                       state.sort.window2, bindingOrder, state.walk.error)) {
+            { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                                   compositionIndex); return false; }
+        }
+        for (const auto bindingIndex : bindingOrder) {
+            const auto& binding = node.parameters[bindingIndex];
+            if (!state.ok(writer.beginObject())) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("role")) ||
+                !state.ok(writer.stringValue(binding.role))) {
+                return false;
+            }
+            if (!emitNamedId(state, "parameterId", binding.parameterId.value())) {
+                return false;
+            }
+            if (!state.ok(writer.endObject())) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+            return false;
+        }
+    }
+    if (!state.ok(writer.endArray())) {
+        return false;
+    }
+
+    if (!state.ok(writer.memberName("edges")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    std::span<const std::size_t> edgeOrder;
+    if (!makeOrder(graph.edges(), [](const EdgeRecord& edge) noexcept { return edge.id.value(); },
+                   state.sort.window1, edgeOrder, state.walk.error)) {
+        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                               compositionIndex); return false; }
+    }
+    for (const auto edgeIndex : edgeOrder) {
+        const auto& edge = graph.edges()[edgeIndex];
+        if (!state.ok(writer.beginObject())) {
+            return false;
+        }
+        if (!emitNamedId(state, "id", edge.id.value())) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("source")) || !emitOutputPortRef(state, edge.source)) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("destination")) || !state.ok(writer.beginObject())) {
+            return false;
+        }
+        if (const auto* nodeInput = std::get_if<NodeInputRef>(&edge.destination)) {
+            if (!state.ok(writer.memberName("kind")) ||
+                !state.ok(writer.stringValue("node-input"))) {
+                return false;
+            }
+            if (!emitNamedId(state, "nodeId", nodeInput->nodeId.value())) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("port")) ||
+                !state.ok(writer.stringValue(nodeInput->port))) {
+                return false;
+            }
+        } else if (const auto* stackInput = std::get_if<LayerStackInputRef>(&edge.destination)) {
+            if (!state.ok(writer.memberName("kind")) ||
+                !state.ok(writer.stringValue("layer-stack-input"))) {
+                return false;
+            }
+            if (!emitNamedId(state, "stackNodeId", stackInput->stackNodeId.value())) {
+                return false;
+            }
+            if (!emitNamedId(state, "slotId", stackInput->slotId.value())) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("role")) ||
+                !state.ok(writer.stringValue(stackInput->role))) {
+                return false;
+            }
+        } else {
+            { state.walk.fail(CanonicalDocumentError::InvalidGraph, compositionIndex); return false; }
+        }
+        if (!state.ok(writer.endObject()) || !state.ok(writer.endObject())) {
+            return false;
+        }
+    }
+    if (!state.ok(writer.endArray())) {
+        return false;
+    }
+
+    if (!state.ok(writer.memberName("layerOutputs")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    std::span<const std::size_t> boundaryOrder;
+    if (!makeOrder(graph.layerOutputs(),
+                   [](const LayerOutputBoundary& boundary) noexcept
+                       -> std::pair<std::uint64_t, std::uint64_t> {
+                       return {boundary.layerId.value(), boundary.nodeId.value()};
+                   },
+                   state.sort.window1, boundaryOrder, state.walk.error)) {
+        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity,
+                               compositionIndex); return false; }
+    }
+    for (const auto boundaryIndex : boundaryOrder) {
+        const auto& boundary = graph.layerOutputs()[boundaryIndex];
+        if (!state.ok(writer.beginObject())) {
+            return false;
+        }
+        if (!emitNamedId(state, "nodeId", boundary.nodeId.value())) {
+            return false;
+        }
+        if (!emitNamedId(state, "layerId", boundary.layerId.value())) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("name")) || !state.ok(writer.stringValue(boundary.name))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("outputPort")) ||
+            !state.ok(writer.stringValue(boundary.outputPort))) {
+            return false;
+        }
+        if (!state.ok(writer.endObject())) {
+            return false;
+        }
+    }
+    if (!state.ok(writer.endArray())) {
+        return false;
+    }
+
+    if (!state.ok(writer.memberName("layerStack")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "nodeId", graph.layerStack().nodeId().value())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("entries")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    for (const auto& entry : graph.layerStack().entries()) {
+        if (!state.ok(writer.beginObject())) {
+            return false;
+        }
+        if (!emitNamedId(state, "slotId", entry.slotId.value())) {
+            return false;
+        }
+        if (!emitNamedId(state, "layerId", entry.layerId.value())) {
+            return false;
+        }
+        if (!state.ok(writer.endObject())) {
+            return false;
+        }
+    }
+    if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+        return false;
+    }
+
+    if (!graph.compositionOutput().has_value()) {
+        { state.walk.fail(CanonicalDocumentError::InvalidGraph, compositionIndex); return false; }
+    }
+    if (!state.ok(writer.memberName("compositionOutput"))) {
+        return false;
+    }
+    if (!emitOutputPortRef(state, *graph.compositionOutput())) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitComposition(EmitState& state, const Composition& composition,
+                                   const std::size_t compositionIndex) noexcept {
+    auto& writer = state.writer;
+    state.walk.compositionIndex = compositionIndex;
+    state.walk.elementIndex = kCanonicalDocumentNoIndex;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "id", composition.id().value())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("name")) ||
+        !state.ok(writer.stringValue(composition.name()))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("duration"))) {
+        return false;
+    }
+    if (!emitRational(state, composition.duration().numerator(),
+                      composition.duration().denominator())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("format")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    const auto format = composition.format();
+    if (!state.ok(writer.memberName("width")) ||
+        !state.ok(writer.integerValue(format.width()))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("height")) ||
+        !state.ok(writer.integerValue(format.height()))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("pixelAspect"))) {
+        return false;
+    }
+    if (!emitRational(state, format.pixelAspect().numerator(),
+                      format.pixelAspect().denominator())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("frameRate"))) {
+        return false;
+    }
+    if (!emitRational(state, format.frameRate().numerator(), format.frameRate().denominator())) {
+        return false;
+    }
+    if (!state.ok(writer.endObject())) {
+        return false;
+    }
+    if (!emitParameters(state, composition, compositionIndex)) {
+        return false;
+    }
+    if (!emitAnimationCurves(state, composition, compositionIndex)) {
+        return false;
+    }
+    if (!emitGraph(state, composition, compositionIndex)) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitLocator(EmitState& state,
+                               const bloom::document::OcioConfigLocator& locator) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    bool emitted = false;
+    if (const auto* builtIn = std::get_if<BuiltInOcioConfigLocator>(&locator)) {
+        emitted = state.ok(writer.memberName("kind")) &&
+                  state.ok(writer.stringValue("builtin")) &&
+                  state.ok(writer.memberName("uri")) && state.ok(writer.stringValue(builtIn->uri));
+    } else if (const auto* projectRelative =
+                   std::get_if<ProjectRelativeOciozLocator>(&locator)) {
+        emitted = state.ok(writer.memberName("kind")) &&
+                  state.ok(writer.stringValue("project-relative-ocioz")) &&
+                  state.ok(writer.memberName("path")) &&
+                  state.ok(writer.stringValue(projectRelative->path));
+    } else if (const auto* externalOcioz = std::get_if<ExternalOciozLocator>(&locator)) {
+        emitted = state.ok(writer.memberName("kind")) &&
+                  state.ok(writer.stringValue("external-ocioz")) &&
+                  state.ok(writer.memberName("uri")) &&
+                  state.ok(writer.stringValue(externalOcioz->uri));
+    } else if (const auto* externalConfig = std::get_if<ExternalOcioConfigLocator>(&locator)) {
+        emitted = state.ok(writer.memberName("kind")) &&
+                  state.ok(writer.stringValue("external-config")) &&
+                  state.ok(writer.memberName("uri")) &&
+                  state.ok(writer.stringValue(externalConfig->uri));
+    }
+    if (!emitted) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitColorSettings(EmitState& state) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    const auto& settings = state.colorSettings;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("schemaVersion"))) {
+        return false;
+    }
+    if (!emitVersion(state, settings.schemaVersion)) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("processColorSpaceId")) ||
+        !state.ok(writer.stringValue(settings.processColorSpaceId))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("ocioConfig")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("schemaVersion"))) {
+        return false;
+    }
+    if (!emitVersion(state, settings.ocioConfig.schemaVersion)) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("locator"))) {
+        return false;
+    }
+    if (!emitLocator(state, settings.ocioConfig.locator)) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("expectedRevision")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("algorithm")) || !state.ok(writer.stringValue("sha256"))) {
+        return false;
+    }
+    const auto hex = settings.ocioConfig.expectedRevision.digest.toLowercaseHex();
+    if (!state.ok(writer.memberName("digest")) ||
+        !state.ok(writer.stringValue(std::string_view(hex.data(), hex.size())))) {
+        return false;
+    }
+    if (!state.ok(writer.endObject())) {
+        return false;
+    }
+    std::string_view portability;
+    switch (settings.ocioConfig.portability) {
+    case OcioConfigPortability::BuiltIn:
+        portability = "builtin";
+        break;
+    case OcioConfigPortability::ProjectRelative:
+        portability = "project-relative";
+        break;
+    case OcioConfigPortability::External:
+        portability = "external";
+        break;
+    default:
+        { state.walk.fail(CanonicalDocumentError::OcioPortabilityMismatch); return false; }
+    }
+    if (!state.ok(writer.memberName("portability")) ||
+        !state.ok(writer.stringValue(portability))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("contextVariables")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    for (const auto& variable : settings.ocioConfig.contextVariables) {
+        if (!state.ok(writer.beginObject())) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("name")) ||
+            !state.ok(writer.stringValue(variable.name))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("value")) ||
+            !state.ok(writer.stringValue(variable.value))) {
+            return false;
+        }
+        if (!state.ok(writer.endObject())) {
+            return false;
+        }
+    }
+    if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitPayload(EmitState& state,
+                               const bloom::document::OpaqueExtensionPayload& payload) noexcept {
+    const auto encodedSize = bloom::project::canonicalBase64EncodedSize(payload.size());
+    if (!encodedSize.hasValue() || *encodedSize.value() > state.payloadScratch.size()) {
+        { state.walk.fail(CanonicalDocumentError::PayloadBufferTooSmall); return false; }
+    }
+    const auto encoded = bloom::project::encodeCanonicalBase64(
+        payload.bytes(), state.payloadScratch.first(*encodedSize.value()));
+    if (!encoded) {
+        { state.walk.fail(CanonicalDocumentError::PayloadBufferTooSmall); return false; }
+    }
+    return state.ok(state.writer.stringValue(
+        std::string_view(state.payloadScratch.data(), *encodedSize.value())));
+}
+
+[[nodiscard]] bool emitExtensionRecord(EmitState& state, const ExtensionRecord& record) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "id", record.id.value())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("ownerId")) || !state.ok(writer.stringValue(record.ownerId))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("typeId")) || !state.ok(writer.stringValue(record.typeId))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("schemaVersion"))) {
+        return false;
+    }
+    if (!emitVersion(state, record.schemaVersion)) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("subject"))) {
+        return false;
+    }
+    if (record.subject.has_value() && !emitTypedTarget(state, *record.subject)) {
+        return false;
+    }
+    if (!record.subject.has_value() && !state.ok(writer.nullValue())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("mediaType")) ||
+        !state.ok(writer.stringValue(record.mediaType))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("referencePolicy")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (std::holds_alternative<NoExtensionReferences>(record.referencePolicy)) {
+        if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("none"))) {
+            return false;
+        }
+    } else if (const auto* table =
+                   std::get_if<ExtensionHostReferenceTable>(&record.referencePolicy)) {
+        if (!state.ok(writer.memberName("kind")) ||
+            !state.ok(writer.stringValue("host-table"))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("references")) || !state.ok(writer.beginArray())) {
+            return false;
+        }
+        for (const auto& reference : table->references) {
+            if (!state.ok(writer.beginObject())) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("key")) ||
+                !state.ok(writer.stringValue(reference.key))) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("target"))) {
+                return false;
+            }
+            if (!emitTypedTarget(state, reference.target)) {
+                return false;
+            }
+            if (!state.ok(writer.endObject())) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.endArray())) {
+            return false;
+        }
+    } else if (const auto* remapper =
+                   std::get_if<ExtensionOwnerRemapper>(&record.referencePolicy)) {
+        if (!state.ok(writer.memberName("kind")) ||
+            !state.ok(writer.stringValue("owner-remapper"))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("remapperId")) ||
+            !state.ok(writer.stringValue(remapper->remapperId))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("version"))) {
+            return false;
+        }
+        if (!emitVersion(state, remapper->version)) {
+            return false;
+        }
+    } else {
+        { state.walk.fail(CanonicalDocumentError::InvalidExtensionRecord); return false; }
+    }
+    if (!state.ok(writer.endObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("payload"))) {
+        return false;
+    }
+    if (!emitPayload(state, record.payload)) {
+        return false;
+    }
+    return state.ok(writer.endObject());
+}
+
+[[nodiscard]] bool emitHighWaterMember(EmitState& state, const std::string_view name,
+                                       const std::uint64_t value) noexcept {
+    return emitNamedId(state, name, value);
+}
+
+[[nodiscard]] bool emitDocumentRoot(EmitState& state) noexcept {
+    using namespace bloom::document;
+    auto& writer = state.writer;
+    if (!state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("schemaVersion"))) {
+        return false;
+    }
+    if (!emitVersion(state, kV1SchemaVersion)) {
+        return false;
+    }
+
+    if (!state.ok(writer.memberName("project")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!emitNamedId(state, "id", state.project.id().value())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("name")) ||
+        !state.ok(writer.stringValue(state.project.name()))) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("colorSettings")) || !emitColorSettings(state)) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("compositions")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    std::span<const std::size_t> compositionOrder;
+    if (!makeOrder(state.project.compositions(),
+                   [](const Composition& composition) noexcept {
+                       return composition.id().value();
+                   },
+                   state.sort.window0, compositionOrder, state.walk.error)) {
+        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity); return false; }
+    }
+    for (const auto compositionIndex : compositionOrder) {
+        if (!emitComposition(state, state.project.compositions()[compositionIndex],
+                             compositionIndex)) {
+            return false;
+        }
+    }
+    if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+        return false;
+    }
+
+    if (!state.ok(writer.memberName("idAllocation")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    if (!state.ok(writer.memberName("highestIssued")) || !state.ok(writer.beginObject())) {
+        return false;
+    }
+    const auto& water = state.highWater;
+    if (!emitHighWaterMember(state, "composition", water.composition) ||
+        !emitHighWaterMember(state, "node", water.node) ||
+        !emitHighWaterMember(state, "edge", water.edge) ||
+        !emitHighWaterMember(state, "layer", water.layer) ||
+        !emitHighWaterMember(state, "layerSlot", water.layerSlot) ||
+        !emitHighWaterMember(state, "parameter", water.parameter) ||
+        !emitHighWaterMember(state, "animationCurve", water.animationCurve) ||
+        !emitHighWaterMember(state, "keyframe", water.keyframe) ||
+        !emitHighWaterMember(state, "driverBinding", water.driverBinding) ||
+        !emitHighWaterMember(state, "extensionRecord", water.extensionRecord)) {
+        return false;
+    }
+    if (!state.ok(writer.endObject()) || !state.ok(writer.endObject())) {
+        return false;
+    }
+
+    if (!state.ok(writer.memberName("extensions")) || !state.ok(writer.beginArray())) {
+        return false;
+    }
+    std::span<const std::size_t> recordOrder;
+    if (!makeOrder(state.project.extensionRecords(),
+                   [](const ExtensionRecord& record) noexcept { return record.id.value(); },
+                   state.sort.window1, recordOrder, state.walk.error)) {
+        { state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity); return false; }
+    }
+    for (const auto recordIndex : recordOrder) {
+        if (!emitExtensionRecord(state, state.project.extensionRecords()[recordIndex])) {
+            return false;
+        }
+    }
+    if (!state.ok(writer.endArray())) {
+        return false;
+    }
+    if (!state.ok(writer.endObject())) {
+        return false;
+    }
+    return state.ok(writer.finish());
+}
+
+[[nodiscard]] bloom::document::OcioConfigPortability
+locatorPortability(const bloom::document::OcioConfigLocator& locator) noexcept {
+    using namespace bloom::document;
+    if (locator.valueless_by_exception()) {
+        return OcioConfigPortability::Unknown;
+    }
+    if (std::holds_alternative<BuiltInOcioConfigLocator>(locator)) {
+        return OcioConfigPortability::BuiltIn;
+    }
+    if (std::holds_alternative<ProjectRelativeOciozLocator>(locator)) {
+        return OcioConfigPortability::ProjectRelative;
+    }
+    if (std::holds_alternative<ExternalOciozLocator>(locator) ||
+        std::holds_alternative<ExternalOcioConfigLocator>(locator)) {
+        return OcioConfigPortability::External;
+    }
+    return OcioConfigPortability::Unknown;
+}
+
+[[nodiscard]] bool isValidPositiveReducedRational(const std::int64_t numerator,
+                                                  const std::int64_t denominator) noexcept {
+    return numerator >= 1 && denominator >= 1 && std::gcd(numerator, denominator) == 1;
+}
+
+[[nodiscard]] WalkState validateRequest(const CanonicalDocumentV1& document,
+                                        const CanonicalDocumentLimits limits,
+                                        SortPlan& plan) noexcept {
+    using namespace bloom::document;
+    WalkState walk;
+
+    if (document.snapshot == nullptr || document.colorSettings == nullptr) {
+        walk.fail(CanonicalDocumentError::MissingInput);
+        return walk;
+    }
+    if (limits.maximumValues > bloom::project::kCanonicalJsonMaximumValues ||
+        limits.maximumContainerEntries >
+            bloom::project::kCanonicalJsonMaximumContainerEntries ||
+        limits.maximumOutputBytes > bloom::project::kCanonicalDocumentMaximumBytes) {
+        walk.fail(CanonicalDocumentError::InvalidLimits);
+        return walk;
+    }
+
+    const auto& snapshot = *document.snapshot;
+    const auto& project = snapshot.project();
+    const auto& settings = *document.colorSettings;
+
+    // Color settings are durable project truth that Project does not own, so this writer performs
+    // their complete admission here, delegating lexical rules to the document-owned validator.
+    if (settings.processColorSpaceId != kProcessColorSpaceIdV1) {
+        walk.fail(CanonicalDocumentError::InvalidProcessColorSpaceId);
+        return walk;
+    }
+    if (settings.schemaVersion != kV1SchemaVersion ||
+        settings.ocioConfig.schemaVersion != kOcioConfigReferenceSchemaVersionV1) {
+        walk.fail(CanonicalDocumentError::InvalidColorSettings);
+        return walk;
+    }
+    if (settings.ocioConfig.expectedRevision.algorithm != OcioRevisionAlgorithm::Sha256) {
+        walk.fail(CanonicalDocumentError::InvalidOcioRevisionAlgorithm);
+        return walk;
+    }
+    const auto expectedPortability = locatorPortability(settings.ocioConfig.locator);
+    if (expectedPortability == OcioConfigPortability::Unknown ||
+        settings.ocioConfig.portability != expectedPortability) {
+        walk.fail(CanonicalDocumentError::OcioPortabilityMismatch);
+        return walk;
+    }
+    if (!settings.validate().ok()) {
+        walk.fail(CanonicalDocumentError::InvalidColorSettings);
+        return walk;
+    }
+
+    // Native v1 Save is a restricted supported-subset encoder: a live driver source is an
+    // unsupported save feature reported with its exact location, never a degraded rewrite.
+    for (std::size_t compositionIndex = 0; compositionIndex < project.compositions().size();
+         ++compositionIndex) {
+        const auto& composition = project.compositions()[compositionIndex];
+        const auto& parameters = composition.parameters().records();
+        for (std::size_t parameterIndex = 0; parameterIndex < parameters.size();
+             ++parameterIndex) {
+            if (std::holds_alternative<DriverBindingSource>(parameters[parameterIndex].source)) {
+                walk.fail(CanonicalDocumentError::UnsupportedDriverBindingSource,
+                          compositionIndex, parameterIndex);
+                return walk;
+            }
+        }
+
+        // Defensive domain re-checks for values whose owning types cannot always guarantee the
+        // serialized domain (for example through setFormat).
+        const auto duration = composition.duration();
+        if (!isValidPositiveReducedRational(duration.numerator(), duration.denominator())) {
+            walk.fail(CanonicalDocumentError::InvalidCompositionDuration, compositionIndex);
+            return walk;
+        }
+        const auto format = composition.format();
+        constexpr std::uint32_t kMaximumDimension = 1U << 20U;
+        if (format.width() == 0 || format.height() == 0 || format.width() > kMaximumDimension ||
+            format.height() > kMaximumDimension ||
+            static_cast<std::uint64_t>(format.width()) *
+                    static_cast<std::uint64_t>(format.height()) >
+                (std::uint64_t{1} << 32U) ||
+            format.pixelAspect().numerator() == 0 || format.pixelAspect().denominator() == 0 ||
+            format.frameRate().numerator() == 0 || format.frameRate().denominator() == 0) {
+            walk.fail(CanonicalDocumentError::InvalidCompositionFormat, compositionIndex);
+            return walk;
+        }
+    }
+
+    plan = measureSortPlan(project);
+    if (plan.total() > document.sortScratch.size()) {
+        walk.fail(CanonicalDocumentError::SortBufferTooSmall);
+        return walk;
+    }
+    for (const auto& record : project.extensionRecords()) {
+        const auto encodedSize =
+            bloom::project::canonicalBase64EncodedSize(record.payload.size());
+        if (!encodedSize.hasValue() || *encodedSize.value() > document.payloadScratch.size()) {
+            walk.fail(CanonicalDocumentError::PayloadBufferTooSmall);
+            return walk;
+        }
+    }
+    return walk;
+}
+
+} // namespace
+
+namespace bloom::project {
+
+CanonicalDocumentSizeResult canonicalDocumentSize(const CanonicalDocumentV1& document,
+                                                  const CanonicalDocumentLimits limits) noexcept {
+    SortPlan plan;
+    const auto validation = validateRequest(document, limits, plan);
+    if (validation.error != CanonicalDocumentError::None) {
+        return CanonicalDocumentSizeResult::failure(validation.error, validation.compositionIndex,
+                                                    validation.elementIndex);
+    }
+
+    const auto& snapshot = *document.snapshot;
+    auto counter =
+        CanonicalJsonWriter::counting({.maximumDepth = kCanonicalDocumentMaximumDepth,
+                                       .maximumValues = limits.maximumValues,
+                                       .maximumContainerEntries = limits.maximumContainerEntries});
+    EmitState state{counter,
+                    snapshot.project(),
+                    snapshot.ids().highWater(),
+                    *document.colorSettings,
+                    splitSortScratch(document.sortScratch, plan),
+                    document.payloadScratch,
+                    {}};
+    if (!emitDocumentRoot(state)) {
+        return CanonicalDocumentSizeResult::failure(state.walk.error, state.walk.compositionIndex,
+                                                    state.walk.elementIndex);
+    }
+    const auto requiredSize = counter.bytesRequired();
+    if (requiredSize > limits.maximumOutputBytes) {
+        return CanonicalDocumentSizeResult::failure(CanonicalDocumentError::DocumentSizeExceeded);
+    }
+    return CanonicalDocumentSizeResult::success(requiredSize);
+}
+
+CanonicalDocumentWriteResult encodeCanonicalDocument(const CanonicalDocumentV1& document,
+                                                     const std::span<char> output,
+                                                     const CanonicalDocumentLimits limits) noexcept {
+    const auto sizeResult = canonicalDocumentSize(document, limits);
+    if (!sizeResult) {
+        return CanonicalDocumentWriteResult::failure(sizeResult.error(), std::nullopt,
+                                                     sizeResult.compositionIndex(),
+                                                     sizeResult.elementIndex());
+    }
+    const auto requiredSize = *sizeResult.value();
+    if (output.size() < requiredSize) {
+        return CanonicalDocumentWriteResult::failure(CanonicalDocumentError::OutputCapacityExceeded,
+                                                     requiredSize);
+    }
+
+    const auto& snapshot = *document.snapshot;
+    CanonicalJsonWriter writer(output.first(requiredSize),
+                               {.maximumDepth = kCanonicalDocumentMaximumDepth,
+                                .maximumValues = limits.maximumValues,
+                                .maximumContainerEntries = limits.maximumContainerEntries});
+    EmitState state{writer,
+                    snapshot.project(),
+                    snapshot.ids().highWater(),
+                    *document.colorSettings,
+                    splitSortScratch(document.sortScratch,
+                                     measureSortPlan(snapshot.project())),
+                    document.payloadScratch,
+                    {}};
+    if (!emitDocumentRoot(state) || writer.bytesWritten() != requiredSize) {
+        std::terminate();
+    }
+    return CanonicalDocumentWriteResult::success(requiredSize);
+}
+
+} // namespace bloom::project

--- a/src/project/include/bloom/project/canonical_document.hpp
+++ b/src/project/include/bloom/project/canonical_document.hpp
@@ -81,12 +81,13 @@ enum class CanonicalDocumentError : std::uint8_t {
 
 class [[nodiscard]] CanonicalDocumentSizeResult final {
   public:
-    [[nodiscard]] static constexpr CanonicalDocumentSizeResult success(const std::size_t size) noexcept {
+    [[nodiscard]] static constexpr CanonicalDocumentSizeResult
+    success(const std::size_t size) noexcept {
         return CanonicalDocumentSizeResult(size);
     }
     [[nodiscard]] static constexpr CanonicalDocumentSizeResult
-    failure(const CanonicalDocumentError error, const std::size_t compositionIndex =
-                                                     kCanonicalDocumentNoIndex,
+    failure(const CanonicalDocumentError error,
+            const std::size_t compositionIndex = kCanonicalDocumentNoIndex,
             const std::size_t elementIndex = kCanonicalDocumentNoIndex) noexcept {
         return CanonicalDocumentSizeResult(error, compositionIndex, elementIndex);
     }
@@ -120,8 +121,9 @@ class [[nodiscard]] CanonicalDocumentWriteResult final {
   public:
     [[nodiscard]] static constexpr CanonicalDocumentWriteResult
     success(const std::size_t bytesWritten) noexcept {
-        return CanonicalDocumentWriteResult(CanonicalDocumentError::None, bytesWritten, bytesWritten,
-                                            kCanonicalDocumentNoIndex, kCanonicalDocumentNoIndex);
+        return CanonicalDocumentWriteResult(CanonicalDocumentError::None, bytesWritten,
+                                            bytesWritten, kCanonicalDocumentNoIndex,
+                                            kCanonicalDocumentNoIndex);
     }
     [[nodiscard]] static constexpr CanonicalDocumentWriteResult
     failure(const CanonicalDocumentError error,

--- a/src/project/include/bloom/project/canonical_document.hpp
+++ b/src/project/include/bloom/project/canonical_document.hpp
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/canonical_json_writer.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <type_traits>
+
+namespace bloom::document {
+
+struct ColorSettings;
+class Snapshot;
+
+} // namespace bloom::document
+
+namespace bloom::project {
+
+inline constexpr document::SchemaVersion kCanonicalDocumentSchemaVersionV1{1, 0};
+// The v1 expanded document.json resource limit from docs/architecture/project-format.md.
+inline constexpr std::size_t kCanonicalDocumentMaximumBytes = 268'435'456;
+// Deepest canonical document emission is nine containers (root through a vec2 keyframe value
+// object). The budget keeps manifest-style headroom over that fixed shape while still bounding
+// every write path.
+inline constexpr std::size_t kCanonicalDocumentMaximumDepth = 12;
+inline constexpr std::size_t kCanonicalDocumentNoIndex = static_cast<std::size_t>(-1);
+
+// One canonical encode request. The snapshot and color settings must outlive the call; Project
+// does not own color settings, so the caller supplies the complete durable value explicitly.
+//
+// Both scratch spans keep the writer allocation-free. payloadScratch receives one base64 spelling
+// at a time and must hold 4 * ceil(n / 3) bytes for the largest opaque extension payload in the
+// snapshot (zero is enough when every payload is empty). sortScratch is partitioned into three
+// disjoint windows so nested index orders never overlap: window zero holds the composition order,
+// window one holds one composition-scoped collection at a time (parameters, animation curves,
+// graph nodes, edges, layer output boundaries) plus the extension records, and window two holds
+// one nested sub-order at a time (node parameter bindings, curve keyframes). The required total is
+// measured from live collection sizes; store-ordered collections (animation curves, keyframes,
+// extension records) are re-sorted defensively through the same windows rather than trusted.
+struct CanonicalDocumentV1 final {
+    const bloom::document::Snapshot* snapshot = nullptr;
+    const bloom::document::ColorSettings* colorSettings = nullptr;
+    std::span<char> payloadScratch{};
+    std::span<std::size_t> sortScratch{};
+};
+
+struct CanonicalDocumentLimits final {
+    std::size_t maximumValues = kCanonicalJsonMaximumValues;
+    std::size_t maximumContainerEntries = kCanonicalJsonMaximumContainerEntries;
+    std::size_t maximumOutputBytes = kCanonicalDocumentMaximumBytes;
+};
+
+enum class CanonicalDocumentError : std::uint8_t {
+    None,
+    MissingInput,
+    InvalidLimits,
+    InvalidName,
+    InvalidCollectionIdentity,
+    MissingAnimationCurve,
+    InvalidCompositionDuration,
+    InvalidCompositionFormat,
+    InvalidParameter,
+    InvalidAnimationCurve,
+    InvalidGraph,
+    InvalidExtensionRecord,
+    InvalidColorSettings,
+    InvalidProcessColorSpaceId,
+    OcioPortabilityMismatch,
+    InvalidOcioRevisionAlgorithm,
+    UnsupportedDriverBindingSource,
+    SortBufferTooSmall,
+    PayloadBufferTooSmall,
+    ValueCountExceeded,
+    ContainerEntryCountExceeded,
+    DocumentSizeExceeded,
+    OutputCapacityExceeded,
+};
+
+class [[nodiscard]] CanonicalDocumentSizeResult final {
+  public:
+    [[nodiscard]] static constexpr CanonicalDocumentSizeResult success(const std::size_t size) noexcept {
+        return CanonicalDocumentSizeResult(size);
+    }
+    [[nodiscard]] static constexpr CanonicalDocumentSizeResult
+    failure(const CanonicalDocumentError error, const std::size_t compositionIndex =
+                                                     kCanonicalDocumentNoIndex,
+            const std::size_t elementIndex = kCanonicalDocumentNoIndex) noexcept {
+        return CanonicalDocumentSizeResult(error, compositionIndex, elementIndex);
+    }
+
+    [[nodiscard]] constexpr bool hasValue() const noexcept { return size_.has_value(); }
+    [[nodiscard]] explicit constexpr operator bool() const noexcept { return hasValue(); }
+    [[nodiscard]] constexpr const std::size_t* value() const& noexcept {
+        return size_.has_value() ? &*size_ : nullptr;
+    }
+    [[nodiscard]] constexpr const std::size_t* value() const&& = delete;
+    [[nodiscard]] constexpr CanonicalDocumentError error() const noexcept { return error_; }
+    [[nodiscard]] constexpr std::size_t compositionIndex() const noexcept {
+        return compositionIndex_;
+    }
+    [[nodiscard]] constexpr std::size_t elementIndex() const noexcept { return elementIndex_; }
+
+  private:
+    constexpr explicit CanonicalDocumentSizeResult(const std::size_t size) noexcept : size_(size) {}
+    constexpr CanonicalDocumentSizeResult(const CanonicalDocumentError error,
+                                          const std::size_t compositionIndex,
+                                          const std::size_t elementIndex) noexcept
+        : error_(error), compositionIndex_(compositionIndex), elementIndex_(elementIndex) {}
+
+    std::optional<std::size_t> size_;
+    CanonicalDocumentError error_ = CanonicalDocumentError::None;
+    std::size_t compositionIndex_ = kCanonicalDocumentNoIndex;
+    std::size_t elementIndex_ = kCanonicalDocumentNoIndex;
+};
+
+class [[nodiscard]] CanonicalDocumentWriteResult final {
+  public:
+    [[nodiscard]] static constexpr CanonicalDocumentWriteResult
+    success(const std::size_t bytesWritten) noexcept {
+        return CanonicalDocumentWriteResult(CanonicalDocumentError::None, bytesWritten, bytesWritten,
+                                            kCanonicalDocumentNoIndex, kCanonicalDocumentNoIndex);
+    }
+    [[nodiscard]] static constexpr CanonicalDocumentWriteResult
+    failure(const CanonicalDocumentError error,
+            const std::optional<std::size_t> requiredSize = std::nullopt,
+            const std::size_t compositionIndex = kCanonicalDocumentNoIndex,
+            const std::size_t elementIndex = kCanonicalDocumentNoIndex) noexcept {
+        return CanonicalDocumentWriteResult(error, requiredSize, 0, compositionIndex, elementIndex);
+    }
+
+    [[nodiscard]] constexpr bool succeeded() const noexcept {
+        return error_ == CanonicalDocumentError::None;
+    }
+    [[nodiscard]] explicit constexpr operator bool() const noexcept { return succeeded(); }
+    [[nodiscard]] constexpr CanonicalDocumentError error() const noexcept { return error_; }
+    [[nodiscard]] constexpr std::optional<std::size_t> requiredSize() const noexcept {
+        return requiredSize_;
+    }
+    [[nodiscard]] constexpr std::size_t bytesWritten() const noexcept { return bytesWritten_; }
+    [[nodiscard]] constexpr std::size_t compositionIndex() const noexcept {
+        return compositionIndex_;
+    }
+    [[nodiscard]] constexpr std::size_t elementIndex() const noexcept { return elementIndex_; }
+
+  private:
+    constexpr CanonicalDocumentWriteResult(const CanonicalDocumentError error,
+                                           const std::optional<std::size_t> requiredSize,
+                                           const std::size_t bytesWritten,
+                                           const std::size_t compositionIndex,
+                                           const std::size_t elementIndex) noexcept
+        : requiredSize_(requiredSize), bytesWritten_(bytesWritten), error_(error),
+          compositionIndex_(compositionIndex), elementIndex_(elementIndex) {}
+
+    std::optional<std::size_t> requiredSize_;
+    std::size_t bytesWritten_ = 0;
+    CanonicalDocumentError error_ = CanonicalDocumentError::None;
+    std::size_t compositionIndex_ = kCanonicalDocumentNoIndex;
+    std::size_t elementIndex_ = kCanonicalDocumentNoIndex;
+};
+
+// Validates the complete v1 document shape against the format contract and returns the exact
+// canonical byte count. Document-owned lexical and domain rules for color settings are delegated to
+// ColorSettings::validate(); live DriverBindingSource parameters are rejected here because native
+// v1 Save is a restricted supported-subset encoder. No destination byte is touched and no memory is
+// allocated beyond the callers' provided scratch spans.
+[[nodiscard]] CanonicalDocumentSizeResult
+canonicalDocumentSize(const CanonicalDocumentV1& document,
+                      CanonicalDocumentLimits limits = CanonicalDocumentLimits{}) noexcept;
+
+// Validation and exact sizing complete before output is touched. Capacity failures report the exact
+// byte requirement, zero bytes written, and leave the destination unchanged. Extra destination
+// capacity is allowed and remains untouched.
+[[nodiscard]] CanonicalDocumentWriteResult
+encodeCanonicalDocument(const CanonicalDocumentV1& document, std::span<char> output,
+                        CanonicalDocumentLimits limits = CanonicalDocumentLimits{}) noexcept;
+
+static_assert(std::is_trivially_copyable_v<CanonicalDocumentV1>);
+static_assert(std::is_trivially_copyable_v<CanonicalDocumentLimits>);
+static_assert(std::is_trivially_copyable_v<CanonicalDocumentSizeResult>);
+static_assert(std::is_trivially_copyable_v<CanonicalDocumentWriteResult>);
+
+} // namespace bloom::project

--- a/src/project/tests/canonical_document_tests.cpp
+++ b/src/project/tests/canonical_document_tests.cpp
@@ -118,8 +118,7 @@ void expectRequestError(Expectations& expectations, const CanonicalDocumentV1& r
                         const CanonicalDocumentLimits limits,
                         const CanonicalDocumentError expectedError,
                         const std::size_t expectedCompositionIndex,
-                        const std::size_t expectedElementIndex,
-                        const std::string_view message) {
+                        const std::size_t expectedElementIndex, const std::string_view message) {
     const auto size = bloom::project::canonicalDocumentSize(request, limits);
     expectations.expect(!size.hasValue() && size.error() == expectedError &&
                             size.compositionIndex() == expectedCompositionIndex &&
@@ -524,22 +523,22 @@ void testComposedGoldenBytes(Expectations& expectations) {
     const auto duration = RationalTime::create(48, 24);
     const auto frameRate = FrameRate::create(24000, 1001);
     const auto pixelAspect = PixelAspectRatio::create(2, 1);
-    const auto format = CompositionFormat::create(
-        1280, 720, pixelAspect.value_or(PixelAspectRatio::square()),
-        frameRate.value_or(FrameRate::framesPerSecond24()));
+    const auto format =
+        CompositionFormat::create(1280, 720, pixelAspect.value_or(PixelAspectRatio::square()),
+                                  frameRate.value_or(FrameRate::framesPerSecond24()));
     if (!duration.has_value() || !format.has_value()) {
         expectations.expect(false, "the composed fixture values are constructible");
         return;
     }
 
     CanonicalGraph graph{NodeId::fromRaw(1)};
-    const NodeRecord layerOutputNode{NodeId::fromRaw(3),
-                                     std::string(kLayerOutputNodeType),
-                                     {{"opacity", ParameterId::fromRaw(3)},
-                                      {"position", ParameterId::fromRaw(5)}},
-                                     kLayerOutputNodeSchemaVersion};
-    const NodeRecord layerStackNode{NodeId::fromRaw(1), std::string(kLayerStackNodeType), {},
-                                    kLayerStackNodeSchemaVersion};
+    const NodeRecord layerOutputNode{
+        NodeId::fromRaw(3),
+        std::string(kLayerOutputNodeType),
+        {{"opacity", ParameterId::fromRaw(3)}, {"position", ParameterId::fromRaw(5)}},
+        kLayerOutputNodeSchemaVersion};
+    const NodeRecord layerStackNode{
+        NodeId::fromRaw(1), std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion};
     const NodeRecord compositionOutputNode{NodeId::fromRaw(4),
                                            std::string(kCompositionOutputNodeType),
                                            {},
@@ -548,9 +547,8 @@ void testComposedGoldenBytes(Expectations& expectations) {
                                      std::string(kSolidSourceNodeType),
                                      {{"color", ParameterId::fromRaw(7)}},
                                      kSolidSourceNodeSchemaVersion};
-    const bool nodesAdded =
-        graph.addNode(layerOutputNode) && graph.addNode(layerStackNode) &&
-        graph.addNode(compositionOutputNode) && graph.addNode(solidSourceNode);
+    const bool nodesAdded = graph.addNode(layerOutputNode) && graph.addNode(layerStackNode) &&
+                            graph.addNode(compositionOutputNode) && graph.addNode(solidSourceNode);
     const EdgeRecord stackToOutputEdge{
         EdgeId::fromRaw(3),
         {NodeId::fromRaw(1), std::string(kLayerStackOutputPort)},
@@ -559,44 +557,41 @@ void testComposedGoldenBytes(Expectations& expectations) {
         EdgeId::fromRaw(1),
         {NodeId::fromRaw(2), std::string(kSolidSourceOutputPort)},
         NodeInputRef{NodeId::fromRaw(3), std::string(kLayerOutputContentInputPort)}};
-    const EdgeRecord layerToStackEdge{
-        EdgeId::fromRaw(2),
-        {NodeId::fromRaw(3), std::string(kLayerOutputOutputPort)},
-        LayerStackInputRef{NodeId::fromRaw(1), LayerSlotId::fromRaw(1),
-                           std::string(kLayerStackContentInputRole)}};
-    const bool edgesAdded =
-        graph.addEdge(stackToOutputEdge) && graph.addEdge(solidToLayerEdge) &&
-        graph.addEdge(layerToStackEdge);
+    const EdgeRecord layerToStackEdge{EdgeId::fromRaw(2),
+                                      {NodeId::fromRaw(3), std::string(kLayerOutputOutputPort)},
+                                      LayerStackInputRef{NodeId::fromRaw(1),
+                                                         LayerSlotId::fromRaw(1),
+                                                         std::string(kLayerStackContentInputRole)}};
+    const bool edgesAdded = graph.addEdge(stackToOutputEdge) && graph.addEdge(solidToLayerEdge) &&
+                            graph.addEdge(layerToStackEdge);
     const bool boundariesAdded =
         graph.addLayerOutput({NodeId::fromRaw(3), LayerId::fromRaw(1), "Hero Plate",
                               std::string(kLayerOutputOutputPort)});
-    expectations.expect(nodesAdded && edgesAdded && boundariesAdded &&
-                            graph.layerStack().append(
-                                {LayerSlotId::fromRaw(1), LayerId::fromRaw(1)}),
-                        "the composed fixture graph accepts its deliberately scrambled parts");
+    expectations.expect(
+        nodesAdded && edgesAdded && boundariesAdded &&
+            graph.layerStack().append({LayerSlotId::fromRaw(1), LayerId::fromRaw(1)}),
+        "the composed fixture graph accepts its deliberately scrambled parts");
 
     graph.setCompositionOutput({NodeId::fromRaw(4), std::string(kCompositionOutputOutputPort)});
     Composition composition{CompositionId::fromRaw(1), "Hero Shot", *duration, std::move(graph),
                             *format};
-    expectations.expect(
-        composition.parameters().insert(
-            {ParameterId::fromRaw(7), std::string(kSolidColorParameterSchemaKey),
-             ConstantValueSource{Color4d{0.0, 0.5, 1.0, 1.0}}}) &&
-            composition.parameters().insert(
-                {ParameterId::fromRaw(5), std::string(kPositionParameterSchemaKey),
-                 ConstantValueSource{Vec2d{96.0, -48.0}}}) &&
-            composition.parameters().insert(
-                {ParameterId::fromRaw(3), std::string(kOpacityParameterSchemaKey),
-                 AnimationCurveSource{AnimationCurveId::fromRaw(9)}}),
-        "the composed fixture parameters insert out of numeric ID order");
+    expectations.expect(composition.parameters().insert(
+                            {ParameterId::fromRaw(7), std::string(kSolidColorParameterSchemaKey),
+                             ConstantValueSource{Color4d{0.0, 0.5, 1.0, 1.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(5), std::string(kPositionParameterSchemaKey),
+                                 ConstantValueSource{Vec2d{96.0, -48.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(3), std::string(kOpacityParameterSchemaKey),
+                                 AnimationCurveSource{AnimationCurveId::fromRaw(9)}}),
+                        "the composed fixture parameters insert out of numeric ID order");
 
     ScalarAnimationCurve curve;
     curve.id = AnimationCurveId::fromRaw(9);
     curve.keyframes.push_back(
         {KeyframeId::fromRaw(21), RationalTime{}, 0.25, KeyframeInterpolation::Hold});
-    curve.keyframes.push_back(
-        {KeyframeId::fromRaw(22), RationalTime::fromInteger(48), 1.0,
-         KeyframeInterpolation::Linear});
+    curve.keyframes.push_back({KeyframeId::fromRaw(22), RationalTime::fromInteger(48), 1.0,
+                               KeyframeInterpolation::Linear});
     expectations.expect(composition.animationCurves().insert(curve),
                         "the composed fixture animation curve inserts");
 
@@ -625,11 +620,10 @@ void testComposedGoldenBytes(Expectations& expectations) {
                                                   .colorSettings = &settings,
                                                   .payloadScratch = payloadScratch,
                                                   .sortScratch = {}};
-    expectRequestError(expectations, requestTooSmallSort, {},
-                       CanonicalDocumentError::SortBufferTooSmall,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       "an exhausted sort scratch budget is rejected before any emission");
+    expectRequestError(
+        expectations, requestTooSmallSort, {}, CanonicalDocumentError::SortBufferTooSmall,
+        bloom::project::kCanonicalDocumentNoIndex, bloom::project::kCanonicalDocumentNoIndex,
+        "an exhausted sort scratch budget is rejected before any emission");
 
     const CanonicalDocumentV1 valid{.snapshot = &snapshot,
                                     .colorSettings = &settings,
@@ -837,14 +831,11 @@ void testExtensionGoldenBytes(Expectations& expectations) {
         "application/x-vendor-table",
         ExtensionHostReferenceTable{{{std::string("primary-comp"), CompositionId::fromRaw(1)}}},
         OpaqueExtensionPayload{}};
-    const ExtensionRecord markerRecord{ExtensionRecordId::fromRaw(5),
-                                       "vendor.module",
-                                       "vendor.module.marker",
-                                       {1, 0},
-                                       CompositionId::fromRaw(1),
-                                       "application/octet-stream",
-                                       NoExtensionReferences{},
-                                       OpaqueExtensionPayload{std::byte{0x00}}};
+    const ExtensionRecord markerRecord{
+        ExtensionRecordId::fromRaw(5), "vendor.module",
+        "vendor.module.marker",        {1, 0},
+        CompositionId::fromRaw(1),     "application/octet-stream",
+        NoExtensionReferences{},       OpaqueExtensionPayload{std::byte{0x00}}};
     const ExtensionRecord remapperRecord{
         ExtensionRecordId::fromRaw(2),
         "vendor.module",
@@ -853,8 +844,7 @@ void testExtensionGoldenBytes(Expectations& expectations) {
         std::nullopt,
         "text/x-vendor-note",
         ExtensionOwnerRemapper{"vendor.module.record-remapper", {1, 0}},
-        OpaqueExtensionPayload{std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE},
-                               std::byte{0xEF}}};
+        OpaqueExtensionPayload{std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE}, std::byte{0xEF}}};
     expectations.expect(newProject.project.addExtensionRecord(linkTableRecord) &&
                             newProject.project.addExtensionRecord(markerRecord) &&
                             newProject.project.addExtensionRecord(remapperRecord),
@@ -870,11 +860,10 @@ void testExtensionGoldenBytes(Expectations& expectations) {
                                                      .colorSettings = &settings,
                                                      .payloadScratch = {},
                                                      .sortScratch = sortScratch};
-    expectRequestError(expectations, requestNoPayloadBuffer, {},
-                       CanonicalDocumentError::PayloadBufferTooSmall,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       "an exhausted payload scratch budget is rejected before any emission");
+    expectRequestError(
+        expectations, requestNoPayloadBuffer, {}, CanonicalDocumentError::PayloadBufferTooSmall,
+        bloom::project::kCanonicalDocumentNoIndex, bloom::project::kCanonicalDocumentNoIndex,
+        "an exhausted payload scratch budget is rejected before any emission");
 
     const CanonicalDocumentV1 valid{.snapshot = &snapshot,
                                     .colorSettings = &settings,
@@ -920,8 +909,7 @@ void testInvalidColorSettingsRejections(Expectations& expectations) {
                        "the revision algorithm must be SHA-256 before encoding");
 
     auto mismatchedPortability = neutralColorSettings();
-    mismatchedPortability.ocioConfig.portability =
-        bloom::document::OcioConfigPortability::External;
+    mismatchedPortability.ocioConfig.portability = bloom::document::OcioConfigPortability::External;
     const CanonicalDocumentV1 portabilityRequest{.snapshot = &snapshot,
                                                  .colorSettings = &mismatchedPortability,
                                                  .payloadScratch = payloadScratch,
@@ -937,13 +925,14 @@ void testInvalidColorSettingsRejections(Expectations& expectations) {
                                          .colorSettings = &foreignBuiltinUri,
                                          .payloadScratch = payloadScratch,
                                          .sortScratch = sortScratch};
-    expectRequestError(expectations, uriRequest, {},
-                       CanonicalDocumentError::InvalidColorSettings, noIndex, noIndex,
+    expectRequestError(expectations, uriRequest, {}, CanonicalDocumentError::InvalidColorSettings,
+                       noIndex, noIndex,
                        "the only writable builtin locator is the qualified Bloom Neutral URI");
 
     auto unsortedContext = neutralColorSettings();
     unsortedContext.ocioConfig.contextVariables = {
-        {"BETA", "1"}, {"ALPHA", "2"},
+        {"BETA", "1"},
+        {"ALPHA", "2"},
     };
     const CanonicalDocumentV1 contextRequest{.snapshot = &snapshot,
                                              .colorSettings = &unsortedContext,
@@ -978,11 +967,10 @@ void testDriverSourceAdmission(Expectations& expectations) {
         expectations.expect(false, "the driver fixture composition exists");
         return;
     }
-    expectations.expect(
-        composition->parameters().insert(
-            {ParameterId::fromRaw(2), std::string(kOpacityParameterSchemaKey),
-             DriverBindingSource{DriverBindingId::fromRaw(4)}}),
-        "the driver fixture parameter inserts with a live driver source");
+    expectations.expect(composition->parameters().insert(
+                            {ParameterId::fromRaw(2), std::string(kOpacityParameterSchemaKey),
+                             DriverBindingSource{DriverBindingId::fromRaw(4)}}),
+                        "the driver fixture parameter inserts with a live driver source");
 
     IdAllocatorHighWater highWater{};
     highWater.composition = 1;
@@ -1020,19 +1008,17 @@ void testLimitsAndCapacityAdversarial(Expectations& expectations) {
 
     CanonicalDocumentLimits raisedCeilings;
     raisedCeilings.maximumValues = bloom::project::kCanonicalJsonMaximumValues + 1;
-    expectRequestError(expectations, request, raisedCeilings,
-                       CanonicalDocumentError::InvalidLimits,
+    expectRequestError(expectations, request, raisedCeilings, CanonicalDocumentError::InvalidLimits,
                        bloom::project::kCanonicalDocumentNoIndex,
                        bloom::project::kCanonicalDocumentNoIndex,
                        "caller budgets cannot raise the accepted v1 ceilings");
 
     CanonicalDocumentLimits starvedValues;
     starvedValues.maximumValues = 10;
-    expectRequestError(expectations, request, starvedValues,
-                       CanonicalDocumentError::ValueCountExceeded,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       "a lower value budget rejects during preflight accounting");
+    expectRequestError(
+        expectations, request, starvedValues, CanonicalDocumentError::ValueCountExceeded,
+        bloom::project::kCanonicalDocumentNoIndex, bloom::project::kCanonicalDocumentNoIndex,
+        "a lower value budget rejects during preflight accounting");
 
     std::array<char, 64> starvedOutput{};
     starvedOutput.fill('?');
@@ -1040,8 +1026,8 @@ void testLimitsAndCapacityAdversarial(Expectations& expectations) {
         bloom::project::encodeCanonicalDocument(request, starvedOutput, starvedValues);
     expectations.expect(!starvedEncode &&
                             starvedEncode.error() == CanonicalDocumentError::ValueCountExceeded &&
-                            starvedEncode.bytesWritten() == 0 &&
-                            starvedOutput.front() == '?' && starvedOutput.back() == '?',
+                            starvedEncode.bytesWritten() == 0 && starvedOutput.front() == '?' &&
+                            starvedOutput.back() == '?',
                         "a value-budget failure leaves the destination untouched");
 
     CanonicalDocumentLimits starvedContainers;
@@ -1060,11 +1046,10 @@ void testLimitsAndCapacityAdversarial(Expectations& expectations) {
 
     CanonicalDocumentLimits oneByteShort;
     oneByteShort.maximumOutputBytes = *exact.value() - 1;
-    expectRequestError(expectations, request, oneByteShort,
-                       CanonicalDocumentError::DocumentSizeExceeded,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       bloom::project::kCanonicalDocumentNoIndex,
-                       "the exact canonical byte count is checked against the output limit");
+    expectRequestError(
+        expectations, request, oneByteShort, CanonicalDocumentError::DocumentSizeExceeded,
+        bloom::project::kCanonicalDocumentNoIndex, bloom::project::kCanonicalDocumentNoIndex,
+        "the exact canonical byte count is checked against the output limit");
 
     CanonicalDocumentLimits atLimit;
     atLimit.maximumOutputBytes = *exact.value();
@@ -1073,14 +1058,12 @@ void testLimitsAndCapacityAdversarial(Expectations& expectations) {
 
     std::vector<char> shortOutput(*exact.value() - 1, '?');
     const auto shortResult = bloom::project::encodeCanonicalDocument(request, shortOutput);
-    expectations.expect(!shortResult &&
-                            shortResult.error() ==
-                                CanonicalDocumentError::OutputCapacityExceeded &&
-                            shortResult.requiredSize().has_value() &&
-                            *shortResult.requiredSize() == *exact.value() &&
-                            shortResult.bytesWritten() == 0 &&
-                            shortOutput.front() == '?' && shortOutput.back() == '?',
-                        "capacity shortage reports the exact requirement and writes nothing");
+    expectations.expect(
+        !shortResult && shortResult.error() == CanonicalDocumentError::OutputCapacityExceeded &&
+            shortResult.requiredSize().has_value() &&
+            *shortResult.requiredSize() == *exact.value() && shortResult.bytesWritten() == 0 &&
+            shortOutput.front() == '?' && shortOutput.back() == '?',
+        "capacity shortage reports the exact requirement and writes nothing");
 
     std::vector<char> exactOutput(*exact.value(), '?');
     const auto exactResult = bloom::project::encodeCanonicalDocument(request, exactOutput);
@@ -1088,7 +1071,6 @@ void testLimitsAndCapacityAdversarial(Expectations& expectations) {
                             exactOutput.back() == '\n',
                         "exact capacity emits the complete document ending in one LF");
 }
-
 
 } // namespace
 

--- a/src/project/tests/canonical_document_tests.cpp
+++ b/src/project/tests/canonical_document_tests.cpp
@@ -1,0 +1,1109 @@
+#include <bloom/project/canonical_document.hpp>
+
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/animation.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/composition_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/extension_records.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <numeric>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using bloom::core::Color4d;
+using bloom::core::PixelAspectRatio;
+using bloom::core::RationalTime;
+using bloom::document::AnimationCurveSource;
+using bloom::document::Composition;
+using bloom::document::CompositionFormat;
+using bloom::document::ConstantValueSource;
+using bloom::document::Document;
+using bloom::document::DriverBindingSource;
+using bloom::document::FrameRate;
+using bloom::document::OpaqueExtensionPayload;
+using bloom::document::Project;
+using bloom::document::ScalarAnimationCurve;
+using bloom::document::ScalarKeyframe;
+using bloom::project::CanonicalDocumentError;
+using bloom::project::CanonicalDocumentLimits;
+using bloom::project::CanonicalDocumentV1;
+
+constexpr std::size_t kScratchSize = 64;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] bloom::document::NewProject makeMinimalProject() {
+    const auto duration = RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    return bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+}
+
+struct Encoded final {
+    bool ok = false;
+    std::string bytes;
+};
+
+// Sizes, encodes at exact capacity plus slack, and reports both results so callers can assert
+// golden bytes and untouched slack in one place.
+[[nodiscard]] Encoded
+encodeWithSlack(const CanonicalDocumentV1& request,
+                const CanonicalDocumentLimits limits = CanonicalDocumentLimits{}) {
+    Encoded encoded;
+    const auto size = bloom::project::canonicalDocumentSize(request, limits);
+    if (!size.hasValue()) {
+        return encoded;
+    }
+    const auto required = *size.value();
+    std::vector<char> output(required + 8, '?');
+    const auto result = bloom::project::encodeCanonicalDocument(request, output, limits);
+    if (!result || result.bytesWritten() != required) {
+        return encoded;
+    }
+    for (std::size_t index = required; index < output.size(); ++index) {
+        if (output[index] != '?') {
+            return encoded;
+        }
+    }
+    encoded.ok = true;
+    encoded.bytes.assign(output.data(), required);
+    return encoded;
+}
+
+void expectRequestError(Expectations& expectations, const CanonicalDocumentV1& request,
+                        const CanonicalDocumentLimits limits,
+                        const CanonicalDocumentError expectedError,
+                        const std::size_t expectedCompositionIndex,
+                        const std::size_t expectedElementIndex,
+                        const std::string_view message) {
+    const auto size = bloom::project::canonicalDocumentSize(request, limits);
+    expectations.expect(!size.hasValue() && size.error() == expectedError &&
+                            size.compositionIndex() == expectedCompositionIndex &&
+                            size.elementIndex() == expectedElementIndex,
+                        message);
+
+    std::array<char, 8> tinyOutput{};
+    tinyOutput.fill('?');
+    const auto encode = bloom::project::encodeCanonicalDocument(request, tinyOutput, limits);
+    expectations.expect(!encode && !encode.requiredSize().has_value() &&
+                            encode.error() == expectedError && encode.bytesWritten() == 0 &&
+                            encode.compositionIndex() == expectedCompositionIndex &&
+                            encode.elementIndex() == expectedElementIndex,
+                        "the matching encode path reports the same typed failure");
+}
+
+void testMinimalGoldenBytes(Expectations& expectations) {
+    constexpr std::string_view expected =
+        "{\n"
+        "  \"schemaVersion\": {\n"
+        "    \"major\": 1,\n"
+        "    \"minor\": 0\n"
+        "  },\n"
+        "  \"project\": {\n"
+        "    \"id\": \"1\",\n"
+        "    \"name\": \"Untitled Project\",\n"
+        "    \"colorSettings\": {\n"
+        "      \"schemaVersion\": {\n"
+        "        \"major\": 1,\n"
+        "        \"minor\": 0\n"
+        "      },\n"
+        "      \"processColorSpaceId\": \"lin_rec709_scene\",\n"
+        "      \"ocioConfig\": {\n"
+        "        \"schemaVersion\": {\n"
+        "          \"major\": 1,\n"
+        "          \"minor\": 0\n"
+        "        },\n"
+        "        \"locator\": {\n"
+        "          \"kind\": \"builtin\",\n"
+        "          \"uri\": \"bloom://ocio/neutral-v1/config.ocio\"\n"
+        "        },\n"
+        "        \"expectedRevision\": {\n"
+        "          \"algorithm\": \"sha256\",\n"
+        "          \"digest\": "
+        "\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"\n"
+        "        },\n"
+        "        \"portability\": \"builtin\",\n"
+        "        \"contextVariables\": []\n"
+        "      }\n"
+        "    },\n"
+        "    \"compositions\": [\n"
+        "      {\n"
+        "        \"id\": \"1\",\n"
+        "        \"name\": \"Main Composition\",\n"
+        "        \"duration\": {\n"
+        "          \"numerator\": \"10\",\n"
+        "          \"denominator\": \"1\"\n"
+        "        },\n"
+        "        \"format\": {\n"
+        "          \"width\": 1920,\n"
+        "          \"height\": 1080,\n"
+        "          \"pixelAspect\": {\n"
+        "            \"numerator\": \"1\",\n"
+        "            \"denominator\": \"1\"\n"
+        "          },\n"
+        "          \"frameRate\": {\n"
+        "            \"numerator\": \"24\",\n"
+        "            \"denominator\": \"1\"\n"
+        "          }\n"
+        "        },\n"
+        "        \"parameters\": [],\n"
+        "        \"animationCurves\": [],\n"
+        "        \"graph\": {\n"
+        "          \"nodes\": [\n"
+        "            {\n"
+        "              \"id\": \"1\",\n"
+        "              \"typeId\": \"bloom.layer-stack\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": []\n"
+        "            },\n"
+        "            {\n"
+        "              \"id\": \"2\",\n"
+        "              \"typeId\": \"bloom.composition-output\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": []\n"
+        "            }\n"
+        "          ],\n"
+        "          \"edges\": [\n"
+        "            {\n"
+        "              \"id\": \"1\",\n"
+        "              \"source\": {\n"
+        "                \"nodeId\": \"1\",\n"
+        "                \"port\": \"image\"\n"
+        "              },\n"
+        "              \"destination\": {\n"
+        "                \"kind\": \"node-input\",\n"
+        "                \"nodeId\": \"2\",\n"
+        "                \"port\": \"image\"\n"
+        "              }\n"
+        "            }\n"
+        "          ],\n"
+        "          \"layerOutputs\": [],\n"
+        "          \"layerStack\": {\n"
+        "            \"nodeId\": \"1\",\n"
+        "            \"entries\": []\n"
+        "          },\n"
+        "          \"compositionOutput\": {\n"
+        "            \"nodeId\": \"2\",\n"
+        "            \"port\": \"image\"\n"
+        "          }\n"
+        "        }\n"
+        "      }\n"
+        "    ]\n"
+        "  },\n"
+        "  \"idAllocation\": {\n"
+        "    \"highestIssued\": {\n"
+        "      \"composition\": \"1\",\n"
+        "      \"node\": \"2\",\n"
+        "      \"edge\": \"1\",\n"
+        "      \"layer\": \"0\",\n"
+        "      \"layerSlot\": \"0\",\n"
+        "      \"parameter\": \"0\",\n"
+        "      \"animationCurve\": \"0\",\n"
+        "      \"keyframe\": \"0\",\n"
+        "      \"driverBinding\": \"0\",\n"
+        "      \"extensionRecord\": \"0\"\n"
+        "    }\n"
+        "  },\n"
+        "  \"extensions\": []\n"
+        "}\n";
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const CanonicalDocumentV1 missingSettings{.snapshot = &snapshot,
+                                              .colorSettings = nullptr,
+                                              .payloadScratch = payloadScratch,
+                                              .sortScratch = sortScratch};
+    expectRequestError(expectations, missingSettings, {}, CanonicalDocumentError::MissingInput,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       "a request without explicit color settings is rejected before sizing");
+
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 valid{.snapshot = &snapshot,
+                                    .colorSettings = &settings,
+                                    .payloadScratch = payloadScratch,
+                                    .sortScratch = sortScratch};
+    const auto size = bloom::project::canonicalDocumentSize(valid);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "minimal new-project preflight returns its exact golden byte count");
+
+    const auto encoded = encodeWithSlack(valid);
+    expectations.expect(encoded.ok && encoded.bytes == expected,
+                        "the minimal document emits exact canonical member order and layout");
+}
+
+// __PART2__
+
+void testComposedGoldenBytes(Expectations& expectations) {
+    constexpr std::string_view expected =
+        "{\n"
+        "  \"schemaVersion\": {\n"
+        "    \"major\": 1,\n"
+        "    \"minor\": 0\n"
+        "  },\n"
+        "  \"project\": {\n"
+        "    \"id\": \"1\",\n"
+        "    \"name\": \"Spot Check\",\n"
+        "    \"colorSettings\": {\n"
+        "      \"schemaVersion\": {\n"
+        "        \"major\": 1,\n"
+        "        \"minor\": 0\n"
+        "      },\n"
+        "      \"processColorSpaceId\": \"lin_rec709_scene\",\n"
+        "      \"ocioConfig\": {\n"
+        "        \"schemaVersion\": {\n"
+        "          \"major\": 1,\n"
+        "          \"minor\": 0\n"
+        "        },\n"
+        "        \"locator\": {\n"
+        "          \"kind\": \"builtin\",\n"
+        "          \"uri\": \"bloom://ocio/neutral-v1/config.ocio\"\n"
+        "        },\n"
+        "        \"expectedRevision\": {\n"
+        "          \"algorithm\": \"sha256\",\n"
+        "          \"digest\": "
+        "\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"\n"
+        "        },\n"
+        "        \"portability\": \"builtin\",\n"
+        "        \"contextVariables\": []\n"
+        "      }\n"
+        "    },\n"
+        "    \"compositions\": [\n"
+        "      {\n"
+        "        \"id\": \"1\",\n"
+        "        \"name\": \"Hero Shot\",\n"
+        "        \"duration\": {\n"
+        "          \"numerator\": \"2\",\n"
+        "          \"denominator\": \"1\"\n"
+        "        },\n"
+        "        \"format\": {\n"
+        "          \"width\": 1280,\n"
+        "          \"height\": 720,\n"
+        "          \"pixelAspect\": {\n"
+        "            \"numerator\": \"2\",\n"
+        "            \"denominator\": \"1\"\n"
+        "          },\n"
+        "          \"frameRate\": {\n"
+        "            \"numerator\": \"24000\",\n"
+        "            \"denominator\": \"1001\"\n"
+        "          }\n"
+        "        },\n"
+        "        \"parameters\": [\n"
+        "          {\n"
+        "            \"id\": \"3\",\n"
+        "            \"schemaKey\": \"bloom.layer.opacity\",\n"
+        "            \"source\": {\n"
+        "              \"kind\": \"animation-curve\",\n"
+        "              \"curveId\": \"9\"\n"
+        "            }\n"
+        "          },\n"
+        "          {\n"
+        "            \"id\": \"5\",\n"
+        "            \"schemaKey\": \"bloom.transform.position\",\n"
+        "            \"source\": {\n"
+        "              \"kind\": \"constant\",\n"
+        "              \"value\": {\n"
+        "                \"kind\": \"vec2\",\n"
+        "                \"x\": 96.0,\n"
+        "                \"y\": -48.0\n"
+        "              }\n"
+        "            }\n"
+        "          },\n"
+        "          {\n"
+        "            \"id\": \"7\",\n"
+        "            \"schemaKey\": \"bloom.solid.color\",\n"
+        "            \"source\": {\n"
+        "              \"kind\": \"constant\",\n"
+        "              \"value\": {\n"
+        "                \"kind\": \"color4\",\n"
+        "                \"red\": 0.0,\n"
+        "                \"green\": 0.5,\n"
+        "                \"blue\": 1.0,\n"
+        "                \"alpha\": 1.0\n"
+        "              }\n"
+        "            }\n"
+        "          }\n"
+        "        ],\n"
+        "        \"animationCurves\": [\n"
+        "          {\n"
+        "            \"id\": \"9\",\n"
+        "            \"kind\": \"scalar\",\n"
+        "            \"keyframes\": [\n"
+        "              {\n"
+        "                \"id\": \"21\",\n"
+        "                \"time\": {\n"
+        "                  \"numerator\": \"0\",\n"
+        "                  \"denominator\": \"1\"\n"
+        "                },\n"
+        "                \"value\": 0.25,\n"
+        "                \"outgoingInterpolation\": \"hold\"\n"
+        "              },\n"
+        "              {\n"
+        "                \"id\": \"22\",\n"
+        "                \"time\": {\n"
+        "                  \"numerator\": \"48\",\n"
+        "                  \"denominator\": \"1\"\n"
+        "                },\n"
+        "                \"value\": 1.0,\n"
+        "                \"outgoingInterpolation\": \"linear\"\n"
+        "              }\n"
+        "            ]\n"
+        "          }\n"
+        "        ],\n"
+        "        \"graph\": {\n"
+        "          \"nodes\": [\n"
+        "            {\n"
+        "              \"id\": \"1\",\n"
+        "              \"typeId\": \"bloom.layer-stack\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": []\n"
+        "            },\n"
+        "            {\n"
+        "              \"id\": \"2\",\n"
+        "              \"typeId\": \"bloom.solid-source\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": [\n"
+        "                {\n"
+        "                  \"role\": \"color\",\n"
+        "                  \"parameterId\": \"7\"\n"
+        "                }\n"
+        "              ]\n"
+        "            },\n"
+        "            {\n"
+        "              \"id\": \"3\",\n"
+        "              \"typeId\": \"bloom.layer-output\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": [\n"
+        "                {\n"
+        "                  \"role\": \"opacity\",\n"
+        "                  \"parameterId\": \"3\"\n"
+        "                },\n"
+        "                {\n"
+        "                  \"role\": \"position\",\n"
+        "                  \"parameterId\": \"5\"\n"
+        "                }\n"
+        "              ]\n"
+        "            },\n"
+        "            {\n"
+        "              \"id\": \"4\",\n"
+        "              \"typeId\": \"bloom.composition-output\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": []\n"
+        "            }\n"
+        "          ],\n"
+        "          \"edges\": [\n"
+        "            {\n"
+        "              \"id\": \"1\",\n"
+        "              \"source\": {\n"
+        "                \"nodeId\": \"2\",\n"
+        "                \"port\": \"image\"\n"
+        "              },\n"
+        "              \"destination\": {\n"
+        "                \"kind\": \"node-input\",\n"
+        "                \"nodeId\": \"3\",\n"
+        "                \"port\": \"image\"\n"
+        "              }\n"
+        "            },\n"
+        "            {\n"
+        "              \"id\": \"2\",\n"
+        "              \"source\": {\n"
+        "                \"nodeId\": \"3\",\n"
+        "                \"port\": \"image\"\n"
+        "              },\n"
+        "              \"destination\": {\n"
+        "                \"kind\": \"layer-stack-input\",\n"
+        "                \"stackNodeId\": \"1\",\n"
+        "                \"slotId\": \"1\",\n"
+        "                \"role\": \"content\"\n"
+        "              }\n"
+        "            },\n"
+        "            {\n"
+        "              \"id\": \"3\",\n"
+        "              \"source\": {\n"
+        "                \"nodeId\": \"1\",\n"
+        "                \"port\": \"image\"\n"
+        "              },\n"
+        "              \"destination\": {\n"
+        "                \"kind\": \"node-input\",\n"
+        "                \"nodeId\": \"4\",\n"
+        "                \"port\": \"image\"\n"
+        "              }\n"
+        "            }\n"
+        "          ],\n"
+        "          \"layerOutputs\": [\n"
+        "            {\n"
+        "              \"nodeId\": \"3\",\n"
+        "              \"layerId\": \"1\",\n"
+        "              \"name\": \"Hero Plate\",\n"
+        "              \"outputPort\": \"image\"\n"
+        "            }\n"
+        "          ],\n"
+        "          \"layerStack\": {\n"
+        "            \"nodeId\": \"1\",\n"
+        "            \"entries\": [\n"
+        "              {\n"
+        "                \"slotId\": \"1\",\n"
+        "                \"layerId\": \"1\"\n"
+        "              }\n"
+        "            ]\n"
+        "          },\n"
+        "          \"compositionOutput\": {\n"
+        "            \"nodeId\": \"4\",\n"
+        "            \"port\": \"image\"\n"
+        "          }\n"
+        "        }\n"
+        "      }\n"
+        "    ]\n"
+        "  },\n"
+        "  \"idAllocation\": {\n"
+        "    \"highestIssued\": {\n"
+        "      \"composition\": \"1\",\n"
+        "      \"node\": \"4\",\n"
+        "      \"edge\": \"3\",\n"
+        "      \"layer\": \"1\",\n"
+        "      \"layerSlot\": \"1\",\n"
+        "      \"parameter\": \"7\",\n"
+        "      \"animationCurve\": \"9\",\n"
+        "      \"keyframe\": \"22\",\n"
+        "      \"driverBinding\": \"0\",\n"
+        "      \"extensionRecord\": \"0\"\n"
+        "    }\n"
+        "  },\n"
+        "  \"extensions\": []\n"
+        "}\n";
+
+    using namespace bloom::document;
+    const auto duration = RationalTime::create(48, 24);
+    const auto frameRate = FrameRate::create(24000, 1001);
+    const auto pixelAspect = PixelAspectRatio::create(2, 1);
+    const auto format = CompositionFormat::create(
+        1280, 720, pixelAspect.value_or(PixelAspectRatio::square()),
+        frameRate.value_or(FrameRate::framesPerSecond24()));
+    if (!duration.has_value() || !format.has_value()) {
+        expectations.expect(false, "the composed fixture values are constructible");
+        return;
+    }
+
+    CanonicalGraph graph{NodeId::fromRaw(1)};
+    const NodeRecord layerOutputNode{NodeId::fromRaw(3),
+                                     std::string(kLayerOutputNodeType),
+                                     {{"opacity", ParameterId::fromRaw(3)},
+                                      {"position", ParameterId::fromRaw(5)}},
+                                     kLayerOutputNodeSchemaVersion};
+    const NodeRecord layerStackNode{NodeId::fromRaw(1), std::string(kLayerStackNodeType), {},
+                                    kLayerStackNodeSchemaVersion};
+    const NodeRecord compositionOutputNode{NodeId::fromRaw(4),
+                                           std::string(kCompositionOutputNodeType),
+                                           {},
+                                           kCompositionOutputNodeSchemaVersion};
+    const NodeRecord solidSourceNode{NodeId::fromRaw(2),
+                                     std::string(kSolidSourceNodeType),
+                                     {{"color", ParameterId::fromRaw(7)}},
+                                     kSolidSourceNodeSchemaVersion};
+    const bool nodesAdded =
+        graph.addNode(layerOutputNode) && graph.addNode(layerStackNode) &&
+        graph.addNode(compositionOutputNode) && graph.addNode(solidSourceNode);
+    const EdgeRecord stackToOutputEdge{
+        EdgeId::fromRaw(3),
+        {NodeId::fromRaw(1), std::string(kLayerStackOutputPort)},
+        NodeInputRef{NodeId::fromRaw(4), std::string(kCompositionOutputInputPort)}};
+    const EdgeRecord solidToLayerEdge{
+        EdgeId::fromRaw(1),
+        {NodeId::fromRaw(2), std::string(kSolidSourceOutputPort)},
+        NodeInputRef{NodeId::fromRaw(3), std::string(kLayerOutputContentInputPort)}};
+    const EdgeRecord layerToStackEdge{
+        EdgeId::fromRaw(2),
+        {NodeId::fromRaw(3), std::string(kLayerOutputOutputPort)},
+        LayerStackInputRef{NodeId::fromRaw(1), LayerSlotId::fromRaw(1),
+                           std::string(kLayerStackContentInputRole)}};
+    const bool edgesAdded =
+        graph.addEdge(stackToOutputEdge) && graph.addEdge(solidToLayerEdge) &&
+        graph.addEdge(layerToStackEdge);
+    const bool boundariesAdded =
+        graph.addLayerOutput({NodeId::fromRaw(3), LayerId::fromRaw(1), "Hero Plate",
+                              std::string(kLayerOutputOutputPort)});
+    expectations.expect(nodesAdded && edgesAdded && boundariesAdded &&
+                            graph.layerStack().append(
+                                {LayerSlotId::fromRaw(1), LayerId::fromRaw(1)}),
+                        "the composed fixture graph accepts its deliberately scrambled parts");
+
+    graph.setCompositionOutput({NodeId::fromRaw(4), std::string(kCompositionOutputOutputPort)});
+    Composition composition{CompositionId::fromRaw(1), "Hero Shot", *duration, std::move(graph),
+                            *format};
+    expectations.expect(
+        composition.parameters().insert(
+            {ParameterId::fromRaw(7), std::string(kSolidColorParameterSchemaKey),
+             ConstantValueSource{Color4d{0.0, 0.5, 1.0, 1.0}}}) &&
+            composition.parameters().insert(
+                {ParameterId::fromRaw(5), std::string(kPositionParameterSchemaKey),
+                 ConstantValueSource{Vec2d{96.0, -48.0}}}) &&
+            composition.parameters().insert(
+                {ParameterId::fromRaw(3), std::string(kOpacityParameterSchemaKey),
+                 AnimationCurveSource{AnimationCurveId::fromRaw(9)}}),
+        "the composed fixture parameters insert out of numeric ID order");
+
+    ScalarAnimationCurve curve;
+    curve.id = AnimationCurveId::fromRaw(9);
+    curve.keyframes.push_back(
+        {KeyframeId::fromRaw(21), RationalTime{}, 0.25, KeyframeInterpolation::Hold});
+    curve.keyframes.push_back(
+        {KeyframeId::fromRaw(22), RationalTime::fromInteger(48), 1.0,
+         KeyframeInterpolation::Linear});
+    expectations.expect(composition.animationCurves().insert(curve),
+                        "the composed fixture animation curve inserts");
+
+    Project project{ProjectId::fromRaw(1), "Spot Check"};
+    expectations.expect(project.addComposition(std::move(composition)),
+                        "the composed fixture composition adds");
+
+    const IdAllocatorHighWater highWater{.composition = 1,
+
+                                         .node = 4,
+                                         .edge = 3,
+                                         .layer = 1,
+                                         .layerSlot = 1,
+                                         .parameter = 7,
+                                         .animationCurve = 9,
+                                         .keyframe = 22,
+                                         .driverBinding = 0,
+                                         .extensionRecord = 0};
+    Document document{std::move(project), highWater};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 requestTooSmallSort{.snapshot = &snapshot,
+                                                  .colorSettings = &settings,
+                                                  .payloadScratch = payloadScratch,
+                                                  .sortScratch = {}};
+    expectRequestError(expectations, requestTooSmallSort, {},
+                       CanonicalDocumentError::SortBufferTooSmall,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       "an exhausted sort scratch budget is rejected before any emission");
+
+    const CanonicalDocumentV1 valid{.snapshot = &snapshot,
+                                    .colorSettings = &settings,
+                                    .payloadScratch = payloadScratch,
+                                    .sortScratch = sortScratch};
+    const auto size = bloom::project::canonicalDocumentSize(valid);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "composed preflight returns its exact golden byte count");
+
+    const auto encoded = encodeWithSlack(valid);
+    expectations.expect(encoded.ok && encoded.bytes == expected,
+                        "scrambled live collections emit in canonical numeric and UTF-8 order");
+
+    const auto repeat = encodeWithSlack(valid);
+    expectations.expect(repeat.ok && repeat.bytes == encoded.bytes,
+                        "repeated encodes of one snapshot are byte-identical");
+}
+
+void testExtensionGoldenBytes(Expectations& expectations) {
+    constexpr std::string_view expected =
+        "{\n"
+        "  \"schemaVersion\": {\n"
+        "    \"major\": 1,\n"
+        "    \"minor\": 0\n"
+        "  },\n"
+        "  \"project\": {\n"
+        "    \"id\": \"1\",\n"
+        "    \"name\": \"Untitled Project\",\n"
+        "    \"colorSettings\": {\n"
+        "      \"schemaVersion\": {\n"
+        "        \"major\": 1,\n"
+        "        \"minor\": 0\n"
+        "      },\n"
+        "      \"processColorSpaceId\": \"lin_rec709_scene\",\n"
+        "      \"ocioConfig\": {\n"
+        "        \"schemaVersion\": {\n"
+        "          \"major\": 1,\n"
+        "          \"minor\": 0\n"
+        "        },\n"
+        "        \"locator\": {\n"
+        "          \"kind\": \"builtin\",\n"
+        "          \"uri\": \"bloom://ocio/neutral-v1/config.ocio\"\n"
+        "        },\n"
+        "        \"expectedRevision\": {\n"
+        "          \"algorithm\": \"sha256\",\n"
+        "          \"digest\": "
+        "\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"\n"
+        "        },\n"
+        "        \"portability\": \"builtin\",\n"
+        "        \"contextVariables\": []\n"
+        "      }\n"
+        "    },\n"
+        "    \"compositions\": [\n"
+        "      {\n"
+        "        \"id\": \"1\",\n"
+        "        \"name\": \"Main Composition\",\n"
+        "        \"duration\": {\n"
+        "          \"numerator\": \"10\",\n"
+        "          \"denominator\": \"1\"\n"
+        "        },\n"
+        "        \"format\": {\n"
+        "          \"width\": 1920,\n"
+        "          \"height\": 1080,\n"
+        "          \"pixelAspect\": {\n"
+        "            \"numerator\": \"1\",\n"
+        "            \"denominator\": \"1\"\n"
+        "          },\n"
+        "          \"frameRate\": {\n"
+        "            \"numerator\": \"24\",\n"
+        "            \"denominator\": \"1\"\n"
+        "          }\n"
+        "        },\n"
+        "        \"parameters\": [],\n"
+        "        \"animationCurves\": [],\n"
+        "        \"graph\": {\n"
+        "          \"nodes\": [\n"
+        "            {\n"
+        "              \"id\": \"1\",\n"
+        "              \"typeId\": \"bloom.layer-stack\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": []\n"
+        "            },\n"
+        "            {\n"
+        "              \"id\": \"2\",\n"
+        "              \"typeId\": \"bloom.composition-output\",\n"
+        "              \"schemaVersion\": 1,\n"
+        "              \"parameters\": []\n"
+        "            }\n"
+        "          ],\n"
+        "          \"edges\": [\n"
+        "            {\n"
+        "              \"id\": \"1\",\n"
+        "              \"source\": {\n"
+        "                \"nodeId\": \"1\",\n"
+        "                \"port\": \"image\"\n"
+        "              },\n"
+        "              \"destination\": {\n"
+        "                \"kind\": \"node-input\",\n"
+        "                \"nodeId\": \"2\",\n"
+        "                \"port\": \"image\"\n"
+        "              }\n"
+        "            }\n"
+        "          ],\n"
+        "          \"layerOutputs\": [],\n"
+        "          \"layerStack\": {\n"
+        "            \"nodeId\": \"1\",\n"
+        "            \"entries\": []\n"
+        "          },\n"
+        "          \"compositionOutput\": {\n"
+        "            \"nodeId\": \"2\",\n"
+        "            \"port\": \"image\"\n"
+        "          }\n"
+        "        }\n"
+        "      }\n"
+        "    ]\n"
+        "  },\n"
+        "  \"idAllocation\": {\n"
+        "    \"highestIssued\": {\n"
+        "      \"composition\": \"1\",\n"
+        "      \"node\": \"2\",\n"
+        "      \"edge\": \"1\",\n"
+        "      \"layer\": \"0\",\n"
+        "      \"layerSlot\": \"0\",\n"
+        "      \"parameter\": \"0\",\n"
+        "      \"animationCurve\": \"0\",\n"
+        "      \"keyframe\": \"0\",\n"
+        "      \"driverBinding\": \"0\",\n"
+        "      \"extensionRecord\": \"9\"\n"
+        "    }\n"
+        "  },\n"
+        "  \"extensions\": [\n"
+        "    {\n"
+        "      \"id\": \"2\",\n"
+        "      \"ownerId\": \"vendor.module\",\n"
+        "      \"typeId\": \"vendor.module.record-type\",\n"
+        "      \"schemaVersion\": {\n"
+        "        \"major\": 1,\n"
+        "        \"minor\": 0\n"
+        "      },\n"
+        "      \"subject\": null,\n"
+        "      \"mediaType\": \"text/x-vendor-note\",\n"
+        "      \"referencePolicy\": {\n"
+        "        \"kind\": \"owner-remapper\",\n"
+        "        \"remapperId\": \"vendor.module.record-remapper\",\n"
+        "        \"version\": {\n"
+        "          \"major\": 1,\n"
+        "          \"minor\": 0\n"
+        "        }\n"
+        "      },\n"
+        "      \"payload\": \"3q2+7w==\"\n"
+        "    },\n"
+        "    {\n"
+        "      \"id\": \"5\",\n"
+        "      \"ownerId\": \"vendor.module\",\n"
+        "      \"typeId\": \"vendor.module.marker\",\n"
+        "      \"schemaVersion\": {\n"
+        "        \"major\": 1,\n"
+        "        \"minor\": 0\n"
+        "      },\n"
+        "      \"subject\": {\n"
+        "        \"kind\": \"composition\",\n"
+        "        \"id\": \"1\"\n"
+        "      },\n"
+        "      \"mediaType\": \"application/octet-stream\",\n"
+        "      \"referencePolicy\": {\n"
+        "        \"kind\": \"none\"\n"
+        "      },\n"
+        "      \"payload\": \"AA==\"\n"
+        "    },\n"
+        "    {\n"
+        "      \"id\": \"9\",\n"
+        "      \"ownerId\": \"vendor.module\",\n"
+        "      \"typeId\": \"vendor.module.link-table\",\n"
+        "      \"schemaVersion\": {\n"
+        "        \"major\": 1,\n"
+        "        \"minor\": 0\n"
+        "      },\n"
+        "      \"subject\": null,\n"
+        "      \"mediaType\": \"application/x-vendor-table\",\n"
+        "      \"referencePolicy\": {\n"
+        "        \"kind\": \"host-table\",\n"
+        "        \"references\": [\n"
+        "          {\n"
+        "            \"key\": \"primary-comp\",\n"
+        "            \"target\": {\n"
+        "              \"kind\": \"composition\",\n"
+        "              \"id\": \"1\"\n"
+        "            }\n"
+        "          }\n"
+        "        ]\n"
+        "      },\n"
+        "      \"payload\": \"\"\n"
+        "    }\n"
+        "  ]\n"
+        "}\n";
+
+    using namespace bloom::document;
+    auto newProject = makeMinimalProject();
+    const ExtensionRecord linkTableRecord{
+        ExtensionRecordId::fromRaw(9),
+        "vendor.module",
+        "vendor.module.link-table",
+        {1, 0},
+        std::nullopt,
+        "application/x-vendor-table",
+        ExtensionHostReferenceTable{{{std::string("primary-comp"), CompositionId::fromRaw(1)}}},
+        OpaqueExtensionPayload{}};
+    const ExtensionRecord markerRecord{ExtensionRecordId::fromRaw(5),
+                                       "vendor.module",
+                                       "vendor.module.marker",
+                                       {1, 0},
+                                       CompositionId::fromRaw(1),
+                                       "application/octet-stream",
+                                       NoExtensionReferences{},
+                                       OpaqueExtensionPayload{std::byte{0x00}}};
+    const ExtensionRecord remapperRecord{
+        ExtensionRecordId::fromRaw(2),
+        "vendor.module",
+        "vendor.module.record-type",
+        {1, 0},
+        std::nullopt,
+        "text/x-vendor-note",
+        ExtensionOwnerRemapper{"vendor.module.record-remapper", {1, 0}},
+        OpaqueExtensionPayload{std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE},
+                               std::byte{0xEF}}};
+    expectations.expect(newProject.project.addExtensionRecord(linkTableRecord) &&
+                            newProject.project.addExtensionRecord(markerRecord) &&
+                            newProject.project.addExtensionRecord(remapperRecord),
+                        "the extension fixture records insert out of numeric ID order");
+
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 requestNoPayloadBuffer{.snapshot = &snapshot,
+                                                     .colorSettings = &settings,
+                                                     .payloadScratch = {},
+                                                     .sortScratch = sortScratch};
+    expectRequestError(expectations, requestNoPayloadBuffer, {},
+                       CanonicalDocumentError::PayloadBufferTooSmall,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       "an exhausted payload scratch budget is rejected before any emission");
+
+    const CanonicalDocumentV1 valid{.snapshot = &snapshot,
+                                    .colorSettings = &settings,
+                                    .payloadScratch = payloadScratch,
+                                    .sortScratch = sortScratch};
+    const auto size = bloom::project::canonicalDocumentSize(valid);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "extension preflight returns its exact golden byte count");
+
+    const auto encoded = encodeWithSlack(valid);
+    expectations.expect(encoded.ok && encoded.bytes == expected,
+                        "extension envelopes emit every policy shape and canonical base64");
+}
+
+void testInvalidColorSettingsRejections(Expectations& expectations) {
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto noIndex = bloom::project::kCanonicalDocumentNoIndex;
+
+    auto wrongProcessSpace = neutralColorSettings();
+    wrongProcessSpace.processColorSpaceId = "rec709_display";
+    const CanonicalDocumentV1 processRequest{.snapshot = &snapshot,
+                                             .colorSettings = &wrongProcessSpace,
+                                             .payloadScratch = payloadScratch,
+                                             .sortScratch = sortScratch};
+    expectRequestError(expectations, processRequest, {},
+                       CanonicalDocumentError::InvalidProcessColorSpaceId, noIndex, noIndex,
+                       "only the fixed v1 process color space identifier is writable");
+
+    auto unknownRevision = neutralColorSettings();
+    unknownRevision.ocioConfig.expectedRevision.algorithm =
+        bloom::document::OcioRevisionAlgorithm::Unknown;
+    const CanonicalDocumentV1 revisionRequest{.snapshot = &snapshot,
+                                              .colorSettings = &unknownRevision,
+                                              .payloadScratch = payloadScratch,
+                                              .sortScratch = sortScratch};
+    expectRequestError(expectations, revisionRequest, {},
+                       CanonicalDocumentError::InvalidOcioRevisionAlgorithm, noIndex, noIndex,
+                       "the revision algorithm must be SHA-256 before encoding");
+
+    auto mismatchedPortability = neutralColorSettings();
+    mismatchedPortability.ocioConfig.portability =
+        bloom::document::OcioConfigPortability::External;
+    const CanonicalDocumentV1 portabilityRequest{.snapshot = &snapshot,
+                                                 .colorSettings = &mismatchedPortability,
+                                                 .payloadScratch = payloadScratch,
+                                                 .sortScratch = sortScratch};
+    expectRequestError(expectations, portabilityRequest, {},
+                       CanonicalDocumentError::OcioPortabilityMismatch, noIndex, noIndex,
+                       "portability must agree with the locator family");
+
+    auto foreignBuiltinUri = neutralColorSettings();
+    foreignBuiltinUri.ocioConfig.locator =
+        bloom::document::BuiltInOcioConfigLocator{"bloom://ocio/neutral-v2/config.ocio"};
+    const CanonicalDocumentV1 uriRequest{.snapshot = &snapshot,
+                                         .colorSettings = &foreignBuiltinUri,
+                                         .payloadScratch = payloadScratch,
+                                         .sortScratch = sortScratch};
+    expectRequestError(expectations, uriRequest, {},
+                       CanonicalDocumentError::InvalidColorSettings, noIndex, noIndex,
+                       "the only writable builtin locator is the qualified Bloom Neutral URI");
+
+    auto unsortedContext = neutralColorSettings();
+    unsortedContext.ocioConfig.contextVariables = {
+        {"BETA", "1"}, {"ALPHA", "2"},
+    };
+    const CanonicalDocumentV1 contextRequest{.snapshot = &snapshot,
+                                             .colorSettings = &unsortedContext,
+                                             .payloadScratch = payloadScratch,
+                                             .sortScratch = sortScratch};
+    expectRequestError(expectations, contextRequest, {},
+                       CanonicalDocumentError::InvalidColorSettings, noIndex, noIndex,
+                       "context variables must already be unique and sorted by UTF-8 name");
+
+    auto staleSchema = neutralColorSettings();
+    staleSchema.schemaVersion = {2, 0};
+    const CanonicalDocumentV1 schemaRequest{.snapshot = &snapshot,
+                                            .colorSettings = &staleSchema,
+                                            .payloadScratch = payloadScratch,
+                                            .sortScratch = sortScratch};
+    expectRequestError(expectations, schemaRequest, {},
+                       CanonicalDocumentError::InvalidColorSettings, noIndex, noIndex,
+                       "color settings schema version is fixed at 1.0");
+}
+
+void testDriverSourceAdmission(Expectations& expectations) {
+    using namespace bloom::document;
+    auto duration = RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        expectations.expect(false, "the driver fixture duration is constructible");
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Driver Project", "Main Composition", *duration);
+    auto* composition = newProject.project.findComposition(newProject.initialCompositionId);
+    if (composition == nullptr) {
+        expectations.expect(false, "the driver fixture composition exists");
+        return;
+    }
+    expectations.expect(
+        composition->parameters().insert(
+            {ParameterId::fromRaw(2), std::string(kOpacityParameterSchemaKey),
+             DriverBindingSource{DriverBindingId::fromRaw(4)}}),
+        "the driver fixture parameter inserts with a live driver source");
+
+    IdAllocatorHighWater highWater{};
+    highWater.composition = 1;
+    highWater.node = 2;
+    highWater.edge = 1;
+    highWater.parameter = 2;
+    highWater.driverBinding = 4;
+    Document document{std::move(newProject.project), highWater};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch};
+    expectRequestError(expectations, request, {},
+                       CanonicalDocumentError::UnsupportedDriverBindingSource, 0, 0,
+                       "a live driver source fails admission with its composition and parameter");
+}
+
+void testLimitsAndCapacityAdversarial(Expectations& expectations) {
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch};
+
+    CanonicalDocumentLimits raisedCeilings;
+    raisedCeilings.maximumValues = bloom::project::kCanonicalJsonMaximumValues + 1;
+    expectRequestError(expectations, request, raisedCeilings,
+                       CanonicalDocumentError::InvalidLimits,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       "caller budgets cannot raise the accepted v1 ceilings");
+
+    CanonicalDocumentLimits starvedValues;
+    starvedValues.maximumValues = 10;
+    expectRequestError(expectations, request, starvedValues,
+                       CanonicalDocumentError::ValueCountExceeded,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       "a lower value budget rejects during preflight accounting");
+
+    std::array<char, 64> starvedOutput{};
+    starvedOutput.fill('?');
+    const auto starvedEncode =
+        bloom::project::encodeCanonicalDocument(request, starvedOutput, starvedValues);
+    expectations.expect(!starvedEncode &&
+                            starvedEncode.error() == CanonicalDocumentError::ValueCountExceeded &&
+                            starvedEncode.bytesWritten() == 0 &&
+                            starvedOutput.front() == '?' && starvedOutput.back() == '?',
+                        "a value-budget failure leaves the destination untouched");
+
+    CanonicalDocumentLimits starvedContainers;
+    starvedContainers.maximumContainerEntries = 3;
+    expectRequestError(expectations, request, starvedContainers,
+                       CanonicalDocumentError::ContainerEntryCountExceeded,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       "the root object member count is checked against the container budget");
+
+    const auto exact = bloom::project::canonicalDocumentSize(request);
+    if (!exact.hasValue()) {
+        expectations.expect(false, "the capacity fixture preflights successfully");
+        return;
+    }
+
+    CanonicalDocumentLimits oneByteShort;
+    oneByteShort.maximumOutputBytes = *exact.value() - 1;
+    expectRequestError(expectations, request, oneByteShort,
+                       CanonicalDocumentError::DocumentSizeExceeded,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       bloom::project::kCanonicalDocumentNoIndex,
+                       "the exact canonical byte count is checked against the output limit");
+
+    CanonicalDocumentLimits atLimit;
+    atLimit.maximumOutputBytes = *exact.value();
+    expectations.expect(bloom::project::canonicalDocumentSize(request, atLimit).hasValue(),
+                        "an output limit equal to the exact canonical size succeeds");
+
+    std::vector<char> shortOutput(*exact.value() - 1, '?');
+    const auto shortResult = bloom::project::encodeCanonicalDocument(request, shortOutput);
+    expectations.expect(!shortResult &&
+                            shortResult.error() ==
+                                CanonicalDocumentError::OutputCapacityExceeded &&
+                            shortResult.requiredSize().has_value() &&
+                            *shortResult.requiredSize() == *exact.value() &&
+                            shortResult.bytesWritten() == 0 &&
+                            shortOutput.front() == '?' && shortOutput.back() == '?',
+                        "capacity shortage reports the exact requirement and writes nothing");
+
+    std::vector<char> exactOutput(*exact.value(), '?');
+    const auto exactResult = bloom::project::encodeCanonicalDocument(request, exactOutput);
+    expectations.expect(exactResult && exactResult.bytesWritten() == *exact.value() &&
+                            exactOutput.back() == '\n',
+                        "exact capacity emits the complete document ending in one LF");
+}
+
+
+} // namespace
+
+int main() {
+    try {
+        Expectations expectations;
+        testMinimalGoldenBytes(expectations);
+        testComposedGoldenBytes(expectations);
+        testExtensionGoldenBytes(expectations);
+        testInvalidColorSettingsRejections(expectations);
+        testDriverSourceAdmission(expectations);
+        testLimitsAndCapacityAdversarial(expectations);
+        return expectations.failures() == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "Unexpected test exception: " << error.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #14.

Adds the version 1 canonical `document.json` writer to `src/project`:

- two-phase `canonicalDocumentSize` / `encodeCanonicalDocument` API over an immutable snapshot plus an explicitly supplied `ColorSettings` value (`Project` does not yet own durable color settings; attaching it remains separate work)
- exact canonical bytes through the existing canonical-layout, decimal, string, and base64 primitives — member orders, sorted collections, decimal-string integers, canonical Float64, allocator high-water state, extension envelopes
- allocation-free: semantic collection orders materialize in caller-provided disjoint sort windows, and extension payloads encode through bounded base64 scratch
- restricted supported-subset admission per the format contract: live `DriverBindingSource` parameters are rejected with their exact composition/parameter location before any emission; frozen v1 duration/format domains are re-validated defensively
- typed failure results carrying error, location, and (for capacity) the exact required size, with transactional output

## Testing

- Golden byte fixtures: minimal new-project document, a composed document with a solid layer and animated scalar curve, and an extensions document exercising all three reference policies
- Rejection tests for invalid color settings, portability mismatches, and driver sources; adversarial capacity, sort-window, payload-scratch, and limit cases
- Full `ci-linux-native` configure, build, and complete CTest suite green in a clean worktree

## Notes

`canonical_document.cpp` is 1374 lines — above the ~700-line guidance, retained as one cohesive emission walk (precedent: `strict_json_preflight.cpp` at 754). A natural split point arrives with the reader if wanted.
