### PR TITLE
feat: validate production dependency locks

### DIFF
--- a/tools/quality/dependency_artifact_checks/CMakeLists.txt
+++ b/tools/quality/dependency_artifact_checks/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(
     dependency_artifact_schema.cpp
     dependency_lock_fixture.cpp
     dependency_prefix_fixture.cpp
+    production_lock_checks.cpp
+    production_lock_checks.hpp
 )
 target_link_libraries(bloom_dependency_artifact_checks PUBLIC bloom_quality_json PRIVATE bloom_core)
 target_compile_features(bloom_dependency_artifact_checks PUBLIC cxx_std_20)
@@ -28,6 +30,7 @@ if(BUILD_TESTING)
         bloom_dependency_artifact_checks_test
         dependency_artifact_boundary_tests.cpp
         dependency_artifact_checks_tests.cpp
+        production_lock_checks_tests.cpp
         dependency_artifact_checks_test_support.hpp
     )
     target_link_libraries(

--- a/tools/quality/dependency_artifact_checks/dependency_artifact_boundary_tests.cpp
+++ b/tools/quality/dependency_artifact_checks/dependency_artifact_boundary_tests.cpp
@@ -79,12 +79,19 @@ void testPublicSurface(const std::filesystem::path& root, Expectations& expectat
         root / "tools/quality/dependency_artifact_checks/dependency_artifact_checks.hpp",
         std::size_t{64} * 1024U);
     expectations.expect(
-        header.find("not a production dependency-lock or installed-prefix validator") !=
-            std::string::npos,
-        "tooling API states its synthetic-only trust boundary");
+        header.find("validates Bloom's checked-in synthetic contract fixtures") !=
+                std::string::npos &&
+            header.find("still not an installed-prefix validator") != std::string::npos,
+        "tooling API states its production-lock scope and prefix-validation boundary");
     expectations.expect(header.find("lockIdentity(") == std::string::npos &&
                             header.find("prefixIdentity(") == std::string::npos,
                         "tooling API exposes no trusted production identity capability");
+    const auto productionHeader =
+        readBounded(root / "tools/quality/dependency_artifact_checks/production_lock_checks.hpp",
+                    std::size_t{64} * 1024U);
+    expectations.expect(
+        productionHeader.find("ASCII-STRICT v1 TIGHTENING") != std::string::npos,
+        "production lock validator documents the deliberate ASCII-strict v1 tightening");
 }
 
 } // namespace

