### PR TITLE
feat: parse bounded strict json dom

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -1,3 +1,5 @@
+bloom_find_dependency(yyjson)
+
 add_library(bloom_project STATIC)
 
 target_sources(
@@ -13,6 +15,7 @@ target_sources(
         manifest_requirements.cpp
         project_io_memory.cpp
         project_io_memory_resource.cpp
+        strict_json_dom.cpp
         strict_json_preflight.cpp
         strict_json_preflight.hpp
         unknown_json_number.cpp
@@ -29,11 +32,13 @@ target_sources(
             include/bloom/project/manifest_requirements.hpp
             include/bloom/project/project_io_memory.hpp
             include/bloom/project/project_io_memory_resource.hpp
+            include/bloom/project/strict_json_dom.hpp
             include/bloom/project/unknown_json_number.hpp
 )
 
 target_compile_features(bloom_project PUBLIC cxx_std_20)
 target_link_libraries(bloom_project PUBLIC bloom_core bloom_document)
+target_link_libraries(bloom_project PRIVATE yyjson::yyjson)
 bloom_enable_warnings(bloom_project)
 
 if(BUILD_TESTING)
@@ -100,6 +105,19 @@ if(BUILD_TESTING)
     bloom_add_test(
         NAME bloom.project.strict_json_preflight
         COMMAND bloom_project_strict_json_preflight_test
+        LABELS unit project persistence security
+    )
+
+    add_executable(bloom_project_strict_json_dom_test tests/strict_json_dom_tests.cpp)
+    target_include_directories(
+        bloom_project_strict_json_dom_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(bloom_project_strict_json_dom_test PRIVATE bloom_project)
+    bloom_enable_warnings(bloom_project_strict_json_dom_test)
+    bloom_add_test(
+        NAME bloom.project.strict_json_dom
+        COMMAND bloom_project_strict_json_dom_test
         LABELS unit project persistence security
     )
 

--- a/src/project/include/bloom/project/strict_json_dom.hpp
+++ b/src/project/include/bloom/project/strict_json_dom.hpp
@@ -1,0 +1,253 @@
+#pragma once
+
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/project_io_memory_resource.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <memory_resource>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// The bounded strict JSON DOM: a reader-side counterpart to the canonical JSON writer described
+// in docs/architecture/project-format.md ("Canonical JSON Primitives" and "Versions, Migrations,
+// And Preservation"). `parseStrictJsonDom()` first runs the existing bounded
+// `bloom::project::detail::preflightStrictJson()` scan, then parses the accepted bytes with a
+// qualified yyjson 0.12 reader whose allocation is bound to the caller's
+// `ProjectIoOperationMemory` budget. No yyjson type, header, or macro appears here or in any
+// other public Bloom contract; yyjson stays an implementation detail of strict_json_dom.cpp. The
+// resulting tree is a move-only, Bloom-owned value type: object member order is preserved exactly
+// as decoded, decoded duplicate object keys are rejected (comparing decoded Unicode strings, so
+// `"a"` and `"a"` collide), and every JSON number keeps its exact source token untouched --
+// typed numeric conversion (canonical decimal/rational/Float64, or the lossless unknown-number
+// subset) remains the caller's responsibility using the existing primitives in
+// canonical_decimal.hpp and unknown_json_number.hpp.
+
+namespace bloom::project {
+
+namespace detail {
+class StrictJsonDomBuilder;
+} // namespace detail
+
+enum class JsonValueKind : std::uint8_t {
+    Null,
+    Boolean,
+    Number,
+    String,
+    Array,
+    Object,
+};
+
+class JsonValue;
+class JsonMember;
+
+// One decoded JSON value in the bounded strict DOM. Copying is disabled so a large tree is never
+// accidentally duplicated; every value moves. All owned storage (the number/string token, the
+// element array, and the member array) allocates through the same PMR resource as its owning
+// document, in turn bounded by the caller's `ProjectIoOperationMemory` budget.
+class JsonValue final {
+  public:
+    // Constructs a Null value bound to `resource`; every other kind is populated by the parse
+    // pipeline. Public so standard containers (which are not implicitly friends even when called
+    // from friended code) can construct DOM nodes in place.
+    explicit JsonValue(std::pmr::memory_resource* resource) noexcept;
+
+    JsonValue(const JsonValue&) = delete;
+    JsonValue& operator=(const JsonValue&) = delete;
+    // Every value reachable from one document shares the same PMR resource pointer, so the
+    // underlying containers' allocators always compare equal and moving never allocates, copies
+    // element-wise, or throws.
+    JsonValue(JsonValue&&) noexcept = default;
+    JsonValue& operator=(JsonValue&&) noexcept = default;
+    ~JsonValue() = default;
+
+    [[nodiscard]] JsonValueKind kind() const noexcept { return kind_; }
+    [[nodiscard]] bool isNull() const noexcept { return kind_ == JsonValueKind::Null; }
+
+    // Valid only when kind() == Boolean; nullopt otherwise.
+    [[nodiscard]] std::optional<bool> asBoolean() const noexcept;
+    // Valid only when kind() == Number. Returns the exact source token bytes (e.g. "-0", "1e10",
+    // "9007199254740992.0"); the DOM performs no numeric conversion or normalization.
+    [[nodiscard]] std::optional<std::string_view> asNumberToken() const noexcept;
+    // Valid only when kind() == String. Returns the decoded Unicode scalar sequence (escapes
+    // already resolved), never the original escaped spelling.
+    [[nodiscard]] std::optional<std::string_view> asString() const noexcept;
+    // Valid only when kind() == Array; empty otherwise.
+    [[nodiscard]] std::span<const JsonValue> arrayElements() const noexcept;
+    // Valid only when kind() == Object; empty otherwise. Members retain exact source order.
+    [[nodiscard]] std::span<const JsonMember> objectMembers() const noexcept;
+    // Linear lookup by decoded key; returns nullptr when kind() != Object or the key is absent.
+    [[nodiscard]] const JsonValue* findMember(std::string_view key) const noexcept;
+
+  private:
+    friend class detail::StrictJsonDomBuilder;
+
+    JsonValueKind kind_ = JsonValueKind::Null;
+    bool boolean_ = false;
+    std::pmr::string text_;
+    std::pmr::vector<JsonValue> elements_;
+    std::pmr::vector<JsonMember> members_;
+};
+
+// One decoded object member in source order: a decoded key plus its owned value.
+class JsonMember final {
+  public:
+    // Constructs a member bound to `resource` with decoded `key` and a Null placeholder value;
+    // the parse pipeline fills in the value in place. Public for the same container-construction
+    // reason as JsonValue's constructor above. Deliberately not noexcept: copying `key` into
+    // PMR-owned storage allocates through ProjectIoMemoryResource's throwing
+    // std::pmr::memory_resource surface (do_allocate), which reports budget rejection as
+    // std::bad_alloc rather than a null pointer. That exception must reach
+    // parseStrictJsonDom()'s catch clause rather than hit a noexcept boundary and terminate.
+    JsonMember(std::pmr::memory_resource* resource, std::string_view key);
+
+    JsonMember(const JsonMember&) = delete;
+    JsonMember& operator=(const JsonMember&) = delete;
+    JsonMember(JsonMember&&) noexcept = default;
+    JsonMember& operator=(JsonMember&&) noexcept = default;
+    ~JsonMember() = default;
+
+    [[nodiscard]] std::string_view key() const noexcept { return key_; }
+    [[nodiscard]] const JsonValue& value() const noexcept { return value_; }
+
+  private:
+    friend class detail::StrictJsonDomBuilder;
+
+    std::pmr::string key_;
+    JsonValue value_;
+};
+
+inline constexpr std::size_t kStrictJsonDomMaximumInputBytes = 256U << 20U;
+inline constexpr std::uint32_t kStrictJsonDomMaximumDepth = 128;
+inline constexpr std::uint64_t kStrictJsonDomMaximumValues = 4'000'000;
+inline constexpr std::uint64_t kStrictJsonDomMaximumContainerEntries = 1'000'000;
+inline constexpr std::uint64_t kStrictJsonDomMaximumDecodedStringBytes = 89'478'488;
+
+// Bounds applied by the preceding preflight scan and carried through to the DOM build. A field
+// above the fixed v1 ceiling (mirroring strict_json_preflight.hpp) is rejected as InvalidLimits;
+// callers only ever lower these budgets.
+struct StrictJsonDomLimits final {
+    std::size_t maximumInputBytes = kStrictJsonDomMaximumInputBytes;
+    std::uint64_t maximumValues = kStrictJsonDomMaximumValues;
+    std::uint64_t maximumContainerEntries = kStrictJsonDomMaximumContainerEntries;
+    std::uint32_t maximumDepth = kStrictJsonDomMaximumDepth;
+    std::uint64_t maximumDecodedStringBytes = kStrictJsonDomMaximumDecodedStringBytes;
+};
+
+enum class StrictJsonDomError : std::uint8_t {
+    None,
+    InvalidLimits,
+    InputTooLarge,
+    BomForbidden,
+    EmptyInput,
+    InvalidUtf8,
+    InvalidSyntax,
+    InvalidEscape,
+    InvalidUnicodeScalar,
+    InvalidNumber,
+    TrailingData,
+    DepthLimitExceeded,
+    ValueLimitExceeded,
+    ContainerEntryLimitExceeded,
+    DecodedStringLimitExceeded,
+    SizeOverflow,
+    // A decoded object key collided with an earlier decoded key in the same object; memberPath()
+    // names the exact offending member.
+    DuplicateObjectKey,
+    // The bounded PMR budget rejected an allocation needed by the qualified reader or the DOM
+    // build; the destination document is never constructed.
+    ResourceExhausted,
+    // The qualified reader rejected input that the preflight scan accepted; this should not occur
+    // given a conforming preflight/reader pair and is reported rather than trusted blindly.
+    ParseFailed,
+};
+
+// A bounded diagnostic path to one JSON member, formatted as `/key/0/key`. Truncated() is true
+// when the exact path did not fit; the retained prefix is still a genuine path prefix.
+class StrictJsonDomPathText final {
+  public:
+    StrictJsonDomPathText() noexcept = default;
+
+    [[nodiscard]] std::string_view view() const& noexcept { return {chars_.data(), size_}; }
+    [[nodiscard]] std::string_view view() const&& = delete;
+    [[nodiscard]] bool truncated() const noexcept { return truncated_; }
+
+  private:
+    friend class detail::StrictJsonDomBuilder;
+
+    std::array<char, 512> chars_{};
+    std::uint16_t size_ = 0;
+    bool truncated_ = false;
+};
+
+// A parsed document owning its PMR resource and root value for as long as the document lives.
+// The resource lives behind a stable heap address so moving the document never invalidates the
+// pointers held by its PMR-allocated tree.
+class StrictJsonDomDocument final {
+  public:
+    StrictJsonDomDocument(const StrictJsonDomDocument&) = delete;
+    StrictJsonDomDocument& operator=(const StrictJsonDomDocument&) = delete;
+    StrictJsonDomDocument(StrictJsonDomDocument&&) noexcept = default;
+    StrictJsonDomDocument& operator=(StrictJsonDomDocument&&) noexcept = default;
+    ~StrictJsonDomDocument() = default;
+
+    [[nodiscard]] const JsonValue& root() const noexcept { return root_; }
+
+  private:
+    friend class detail::StrictJsonDomBuilder;
+
+    StrictJsonDomDocument(std::unique_ptr<ProjectIoMemoryResource> resource,
+                          JsonValue root) noexcept;
+
+    std::unique_ptr<ProjectIoMemoryResource> resource_;
+    JsonValue root_;
+};
+
+// [[nodiscard]] failure-aware result. On success, document() names the parsed tree; on failure,
+// error() names the typed cause with either byteOffset() (preflight/reader-stage failures, an
+// RFC 8259 byte position) or memberPath() (DuplicateObjectKey) populated.
+class [[nodiscard]] StrictJsonDomResult final {
+  public:
+    StrictJsonDomResult(const StrictJsonDomResult&) = delete;
+    StrictJsonDomResult& operator=(const StrictJsonDomResult&) = delete;
+    StrictJsonDomResult(StrictJsonDomResult&&) noexcept = default;
+    StrictJsonDomResult& operator=(StrictJsonDomResult&&) noexcept = default;
+    ~StrictJsonDomResult() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error_ == StrictJsonDomError::None;
+    }
+    [[nodiscard]] StrictJsonDomError error() const noexcept { return error_; }
+    [[nodiscard]] std::size_t byteOffset() const noexcept { return byteOffset_; }
+    [[nodiscard]] std::string_view memberPath() const noexcept { return path_.view(); }
+    [[nodiscard]] const StrictJsonDomDocument* document() const& noexcept {
+        return document_.has_value() ? &*document_ : nullptr;
+    }
+    [[nodiscard]] const StrictJsonDomDocument* document() const&& = delete;
+
+  private:
+    friend class detail::StrictJsonDomBuilder;
+
+    StrictJsonDomResult() noexcept = default;
+
+    std::optional<StrictJsonDomDocument> document_;
+    StrictJsonDomError error_ = StrictJsonDomError::InvalidLimits;
+    std::size_t byteOffset_ = 0;
+    StrictJsonDomPathText path_;
+};
+
+// Runs the bounded preflight scan with `limits`, then parses the accepted bytes into a bounded
+// Bloom-owned DOM. `operation` supplies and bounds every allocation made on this call's behalf,
+// including the qualified reader's internal working memory; a budget rejection is reported as
+// ResourceExhausted rather than throwing or falling back to unmetered heap allocation. Never
+// throws.
+[[nodiscard]] StrictJsonDomResult parseStrictJsonDom(std::span<const std::byte> input,
+                                                     const StrictJsonDomLimits& limits,
+                                                     ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::project

--- a/src/project/strict_json_dom.cpp
+++ b/src/project/strict_json_dom.cpp
@@ -1,0 +1,431 @@
+#include <bloom/project/strict_json_dom.hpp>
+
+#include "strict_json_preflight.hpp"
+
+#include <yyjson.h>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <memory_resource>
+#include <new>
+#include <span>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+
+namespace bloom::project {
+
+JsonValue::JsonValue(std::pmr::memory_resource* const resource) noexcept
+    : text_(resource), elements_(resource), members_(resource) {}
+
+std::optional<bool> JsonValue::asBoolean() const noexcept {
+    if (kind_ != JsonValueKind::Boolean) {
+        return std::nullopt;
+    }
+    return boolean_;
+}
+
+std::optional<std::string_view> JsonValue::asNumberToken() const noexcept {
+    if (kind_ != JsonValueKind::Number) {
+        return std::nullopt;
+    }
+    return std::string_view{text_};
+}
+
+std::optional<std::string_view> JsonValue::asString() const noexcept {
+    if (kind_ != JsonValueKind::String) {
+        return std::nullopt;
+    }
+    return std::string_view{text_};
+}
+
+std::span<const JsonValue> JsonValue::arrayElements() const noexcept {
+    if (kind_ != JsonValueKind::Array) {
+        return {};
+    }
+    return {elements_.data(), elements_.size()};
+}
+
+std::span<const JsonMember> JsonValue::objectMembers() const noexcept {
+    if (kind_ != JsonValueKind::Object) {
+        return {};
+    }
+    return {members_.data(), members_.size()};
+}
+
+const JsonValue* JsonValue::findMember(const std::string_view key) const noexcept {
+    if (kind_ != JsonValueKind::Object) {
+        return nullptr;
+    }
+    for (const auto& member : members_) {
+        if (member.key() == key) {
+            return &member.value();
+        }
+    }
+    return nullptr;
+}
+
+JsonMember::JsonMember(std::pmr::memory_resource* const resource, const std::string_view key)
+    : key_(key.data(), key.size(), resource), value_(resource) {}
+
+StrictJsonDomDocument::StrictJsonDomDocument(std::unique_ptr<ProjectIoMemoryResource> resource,
+                                             JsonValue root) noexcept
+    : resource_(std::move(resource)), root_(std::move(root)) {}
+
+} // namespace bloom::project
+
+namespace bloom::project::detail {
+
+namespace {
+
+static_assert(kStrictJsonDomMaximumInputBytes == kStrictJsonDocumentMaximumInputBytes);
+static_assert(kStrictJsonDomMaximumDepth == kStrictJsonMaximumDepth);
+static_assert(kStrictJsonDomMaximumValues == kStrictJsonMaximumValues);
+static_assert(kStrictJsonDomMaximumContainerEntries == kStrictJsonMaximumContainerEntries);
+static_assert(kStrictJsonDomMaximumDecodedStringBytes == kStrictJsonMaximumDecodedStringBytes);
+
+[[nodiscard]] StrictJsonDomError
+translatePreflightError(const StrictJsonPreflightError error) noexcept {
+    switch (error) {
+    case StrictJsonPreflightError::None:
+        return StrictJsonDomError::None;
+    case StrictJsonPreflightError::InvalidLimits:
+        return StrictJsonDomError::InvalidLimits;
+    case StrictJsonPreflightError::InputTooLarge:
+        return StrictJsonDomError::InputTooLarge;
+    case StrictJsonPreflightError::BomForbidden:
+        return StrictJsonDomError::BomForbidden;
+    case StrictJsonPreflightError::EmptyInput:
+        return StrictJsonDomError::EmptyInput;
+    case StrictJsonPreflightError::InvalidUtf8:
+        return StrictJsonDomError::InvalidUtf8;
+    case StrictJsonPreflightError::InvalidSyntax:
+        return StrictJsonDomError::InvalidSyntax;
+    case StrictJsonPreflightError::InvalidEscape:
+        return StrictJsonDomError::InvalidEscape;
+    case StrictJsonPreflightError::InvalidUnicodeScalar:
+        return StrictJsonDomError::InvalidUnicodeScalar;
+    case StrictJsonPreflightError::InvalidNumber:
+        return StrictJsonDomError::InvalidNumber;
+    case StrictJsonPreflightError::TrailingData:
+        return StrictJsonDomError::TrailingData;
+    case StrictJsonPreflightError::DepthLimitExceeded:
+        return StrictJsonDomError::DepthLimitExceeded;
+    case StrictJsonPreflightError::ValueLimitExceeded:
+        return StrictJsonDomError::ValueLimitExceeded;
+    case StrictJsonPreflightError::ContainerEntryLimitExceeded:
+        return StrictJsonDomError::ContainerEntryLimitExceeded;
+    case StrictJsonPreflightError::DecodedStringLimitExceeded:
+        return StrictJsonDomError::DecodedStringLimitExceeded;
+    case StrictJsonPreflightError::SizeOverflow:
+        return StrictJsonDomError::SizeOverflow;
+    case StrictJsonPreflightError::Cancelled:
+        return StrictJsonDomError::ParseFailed;
+    }
+    return StrictJsonDomError::ParseFailed;
+}
+
+struct PathSegment final {
+    bool isIndex = false;
+    std::string_view key;
+    std::size_t index = 0;
+};
+
+// A fixed-capacity stack of path segments from the document root to the value currently being
+// built. Sized to the fixed v1 depth ceiling, which every accepted `StrictJsonDomLimits` is
+// checked against before this stack is used.
+class PathStack final {
+  public:
+    void pushKey(const std::string_view key) noexcept {
+        entries_[size_] = PathSegment{.isIndex = false, .key = key, .index = 0};
+        ++size_;
+    }
+    void pushIndex(const std::size_t index) noexcept {
+        entries_[size_] = PathSegment{.isIndex = true, .key = {}, .index = index};
+        ++size_;
+    }
+    void pop() noexcept { --size_; }
+    [[nodiscard]] std::span<const PathSegment> segments() const noexcept {
+        return {entries_.data(), size_};
+    }
+
+  private:
+    std::array<PathSegment, kStrictJsonDomMaximumDepth> entries_{};
+    std::size_t size_ = 0;
+};
+
+} // namespace
+
+// All yyjson use is confined to this translation unit; no yyjson type crosses strict_json_dom.hpp.
+class StrictJsonDomBuilder final {
+  public:
+    [[nodiscard]] static StrictJsonDomResult parse(std::span<const std::byte> input,
+                                                   const StrictJsonDomLimits& limits,
+                                                   ProjectIoOperationMemory operation) noexcept;
+
+  private:
+    // Not noexcept: the DOM walk copies decoded tokens/keys into PMR-owned containers using
+    // ordinary std::pmr::string/vector/unordered_set operations, which allocate through
+    // ProjectIoMemoryResource's throwing memory_resource surface (do_allocate). A budget
+    // rejection here must propagate as std::bad_alloc to parse()'s try/catch, which reports
+    // ResourceExhausted; the allocator adapters used only by yyjson's C callbacks are the
+    // noexcept ones (checkedAllocate), not this walk.
+    [[nodiscard]] static bool buildValue(yyjson_val* value, JsonValue& out, PathStack& path,
+                                         std::pmr::memory_resource* resource,
+                                         StrictJsonDomPathText& errorPath);
+    [[nodiscard]] static StrictJsonDomPathText formatPath(const PathStack& stack,
+                                                          std::string_view finalKey) noexcept;
+
+    [[nodiscard]] static StrictJsonDomResult makeFailure(StrictJsonDomError error,
+                                                         std::size_t byteOffset) noexcept;
+    [[nodiscard]] static StrictJsonDomResult makeSuccess(StrictJsonDomDocument document) noexcept;
+    [[nodiscard]] static StrictJsonDomResult
+    makeDuplicateKeyFailure(StrictJsonDomPathText path) noexcept;
+
+    static void* allocatorMalloc(void* ctx, std::size_t size) noexcept;
+    static void* allocatorRealloc(void* ctx, void* ptr, std::size_t oldSize,
+                                  std::size_t size) noexcept;
+    static void allocatorFree(void* ctx, void* ptr) noexcept;
+};
+
+StrictJsonDomResult StrictJsonDomBuilder::parse(const std::span<const std::byte> input,
+                                                const StrictJsonDomLimits& limits,
+                                                ProjectIoOperationMemory operation) noexcept {
+    if (limits.maximumInputBytes > kStrictJsonDocumentMaximumInputBytes ||
+        limits.maximumValues > kStrictJsonMaximumValues ||
+        limits.maximumContainerEntries > kStrictJsonMaximumContainerEntries ||
+        limits.maximumDepth > kStrictJsonMaximumDepth ||
+        limits.maximumDecodedStringBytes > kStrictJsonMaximumDecodedStringBytes) {
+        return makeFailure(StrictJsonDomError::InvalidLimits, 0);
+    }
+
+    const StrictJsonPreflightLimits preflightLimits{
+        .maximumInputBytes = limits.maximumInputBytes,
+        .maximumValues = limits.maximumValues,
+        .maximumContainerEntries = limits.maximumContainerEntries,
+        .maximumDepth = limits.maximumDepth,
+        .maximumDecodedStringBytes = limits.maximumDecodedStringBytes,
+    };
+    const auto preflight = preflightStrictJson(input, preflightLimits);
+    if (!preflight.succeeded()) {
+        return makeFailure(translatePreflightError(preflight.error), preflight.errorOffset);
+    }
+
+    std::unique_ptr<ProjectIoMemoryResource> resource;
+    try {
+        resource = std::make_unique<ProjectIoMemoryResource>(std::move(operation));
+    } catch (const std::bad_alloc&) {
+        return makeFailure(StrictJsonDomError::ResourceExhausted, 0);
+    }
+
+    const yyjson_alc allocator{&allocatorMalloc, &allocatorRealloc, &allocatorFree, resource.get()};
+    yyjson_read_err readError{};
+    // NOFLAG plus NUMBER_AS_RAW: strict RFC 8259 grammar (matching the preceding preflight scan)
+    // with every number preserved as its exact source token. `input` is not modified because
+    // YYJSON_READ_INSITU is not set.
+    yyjson_doc* const doc =
+        yyjson_read_opts(const_cast<char*>(reinterpret_cast<const char*>(input.data())),
+                         input.size(), YYJSON_READ_NUMBER_AS_RAW, &allocator, &readError);
+    if (doc == nullptr) {
+        const auto error = readError.code == YYJSON_READ_ERROR_MEMORY_ALLOCATION
+                               ? StrictJsonDomError::ResourceExhausted
+                               : StrictJsonDomError::ParseFailed;
+        return makeFailure(error, readError.pos);
+    }
+
+    struct DocGuard final {
+        yyjson_doc* doc;
+        ~DocGuard() { yyjson_doc_free(doc); }
+    } docGuard{doc};
+
+    try {
+        PathStack path;
+        JsonValue root(resource.get());
+        StrictJsonDomPathText errorPath;
+        if (!buildValue(yyjson_doc_get_root(doc), root, path, resource.get(), errorPath)) {
+            return makeDuplicateKeyFailure(errorPath);
+        }
+        StrictJsonDomDocument document(std::move(resource), std::move(root));
+        return makeSuccess(std::move(document));
+    } catch (const std::bad_alloc&) {
+        return makeFailure(StrictJsonDomError::ResourceExhausted, 0);
+    } catch (...) {
+        return makeFailure(StrictJsonDomError::ParseFailed, 0);
+    }
+}
+
+bool StrictJsonDomBuilder::buildValue(yyjson_val* const value, JsonValue& out, PathStack& path,
+                                      std::pmr::memory_resource* const resource,
+                                      StrictJsonDomPathText& errorPath) {
+    switch (yyjson_get_type(value)) {
+    case YYJSON_TYPE_NULL:
+        out.kind_ = JsonValueKind::Null;
+        return true;
+    case YYJSON_TYPE_BOOL:
+        out.kind_ = JsonValueKind::Boolean;
+        out.boolean_ = yyjson_is_true(value);
+        return true;
+    case YYJSON_TYPE_RAW:
+        out.kind_ = JsonValueKind::Number;
+        out.text_.assign(yyjson_get_raw(value), yyjson_get_len(value));
+        return true;
+    case YYJSON_TYPE_STR:
+        out.kind_ = JsonValueKind::String;
+        out.text_.assign(yyjson_get_str(value), yyjson_get_len(value));
+        return true;
+    case YYJSON_TYPE_ARR: {
+        out.kind_ = JsonValueKind::Array;
+        out.elements_.reserve(yyjson_arr_size(value));
+        yyjson_arr_iter iter{};
+        yyjson_arr_iter_init(value, &iter);
+        std::size_t index = 0;
+        for (yyjson_val* element = yyjson_arr_iter_next(&iter); element != nullptr;
+             element = yyjson_arr_iter_next(&iter)) {
+            out.elements_.emplace_back(resource);
+            path.pushIndex(index);
+            const bool built = buildValue(element, out.elements_.back(), path, resource, errorPath);
+            path.pop();
+            if (!built) {
+                return false;
+            }
+            ++index;
+        }
+        return true;
+    }
+    case YYJSON_TYPE_OBJ: {
+        out.kind_ = JsonValueKind::Object;
+        const auto count = yyjson_obj_size(value);
+        out.members_.reserve(count);
+        std::pmr::unordered_set<std::string_view> seenKeys(resource);
+        seenKeys.reserve(count);
+        yyjson_obj_iter iter{};
+        yyjson_obj_iter_init(value, &iter);
+        for (yyjson_val* key = yyjson_obj_iter_next(&iter); key != nullptr;
+             key = yyjson_obj_iter_next(&iter)) {
+            yyjson_val* const memberValue = yyjson_obj_iter_get_val(key);
+            const std::string_view decodedKey(yyjson_get_str(key), yyjson_get_len(key));
+            if (!seenKeys.insert(decodedKey).second) {
+                errorPath = formatPath(path, decodedKey);
+                return false;
+            }
+            out.members_.emplace_back(resource, decodedKey);
+            path.pushKey(decodedKey);
+            const bool built =
+                buildValue(memberValue, out.members_.back().value_, path, resource, errorPath);
+            path.pop();
+            if (!built) {
+                return false;
+            }
+        }
+        return true;
+    }
+    default:
+        // YYJSON_TYPE_NONE is unreachable: the preceding preflight scan already proved `input`
+        // holds exactly one well-formed root value.
+        return true;
+    }
+}
+
+StrictJsonDomPathText StrictJsonDomBuilder::formatPath(const PathStack& stack,
+                                                       const std::string_view finalKey) noexcept {
+    StrictJsonDomPathText text;
+    const auto appendSlice = [&text](const std::string_view piece) noexcept {
+        if (text.truncated_) {
+            return;
+        }
+        const auto available = text.chars_.size() - text.size_;
+        const auto copyBytes = std::min(available, piece.size());
+        std::memcpy(text.chars_.data() + text.size_, piece.data(), copyBytes);
+        text.size_ = static_cast<std::uint16_t>(text.size_ + copyBytes);
+        if (copyBytes < piece.size()) {
+            text.truncated_ = true;
+        }
+    };
+
+    for (const auto& segment : stack.segments()) {
+        appendSlice("/");
+        if (segment.isIndex) {
+            std::array<char, 24> buffer{};
+            const auto conversion =
+                std::to_chars(buffer.data(), buffer.data() + buffer.size(), segment.index);
+            appendSlice(std::string_view(buffer.data(),
+                                         static_cast<std::size_t>(conversion.ptr - buffer.data())));
+        } else {
+            appendSlice(segment.key);
+        }
+    }
+    appendSlice("/");
+    appendSlice(finalKey);
+    return text;
+}
+
+StrictJsonDomResult StrictJsonDomBuilder::makeFailure(const StrictJsonDomError error,
+                                                      const std::size_t byteOffset) noexcept {
+    StrictJsonDomResult result;
+    result.error_ = error;
+    result.byteOffset_ = byteOffset;
+    return result;
+}
+
+StrictJsonDomResult StrictJsonDomBuilder::makeSuccess(StrictJsonDomDocument document) noexcept {
+    StrictJsonDomResult result;
+    result.error_ = StrictJsonDomError::None;
+    result.document_.emplace(std::move(document));
+    return result;
+}
+
+StrictJsonDomResult
+StrictJsonDomBuilder::makeDuplicateKeyFailure(StrictJsonDomPathText path) noexcept {
+    StrictJsonDomResult result;
+    result.error_ = StrictJsonDomError::DuplicateObjectKey;
+    result.path_ = path;
+    return result;
+}
+
+void* StrictJsonDomBuilder::allocatorMalloc(void* const ctx, const std::size_t size) noexcept {
+    auto* const resource = static_cast<ProjectIoMemoryResource*>(ctx);
+    const auto result = resource->checkedAllocate(size, alignof(std::max_align_t));
+    return result ? result.pointer() : nullptr;
+}
+
+void* StrictJsonDomBuilder::allocatorRealloc(void* const ctx, void* const ptr,
+                                             const std::size_t oldSize,
+                                             const std::size_t size) noexcept {
+    auto* const resource = static_cast<ProjectIoMemoryResource*>(ctx);
+    const auto result = resource->checkedAllocate(size, alignof(std::max_align_t));
+    if (!result) {
+        return nullptr;
+    }
+    if (ptr != nullptr && oldSize > 0) {
+        std::memcpy(result.pointer(), ptr, std::min(oldSize, size));
+    }
+    if (ptr != nullptr) {
+        resource->deallocate(ptr, oldSize, alignof(std::max_align_t));
+    }
+    return result.pointer();
+}
+
+void StrictJsonDomBuilder::allocatorFree(void* const ctx, void* const ptr) noexcept {
+    if (ptr == nullptr) {
+        return;
+    }
+    auto* const resource = static_cast<ProjectIoMemoryResource*>(ctx);
+    resource->deallocate(ptr, 0, alignof(std::max_align_t));
+}
+
+} // namespace bloom::project::detail
+
+namespace bloom::project {
+
+StrictJsonDomResult parseStrictJsonDom(const std::span<const std::byte> input,
+                                       const StrictJsonDomLimits& limits,
+                                       ProjectIoOperationMemory operation) noexcept {
+    return detail::StrictJsonDomBuilder::parse(input, limits, std::move(operation));
+}
+
+} // namespace bloom::project

--- a/src/project/tests/strict_json_dom_tests.cpp
+++ b/src/project/tests/strict_json_dom_tests.cpp
@@ -1,0 +1,807 @@
+#include <bloom/project/strict_json_dom.hpp>
+
+#include "strict_json_preflight.hpp"
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/project_io_memory.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <initializer_list>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using bloom::project::JsonValue;
+using bloom::project::JsonValueKind;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::StrictJsonDomError;
+using bloom::project::StrictJsonDomLimits;
+using bloom::project::StrictJsonDomResult;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 8ULL << 20U; // 8 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = bloom::project::ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] StrictJsonDomResult parseGenerous(const std::string_view text,
+                                                const StrictJsonDomLimits& limits = {}) {
+    return bloom::project::parseStrictJsonDom(asBytes(text), limits,
+                                              makeOperation(kGenerousOperationBudget));
+}
+
+// ---------------------------------------------------------------------------------------------
+// Duplicate-key rejection
+// ---------------------------------------------------------------------------------------------
+
+void testDuplicateKeyRejection(Expectations& expectations) {
+    {
+        const auto result = parseGenerous(R"({"a":1,"a":2})");
+        expectations.expect(!result && result.error() == StrictJsonDomError::DuplicateObjectKey &&
+                                result.memberPath() == "/a",
+                            "a top-level duplicate key is rejected with its exact path");
+    }
+    {
+        const auto result = parseGenerous(R"({"a":1,"b":{"x":1,"x":2}})");
+        expectations.expect(!result && result.error() == StrictJsonDomError::DuplicateObjectKey &&
+                                result.memberPath() == "/b/x",
+                            "a nested object duplicate key reports its full member path");
+    }
+    {
+        const auto result = parseGenerous(R"({"list":[{"n":1,"n":2}]})");
+        expectations.expect(!result && result.error() == StrictJsonDomError::DuplicateObjectKey &&
+                                result.memberPath() == "/list/0/n",
+                            "a duplicate key inside an array element includes the array index");
+    }
+    {
+        // "a" decodes to the same Unicode scalar sequence as "a"; duplicate detection
+        // compares decoded strings, not escaped spellings.
+        const auto result = parseGenerous(R"({"a":1,"a":2})");
+        expectations.expect(!result && result.error() == StrictJsonDomError::DuplicateObjectKey &&
+                                result.memberPath() == "/a",
+                            "an escaped-spelling collision is rejected the same as a literal one");
+    }
+    {
+        const auto result = parseGenerous(R"({"a":{"b":{"c":1,"c":2}}})");
+        expectations.expect(!result && result.error() == StrictJsonDomError::DuplicateObjectKey &&
+                                result.memberPath() == "/a/b/c",
+                            "a duplicate several levels deep still reports the exact path");
+    }
+    {
+        const auto result = parseGenerous(R"({"a":1,"b":2,"c":3})");
+        expectations.expect(static_cast<bool>(result), "distinct sibling keys are accepted");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Raw number token preservation
+// ---------------------------------------------------------------------------------------------
+
+void testRawNumberTokenPreservation(Expectations& expectations) {
+    constexpr std::string_view tokens[] = {
+        "-9223372036854775808",
+        "9223372036854775807",
+        "-0",
+        "0",
+        "1e10",
+        "1E+21",
+        // The canonical Float64 golden subset mirrored from unknown_json_number_tests.cpp.
+        "0.0",
+        "-0.0",
+        "5e-324",
+        "-5e-324",
+        "2.225073858507201e-308",
+        "2.2250738585072014e-308",
+        "1.7976931348623157e+308",
+        "-1.7976931348623157e+308",
+        "9007199254740992.0",
+        "9.999999999999997e-7",
+        "0.000001",
+        "999999999999999900000.0",
+        "1e+21",
+    };
+
+    std::string document = "[";
+    for (std::size_t index = 0; index < std::size(tokens); ++index) {
+        if (index != 0) {
+            document += ',';
+        }
+        document += tokens[index];
+    }
+    document += ']';
+
+    const auto result = parseGenerous(document);
+    if (!result) {
+        expectations.expect(false, "the raw-number fixture document parses");
+        return;
+    }
+    const auto& root = result.document()->root();
+    expectations.expect(root.kind() == JsonValueKind::Array, "the raw-number fixture is an array");
+    const auto elements = root.arrayElements();
+    expectations.expect(elements.size() == std::size(tokens),
+                        "every fixture token becomes one array element");
+    for (std::size_t index = 0; index < std::size(tokens) && index < elements.size(); ++index) {
+        const auto token = elements[index].asNumberToken();
+        expectations.expect(elements[index].kind() == JsonValueKind::Number && token.has_value() &&
+                                *token == tokens[index],
+                            "the source number token is preserved exactly, unconverted");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Member order preservation
+// ---------------------------------------------------------------------------------------------
+
+void testMemberOrderPreservation(Expectations& expectations) {
+    const auto result = parseGenerous(R"({"zebra":1,"apple":2,"mango":3,"banana":4})");
+    if (!result) {
+        expectations.expect(false, "the member-order fixture parses");
+        return;
+    }
+    const auto members = result.document()->root().objectMembers();
+    const std::string_view expectedOrder[] = {"zebra", "apple", "mango", "banana"};
+    expectations.expect(members.size() == std::size(expectedOrder),
+                        "the member-order fixture keeps every member");
+    for (std::size_t index = 0; index < std::size(expectedOrder) && index < members.size();
+         ++index) {
+        expectations.expect(members[index].key() == expectedOrder[index],
+                            "object members retain their exact source order, not sorted order");
+    }
+    const auto* mango = result.document()->root().findMember("mango");
+    expectations.expect(mango != nullptr && mango->asNumberToken() == "3",
+                        "findMember locates a member regardless of its source position");
+    expectations.expect(result.document()->root().findMember("missing") == nullptr,
+                        "findMember reports absence with a null pointer");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Depth/limit agreement with the preflight scan
+// ---------------------------------------------------------------------------------------------
+
+void testDepthLimitAgreesWithPreflight(Expectations& expectations) {
+    const auto depth = bloom::project::kStrictJsonDomMaximumDepth;
+
+    std::string exact(depth, '[');
+    exact.append(depth, ']');
+    const auto exactResult = parseGenerous(exact);
+    expectations.expect(static_cast<bool>(exactResult),
+                        "the absolute depth boundary, root included, is accepted");
+
+    std::string over(depth + 1, '[');
+    over.append(depth + 1, ']');
+    const auto overResult = parseGenerous(over);
+    expectations.expect(!overResult &&
+                            overResult.error() == StrictJsonDomError::DepthLimitExceeded &&
+                            overResult.byteOffset() == depth,
+                        "one level beyond the boundary is rejected at the preflight's own offset");
+
+    StrictJsonDomLimits lowered;
+    lowered.maximumDepth = 4;
+    const auto loweredExact = parseGenerous("[[[[]]]]", lowered);
+    expectations.expect(static_cast<bool>(loweredExact),
+                        "a caller-lowered depth budget is honored at its own exact boundary");
+    const auto loweredOver = parseGenerous("[[[[[]]]]]", lowered);
+    expectations.expect(!loweredOver &&
+                            loweredOver.error() == StrictJsonDomError::DepthLimitExceeded,
+                        "a caller-lowered depth budget rejects one level beyond its own boundary");
+
+    StrictJsonDomLimits raised;
+    raised.maximumDepth = bloom::project::kStrictJsonDomMaximumDepth + 1;
+    const auto raisedResult = parseGenerous("null", raised);
+    expectations.expect(!raisedResult && raisedResult.error() == StrictJsonDomError::InvalidLimits,
+                        "a caller cannot raise the depth budget above the fixed v1 ceiling");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Writer/DOM round trip over the canonical minimal document golden fixture
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] bloom::document::NewProject makeMinimalProject() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    return bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+}
+
+[[nodiscard]] const JsonValue* expectChild(Expectations& expectations, const JsonValue& parent,
+                                           const std::string_view key,
+                                           const std::string_view context) {
+    const auto* child = parent.findMember(key);
+    expectations.expect(child != nullptr, context);
+    return child;
+}
+
+void expectKeyOrder(Expectations& expectations, const JsonValue& value,
+                    const std::initializer_list<std::string_view> keys,
+                    const std::string_view context) {
+    expectations.expect(value.kind() == JsonValueKind::Object, context);
+    if (value.kind() != JsonValueKind::Object) {
+        return;
+    }
+    const auto members = value.objectMembers();
+    bool matches = members.size() == keys.size();
+    std::size_t index = 0;
+    for (const auto expectedKey : keys) {
+        matches = matches && index < members.size() && members[index].key() == expectedKey;
+        ++index;
+    }
+    expectations.expect(matches, context);
+}
+
+void expectString(Expectations& expectations, const JsonValue& value,
+                  const std::string_view expected, const std::string_view context) {
+    const auto actual = value.asString();
+    expectations.expect(actual.has_value() && *actual == expected, context);
+}
+
+void expectNumber(Expectations& expectations, const JsonValue& value,
+                  const std::string_view expected, const std::string_view context) {
+    const auto actual = value.asNumberToken();
+    expectations.expect(actual.has_value() && *actual == expected, context);
+}
+
+void expectEmptyArray(Expectations& expectations, const JsonValue& value,
+                      const std::string_view context) {
+    expectations.expect(value.kind() == JsonValueKind::Array && value.arrayElements().empty(),
+                        context);
+}
+
+void testWriterDomRoundTrip(Expectations& expectations) {
+    auto newProject = makeMinimalProject();
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    constexpr std::size_t kScratchSize = 64;
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const bloom::project::CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                                      .colorSettings = &settings,
+                                                      .payloadScratch = payloadScratch,
+                                                      .sortScratch = sortScratch};
+
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    if (!size.hasValue()) {
+        expectations.expect(false, "the round-trip fixture preflights with the canonical writer");
+        return;
+    }
+    std::vector<char> encoded(*size.value(), '\0');
+    const auto written = bloom::project::encodeCanonicalDocument(request, encoded);
+    if (!written || written.bytesWritten() != *size.value()) {
+        expectations.expect(false, "the round-trip fixture encodes with the canonical writer");
+        return;
+    }
+
+    const std::string_view encodedText(encoded.data(), encoded.size());
+    const auto parsed = parseGenerous(encodedText);
+    if (!parsed) {
+        expectations.expect(false, "the canonical writer's own minimal document is accepted");
+        return;
+    }
+
+    const auto& root = parsed.document()->root();
+    expectKeyOrder(expectations, root, {"schemaVersion", "project", "idAllocation", "extensions"},
+                   "the root object keeps the canonical writer's exact member order");
+
+    if (const auto* schemaVersion = expectChild(expectations, root, "schemaVersion",
+                                                "the root has a schemaVersion member")) {
+        expectKeyOrder(expectations, *schemaVersion, {"major", "minor"},
+                       "schemaVersion keeps its exact member order");
+        if (const auto* major =
+                expectChild(expectations, *schemaVersion, "major", "major exists")) {
+            expectNumber(expectations, *major, "1", "the document schema major is preserved");
+        }
+        if (const auto* minor =
+                expectChild(expectations, *schemaVersion, "minor", "minor exists")) {
+            expectNumber(expectations, *minor, "0", "the document schema minor is preserved");
+        }
+    }
+
+    const auto* project =
+        expectChild(expectations, root, "project", "the root has a project member");
+    if (project != nullptr) {
+        expectKeyOrder(expectations, *project, {"id", "name", "colorSettings", "compositions"},
+                       "project keeps its exact member order");
+        if (const auto* id = expectChild(expectations, *project, "id", "project.id exists")) {
+            expectString(expectations, *id, "1", "the project id is preserved as a decimal string");
+        }
+        if (const auto* name = expectChild(expectations, *project, "name", "project.name exists")) {
+            expectString(expectations, *name, "Untitled Project", "the project name is preserved");
+        }
+
+        const auto* colorSettings =
+            expectChild(expectations, *project, "colorSettings", "project.colorSettings exists");
+        if (colorSettings != nullptr) {
+            expectKeyOrder(expectations, *colorSettings,
+                           {"schemaVersion", "processColorSpaceId", "ocioConfig"},
+                           "colorSettings keeps its exact member order");
+            if (const auto* processColorSpaceId =
+                    expectChild(expectations, *colorSettings, "processColorSpaceId",
+                                "processColorSpaceId exists")) {
+                expectString(expectations, *processColorSpaceId, "lin_rec709_scene",
+                             "the fixed v1 process color space id is preserved");
+            }
+            const auto* ocioConfig =
+                expectChild(expectations, *colorSettings, "ocioConfig", "ocioConfig exists");
+            if (ocioConfig != nullptr) {
+                expectKeyOrder(expectations, *ocioConfig,
+                               {"schemaVersion", "locator", "expectedRevision", "portability",
+                                "contextVariables"},
+                               "ocioConfig keeps its exact member order");
+                const auto* locator =
+                    expectChild(expectations, *ocioConfig, "locator", "locator exists");
+                if (locator != nullptr) {
+                    expectKeyOrder(expectations, *locator, {"kind", "uri"},
+                                   "the builtin locator keeps its exact member order");
+                    if (const auto* kind =
+                            expectChild(expectations, *locator, "kind", "locator.kind exists")) {
+                        expectString(expectations, *kind, "builtin",
+                                     "the locator kind is preserved");
+                    }
+                    if (const auto* uri =
+                            expectChild(expectations, *locator, "uri", "locator.uri exists")) {
+                        expectString(expectations, *uri, "bloom://ocio/neutral-v1/config.ocio",
+                                     "the builtin locator URI is preserved");
+                    }
+                }
+                const auto* expectedRevision = expectChild(
+                    expectations, *ocioConfig, "expectedRevision", "expectedRevision exists");
+                if (expectedRevision != nullptr) {
+                    expectKeyOrder(expectations, *expectedRevision, {"algorithm", "digest"},
+                                   "expectedRevision keeps its exact member order");
+                    if (const auto* digest = expectChild(expectations, *expectedRevision, "digest",
+                                                         "expectedRevision.digest exists")) {
+                        expectString(
+                            expectations, *digest,
+                            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+                            "the ascending digest fixture bytes are preserved as lowercase hex");
+                    }
+                }
+                if (const auto* portability = expectChild(expectations, *ocioConfig, "portability",
+                                                          "portability exists")) {
+                    expectString(expectations, *portability, "builtin", "portability is preserved");
+                }
+                if (const auto* contextVariables = expectChild(
+                        expectations, *ocioConfig, "contextVariables", "contextVariables exists")) {
+                    expectEmptyArray(expectations, *contextVariables,
+                                     "the minimal fixture has no context variables");
+                }
+            }
+        }
+
+        const auto* compositions =
+            expectChild(expectations, *project, "compositions", "project.compositions exists");
+        if (compositions != nullptr) {
+            expectations.expect(compositions->kind() == JsonValueKind::Array &&
+                                    compositions->arrayElements().size() == 1,
+                                "the minimal fixture has exactly one composition");
+            if (compositions->kind() == JsonValueKind::Array &&
+                !compositions->arrayElements().empty()) {
+                const auto& composition = compositions->arrayElements().front();
+                expectKeyOrder(
+                    expectations, composition,
+                    {"id", "name", "duration", "format", "parameters", "animationCurves", "graph"},
+                    "the composition keeps its exact member order");
+                if (const auto* name =
+                        expectChild(expectations, composition, "name", "composition.name exists")) {
+                    expectString(expectations, *name, "Main Composition",
+                                 "the composition name is preserved");
+                }
+                const auto* durationValue = expectChild(expectations, composition, "duration",
+                                                        "composition.duration exists");
+                if (durationValue != nullptr) {
+                    expectKeyOrder(expectations, *durationValue, {"numerator", "denominator"},
+                                   "duration keeps its exact member order");
+                    if (const auto* numerator =
+                            expectChild(expectations, *durationValue, "numerator",
+                                        "duration.numerator exists")) {
+                        expectString(expectations, *numerator, "10",
+                                     "the reduced duration numerator is preserved");
+                    }
+                }
+                const auto* format =
+                    expectChild(expectations, composition, "format", "composition.format exists");
+                if (format != nullptr) {
+                    expectKeyOrder(expectations, *format,
+                                   {"width", "height", "pixelAspect", "frameRate"},
+                                   "format keeps its exact member order");
+                    if (const auto* width =
+                            expectChild(expectations, *format, "width", "format.width exists")) {
+                        expectNumber(expectations, *width, "1920",
+                                     "the default composition width is preserved");
+                    }
+                    if (const auto* height =
+                            expectChild(expectations, *format, "height", "format.height exists")) {
+                        expectNumber(expectations, *height, "1080",
+                                     "the default composition height is preserved");
+                    }
+                }
+                if (const auto* parameters = expectChild(expectations, composition, "parameters",
+                                                         "composition.parameters exists")) {
+                    expectEmptyArray(expectations, *parameters,
+                                     "the minimal fixture has no parameters");
+                }
+                if (const auto* animationCurves =
+                        expectChild(expectations, composition, "animationCurves",
+                                    "composition.animationCurves exists")) {
+                    expectEmptyArray(expectations, *animationCurves,
+                                     "the minimal fixture has no animation curves");
+                }
+
+                const auto* graph =
+                    expectChild(expectations, composition, "graph", "composition.graph exists");
+                if (graph != nullptr) {
+                    expectKeyOrder(
+                        expectations, *graph,
+                        {"nodes", "edges", "layerOutputs", "layerStack", "compositionOutput"},
+                        "graph keeps its exact member order");
+                    const auto* nodes =
+                        expectChild(expectations, *graph, "nodes", "graph.nodes exists");
+                    if (nodes != nullptr) {
+                        expectations.expect(nodes->kind() == JsonValueKind::Array &&
+                                                nodes->arrayElements().size() == 2,
+                                            "the minimal graph has exactly two nodes");
+                        if (nodes->kind() == JsonValueKind::Array &&
+                            nodes->arrayElements().size() == 2) {
+                            const auto& firstNode = nodes->arrayElements()[0];
+                            expectKeyOrder(expectations, firstNode,
+                                           {"id", "typeId", "schemaVersion", "parameters"},
+                                           "a node keeps its exact member order");
+                            if (const auto* typeId = expectChild(expectations, firstNode, "typeId",
+                                                                 "node.typeId exists")) {
+                                expectString(expectations, *typeId, "bloom.layer-stack",
+                                             "the layer-stack node type id is preserved");
+                            }
+                            const auto& secondNode = nodes->arrayElements()[1];
+                            if (const auto* typeId = expectChild(expectations, secondNode, "typeId",
+                                                                 "second node.typeId exists")) {
+                                expectString(expectations, *typeId, "bloom.composition-output",
+                                             "the composition-output node type id is preserved");
+                            }
+                        }
+                    }
+                    const auto* edges =
+                        expectChild(expectations, *graph, "edges", "graph.edges exists");
+                    if (edges != nullptr && edges->kind() == JsonValueKind::Array &&
+                        edges->arrayElements().size() == 1) {
+                        const auto& edge = edges->arrayElements().front();
+                        expectKeyOrder(expectations, edge, {"id", "source", "destination"},
+                                       "an edge keeps its exact member order");
+                        const auto* destination = expectChild(expectations, edge, "destination",
+                                                              "edge.destination exists");
+                        if (destination != nullptr) {
+                            expectKeyOrder(expectations, *destination, {"kind", "nodeId", "port"},
+                                           "a node-input destination keeps its exact member order");
+                            if (const auto* kind = expectChild(expectations, *destination, "kind",
+                                                               "destination.kind exists")) {
+                                expectString(expectations, *kind, "node-input",
+                                             "the edge destination kind is preserved");
+                            }
+                        }
+                    } else {
+                        expectations.expect(false, "the minimal graph has exactly one edge");
+                    }
+                    if (const auto* layerOutputs = expectChild(expectations, *graph, "layerOutputs",
+                                                               "graph.layerOutputs exists")) {
+                        expectEmptyArray(expectations, *layerOutputs,
+                                         "the minimal fixture has no layer output boundaries");
+                    }
+                    const auto* layerStack =
+                        expectChild(expectations, *graph, "layerStack", "graph.layerStack exists");
+                    if (layerStack != nullptr) {
+                        expectKeyOrder(expectations, *layerStack, {"nodeId", "entries"},
+                                       "layerStack keeps its exact member order");
+                        if (const auto* entries = expectChild(expectations, *layerStack, "entries",
+                                                              "layerStack.entries exists")) {
+                            expectEmptyArray(expectations, *entries,
+                                             "the minimal fixture has no layer stack entries");
+                        }
+                    }
+                    const auto* compositionOutput =
+                        expectChild(expectations, *graph, "compositionOutput",
+                                    "graph.compositionOutput exists");
+                    if (compositionOutput != nullptr) {
+                        expectKeyOrder(expectations, *compositionOutput, {"nodeId", "port"},
+                                       "compositionOutput keeps its exact member order");
+                    }
+                }
+            }
+        }
+    }
+
+    const auto* idAllocation =
+        expectChild(expectations, root, "idAllocation", "the root has an idAllocation member");
+    if (idAllocation != nullptr) {
+        expectKeyOrder(expectations, *idAllocation, {"highestIssued"},
+                       "idAllocation keeps its exact member order");
+        const auto* highestIssued = expectChild(expectations, *idAllocation, "highestIssued",
+                                                "idAllocation.highestIssued exists");
+        if (highestIssued != nullptr) {
+            expectKeyOrder(expectations, *highestIssued,
+                           {"composition", "node", "edge", "layer", "layerSlot", "parameter",
+                            "animationCurve", "keyframe", "driverBinding", "extensionRecord"},
+                           "highestIssued keeps its exact member order across every namespace");
+            if (const auto* composition = expectChild(expectations, *highestIssued, "composition",
+                                                      "highestIssued.composition exists")) {
+                expectString(expectations, *composition, "1",
+                             "the composition high-water mark is preserved");
+            }
+            if (const auto* node = expectChild(expectations, *highestIssued, "node",
+                                               "highestIssued.node exists")) {
+                expectString(expectations, *node, "2", "the node high-water mark is preserved");
+            }
+            if (const auto* driverBinding =
+                    expectChild(expectations, *highestIssued, "driverBinding",
+                                "highestIssued.driverBinding exists")) {
+                expectString(expectations, *driverBinding, "0",
+                             "the untouched driverBinding high-water mark is preserved");
+            }
+        }
+    }
+
+    if (const auto* extensions =
+            expectChild(expectations, root, "extensions", "the root has an extensions member")) {
+        expectEmptyArray(expectations, *extensions, "the minimal fixture has no extension records");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// PMR budget exhaustion
+// ---------------------------------------------------------------------------------------------
+
+void testPmrBudgetExhaustion(Expectations& expectations) {
+    const auto result = bloom::project::parseStrictJsonDom(asBytes("null"), {}, makeOperation(4));
+    expectations.expect(!result && result.error() == StrictJsonDomError::ResourceExhausted,
+                        "an operation budget too small for even one allocation is reported");
+    expectations.expect(result.document() == nullptr,
+                        "a budget-exhaustion failure leaves the destination document untouched");
+    expectations.expect(!static_cast<bool>(result),
+                        "the result's boolean conversion agrees with the typed failure");
+}
+
+// Exhausts the budget *during the DOM walk itself*, not during yyjson's own read. The fixture is
+// a flat, grammatically trivial JSON array (so yyjson's own working set is small and roughly
+// proportional to the raw input bytes) holding many long strings (so the Bloom DOM's independent
+// PMR-owned copy of every decoded string -- built through JsonMember's converting constructor and
+// JsonValue::text_.assign/elements_.reserve/emplace_back, all ordinary throwing
+// std::pmr::memory_resource operations, never the noexcept yyjson_alc adapter -- is large). A
+// budget that comfortably funds yyjson_read_opts() but not that second copy must fail partway
+// through buildValue(), strictly after the read already succeeded. Before the fix for the
+// supervisor-reported defect (buildValue/JsonMember's converting constructor were incorrectly
+// noexcept), any such budget crashed the process via std::terminate() instead of returning
+// ResourceExhausted; this test's whole sweep completing at all, with no ParseFailed anywhere,
+// is the evidence that the fix holds.
+void testPmrBudgetExhaustionDuringDomWalk(Expectations& expectations) {
+    constexpr std::size_t kElementCount = 400;
+    constexpr std::size_t kStringLength = 2000;
+    std::string content = "[";
+    for (std::size_t index = 0; index < kElementCount; ++index) {
+        if (index != 0) {
+            content += ',';
+        }
+        content += '"';
+        content.append(kStringLength, static_cast<char>('a' + static_cast<char>(index % 26)));
+        content += '"';
+    }
+    content += ']';
+    const auto rawBytes = static_cast<std::uint64_t>(content.size());
+
+    // A generous known-good budget: comfortably above both yyjson's own read footprint and a
+    // second full PMR-owned copy of every string.
+    const auto generousResult =
+        bloom::project::parseStrictJsonDom(asBytes(content), {}, makeOperation(rawBytes * 8));
+    expectations.expect(static_cast<bool>(generousResult),
+                        "a generous budget covers both the read and the full DOM walk");
+
+    bool sawSuccess = false;
+    bool sawResourceExhausted = false;
+    bool sawResourceExhaustedAboveRawInputBytes = false;
+    bool sawParseFailed = false;
+    for (std::uint64_t numerator = 1; numerator <= 64; ++numerator) {
+        const auto budget = rawBytes * numerator / 8;
+        if (budget == 0) {
+            continue;
+        }
+        const auto result =
+            bloom::project::parseStrictJsonDom(asBytes(content), {}, makeOperation(budget));
+        if (result) {
+            sawSuccess = true;
+            expectations.expect(result.document() != nullptr,
+                                "a successful sweep result names a document");
+            continue;
+        }
+        if (result.error() == StrictJsonDomError::ResourceExhausted) {
+            sawResourceExhausted = true;
+            // yyjson cannot decode this fixture's string content in less than `rawBytes` of
+            // working memory (it holds no escapes, so decoded length equals source length); a
+            // rejection at a budget already above the raw input size is therefore evidence the
+            // read itself had room to succeed and the DOM's own second copy is what exhausted the
+            // budget.
+            if (budget > rawBytes) {
+                sawResourceExhaustedAboveRawInputBytes = true;
+            }
+            expectations.expect(result.document() == nullptr,
+                                "a budget-exhaustion failure leaves the destination untouched at "
+                                "every point in the descending sweep");
+        } else if (result.error() == StrictJsonDomError::ParseFailed) {
+            sawParseFailed = true;
+        }
+    }
+
+    expectations.expect(sawSuccess,
+                        "the descending-budget sweep reaches a comfortably successful budget");
+    expectations.expect(sawResourceExhausted,
+                        "the descending-budget sweep reaches a budget too small to finish the DOM "
+                        "walk, reported as a typed error rather than crashing the process");
+    expectations.expect(sawResourceExhaustedAboveRawInputBytes,
+                        "at least one rejection happens at a budget already large enough for "
+                        "yyjson's own read, so that rejection occurs inside the DOM walk itself");
+    expectations.expect(!sawParseFailed,
+                        "no budget-driven rejection is ever misreported as ParseFailed, "
+                        "confirming yyjson's own read never observed a grammar failure here");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Hostile inputs rejected by the preflight stage
+// ---------------------------------------------------------------------------------------------
+
+void testHostileInputsRejectedByPreflight(Expectations& expectations) {
+    {
+        std::string bom;
+        bom.push_back(static_cast<char>(0xEFU));
+        bom.push_back(static_cast<char>(0xBBU));
+        bom.push_back(static_cast<char>(0xBFU));
+        bom += "null";
+        const auto result = parseGenerous(bom);
+        expectations.expect(!result && result.error() == StrictJsonDomError::BomForbidden &&
+                                result.byteOffset() == 0,
+                            "a UTF-8 BOM is rejected by the preflight stage, reporting its error");
+    }
+    {
+        // A string value containing a lone UTF-8 lead byte with no continuation byte.
+        std::string truncated = R"({"a":")";
+        truncated.push_back(static_cast<char>(0xC2U));
+        truncated += "\"}";
+        const auto result = parseGenerous(truncated);
+        expectations.expect(!result && result.error() == StrictJsonDomError::InvalidUtf8,
+                            "truncated UTF-8 is rejected by the preflight stage, reporting its "
+                            "error");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Value-kind accessor coverage
+// ---------------------------------------------------------------------------------------------
+
+void testValueKindsAndAccessors(Expectations& expectations) {
+    const auto result = parseGenerous(
+        R"({"n":null,"b":true,"f":false,"num":42,"str":"hi","arr":[1,2],"obj":{"x":1}})");
+    if (!result) {
+        expectations.expect(false, "the value-kind fixture parses");
+        return;
+    }
+    const auto& root = result.document()->root();
+
+    const auto* nullValue = root.findMember("n");
+    expectations.expect(nullValue != nullptr && nullValue->kind() == JsonValueKind::Null &&
+                            nullValue->isNull(),
+                        "a JSON null decodes to Null");
+
+    const auto* trueValue = root.findMember("b");
+    expectations.expect(trueValue != nullptr && trueValue->kind() == JsonValueKind::Boolean &&
+                            trueValue->asBoolean() == std::optional<bool>(true),
+                        "a JSON true decodes to Boolean(true)");
+    const auto* falseValue = root.findMember("f");
+    expectations.expect(falseValue != nullptr && falseValue->kind() == JsonValueKind::Boolean &&
+                            falseValue->asBoolean() == std::optional<bool>(false),
+                        "a JSON false decodes to Boolean(false)");
+
+    const auto* numberValue = root.findMember("num");
+    expectations.expect(numberValue != nullptr && numberValue->kind() == JsonValueKind::Number &&
+                            numberValue->asNumberToken() == std::optional<std::string_view>("42"),
+                        "a JSON number decodes to Number with its exact token");
+    expectations.expect(!numberValue->asString().has_value() &&
+                            !numberValue->asBoolean().has_value(),
+                        "wrong-kind accessors report nullopt rather than a default value");
+
+    const auto* stringValue = root.findMember("str");
+    expectations.expect(stringValue != nullptr && stringValue->kind() == JsonValueKind::String &&
+                            stringValue->asString() == std::optional<std::string_view>("hi"),
+                        "a JSON string decodes to String with its decoded content");
+
+    const auto* arrayValue = root.findMember("arr");
+    expectations.expect(arrayValue != nullptr && arrayValue->kind() == JsonValueKind::Array &&
+                            arrayValue->arrayElements().size() == 2 &&
+                            arrayValue->arrayElements()[0].asNumberToken() == "1" &&
+                            arrayValue->arrayElements()[1].asNumberToken() == "2",
+                        "a JSON array decodes to Array with its elements in order");
+    expectations.expect(arrayValue->objectMembers().empty() &&
+                            arrayValue->findMember("x") == nullptr,
+                        "object-only accessors are empty/null on a non-object value");
+
+    const auto* objectValue = root.findMember("obj");
+    expectations.expect(objectValue != nullptr && objectValue->kind() == JsonValueKind::Object &&
+                            objectValue->arrayElements().empty(),
+                        "a JSON object decodes to Object; array-only accessors are empty");
+    const auto* nestedX = objectValue != nullptr ? objectValue->findMember("x") : nullptr;
+    expectations.expect(nestedX != nullptr && nestedX->asNumberToken() == "1",
+                        "findMember resolves a nested object member");
+}
+
+} // namespace
+
+int main() {
+    try {
+        Expectations expectations;
+        testDuplicateKeyRejection(expectations);
+        testRawNumberTokenPreservation(expectations);
+        testMemberOrderPreservation(expectations);
+        testDepthLimitAgreesWithPreflight(expectations);
+        testWriterDomRoundTrip(expectations);
+        testPmrBudgetExhaustion(expectations);
+        testPmrBudgetExhaustionDuringDomWalk(expectations);
+        testHostileInputsRejectedByPreflight(expectations);
+        testValueKindsAndAccessors(expectations);
+        return expectations.failures() == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "Unexpected test exception: " << error.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #28. The first in-tree consumer of the qualified dependency chain (intake slice D2).

- `parseStrictJsonDom`: preflight acceptance as a hard precondition (limits mirrored and static-asserted against the scanner's ceilings), then a qualified yyjson 0.12 parse with numbers read as raw tokens, then one walk into a move-only Bloom-owned tree
- yyjson confined entirely to `strict_json_dom.cpp` — no yyjson type, header, or macro in any public contract
- member order preserved; duplicate decoded keys rejected with the exact bounded member path; strings exposed as decoded scalars, numbers as exact source tokens (typed conversion stays with the existing canonical/unknown-number primitives)
- every allocation bounded by the caller's `ProjectIoOperationMemory`: the DOM through a stable-address PMR resource, yyjson's own working memory through a `yyjson_alc` adapter over the non-throwing `checkedAllocate` surface; exhaustion is typed `ResourceExhausted` on both the read and build paths

## Review finding fixed before merge

Supervisor review found the walk path declared `noexcept` while allocating through the PMR surface, whose `do_allocate` throws on budget rejection — exhaustion mid-build would have terminated the process. Fixed by letting `bad_alloc` propagate to the parse function's catch (public API stays `noexcept` truthfully), with a regression test that demonstrably aborts (SIGABRT) against the unfixed code and passes with the fix, sweeping budgets across the yyjson-footprint/DOM-footprint boundary.

## Testing

- Duplicate-key rejection incl. escaped collisions and nested objects with exact paths; raw-token extremes; member-order preservation; preflight limit agreement at exact boundaries and one over; canonical-writer golden document round-trip parsed structurally equal; budget-exhaustion sweeps on both paths; hostile inputs rejected at the preflight stage
- Full `ci-linux-native` suite 55/55 and `bloom-format-check` green, re-verified independently by the supervising session

Implemented by a Claude Sonnet subagent from the bounded task specification; reviewed in full by the supervising session, one defect found and fixed through the review loop.