### PR TITLE
build: consume dependency prefix in root build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes clang-22 clang-format-22 clang-tidy-22
 
+      - name: Cache dependency archives
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/bloom-dependency-downloads
+          key: bloom-dependency-archives-b16246f617b2a136c78d73e5e2647c6f1de1313e46678062985bdcf1f40bb75d
+
+      - name: Build dependency superbuild prefix
+        run: |
+          cmake -S dependencies/superbuild -B "${{ runner.temp }}/bloom-superbuild" -G Ninja \
+            -DBLOOM_DEPENDENCY_DOWNLOAD_DIR="${{ runner.temp }}/bloom-dependency-downloads" \
+            -DBLOOM_DEPENDENCY_PREFIX="$GITHUB_WORKSPACE/build/dependency-prefix"
+          cmake --build "${{ runner.temp }}/bloom-superbuild"
+
       - name: Configure Clang and clang-tidy
         run: cmake --preset ci-linux-native
 
@@ -60,22 +73,10 @@ jobs:
       - name: Test Clang build
         run: ctest --preset ci-linux-native --output-on-failure
 
-      - name: Cache dependency archives
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ${{ runner.temp }}/bloom-dependency-downloads
-          key: bloom-dependency-archives-b16246f617b2a136c78d73e5e2647c6f1de1313e46678062985bdcf1f40bb75d
-
-      - name: Build dependency superbuild prefix
-        run: |
-          cmake -S dependencies/superbuild -B "${{ runner.temp }}/bloom-superbuild" -G Ninja \
-            -DBLOOM_DEPENDENCY_DOWNLOAD_DIR="${{ runner.temp }}/bloom-dependency-downloads"
-          cmake --build "${{ runner.temp }}/bloom-superbuild"
-
       - name: Consume prefix in qualified mode
         run: |
           cmake -S tests/dependency-consumption -B "${{ runner.temp }}/bloom-consume" -G Ninja \
             -DBLOOM_DEPENDENCY_MODE=qualified \
-            -DBLOOM_DEPENDENCY_PREFIX="${{ runner.temp }}/bloom-superbuild/prefix"
+            -DBLOOM_DEPENDENCY_PREFIX="$GITHUB_WORKSPACE/build/dependency-prefix"
           cmake --build "${{ runner.temp }}/bloom-consume"
           "${{ runner.temp }}/bloom-consume/bloom_consume_smoke"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CTest)
 include(BloomQuality)
 include(BloomWarnings)
+include(BloomDependencyPrefix)
+
+# Dependency-prefix consumption is implemented, so an explicit mode is required: 'qualified'
+# validates the reviewed lock and resolves dependency packages only from the superbuild prefix;
+# 'developer-system' iterates against host packages and is labeled Unqualified. CI, release,
+# package, and conformance builds use qualified mode.
+bloom_consume_dependency_prefix()
 
 bloom_configure_quality_tools()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "BUILD_TESTING": "ON"