--- a/tools/quality/dependency_artifact_checks/dependency_artifact_checks.hpp
+++ b/tools/quality/dependency_artifact_checks/dependency_artifact_checks.hpp
@@ -13,8 +13,10 @@
 
 namespace bloom::quality::dependencies {
 
-// This tooling validates only Bloom's checked-in synthetic contract fixtures. It is deliberately
-// not a production dependency-lock or installed-prefix validator.
+// This tooling validates Bloom's checked-in synthetic contract fixtures and, since the production
+// lock validator landed, the production dependency lock at dependencies/dependencies.lock.json.
+// It is still not an installed-prefix validator: production prefix-manifest validation remains out
+// of scope.
 
 enum class ArtifactKind {
     Lock,
@@ -47,6 +49,8 @@ struct FixtureContext final {
 struct CheckResult final {
     std::string lockVector;
     std::string prefixVector;
+    bool productionLockPresent{false};
+    std::string productionLockIdentity;
 };
 
 [[nodiscard]] auto limitsFor(ArtifactKind kind) noexcept -> ArtifactLimits;

--- a/tools/quality/dependency_artifact_checks/dependency_artifact_checks_main.cpp
+++ b/tools/quality/dependency_artifact_checks/dependency_artifact_checks_main.cpp
@@ -25,6 +25,13 @@ int main(const int argumentCount, char** arguments) {
             bloom::quality::dependencies::checkRepository(repositoryRoot(argumentCount, arguments));
         std::cout << "Synthetic dependency contract check passed (lock " << result.lockVector
                   << ", prefix " << result.prefixVector << ")\n";
+        if (result.productionLockPresent) {
+            std::cout << "Production dependency lock validated (identity "
+                      << result.productionLockIdentity << ")\n";
+        } else {
+            std::cout << "Production dependency lock absent; Unicode 15.1 bootstrap allowlist "
+                         "verified\n";
+        }
         return 0;
     } catch (const std::exception& error) {
         std::cerr << "Dependency artifact check failed: " << error.what() << '\n';

--- a/tools/quality/dependency_artifact_checks/dependency_artifact_checks_test_support.hpp
+++ b/tools/quality/dependency_artifact_checks/dependency_artifact_checks_test_support.hpp
@@ -91,5 +91,6 @@ class TemporaryDirectory final {
 };
 
 [[nodiscard]] auto runBoundaryTests(const std::filesystem::path& repositoryRoot) -> int;
+[[nodiscard]] auto runProductionLockTests(const std::filesystem::path& repositoryRoot) -> int;
 
 } // namespace bloom::quality::dependencies::tests

--- a/tools/quality/dependency_artifact_checks/dependency_artifact_checks_tests.cpp
+++ b/tools/quality/dependency_artifact_checks/dependency_artifact_checks_tests.cpp
@@ -610,7 +610,9 @@ int main(const int argumentCount, char** arguments) {
         testPrefixFilesystemAndRoles(fixture, expectations);
         const auto boundaryFailures =
             bloom::quality::dependencies::tests::runBoundaryTests(fixture.root);
-        return expectations.failures() + boundaryFailures == 0 ? 0 : 1;
+        const auto productionFailures =
+            bloom::quality::dependencies::tests::runProductionLockTests(fixture.root);
+        return expectations.failures() + boundaryFailures + productionFailures == 0 ? 0 : 1;
     } catch (const std::exception& error) {
         std::cerr << "fatal dependency checker self-test error: " << error.what() << '\n';
         return 2;

--- a/tools/quality/dependency_artifact_checks/dependency_artifact_schema.cpp
+++ b/tools/quality/dependency_artifact_checks/dependency_artifact_schema.cpp
@@ -1,5 +1,7 @@
 #include "dependency_artifact_checks_internal.hpp"
 
+#include "production_lock_checks.hpp"
+
 #include <array>
 
 #include <functional>
@@ -40,8 +42,11 @@ auto checkRepository(const Path& inputRoot) -> CheckResult {
                     limitsFor(ArtifactKind::Prefix).maximumBytes);
     const auto prefix = parseCanonicalFixture(prefixEncoded, ArtifactKind::Prefix);
     validatePrefixFixture(prefix, lock, lockEncoded, context);
+    const auto production = validateProductionLock(root);
     return {.lockVector = identityVector("bloom.dependencies.lock.v1", lockEncoded),
-            .prefixVector = identityVector("bloom.dependencies.prefix.v1", prefixEncoded)};
+            .prefixVector = identityVector("bloom.dependencies.prefix.v1", prefixEncoded),
+            .productionLockPresent = production.present,
+            .productionLockIdentity = production.identity};
 }
 void validateSchemaArtifact(const Value& value, const ArtifactKind kind) {
     constexpr std::string_view draft = "https://json-schema.org/draft/2020-12/schema";

--- a/tools/quality/dependency_artifact_checks/production_lock_checks.cpp
+++ b/tools/quality/dependency_artifact_checks/production_lock_checks.cpp
@@ -1,0 +1,550 @@
+#include "production_lock_checks.hpp"
+
+#include "dependency_artifact_checks_internal.hpp"
+
+#include <bloom/core/sha256.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <ranges>
+#include <set>
+#include <span>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace bloom::quality::dependencies {
+
+using namespace detail;
+
+namespace {
+
+constexpr std::string_view kUnicodeRepositoryDirectory = "dependencies/unicode/15.1.0";
+constexpr std::string_view kDependenciesPrefix = "dependencies/";
+constexpr std::string_view kFixtureTreePrefix = "dependencies/tests/fixtures/";
+constexpr std::string_view kPatchesPrefix = "dependencies/patches/";
+
+// ASCII-STRICT v1 TIGHTENING: see production_lock_checks.hpp. The canonical profile emits
+// non-control Unicode directly as UTF-8 and admits only lowercase \u00xx control escapes, so a raw
+// byte scan before parsing rejects exactly the locks whose decoded strings or keys leave ASCII.
+void requireAsciiStrict(const std::string_view encoded) {
+    const auto* const offending = std::ranges::find_if(
+        encoded, [](const char byte) { return static_cast<unsigned char>(byte) >= 0x80U; });
+    if (offending != encoded.end()) {
+        fail("ascii-strict", "$",
+             "production lock v1 deliberately tightens decoded strings and keys to ASCII; ASCII is "
+             "closed under NFC so Unicode normalization machinery stays deferred, and contract "
+             "policy may tighten but never loosen");
+    }
+}
+
+void verifyBootstrapTables(const Path& root) {
+    for (const auto& [name, expectedHex] : kUnicodeBootstrapFiles) {
+        const auto relative = Path{kUnicodeRepositoryDirectory} / name;
+        auto candidate = root;
+        for (const auto& component : relative) {
+            candidate /= component;
+            std::error_code walkError;
+            const auto walkStatus = std::filesystem::symlink_status(candidate, walkError);
+            if (!walkError && std::filesystem::is_symlink(walkStatus)) {
+                fail("unicode-bootstrap", relative.string(),
+                     "checked-in Unicode tables must not traverse a symlink");
+            }
+        }
+        std::error_code error;
+        const auto absolute = std::filesystem::weakly_canonical(root / relative, error);
+        if (error) {
+            fail("unicode-bootstrap", relative.string(), error.message());
+        }
+        const auto status = std::filesystem::symlink_status(absolute, error);
+        if (error || !std::filesystem::is_regular_file(status)) {
+            fail("unicode-bootstrap", relative.string(),
+                 "expected the checked-in regular Unicode 15.1 table");
+        }
+        const auto actual =
+            digestHex(readBounded(absolute, limitsFor(ArtifactKind::Lock).maximumBytes));
+        if (actual != expectedHex) {
+            fail("unicode-bootstrap", relative.string(),
+                 "checked-in bytes differ from the reviewed bootstrap allowlist");
+        }
+    }
+}
+
+// Resolves a lexically validated repository-relative evidence path to its checked-in regular file
+// and verifies the bytes reproduce the recorded digest. Enforces the dependencies/ prefix, the
+// synthetic-fixture separation, and the patch component-directory rule.
+void resolveProductionEvidence(const std::string_view path, const std::string_view digest,
+                               const std::string_view location, const Path& root,
+                               const std::string_view componentName, const bool patch) {
+    if (!path.starts_with(kDependenciesPrefix)) {
+        fail("artifact-path", location,
+             "repository artifact references are repository-root-relative below dependencies/");
+    }
+    if (path.starts_with(kFixtureTreePrefix)) {
+        fail("production-path", location,
+             "the synthetic fixture tree is never a production artifact source");
+    }
+    if (patch) {
+        const std::string expectedPrefix =
+            std::string(kPatchesPrefix).append(componentName).append(1, '/');
+        if (!path.starts_with(expectedPrefix)) {
+            fail("patch-path", location,
+                 "patch references resolve below dependencies/patches/<component>/");
+        }
+    }
+    auto candidate = root;
+    for (const auto& component : Path(path)) {
+        candidate /= component;
+        std::error_code walkError;
+        const auto walkStatus = std::filesystem::symlink_status(candidate, walkError);
+        if (!walkError && std::filesystem::is_symlink(walkStatus)) {
+            fail("artifact-evidence", location, "artifact paths must not traverse a symlink");
+        }
+    }
+    std::error_code error;
+    const auto absolute = std::filesystem::weakly_canonical(root / Path(path), error);
+    if (error) {
+        fail("artifact-evidence", location, error.message());
+    }
+    const auto status = std::filesystem::symlink_status(absolute, error);
+    if (error || !std::filesystem::is_regular_file(status)) {
+        fail("artifact-evidence", location, "must name a checked-in regular repository file");
+    }
+    const auto actual =
+        "sha256:" + digestHex(readBounded(absolute, limitsFor(ArtifactKind::Lock).maximumBytes));
+    if (actual != digest) {
+        fail("artifact-evidence", location, "referenced bytes differ from the recorded sha256");
+    }
+}
+
+void verifyProductionArtifactReference(const Value& reference, const std::string& location,
+                                       const Path& root) {
+    object(reference, {"path", "sha256"}, location);
+    const auto& path = portablePath(reference.at("path"), location + ".path");
+    const auto& digest = digestValue(reference.at("sha256"), location + ".sha256");
+    resolveProductionEvidence(path, digest, location, root, {}, false);
+}
+
+void validateProductionArtifactArray(const Value& value, const std::string& location,
+                                     const Path& root, const std::size_t minimum) {
+    const auto& values = array(value, location, 8192, minimum);
+    for (std::size_t index = 0; index < values.size(); ++index) {
+        verifyProductionArtifactReference(values[index],
+                                          location + '[' + std::to_string(index) + ']', root);
+    }
+    requireOrdered(
+        values, [](const Value& child) { return child.at("path").asString(); }, location);
+}
+
+void validateProductionProvenance(const Value& source, const std::string& location,
+                                  const Path& root) {
+    const auto& provenance = array(source.at("provenance"), location + ".provenance", 8192);
+    for (std::size_t index = 0; index < provenance.size(); ++index) {
+        const auto itemLocation = location + ".provenance[" + std::to_string(index) + ']';
+        object(provenance[index], {"kind", "evidence", "identity", "issuer", "policy"},
+               itemLocation);
+        enumString(provenance[index].at("kind"),
+                   {"detached-signature", "sigstore-bundle", "signed-tag"}, itemLocation + ".kind");
+        verifyProductionArtifactReference(provenance[index].at("evidence"),
+                                          itemLocation + ".evidence", root);
+        stringValue(provenance[index].at("identity"), itemLocation + ".identity");
+        nullableString(provenance[index].at("issuer"), itemLocation + ".issuer");
+        stringValue(provenance[index].at("policy"), itemLocation + ".policy");
+    }
+    requireOrdered(
+        provenance,
+        [](const Value& child) {
+            return std::pair(child.at("kind").asString(),
+                             child.at("evidence").at("path").asString());
+        },
+        location + ".provenance");
+    const auto& policy = enumString(source.at("provenancePolicy"), {"required", "not-published"},
+                                    location + ".provenancePolicy");
+    if ((policy == "required") != !provenance.empty()) {
+        fail("provenance-policy", location, "policy and evidence presence disagree");
+    }
+}
+
+void validateProductionLicense(const Value& license, const std::string& location,
+                               const Path& root) {
+    object(license,
+           {"spdxExpression", "licenseFiles", "copyrightFiles", "noticeFiles", "sourceObligation",
+            "modified", "reviewRecord", "reviewedAt"},
+           location);
+    stringValue(license.at("spdxExpression"), location + ".spdxExpression");
+    validateProductionArtifactArray(license.at("licenseFiles"), location + ".licenseFiles", root,
+                                    1);
+    validateProductionArtifactArray(license.at("copyrightFiles"), location + ".copyrightFiles",
+                                    root, 0);
+    validateProductionArtifactArray(license.at("noticeFiles"), location + ".noticeFiles", root, 0);
+    enumString(license.at("sourceObligation"),
+               {"none", "ship-corresponding-source", "ship-source-offer"},
+               location + ".sourceObligation");
+    static_cast<void>(booleanValue(license.at("modified"), location + ".modified"));
+    verifyProductionArtifactReference(license.at("reviewRecord"), location + ".reviewRecord", root);
+    validateDate(license.at("reviewedAt"), location + ".reviewedAt");
+}
+
+void validateProductionPatches(const Value& component, const std::string& componentName,
+                               const std::string& location, const Path& root, const bool modified) {
+    const auto& patches = array(component.at("patches"), location + ".patches", 8192);
+    for (std::size_t index = 0; index < patches.size(); ++index) {
+        const auto itemLocation = location + ".patches[" + std::to_string(index) + ']';
+        object(patches[index], {"path", "sha256", "applyOrder", "reason"}, itemLocation);
+        const auto& path = portablePath(patches[index].at("path"), itemLocation + ".path");
+        const auto& patchDigest =
+            digestValue(patches[index].at("sha256"), itemLocation + ".sha256");
+        resolveProductionEvidence(path, patchDigest, itemLocation, root, componentName, true);
+        if (uintValue(patches[index].at("applyOrder"), itemLocation + ".applyOrder",
+                      std::numeric_limits<std::uint32_t>::max()) != index) {
+            fail("patch-order", itemLocation + ".applyOrder", "apply order must equal index");
+        }
+        stringValue(patches[index].at("reason"), itemLocation + ".reason");
+    }
+    if (modified != !patches.empty()) {
+        fail("modified", location, "patch presence and modified flag disagree");
+    }
+}
+
+void validateComponentProduction(const Value& value, const std::string& location,
+                                 const Path& root) {
+    object(value,
+           {"name", "version", "source", "license", "patches", "dependencies", "profileBuilds",
+            "securityReview"},
+           location);
+    const auto& componentName = identifier(value.at("name"), location + ".name");
+    stringValue(value.at("version"), location + ".version");
+
+    const auto& source = value.at("source");
+    object(source,
+           {"url", "archiveSha256", "commit", "provenancePolicy", "provenanceReview", "provenance"},
+           location + ".source");
+    stringValue(source.at("url"), location + ".source.url");
+    digestValue(source.at("archiveSha256"), location + ".source.archiveSha256");
+    nullableString(source.at("commit"), location + ".source.commit");
+    verifyProductionArtifactReference(source.at("provenanceReview"),
+                                      location + ".source.provenanceReview", root);
+    validateProductionProvenance(source, location, root);
+
+    validateProductionLicense(value.at("license"), location + ".license", root);
+    validateProductionPatches(
+        value, componentName, location, root,
+        booleanValue(value.at("license").at("modified"), location + ".license.modified"));
+
+    const auto& dependencies = array(value.at("dependencies"), location + ".dependencies", 8192);
+    for (std::size_t index = 0; index < dependencies.size(); ++index) {
+        const auto itemLocation = location + ".dependencies[" + std::to_string(index) + ']';
+        object(dependencies[index], {"name", "relationship"}, itemLocation);
+        identifier(dependencies[index].at("name"), itemLocation + ".name");
+        enumString(dependencies[index].at("relationship"),
+                   {"build", "link", "runtime-plugin", "vendored"}, itemLocation + ".relationship");
+    }
+    requireOrdered(
+        dependencies,
+        [](const Value& child) {
+            return std::pair(child.at("name").asString(), child.at("relationship").asString());
+        },
+        location + ".dependencies");
+
+    const auto& builds = array(value.at("profileBuilds"), location + ".profileBuilds", 256, 1);
+    for (std::size_t index = 0; index < builds.size(); ++index) {
+        const auto buildLocation = location + ".profileBuilds[" + std::to_string(index) + ']';
+        const auto& build = builds[index];
+        object(build,
+               {"profileId", "linkage", "cmakeOptions", "featureDecisions", "capabilities",
+                "shippingRoles", "conformanceFixtureSets"},
+               buildLocation);
+        identifier(build.at("profileId"), buildLocation + ".profileId");
+        enumString(build.at("linkage"),
+                   {"dynamic", "static", "header-only", "executable", "data-only"},
+                   buildLocation + ".linkage");
+
+        const auto& options =
+            array(build.at("cmakeOptions"), buildLocation + ".cmakeOptions", 8192);
+        for (std::size_t optionIndex = 0; optionIndex < options.size(); ++optionIndex) {
+            const auto itemLocation =
+                buildLocation + ".cmakeOptions[" + std::to_string(optionIndex) + ']';
+            object(options[optionIndex], {"name", "value"}, itemLocation);
+            const auto& name =
+                stringValue(options[optionIndex].at("name"), itemLocation + ".name", 256);
+            if (!isCmakeOption(name)) {
+                fail("lexical", itemLocation + ".name", "invalid CMake option name");
+            }
+            stringValue(options[optionIndex].at("value"), itemLocation + ".value");
+        }
+        requireOrdered(
+            options, [](const Value& child) { return child.at("name").asString(); },
+            buildLocation + ".cmakeOptions");
+
+        // Deferred rule: feature decisions closed against the owning recipe's vocabulary. See
+        // production_lock_checks.hpp; only shape, enums, and ordering are checked here.
+        const auto& decisions =
+            array(build.at("featureDecisions"), buildLocation + ".featureDecisions", 8192);
+        for (std::size_t decisionIndex = 0; decisionIndex < decisions.size(); ++decisionIndex) {
+            const auto itemLocation =
+                buildLocation + ".featureDecisions[" + std::to_string(decisionIndex) + ']';
+            object(decisions[decisionIndex], {"id", "state", "reason"}, itemLocation);
+            identifier(decisions[decisionIndex].at("id"), itemLocation + ".id");
+            enumString(decisions[decisionIndex].at("state"), {"enabled", "disabled"},
+                       itemLocation + ".state");
+            stringValue(decisions[decisionIndex].at("reason"), itemLocation + ".reason");
+        }
+        requireOrdered(
+            decisions, [](const Value& child) { return child.at("id").asString(); },
+            buildLocation + ".featureDecisions");
+
+        const auto& capabilities =
+            array(build.at("capabilities"), buildLocation + ".capabilities", 65'536);
+        for (std::size_t capabilityIndex = 0; capabilityIndex < capabilities.size();
+             ++capabilityIndex) {
+            identifier(capabilities[capabilityIndex],
+                       buildLocation + ".capabilities[" + std::to_string(capabilityIndex) + ']');
+        }
+        requireOrdered(
+            capabilities, [](const Value& child) { return child.asString(); },
+            buildLocation + ".capabilities");
+
+        const auto& roles =
+            array(build.at("shippingRoles"), buildLocation + ".shippingRoles", 8, 1);
+        for (std::size_t roleIndex = 0; roleIndex < roles.size(); ++roleIndex) {
+            enumString(roles[roleIndex],
+                       {"library", "executable", "plugin", "data", "cmake-package", "license",
+                        "notice", "source"},
+                       buildLocation + ".shippingRoles[" + std::to_string(roleIndex) + ']');
+        }
+        requireOrdered(
+            roles, [](const Value& child) { return child.asString(); },
+            buildLocation + ".shippingRoles");
+
+        const auto& fixtureSets = array(build.at("conformanceFixtureSets"),
+                                        buildLocation + ".conformanceFixtureSets", 8192);
+        for (std::size_t fixtureIndex = 0; fixtureIndex < fixtureSets.size(); ++fixtureIndex) {
+            const auto itemLocation =
+                buildLocation + ".conformanceFixtureSets[" + std::to_string(fixtureIndex) + ']';
+            object(fixtureSets[fixtureIndex], {"id", "artifact"}, itemLocation);
+            identifier(fixtureSets[fixtureIndex].at("id"), itemLocation + ".id");
+            verifyProductionArtifactReference(fixtureSets[fixtureIndex].at("artifact"),
+                                              itemLocation + ".artifact", root);
+        }
+        requireOrdered(
+            fixtureSets, [](const Value& child) { return child.at("id").asString(); },
+            buildLocation + ".conformanceFixtureSets");
+    }
+    requireOrdered(
+        builds, [](const Value& child) { return child.at("profileId").asString(); },
+        location + ".profileBuilds");
+
+    const auto& security = value.at("securityReview");
+    object(security, {"reviewedAt", "record", "vulnerabilities"}, location + ".securityReview");
+    validateDate(security.at("reviewedAt"), location + ".securityReview.reviewedAt");
+    verifyProductionArtifactReference(security.at("record"), location + ".securityReview.record",
+                                      root);
+    const auto& vulnerabilities =
+        array(security.at("vulnerabilities"), location + ".securityReview.vulnerabilities", 8192);
+    for (std::size_t index = 0; index < vulnerabilities.size(); ++index) {
+        const auto itemLocation =
+            location + ".securityReview.vulnerabilities[" + std::to_string(index) + ']';
+        object(vulnerabilities[index], {"id", "disposition", "record"}, itemLocation);
+        identifier(vulnerabilities[index].at("id"), itemLocation + ".id");
+        enumString(vulnerabilities[index].at("disposition"),
+                   {"not-affected", "mitigated", "accepted-risk"}, itemLocation + ".disposition");
+        verifyProductionArtifactReference(vulnerabilities[index].at("record"),
+                                          itemLocation + ".record", root);
+    }
+    requireOrdered(
+        vulnerabilities, [](const Value& child) { return child.at("id").asString(); },
+        location + ".securityReview.vulnerabilities");
+}
+
+void validateProductionUnicodeProfile(const Value& unicode) {
+    object(unicode, {"version", "sourceUrl", "archiveSha256", "files"}, "$.unicodeProfile");
+    if (!unicode.at("version").isString() ||
+        unicode.at("version").asString() != kUnicodeBootstrapVersion) {
+        fail("unicode-version", "$.unicodeProfile.version",
+             "expected the bootstrap Unicode version 15.1.0");
+    }
+    const auto mismatch = [location = std::string_view("$.unicodeProfile")]() {
+        fail("unicode-profile", location,
+             "lock Unicode profile differs from the reviewed bootstrap allowlist member");
+    };
+    if (!unicode.at("sourceUrl").isString() ||
+        unicode.at("sourceUrl").asString() != kUnicodeBootstrapSourceUrl ||
+        !unicode.at("archiveSha256").isString() ||
+        unicode.at("archiveSha256").asString() !=
+            "sha256:" + std::string(kUnicodeBootstrapArchiveHex)) {
+        mismatch();
+    }
+    const auto& files = array(unicode.at("files"), "$.unicodeProfile.files", 5, 5);
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        const auto location = "$.unicodeProfile.files[" + std::to_string(index) + ']';
+        object(files[index], {"path", "sha256"}, location);
+        if (!files[index].at("path").isString() ||
+            files[index].at("path").asString() != kUnicodeBootstrapFiles[index].name ||
+            !files[index].at("sha256").isString() ||
+            files[index].at("sha256").asString() !=
+                "sha256:" + std::string(kUnicodeBootstrapFiles[index].sha256Hex)) {
+            fail("unicode-profile", location,
+                 "Unicode file record differs from the fixed bootstrap order and digests");
+        }
+    }
+}
+
+} // namespace
+
+auto sha256DigestText(const std::string_view bytes) -> std::string {
+    const auto digest =
+        core::Sha256Hasher::hash(std::as_bytes(std::span{bytes.data(), bytes.size()}));
+    if (!digest.has_value()) {
+        fail("sha256", "$", "input exceeds the SHA-256 implementation limit");
+    }
+    const auto hexadecimal = digest->toLowercaseHex();
+    return "sha256:" + std::string(hexadecimal.data(), hexadecimal.size());
+}
+
+void verifyUnicodeBootstrap(const std::filesystem::path& root) { verifyBootstrapTables(root); }
+
+void validateProductionLockDocument(const Value& value, const Path& root) {
+    object(value, {"format", "schemaVersion", "unicodeProfile", "profiles", "components"}, "$");
+    if (!value.at("format").isString() ||
+        value.at("format").asString() != "org.kinetik.bloom.dependencies.lock") {
+        fail("format", "$.format", "unexpected lock format");
+    }
+    const auto& version = value.at("schemaVersion");
+    object(version, {"major", "minor"}, "$.schemaVersion");
+    if (!version.at("major").isNumber() || version.at("major").asNumber().spelling != "1" ||
+        !version.at("minor").isNumber() || version.at("minor").asNumber().spelling != "0") {
+        fail("version", "$.schemaVersion", "expected exact version 1.0");
+    }
+
+    validateProductionUnicodeProfile(value.at("unicodeProfile"));
+
+    const auto& profiles = array(value.at("profiles"), "$.profiles", 256, 1);
+    for (std::size_t index = 0; index < profiles.size(); ++index) {
+        validateProfile(profiles[index], "$.profiles[" + std::to_string(index) + ']');
+    }
+    requireOrdered(
+        profiles, [](const Value& child) { return child.at("id").asString(); }, "$.profiles");
+
+    const auto& components = array(value.at("components"), "$.components", 4096, 1);
+    for (std::size_t index = 0; index < components.size(); ++index) {
+        validateComponentProduction(components[index],
+                                    "$.components[" + std::to_string(index) + ']', root);
+    }
+    requireOrdered(
+        components, [](const Value& child) { return child.at("name").asString(); }, "$.components");
+
+    std::set<std::string> profileIds;
+    for (const auto& profile : profiles) {
+        profileIds.insert(profile.at("id").asString());
+    }
+    std::set<std::string> componentNames;
+    for (const auto& component : components) {
+        componentNames.insert(component.at("name").asString());
+    }
+    for (const auto& component : components) {
+        const auto& componentName = component.at("name").asString();
+        for (const auto& build : component.at("profileBuilds").asArray()) {
+            if (!profileIds.contains(build.at("profileId").asString())) {
+                fail("profile-reference", "component " + componentName,
+                     build.at("profileId").asString());
+            }
+        }
+        for (const auto& dependency : component.at("dependencies").asArray()) {
+            const auto& dependencyName = dependency.at("name").asString();
+            if (!componentNames.contains(dependencyName) || dependencyName == componentName) {
+                fail("dependency-reference", "component " + componentName, dependencyName);
+            }
+        }
+    }
+
+    for (const auto& profile : profiles) {
+        const auto& profileId = profile.at("id").asString();
+        std::map<std::string, const Value*> participating;
+        for (const auto& component : components) {
+            const auto participates = std::ranges::any_of(
+                component.at("profileBuilds").asArray(), [&profileId](const Value& build) {
+                    return build.at("profileId").asString() == profileId;
+                });
+            if (participates) {
+                participating.emplace(component.at("name").asString(), &component);
+            }
+        }
+        if (participating.empty()) {
+            fail("profile-empty", "profile " + profileId, "no participating component");
+        }
+        std::map<std::string, std::string> capabilityOwners;
+        for (const auto& [name, component] : participating) {
+            for (const auto& dependency : component->at("dependencies").asArray()) {
+                if (!participating.contains(dependency.at("name").asString())) {
+                    fail("dependency-closure", "profile " + profileId, name);
+                }
+            }
+            const auto build = std::ranges::find_if(
+                component->at("profileBuilds").asArray(), [&profileId](const Value& candidate) {
+                    return candidate.at("profileId").asString() == profileId;
+                });
+            for (const auto& capability : build->at("capabilities").asArray()) {
+                const auto [entry, inserted] =
+                    capabilityOwners.emplace(capability.asString(), name);
+                static_cast<void>(entry);
+                if (!inserted) {
+                    fail("capability-owner", "profile " + profileId, capability.asString());
+                }
+            }
+        }
+
+        std::set<std::string> visiting;
+        std::set<std::string> visited;
+        std::function<void(const std::string&)> visit = [&](const std::string& name) {
+            if (visiting.contains(name)) {
+                fail("dependency-cycle", "profile " + profileId, name);
+            }
+            if (visited.contains(name)) {
+                return;
+            }
+            visiting.insert(name);
+            for (const auto& edge : participating.at(name)->at("dependencies").asArray()) {
+                visit(edge.at("name").asString());
+            }
+            visiting.erase(name);
+            visited.insert(name);
+        };
+        for (const auto& [name, component] : participating) {
+            static_cast<void>(component);
+            visit(name);
+        }
+    }
+}
+
+auto validateProductionLock(const std::filesystem::path& inputRoot) -> ProductionLockResult {
+    std::error_code error;
+    const auto root = std::filesystem::canonical(inputRoot, error);
+    if (error) {
+        fail("repository-root", inputRoot.string(), error.message());
+    }
+    verifyUnicodeBootstrap(root);
+    const Path expected = root / Path{kProductionLockRepositoryPath};
+    std::error_code lockError;
+    const auto lockStatus = std::filesystem::symlink_status(expected, lockError);
+    if (lockError && lockError != std::errc::no_such_file_or_directory) {
+        fail("production-path", expected.string(), lockError.message());
+    }
+    if (lockError != std::error_code{} || !std::filesystem::exists(lockStatus)) {
+        // While no production lock file exists, validation reports absence as success; the
+        // Unicode bootstrap self-check above has always run by this point.
+        return {};
+    }
+    if (!std::filesystem::is_regular_file(lockStatus)) {
+        fail("production-path", expected.string(), "the production lock must be a regular file");
+    }
+    rejectFixtureAsProductionPath(expected, expected, root / Path{kFixtureDirectory});
+    const auto encoded = readBounded(expected, limitsFor(ArtifactKind::Lock).maximumBytes);
+    requireAsciiStrict(encoded);
+    const auto value = parseCanonicalFixture(encoded, ArtifactKind::Lock);
+    validateProductionLockDocument(value, root);
+    return {.present = true, .identity = identityVector("bloom.dependencies.lock.v1", encoded)};
+}
+
+} // namespace bloom::quality::dependencies

--- a/tools/quality/dependency_artifact_checks/production_lock_checks.hpp
+++ b/tools/quality/dependency_artifact_checks/production_lock_checks.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "dependency_artifact_checks.hpp"
+
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace bloom::quality::dependencies {
+
+// Production dependency-lock validation bound to the exact repository path
+// dependencies/dependencies.lock.json. The synthetic-fixture validators remain unchanged; this
+// surface is still not an installed-prefix validator, and production prefix-manifest validation
+// remains out of scope.
+//
+// While the production lock file is absent the validator reports absence as success so CI stays
+// green; the Unicode 15.1 bootstrap self-check below always runs regardless.
+//
+// Unicode 15.1 bootstrap two-source equality: the constants below are the reviewed official
+// archive and extracted-file digests recorded in dependencies/unicode/provenance.md. The validator
+// hashes the raw checked-in files at dependencies/unicode/15.1.0/<name> against this allowlist and
+// separately requires a present lock's unicodeProfile to equal the same constants member for
+// member. The lock can therefore never authorize the tables that validate it.
+//
+// ASCII-STRICT v1 TIGHTENING: any decoded string or object-key byte >= 0x80 anywhere in a
+// production lock is rejected with the distinct "ascii-strict" error code before parsing. This is
+// a deliberate v1 policy tightening, not a contract reading: canonical JSON emits non-control
+// Unicode directly as UTF-8, escapes cannot smuggle non-ASCII scalars past the canonical profile,
+// and ASCII is closed under Unicode 15.1 NFC, so the full normalization and Default Case Folding
+// machinery can be deferred without weakening acceptance. The contract permits policy to tighten
+// but never loosen. Fixture-validation behavior is unchanged.
+//
+// Supporting-artifact interpretation: per the contract every artifact reference is
+// repository-root-relative and begins with "dependencies/", never redirects by artifact values,
+// and must be a regular checked-in file whose bytes reproduce its recorded sha256. This validator
+// additionally refuses any reference resolved below dependencies/tests/fixtures/, because that
+// tree is reserved for synthetic fixtures, and confines patch references below
+// dependencies/patches/<component>/. Other evidence directories (licenses, reviews, provenance,
+// security, conformance fixtures) are accepted wherever below dependencies/ they declare;
+// narrowing them further is deferred until the production lock exists.
+//
+// Deferred rules (tracked here, deliberately not implemented in v1):
+// - feature decisions closed against each recipe's owned feature vocabulary: unrecognized or
+//   omitted recipe features remain a human lock/recipe review duty until recipe ownership data is
+//   available to this offline checker;
+// - full Unicode 15.1 NFC and Default Case Folding validation of decoded strings, deferred behind
+//   the ASCII-strict tightening above;
+// - acquisition-time provenance-policy signature verification and source-archive digest binding,
+//   which belong to the acquire phase rather than offline lock review;
+// - non-machine-checkable review obligations, such as whether empty copyrightFiles or noticeFiles
+//   are permitted by a component's reviewed license terms.
+
+inline constexpr std::string_view kProductionLockRepositoryPath =
+    "dependencies/dependencies.lock.json";
+
+struct UnicodeBootstrapRecord final {
+    std::string_view name;
+    std::string_view sha256Hex;
+};
+
+inline constexpr std::string_view kUnicodeBootstrapVersion = "15.1.0";
+inline constexpr std::string_view kUnicodeBootstrapSourceUrl =
+    "https://www.unicode.org/Public/15.1.0/ucd/UCD.zip";
+inline constexpr std::string_view kUnicodeBootstrapArchiveHex =
+    "cb1c663d053926500cd501229736045752713a066bd75802098598b7a7056177";
+inline constexpr std::array<UnicodeBootstrapRecord, 5> kUnicodeBootstrapFiles{{
+    {"UnicodeData.txt", "2fc713e6a31a87c4850a37fe2caffa4218180fadb5de86b43a143ddb4581fb86"},
+    {"CompositionExclusions.txt",
+     "59d2d9e3dfdf0a999cf9dae11d594f053631222679a2f5710315ea07f7fe82af"},
+    {"DerivedNormalizationProps.txt",
+     "8875dccee2bc1a7c1fe568a3b502a9e78c9e0495afd96b6568b4294d0ed1f7e1"},
+    {"CaseFolding.txt", "4e55acfdc32825a22e87670e9056a3bf94ad7c5400065778e9e10f8314372bcf"},
+    {"NormalizationTest.txt", "871238e37e3be0696ec2bd0891119a041b052da1a84485eda05a5438724b223e"},
+}};
+
+struct ProductionLockResult final {
+    bool present{false};
+    std::string identity;
+};
+
+[[nodiscard]] auto sha256DigestText(std::string_view bytes) -> std::string;
+void verifyUnicodeBootstrap(const std::filesystem::path& root);
+void validateProductionLockDocument(const json::Value& value, const std::filesystem::path& root);
+[[nodiscard]] auto validateProductionLock(const std::filesystem::path& root)
+    -> ProductionLockResult;
+
+} // namespace bloom::quality::dependencies

--- a/tools/quality/dependency_artifact_checks/production_lock_checks_tests.cpp
+++ b/tools/quality/dependency_artifact_checks/production_lock_checks_tests.cpp
@@ -1,0 +1,399 @@
+#include "dependency_artifact_checks_test_support.hpp"
+
+#include "production_lock_checks.hpp"
+
+#include <array>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace {
+
+namespace dependency = bloom::quality::dependencies;
+namespace json = bloom::quality::json;
+using Path = std::filesystem::path;
+using Value = json::Value;
+using bloom::quality::dependencies::tests::Expectations;
+using bloom::quality::dependencies::tests::TemporaryDirectory;
+
+[[nodiscard]] auto text(const std::string_view value) -> Value { return Value{std::string(value)}; }
+
+[[nodiscard]] auto number(const std::uint64_t value) -> Value {
+    return Value{json::Number{std::to_string(value)}};
+}
+
+[[nodiscard]] auto object(std::initializer_list<std::pair<std::string, Value>> members) -> Value {
+    return Value{Value::Object(members)};
+}
+
+[[nodiscard]] auto array(std::initializer_list<Value> values) -> Value {
+    return Value{Value::Array(values)};
+}
+
+void replace(Value& objectValue, const std::string_view key, Value replacement) {
+    objectValue.at(key) = std::move(replacement);
+}
+
+constexpr std::string_view kSyntheticEvidenceBytes =
+    "synthetic evidence bytes for the production lock validator\n";
+constexpr std::string_view kFrozenLockIdentity =
+    "sha256:39d25ceb673a07c28045271cb3138f44d03e41df2345ede4ac73147c0ef576a8";
+
+[[nodiscard]] auto evidenceDigest() -> std::string {
+    return dependency::sha256DigestText(kSyntheticEvidenceBytes);
+}
+
+[[nodiscard]] auto evidenceReference(const std::string_view path) -> Value {
+    return object({{"path", text(path)}, {"sha256", text(evidenceDigest())}});
+}
+
+[[nodiscard]] auto zeroDigest() -> std::string { return "sha256:" + std::string(64, '0'); }
+
+[[nodiscard]] auto bootstrapFileReference(const std::size_t index) -> Value {
+    const auto& record = dependency::kUnicodeBootstrapFiles[index];
+    return object(
+        {{"path", text(record.name)}, {"sha256", text("sha256:" + std::string(record.sha256Hex))}});
+}
+
+[[nodiscard]] auto unicodeProfile() -> Value {
+    return object(
+        {{"version", text(dependency::kUnicodeBootstrapVersion)},
+         {"sourceUrl", text(dependency::kUnicodeBootstrapSourceUrl)},
+         {"archiveSha256", text("sha256:" + std::string(dependency::kUnicodeBootstrapArchiveHex))},
+         {"files",
+          array({bootstrapFileReference(0), bootstrapFileReference(1), bootstrapFileReference(2),
+                 bootstrapFileReference(3), bootstrapFileReference(4)})}});
+}
+
+[[nodiscard]] auto minimalProductionLock() -> Value {
+    return object(
+        {{"format", text("org.kinetik.bloom.dependencies.lock")},
+         {"schemaVersion", object({{"major", number(1)}, {"minor", number(0)}})},
+         {"unicodeProfile", unicodeProfile()},
+         {"profiles",
+          array({object(
+              {{"id", text("bloom.profile.linux-release")},
+               {"target", object({{"triple", text("x86_64-unknown-linux-gnu")},
+                                  {"operatingSystem", text("linux")},
+                                  {"architecture", text("x86_64")},
+                                  {"minimumOsVersion", Value{nullptr}}})},
+               {"buildConfiguration", text("release")},
+               {"consumerAbi", object({{"cxxStandard", number(20)},
+                                       {"compilerFamily", text("gcc")},
+                                       {"compilerAbi", text("gcc.synthetic-abi")},
+                                       {"standardLibrary", text("libstdc++")},
+                                       {"standardLibraryAbi", text("libstdcxx.synthetic-abi")},
+                                       {"cxxRuntime", text("libgcc")},
+                                       {"cxxRuntimeAbi", text("libgcc.synthetic-abi")},
+                                       {"cxxRuntimeLinkage", text("dynamic")},
+                                       {"platformRuntime", text("glibc")},
+                                       {"platformRuntimeAbi", text("glibc.synthetic-abi")},
+                                       {"exceptions", Value{true}},
+                                       {"rtti", Value{true}},
+                                       {"libstdcxxCxx11Abi", number(1)},
+                                       {"msvcRuntime", Value{nullptr}},
+                                       {"msvcIteratorDebugLevel", Value{nullptr}},
+                                       {"windowsSdk", Value{nullptr}},
+                                       {"windowsSdkVersion", Value{nullptr}},
+                                       {"appleSdk", Value{nullptr}},
+                                       {"appleSdkVersion", Value{nullptr}},
+                                       {"appleDeploymentTarget", Value{nullptr}},
+                                       {"abiFlags", array({})}})},
+               {"toolchain",
+                object({{"cmake", object({{"name", text("cmake")},
+                                          {"version", text("synthetic")},
+                                          {"identity", text("synthetic-cmake")}})},
+                        {"generator", object({{"name", text("ninja")},
+                                              {"version", text("synthetic")},
+                                              {"identity", text("synthetic-generator")}})},
+                        {"buildTool", object({{"name", text("ninja")},
+                                              {"version", text("synthetic")},
+                                              {"identity", text("synthetic-build-tool")}})},
+                        {"compiler", object({{"name", text("gcc")},
+                                             {"version", text("synthetic")},
+                                             {"identity", text("synthetic-compiler")}})},
+                        {"linker", object({{"name", text("ld")},
+                                           {"version", text("synthetic")},
+                                           {"identity", text("synthetic-linker")}})},
+                        {"standardLibrary",
+                         object({{"name", text("libstdc++")},
+                                 {"version", text("synthetic")},
+                                 {"identity", text("synthetic-standard-library")}})},
+                        {"sdk", object({{"name", text("linux-sysroot")},
+                                        {"version", text("synthetic")},
+                                        {"identity", text("synthetic-sdk")}})}})},
+               {"environment", object({{"profileId", text("bloom.environment.linux-release")},
+                                       {"sourceDateEpoch", number(0)},
+                                       {"variables", array({})}})},
+               {"qualificationGates", array({object({{"gateId", text("bloom.gate.synthetic")},
+                                                     {"disposition", text("required")},
+                                                     {"reason", Value{nullptr}}})})}})})},
+         {"components",
+          array({object(
+              {{"name", text("component.synthetic")},
+               {"version", text("synthetic-1.0")},
+               {"source", object({{"url", text("https://example.invalid/synthetic-source.tar")},
+                                  {"archiveSha256", text(zeroDigest())},
+                                  {"commit", Value{nullptr}},
+                                  {"provenancePolicy", text("not-published")},
+                                  {"provenanceReview",
+                                   evidenceReference(
+                                       "dependencies/licenses/component.synthetic/provenance.md")},
+                                  {"provenance", array({})}})},
+               {"license",
+                object(
+                    {{"spdxExpression", text("LicenseRef-Synthetic")},
+                     {"licenseFiles", array({evidenceReference(
+                                          "dependencies/licenses/component.synthetic/LICENSE")})},
+                     {"copyrightFiles", array({})},
+                     {"noticeFiles", array({})},
+                     {"sourceObligation", text("none")},
+                     {"modified", Value{false}},
+                     {"reviewRecord",
+                      evidenceReference("dependencies/licenses/component.synthetic/review.md")},
+                     {"reviewedAt", text("2026-08-26")}})},
+               {"patches", array({})},
+               {"dependencies", array({})},
+               {"profileBuilds", array({object({{"profileId", text("bloom.profile.linux-release")},
+                                                {"linkage", text("dynamic")},
+                                                {"cmakeOptions", array({})},
+                                                {"featureDecisions", array({})},
+                                                {"capabilities", array({})},
+                                                {"shippingRoles", array({text("library")})},
+                                                {"conformanceFixtureSets", array({})}})})},
+               {"securityReview",
+                object({{"reviewedAt", text("2026-08-26")},
+                        {"record", evidenceReference(
+                                       "dependencies/licenses/component.synthetic/security.md")},
+                        {"vulnerabilities", array({})}})}})})}});
+}
+
+void copyBootstrapTables(const Path& repositoryRoot, const TemporaryDirectory& temporary) {
+    for (const auto& record : dependency::kUnicodeBootstrapFiles) {
+        const auto table = dependency::readBounded(
+            repositoryRoot / "dependencies/unicode/15.1.0" / record.name,
+            dependency::limitsFor(dependency::ArtifactKind::Lock).maximumBytes);
+        temporary.write(Path("dependencies/unicode/15.1.0") / record.name, table);
+    }
+}
+
+void writeEvidenceTree(const TemporaryDirectory& temporary) {
+    for (const auto* name : {"provenance.md", "LICENSE", "review.md", "security.md"}) {
+        temporary.write(Path("dependencies/licenses/component.synthetic") / name,
+                        kSyntheticEvidenceBytes);
+    }
+}
+
+// Every present-lock case runs through the real orchestrator, so each synthetic repository root
+// carries verified Unicode tables plus the minimal lock's supporting evidence tree.
+struct ProductionFixture final {
+    explicit ProductionFixture(const Path& repositoryRoot) : temporary() {
+        copyBootstrapTables(repositoryRoot, temporary);
+        writeEvidenceTree(temporary);
+    }
+
+    void rejectsWith(const Value& lock, const std::string_view code, Expectations& expectations,
+                     const std::string_view message) const {
+        temporary.write("dependencies/dependencies.lock.json", dependency::encodeCanonical(lock));
+        expectations.rejects(
+            code, [&] { static_cast<void>(dependency::validateProductionLock(temporary.root())); },
+            message);
+    }
+
+    TemporaryDirectory temporary;
+};
+
+void testAbsentLockAndGoldenConstants(const Path& repositoryRoot, Expectations& expectations) {
+    const auto result = dependency::validateProductionLock(repositoryRoot);
+    expectations.expect(!result.present && result.identity.empty(),
+                        "absent production lock reports absence as success without identity");
+    expectations.expect(dependency::kProductionLockRepositoryPath ==
+                            std::string_view("dependencies/dependencies.lock.json"),
+                        "production mode binds exactly the contract lock path");
+    constexpr std::array<std::string_view, 5> kFixedOrder{
+        "UnicodeData.txt", "CompositionExclusions.txt", "DerivedNormalizationProps.txt",
+        "CaseFolding.txt", "NormalizationTest.txt"};
+    for (std::size_t index = 0; index < dependency::kUnicodeBootstrapFiles.size(); ++index) {
+        expectations.expect(dependency::kUnicodeBootstrapFiles[index].name == kFixedOrder[index],
+                            "bootstrap allowlist keeps the fixed Unicode record order");
+    }
+    expectations.expect(dependency::kUnicodeBootstrapSourceUrl ==
+                            std::string_view("https://www.unicode.org/Public/15.1.0/ucd/UCD.zip"),
+                        "bootstrap archive URL matches the reviewed provenance record");
+    expectations.expect(dependency::kUnicodeBootstrapArchiveHex ==
+                            std::string_view("cb1c663d053926500cd501229736045752713a066bd7580209"
+                                             "8598b7a7056177"),
+                        "bootstrap archive digest matches the reviewed provenance record");
+}
+
+void testBootstrapDetectsDriftedTables(const Path& repositoryRoot, Expectations& expectations) {
+    TemporaryDirectory temporary;
+    copyBootstrapTables(repositoryRoot, temporary);
+    auto corrupted =
+        dependency::readBounded(repositoryRoot / "dependencies/unicode/15.1.0/"
+                                                 "CompositionExclusions.txt",
+                                dependency::limitsFor(dependency::ArtifactKind::Lock).maximumBytes);
+    corrupted.at(0) = corrupted.at(0) == '!' ? '#' : '!';
+    temporary.write("dependencies/unicode/15.1.0/CompositionExclusions.txt", corrupted);
+    expectations.rejects(
+        "unicode-bootstrap", [&] { dependency::verifyUnicodeBootstrap(temporary.root()); },
+        "bootstrap self-check rejects drifted checked-in Unicode tables");
+
+    TemporaryDirectory missing;
+    copyBootstrapTables(repositoryRoot, missing);
+    std::error_code error;
+    std::filesystem::remove(missing.root() / "dependencies/unicode/15.1.0/CaseFolding.txt", error);
+    expectations.rejects(
+        "unicode-bootstrap", [&] { dependency::verifyUnicodeBootstrap(missing.root()); },
+        "bootstrap self-check requires every checked-in Unicode table");
+}
+
+void testMinimalLockIdentityVector(const Path& repositoryRoot, Expectations& expectations) {
+    const ProductionFixture fixture(repositoryRoot);
+    fixture.temporary.write("dependencies/dependencies.lock.json",
+                            dependency::encodeCanonical(minimalProductionLock()));
+    const auto result = dependency::validateProductionLock(fixture.temporary.root());
+    expectations.expect(result.present && result.identity == kFrozenLockIdentity,
+                        "minimal production lock reproduces the frozen identity vector");
+}
+
+void testByteInequalityAndAsciiStrictness(const Path& repositoryRoot, Expectations& expectations) {
+    const ProductionFixture fixture(repositoryRoot);
+    auto leadingSpace = dependency::encodeCanonical(minimalProductionLock());
+    leadingSpace.insert(leadingSpace.begin(), ' ');
+    fixture.temporary.write("dependencies/dependencies.lock.json", leadingSpace);
+    expectations.rejects(
+        "canonical-token",
+        [&] { static_cast<void>(dependency::validateProductionLock(fixture.temporary.root())); },
+        "production locks reproduce canonical bytes exactly; whitespace is rejected");
+
+    const std::string nonAscii = "{\"format\":\"\xC3\xA9\"}";
+    fixture.temporary.write("dependencies/dependencies.lock.json", nonAscii);
+    expectations.rejects(
+        "ascii-strict",
+        [&] { static_cast<void>(dependency::validateProductionLock(fixture.temporary.root())); },
+        "ASCII-strict v1 tightening rejects any non-ASCII byte before parsing");
+}
+
+void testUnicodeProfileEquality(const Path& repositoryRoot, Expectations& expectations) {
+    const ProductionFixture fixture(repositoryRoot);
+
+    auto wrongArchive = minimalProductionLock();
+    replace(wrongArchive.at("unicodeProfile"), "archiveSha256", text(zeroDigest()));
+    fixture.rejectsWith(wrongArchive, "unicode-profile", expectations,
+                        "lock archive digest must equal the bootstrap allowlist member");
+
+    auto wrongFile = minimalProductionLock();
+    replace(wrongFile.at("unicodeProfile").at("files").asArray().at(3), "sha256",
+            text(zeroDigest()));
+    fixture.rejectsWith(wrongFile, "unicode-profile", expectations,
+                        "each locked Unicode digest must equal the bootstrap member");
+
+    auto wrongUrl = minimalProductionLock();
+    replace(wrongUrl.at("unicodeProfile"), "sourceUrl", text("https://example.invalid/ucd.zip"));
+    fixture.rejectsWith(wrongUrl, "unicode-profile", expectations,
+                        "locked Unicode source URL must equal the reviewed official archive");
+}
+
+void testArtifactReferenceDigests(const Path& repositoryRoot, Expectations& expectations) {
+    const ProductionFixture fixture(repositoryRoot);
+
+    auto inventedDigest = minimalProductionLock();
+    replace(inventedDigest.at("components")
+                .asArray()
+                .front()
+                .at("license")
+                .at("licenseFiles")
+                .asArray()
+                .front(),
+            "sha256", text(zeroDigest()));
+    fixture.rejectsWith(inventedDigest, "artifact-evidence", expectations,
+                        "recorded artifact digests must reproduce referenced bytes");
+
+    auto missingFile = minimalProductionLock();
+    replace(missingFile.at("components").asArray().front().at("source").at("provenanceReview"),
+            "path", text("dependencies/licenses/component.synthetic/absent.md"));
+    fixture.rejectsWith(missingFile, "artifact-evidence", expectations,
+                        "artifact references must resolve to checked-in regular files");
+
+    auto outsideTree = minimalProductionLock();
+    replace(outsideTree.at("components").asArray().front().at("securityReview").at("record"),
+            "path", text("dependencies/tests/fixtures/payloads/alpha-security-review.txt"));
+    fixture.rejectsWith(outsideTree, "production-path", expectations,
+                        "fixture-tree references never count as production artifacts");
+}
+
+void testPatchRules(const Path& repositoryRoot, Expectations& expectations) {
+    const ProductionFixture fixture(repositoryRoot);
+
+    fixture.temporary.write("dependencies/patches/component.synthetic/fix.patch",
+                            kSyntheticEvidenceBytes);
+    auto unmodifiedPatch = minimalProductionLock();
+    replace(unmodifiedPatch.at("components").asArray().front(), "patches",
+            array({object({{"path", text("dependencies/patches/component.synthetic/fix.patch")},
+                           {"sha256", text(evidenceDigest())},
+                           {"applyOrder", number(0)},
+                           {"reason", text("Synthetic patch without modified flag")}})}));
+    fixture.rejectsWith(unmodifiedPatch, "modified", expectations,
+                        "non-empty patches require license.modified true");
+
+    auto misplacedPatch = minimalProductionLock();
+    replace(misplacedPatch.at("components").asArray().front(), "patches",
+            array({object({{"path", text("dependencies/patches/other.component/fix.patch")},
+                           {"sha256", text(evidenceDigest())},
+                           {"applyOrder", number(0)},
+                           {"reason", text("Synthetic patch outside component directory")}})}));
+    fixture.rejectsWith(misplacedPatch, "patch-path", expectations,
+                        "patches resolve below dependencies/patches/<component>/");
+}
+
+void testCrossReferencesAndSets(const Path& repositoryRoot, Expectations& expectations) {
+    const ProductionFixture fixture(repositoryRoot);
+
+    auto selfDependency = minimalProductionLock();
+    replace(
+        selfDependency.at("components").asArray().front(), "dependencies",
+        array({object({{"name", text("component.synthetic")}, {"relationship", text("link")}})}));
+    fixture.rejectsWith(selfDependency, "dependency-reference", expectations,
+                        "dependency edges may not name their own component");
+
+    auto unknownProfile = minimalProductionLock();
+    replace(unknownProfile.at("components").asArray().front().at("profileBuilds").asArray().front(),
+            "profileId", text("bloom.profile.missing"));
+    fixture.rejectsWith(unknownProfile, "profile-reference", expectations,
+                        "profile builds must reference declared root profiles");
+
+    auto duplicateCapability = minimalProductionLock();
+    replace(duplicateCapability.at("components")
+                .asArray()
+                .front()
+                .at("profileBuilds")
+                .asArray()
+                .front(),
+            "capabilities",
+            array({text("bloom.capability.alpha"), text("bloom.capability.alpha")}));
+    fixture.rejectsWith(duplicateCapability, "duplicate-identity", expectations,
+                        "ordered sets remain duplicate-free");
+}
+
+} // namespace
+
+namespace bloom::quality::dependencies::tests {
+
+auto runProductionLockTests(const std::filesystem::path& repositoryRoot) -> int {
+    Expectations expectations;
+    testAbsentLockAndGoldenConstants(repositoryRoot, expectations);
+    testBootstrapDetectsDriftedTables(repositoryRoot, expectations);
+    testMinimalLockIdentityVector(repositoryRoot, expectations);
+    testByteInequalityAndAsciiStrictness(repositoryRoot, expectations);
+    testUnicodeProfileEquality(repositoryRoot, expectations);
+    testArtifactReferenceDigests(repositoryRoot, expectations);
+    testPatchRules(repositoryRoot, expectations);
+    testCrossReferencesAndSets(repositoryRoot, expectations);
+    return expectations.failures();
+}
+
+} // namespace bloom::quality::dependencies::tests


### PR DESCRIPTION
## Summary

Closes #22.

Adds production dependency-lock validation to the offline checker (intake slice B2):

- `validateProductionLock`: exact binding to `dependencies/dependencies.lock.json`, fixture-tree rejection, canonical parse + byte-reproduction via the existing canonical profile decoder
- full Lock v1 rules: member orders, closed enums, lexical bounds, ordered duplicate-free sets, conditional consistency (provenance policy ⇔ evidence, patches ⇔ `license.modified`, applyOrder = index)
- cross-references and per-profile graph closure, cycle detection, and single capability ownership
- artifact references resolved as symlink-free regular repository files whose bytes reproduce their recorded SHA-256; patches confined to `dependencies/patches/<component>/`
- Unicode 15.1 bootstrap two-source equality: golden self-test hashes the checked-in tables against embedded allowlist constants, and any lock's `unicodeProfile` must equal the same constants member for member
- ASCII-strict v1 tightening for decoded strings, documented in the header (ASCII is closed under NFC; the contract permits tightening, never loosening)
- lock identity through the existing identity-vector helper, with a frozen golden vector independently derived over the contract preimage
- lock absence reports success while the bootstrap self-check always runs, so CI stays green until slice B3 authors the real lock

Production prefix-manifest validation remains explicitly out of scope; deferred rules (recipe feature vocabulary closure, full NFC/case folding, acquisition-time signature verification) are documented in the header.

## Testing

- Golden bootstrap self-test plus adversarial fixtures: non-canonical whitespace, non-ASCII strings, three unicodeProfile mismatch variants, invented/missing/fixture-tree artifact digests, patch violations, self-dependency, unknown profile reference, duplicate capability identity, frozen identity vector
- Full `ci-linux-native` suite (54 tests) and `bloom-format-check` green, re-verified independently by the supervising session
- Both binaries exercised live: fixture check unchanged, production line reports absent-lock + verified bootstrap

Implemented by Ox Alpha from a bounded task specification; reviewed in full by the supervising session (allowlist digests verified against the acquired Unicode bytes).