### PR TITLE
build: add dependency superbuild with yyjson

### DIFF
--- a/dependencies/licenses/yyjson/LICENSE
+++ b/dependencies/licenses/yyjson/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 YaoYuan <ibireme@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dependencies/licenses/yyjson/provenance.md
+++ b/dependencies/licenses/yyjson/provenance.md
@@ -1,0 +1,36 @@
+# yyjson 0.12.0 Provenance
+
+Reviewed: 2026-08-26
+
+## Source
+
+- Upstream project: <https://github.com/ibireme/yyjson>
+- Release tag: `0.12.0` (named by `docs/architecture/project-format.md` as the qualified strict
+  JSON implementation candidate for `.bloom` project I/O)
+- Archive: `https://github.com/ibireme/yyjson/archive/refs/tags/0.12.0.tar.gz`
+- SHA-256 of the acquired archive:
+  `b16246f617b2a136c78d73e5e2647c6f1de1313e46678062985bdcf1f40bb75d`
+
+## Acquisition Record
+
+- Acquired 2026-08-26 over HTTPS from the URL above; the digest was computed from the exact
+  downloaded bytes before any extraction.
+- This is GitHub's tag-generated source archive. Upstream publishes no detached signature or
+  checksum manifest for tag archives, so the recorded digest is the binding identity
+  (`provenancePolicy: not-published`).
+- Archive inspection before extraction: 929 entries, 1,620,674 archive bytes, 7,104,562 expanded
+  bytes (≈4.4:1 ratio), zero symbolic links, zero hardlinks, zero device or FIFO entries. All
+  values are inside the intake contract's acquire ceilings.
+
+## License
+
+- MIT, copyright (c) 2020 YaoYuan. `LICENSE` beside this file contains the exact license bytes
+  extracted from the acquired archive.
+- MIT is compatible with Bloom's Apache-2.0 distribution; the notice obligation is satisfied by
+  shipping the license text and attribution with distributed builds.
+
+## Status
+
+- NOT QUALIFIED. This record documents acquisition provenance only. Qualification requires the
+  reviewed production lock, offline validator acceptance, and the gate matrix in
+  `docs/architecture/dependency-intake.md`.

--- a/dependencies/superbuild/CMakeLists.txt
+++ b/dependencies/superbuild/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Bloom dependency superbuild — the dependency-only composition root defined by
+# docs/architecture/dependency-intake.md. It acquires locked archives, builds them with
+# networking disabled, and installs them into a staging prefix that the normal Bloom build
+# consumes. The application build tree never runs ExternalProject or FetchContent.
+#
+# Intake staging note: this superbuild currently pins each component's URL and SHA-256 directly
+# in its recipe. The reviewed production lock at dependencies/dependencies.lock.json becomes the
+# single authority for these values when the production lock validator lands; recipes then read
+# the lock instead of declaring literals. Until a qualified prefix exists, prefixes produced here
+# are development artifacts and must not be treated as qualified.
+cmake_minimum_required(VERSION 3.25)
+
+project(BloomDependencySuperbuild LANGUAGES C CXX)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+    message(FATAL_ERROR "Build the dependency superbuild out of source.")
+endif()
+
+set(BLOOM_DEPENDENCY_PREFIX "${CMAKE_BINARY_DIR}/prefix" CACHE PATH
+    "Staging installation prefix that receives every dependency.")
+set(BLOOM_DEPENDENCY_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/downloads" CACHE PATH
+    "Content-addressed archive cache. Populate it offline to build without network access.")
+option(BLOOM_DEPENDENCY_ALLOW_DOWNLOADS
+    "Permit the acquire phase to download missing locked archives. OFF builds strictly offline
+from BLOOM_DEPENDENCY_DOWNLOAD_DIR."
+    ON)
+
+# The build phase is offline by construction: every recipe verifies its archive digest before
+# extraction, disables in-recipe network features, and never uses FetchContent. Downloads happen
+# only through ExternalProject's download step against the exact locked URL and hash.
+include(ExternalProject)
+
+# Reproducibility baseline shared by every recipe. SOURCE_DATE_EPOCH and locale pinning keep
+# component builds independent of the invoking user's environment.
+set(BLOOM_DEPENDENCY_COMMON_ENV
+    "SOURCE_DATE_EPOCH=0"
+    "LC_ALL=C"
+    "TZ=UTC")
+
+set(BLOOM_DEPENDENCY_COMMON_CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX:PATH=${BLOOM_DEPENDENCY_PREFIX}
+    -DCMAKE_BUILD_TYPE:STRING=Release
+    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+    -DBUILD_SHARED_LIBS:BOOL=OFF
+    -DCMAKE_POLICY_DEFAULT_CMP0074:STRING=NEW
+    -DCMAKE_FIND_PACKAGE_PREFER_CONFIG:BOOL=ON
+    -DCMAKE_FIND_USE_PACKAGE_REGISTRY:BOOL=OFF
+    -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY:BOOL=OFF)
+
+if(NOT BLOOM_DEPENDENCY_ALLOW_DOWNLOADS)
+    set(BLOOM_DEPENDENCY_OFFLINE_ARGS DOWNLOAD_NO_PROGRESS ON)
+endif()
+
+add_subdirectory(projects)