+        "BUILD_TESTING": "ON",
+        "BLOOM_DEPENDENCY_MODE": "developer-system"
       }
     },
     {
@@ -26,7 +27,9 @@
         "BLOOM_BUILD_DESKTOP": "OFF",
         "BLOOM_ENABLE_CLANG_TIDY": "ON",
         "BLOOM_ENABLE_TEST_CLANG_TIDY": "ON",
-        "BLOOM_LLVM_TOOLCHAIN_MAJOR": "22"
+        "BLOOM_LLVM_TOOLCHAIN_MAJOR": "22",
+        "BLOOM_DEPENDENCY_MODE": "qualified",
+        "BLOOM_DEPENDENCY_PREFIX": "${sourceDir}/build/dependency-prefix"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ The desktop development build requires:
 - Ninja
 - Qt 6.8 or newer with Qt Widgets
 
+Every build selects an explicit dependency mode. The `dev` preset uses `developer-system` mode
+(host packages, labeled Unqualified); the CI preset uses `qualified` mode, which validates the
+reviewed dependency lock and resolves dependency packages only from the superbuild prefix:
+
 ```sh
 cmake --preset dev
 cmake --build --preset dev
@@ -62,10 +66,17 @@ ctest --preset dev
 
 On Linux, the development executable is written to `build/dev/apps/bloom/Bloom`.
 
-The repository also provides a Qt-free Linux CI preset for core and quality checks:
+The repository also provides a Qt-free Linux CI preset for core and quality checks. It expects
+the dependency prefix at `build/dependency-prefix` (a one-time step per checkout, rerun after a
+lock change) and the toolchain named by the dependency lock:
 
 ```sh
-cmake --preset ci-linux-native
+cmake -S dependencies/superbuild -B build/dependency-superbuild \
+    -DBLOOM_DEPENDENCY_PREFIX="$PWD/build/dependency-prefix" \
+    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+cmake --build build/dependency-superbuild
+
+CC=clang CXX=clang++ cmake --preset ci-linux-native
 cmake --build --preset ci-linux-native
 ctest --preset ci-linux-native
 ```

--- a/cmake/BloomDependencyPrefix.cmake
+++ b/cmake/BloomDependencyPrefix.cmake
@@ -94,15 +94,28 @@ function(bloom_consume_dependency_prefix)
             "is the authority; use developer-system mode for local iteration.")
     endif()
 
-    # Restrict package resolution to the validated prefix. No host fallback, no registries, no
-    # network-backed discovery.
-    set(CMAKE_PREFIX_PATH "${BLOOM_DEPENDENCY_PREFIX}" PARENT_SCOPE)
-    set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON PARENT_SCOPE)
-    set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF PARENT_SCOPE)
-    set(CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY OFF PARENT_SCOPE)
-    set(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH OFF PARENT_SCOPE)
-    set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH OFF PARENT_SCOPE)
     set(BLOOM_DEPENDENCY_MODE_LABEL "Qualified-pending-manifest" PARENT_SCOPE)
     message(STATUS "Bloom dependencies: qualified mode against ${BLOOM_DEPENDENCY_PREFIX} "
         "(production lock present; full validation is enforced by the offline checker).")
+endfunction()
+
+# Resolves one qualified dependency package. Search restriction is per-package rather than
+# build-global so Bloom's separately governed boundaries (Qt discovery under ADR 0014) remain
+# untouched: in qualified mode the package resolves only from the validated prefix with
+# registries and default paths disabled; developer-system mode resolves from the host and stays
+# labeled Unqualified.
+function(bloom_find_dependency package)
+    if(BLOOM_DEPENDENCY_MODE STREQUAL "qualified")
+        set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF)
+        set(CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY OFF)
+        find_package(${package} REQUIRED CONFIG
+            PATHS "${BLOOM_DEPENDENCY_PREFIX}"
+            NO_DEFAULT_PATH)
+    elseif(BLOOM_DEPENDENCY_MODE STREQUAL "developer-system")
+        find_package(${package} REQUIRED CONFIG)
+    else()
+        message(FATAL_ERROR
+            "bloom_find_dependency(${package}) requires bloom_consume_dependency_prefix() to have "
+            "accepted an explicit BLOOM_DEPENDENCY_MODE first.")
+    endif()
 endfunction()

--- a/tests/dependency-consumption/CMakeLists.txt
+++ b/tests/dependency-consumption/CMakeLists.txt
@@ -8,8 +8,7 @@ project(BloomDependencyConsumptionSmoke LANGUAGES CXX)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/BloomDependencyPrefix.cmake")
 bloom_consume_dependency_prefix()
-
-find_package(yyjson REQUIRED CONFIG)
+bloom_find_dependency(yyjson)
 
 file(WRITE "${CMAKE_BINARY_DIR}/consume_smoke.cpp" [[
 #include <yyjson.h>


### PR DESCRIPTION
## Summary

Closes #26. Activates root-build dependency consumption (intake slice D1, the plumbing for the first consuming target):

- root `CMakeLists.txt` calls `bloom_consume_dependency_prefix()` — an explicit `BLOOM_DEPENDENCY_MODE` is now required for every configure, per the contract's mode-absence rule
- presets encode the split: `dev` → `developer-system` (Unqualified label, host packages), `ci-linux-native` → `qualified` + `build/dependency-prefix`
- `bloom_find_dependency()` replaces global search restriction with per-package restricted resolution (`PATHS <prefix> NO_DEFAULT_PATH`, registries off), so Qt discovery under ADR 0014 stays untouched
- CI builds the superbuild prefix (digest-keyed cache) before the main configure; the standalone qualified smoke consumer remains as the explicit chain proof
- README documents the one-time superbuild step and the locked-toolchain expectation

## Validation

- Fresh local configure in qualified mode with clang: accepted, full 54/54 suite green from scratch, format check green
- The consume line confirms lock presence at configure; the offline checker remains the full-lock authority in the test phase

Supervisor-implemented. Next slice dispatches the first consuming target (strict JSON DOM) as an agent package.