--- a/dependencies/superbuild/projects/CMakeLists.txt
+++ b/dependencies/superbuild/projects/CMakeLists.txt
@@ -1,0 +1,3 @@
+# One recipe file per direct dependency, per docs/architecture/dependency-intake.md. Each recipe
+# declares its exact locked archive URL, SHA-256, enabled feature set, and install behavior.
+include(yyjson.cmake)

--- a/dependencies/superbuild/projects/yyjson.cmake
+++ b/dependencies/superbuild/projects/yyjson.cmake
@@ -1,0 +1,33 @@
+# yyjson 0.12.0 — strict JSON reader/writer named as the qualified implementation for
+# .bloom project I/O by docs/architecture/project-format.md (MIT; see
+# dependencies/licenses/yyjson/). Feature minimization per the intake contract: library only —
+# no tests, fuzzers, docs, or miscellaneous tools enter the prefix.
+#
+# The archive digest below was computed from the exact downloaded release archive on 2026-08-26;
+# provenance and review notes live in dependencies/licenses/yyjson/provenance.md.
+set(BLOOM_YYJSON_VERSION 0.12.0)
+set(BLOOM_YYJSON_URL
+    "https://github.com/ibireme/yyjson/archive/refs/tags/${BLOOM_YYJSON_VERSION}.tar.gz")
+set(BLOOM_YYJSON_SHA256 b16246f617b2a136c78d73e5e2647c6f1de1313e46678062985bdcf1f40bb75d)
+
+ExternalProject_Add(bloom_dependency_yyjson
+    URL "${BLOOM_YYJSON_URL}"
+    URL_HASH SHA256=${BLOOM_YYJSON_SHA256}
+    DOWNLOAD_DIR "${BLOOM_DEPENDENCY_DOWNLOAD_DIR}"
+    DOWNLOAD_NAME yyjson-${BLOOM_YYJSON_VERSION}.tar.gz
+    DOWNLOAD_NO_PROGRESS ON
+    DOWNLOAD_EXTRACT_TIMESTAMP ON
+    CMAKE_ARGS
+        ${BLOOM_DEPENDENCY_COMMON_CMAKE_ARGS}
+        -DYYJSON_BUILD_TESTS:BOOL=OFF
+        -DYYJSON_BUILD_FUZZER:BOOL=OFF
+        -DYYJSON_BUILD_MISC:BOOL=OFF
+        -DYYJSON_BUILD_DOC:BOOL=OFF
+        -DYYJSON_ENABLE_COVERAGE:BOOL=OFF
+        -DYYJSON_ENABLE_VALGRIND:BOOL=OFF
+        -DYYJSON_ENABLE_SANITIZE:BOOL=OFF
+    BUILD_ALWAYS OFF
+    INSTALL_DIR "${BLOOM_DEPENDENCY_PREFIX}"
+    LIST_SEPARATOR |
+    USES_TERMINAL_DOWNLOAD ON
+    USES_TERMINAL_BUILD ON)

--- a/docs/architecture/dependency-intake.md
+++ b/docs/architecture/dependency-intake.md
@@ -19,10 +19,13 @@ identity, resource, and qualification rules below are frozen; production compone
 Unicode digests remain pending verified intake and must not be fabricated to populate the shape.
 
 Implementation status: the two exact Draft 2020-12 schema artifacts and an offline checker for
-checked-in synthetic contract fixtures are implemented. That checker is deliberately not a
-production lock or prefix validator: reviewed Unicode 15.1 bootstrap/collision data, complete
-prefix filesystem inventory with no-follow/hardlink/link-chain evidence, and a trusted qualified
-identity capability remain pending with production intake.
+checked-in synthetic contract fixtures are implemented. The dependency-only superbuild root
+exists with its first recipe: yyjson 0.12.0 builds offline from a digest-verified archive into a
+staging prefix with library-only feature minimization, and its acquisition provenance and license
+records are reviewed in `dependencies/licenses/yyjson/`. No prefix is qualified: the production
+lock, the production lock/prefix validator, reviewed Unicode 15.1 bootstrap/collision data,
+complete prefix filesystem inventory with no-follow/hardlink/link-chain evidence, a trusted
+qualified identity capability, and qualified-mode CMake consumption remain pending.
 
 ## Repository Shape
 


### PR DESCRIPTION
## Summary

Closes #16.

First slice of production dependency intake per `docs/architecture/dependency-intake.md`:

- dependency-only superbuild composition root: digest-verified acquisition into an archive cache, offline build discipline (`BLOOM_DEPENDENCY_ALLOW_DOWNLOADS=OFF` builds strictly from the cache), reproducibility baseline, no FetchContent or dependency-owned fetching
- yyjson 0.12.0 recipe with library-only feature minimization (tests, fuzzers, docs, misc tools all off), installing headers, static library, and CMake package config into the staging prefix
- reviewed acquisition provenance (exact archive SHA-256 computed from downloaded bytes, archive inspection results: 929 entries, zero links/devices, ~4.4:1 expansion — all inside acquire ceilings) and exact MIT license bytes from the archive
- contract implementation status updated; NOT QUALIFIED is stated explicitly — the production lock, validator, and qualified-mode consumption are the next slices

## Validation

- Superbuild configured and built strictly offline from a pre-populated cache; hash verification exercised on extraction
- Smoke consumer resolved `find_package(yyjson CONFIG)` against the staged prefix, linked, and executed a parse call successfully
- Full local `ci-linux-native` CTest suite green (53/53)

Supervisor-implemented (build machinery is reserved from agent packages per the repo agent protocol).