### PR TITLE
feat: decode typed document envelope

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
         canonical_json_string_detail.hpp
         canonical_json_writer.cpp
         canonical_manifest.cpp
+        document_decode.cpp
         manifest_requirements.cpp
         project_io_memory.cpp
         project_io_memory_resource.cpp
@@ -29,6 +30,7 @@ target_sources(
             include/bloom/project/canonical_json_string.hpp
             include/bloom/project/canonical_json_writer.hpp
             include/bloom/project/canonical_manifest.hpp
+            include/bloom/project/document_decode.hpp
             include/bloom/project/manifest_requirements.hpp
             include/bloom/project/project_io_memory.hpp
             include/bloom/project/project_io_memory_resource.hpp
@@ -72,6 +74,15 @@ if(BUILD_TESTING)
     bloom_add_test(
         NAME bloom.project.canonical_document
         COMMAND bloom_project_canonical_document_test
+        LABELS unit project persistence document
+    )
+
+    add_executable(bloom_project_document_decode_test tests/document_decode_tests.cpp)
+    target_link_libraries(bloom_project_document_decode_test PRIVATE bloom_project)
+    bloom_enable_warnings(bloom_project_document_decode_test)
+    bloom_add_test(
+        NAME bloom.project.document_decode
+        COMMAND bloom_project_document_decode_test
         LABELS unit project persistence document
     )
 

--- a/src/project/document_decode.cpp
+++ b/src/project/document_decode.cpp
@@ -1,0 +1,711 @@
+#include <bloom/project/document_decode.hpp>
+
+#include <bloom/core/sha256.hpp>
+#include <bloom/project/canonical_decimal.hpp>
+#include <bloom/project/canonical_document.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace bloom::project {
+
+namespace {
+
+using document::ColorSettings;
+using document::CompositionFormat;
+using document::CompositionId;
+using document::FrameRate;
+using document::OcioConfigLocator;
+using document::OcioConfigPortability;
+using document::OcioConfigReference;
+using document::OcioConfigRevision;
+using document::OcioContextVariable;
+using document::OcioRevisionAlgorithm;
+using document::ProjectId;
+using document::SchemaVersion;
+
+// Threads a first-failure-wins typed error and its exact member path through the recursive
+// decode walk, mirroring the WalkState/EmitState pattern used by the canonical document writer.
+struct DecodeState final {
+    DocumentDecodeError error = DocumentDecodeError::None;
+    std::string path;
+
+    void fail(const DocumentDecodeError newError, std::string newPath) noexcept {
+        if (error == DocumentDecodeError::None) {
+            error = newError;
+            path = std::move(newPath);
+        }
+    }
+};
+
+[[nodiscard]] std::string joinPath(const std::string& base, std::string_view segment) {
+    std::string result;
+    result.reserve(base.size() + 1 + segment.size());
+    result.append(base);
+    result.push_back('/');
+    result.append(segment);
+    return result;
+}
+
+[[nodiscard]] std::string joinPathIndex(const std::string& base, const std::size_t index) {
+    return joinPath(base, std::to_string(index));
+}
+
+// Checks that `object` is a JSON object whose leading members exactly match `expectedKeys` in
+// order, filling `outValues` with pointers to each matched member's value. When
+// `rejectExtraMembers` is true the object must contain exactly `expectedKeys.size()` members;
+// otherwise trailing members beyond the matched prefix are accepted without inspection (used for
+// composition, whose parameters/animationCurves/graph members are outside this package's scope
+// but always present in a writer-produced document).
+[[nodiscard]] bool matchOrderedMembers(const JsonValue& object,
+                                       const std::span<const std::string_view> expectedKeys,
+                                       const bool rejectExtraMembers, DecodeState& state,
+                                       const std::string& basePath,
+                                       std::vector<const JsonValue*>& outValues) {
+    if (object.kind() != JsonValueKind::Object) {
+        state.fail(DocumentDecodeError::WrongValueKind, basePath);
+        return false;
+    }
+
+    const auto members = object.objectMembers();
+    outValues.clear();
+    outValues.reserve(expectedKeys.size());
+    for (std::size_t index = 0; index < expectedKeys.size(); ++index) {
+        if (members.size() <= index) {
+            state.fail(DocumentDecodeError::MissingMember, joinPath(basePath, expectedKeys[index]));
+            return false;
+        }
+        if (members[index].key() != expectedKeys[index]) {
+            const bool knownElsewhere = std::find(expectedKeys.begin(), expectedKeys.end(),
+                                                  members[index].key()) != expectedKeys.end();
+            state.fail(knownElsewhere ? DocumentDecodeError::MemberOutOfOrder
+                                      : DocumentDecodeError::UnknownMember,
+                       joinPath(basePath, members[index].key()));
+            return false;
+        }
+        outValues.push_back(&members[index].value());
+    }
+
+    if (rejectExtraMembers && members.size() > expectedKeys.size()) {
+        state.fail(DocumentDecodeError::UnknownMember,
+                   joinPath(basePath, members[expectedKeys.size()].key()));
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] DocumentDecodeError mapUInt32Error(const CanonicalDecimalError error) noexcept {
+    return error == CanonicalDecimalError::InvalidLexicalForm
+               ? DocumentDecodeError::InvalidJsonUInt32
+               : DocumentDecodeError::DomainViolation;
+}
+
+[[nodiscard]] DocumentDecodeError mapRationalError(const CanonicalDecimalError error) noexcept {
+    return error == CanonicalDecimalError::NotReduced
+               ? DocumentDecodeError::UnreducedRational
+               : DocumentDecodeError::InvalidRationalComponent;
+}
+
+[[nodiscard]] std::string fieldPath(const std::string& base, const CanonicalDecimalField field) {
+    switch (field) {
+    case CanonicalDecimalField::Numerator:
+        return joinPath(base, "numerator");
+    case CanonicalDecimalField::Denominator:
+        return joinPath(base, "denominator");
+    case CanonicalDecimalField::Value:
+    case CanonicalDecimalField::None:
+        break;
+    }
+    return base;
+}
+
+// Translates a bloom::document::ValidationIssue path (dot/bracket notation, e.g.
+// "ocioConfig.contextVariables[3].name") into this module's slash-separated path convention
+// (e.g. "ocioConfig/contextVariables/3/name").
+[[nodiscard]] std::string translateValidationPath(const std::string_view dotted) {
+    std::string result;
+    result.reserve(dotted.size() + 4);
+    for (std::size_t index = 0; index < dotted.size();) {
+        const char character = dotted[index];
+        if (character == '.') {
+            result.push_back('/');
+            ++index;
+        } else if (character == '[') {
+            result.push_back('/');
+            ++index;
+            while (index < dotted.size() && dotted[index] != ']') {
+                result.push_back(dotted[index]);
+                ++index;
+            }
+            if (index < dotted.size()) {
+                ++index;
+            }
+        } else {
+            result.push_back(character);
+            ++index;
+        }
+    }
+    return result;
+}
+
+[[nodiscard]] bool decodeStringMember(const JsonValue& value, DecodeState& state,
+                                      const std::string& path, std::string_view& out) noexcept {
+    if (value.kind() != JsonValueKind::String) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto text = value.asString();
+    if (!text.has_value()) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    out = *text;
+    return true;
+}
+
+// asNumberToken()/asString() are documented to return a value whenever kind() already matches, but
+// that invariant is not visible to static analysis; every caller re-checks has_value() immediately
+// before dereferencing rather than trusting the prior kind() check alone.
+[[nodiscard]] bool decodeUInt32Member(const JsonValue& value, DecodeState& state,
+                                      const std::string& path, const std::uint32_t maximum,
+                                      std::uint32_t& out) {
+    if (value.kind() != JsonValueKind::Number) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto token = value.asNumberToken();
+    if (!token.has_value()) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto parsed = parseCanonicalJsonUInt32(*token, maximum);
+    if (!parsed) {
+        state.fail(mapUInt32Error(parsed.error()), path);
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+[[nodiscard]] bool decodeSchemaVersionField(const JsonValue& node, DecodeState& state,
+                                            const std::string& path, SchemaVersion& out) {
+    static constexpr std::array<std::string_view, 2> kKeys{"major", "minor"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    std::uint32_t major = 0;
+    if (!decodeUInt32Member(*members[0], state, joinPath(path, "major"),
+                            std::numeric_limits<std::uint32_t>::max(), major)) {
+        return false;
+    }
+    std::uint32_t minor = 0;
+    if (!decodeUInt32Member(*members[1], state, joinPath(path, "minor"),
+                            std::numeric_limits<std::uint32_t>::max(), minor)) {
+        return false;
+    }
+
+    out.major = major;
+    out.minor = minor;
+    return true;
+}
+
+[[nodiscard]] bool decodeRationalStrings(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, std::string_view& numeratorText,
+                                         std::string_view& denominatorText) {
+    static constexpr std::array<std::string_view, 2> kKeys{"numerator", "denominator"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+    if (!decodeStringMember(*members[0], state, joinPath(path, "numerator"), numeratorText)) {
+        return false;
+    }
+    return decodeStringMember(*members[1], state, joinPath(path, "denominator"), denominatorText);
+}
+
+[[nodiscard]] bool decodeDuration(const JsonValue& node, DecodeState& state,
+                                  const std::string& path, core::RationalTime& out) {
+    std::string_view numeratorText;
+    std::string_view denominatorText;
+    if (!decodeRationalStrings(node, state, path, numeratorText, denominatorText)) {
+        return false;
+    }
+    const auto parsed = parseCanonicalRationalTime(numeratorText, denominatorText);
+    if (!parsed) {
+        state.fail(mapRationalError(parsed.error()), fieldPath(path, parsed.field()));
+        return false;
+    }
+    if (parsed.value()->numerator() <= 0) {
+        state.fail(DocumentDecodeError::NonPositiveDuration, path);
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+[[nodiscard]] bool decodePixelAspect(const JsonValue& node, DecodeState& state,
+                                     const std::string& path, core::PixelAspectRatio& out) {
+    std::string_view numeratorText;
+    std::string_view denominatorText;
+    if (!decodeRationalStrings(node, state, path, numeratorText, denominatorText)) {
+        return false;
+    }
+    const auto parsed = parseCanonicalPixelAspectRatio(numeratorText, denominatorText);
+    if (!parsed) {
+        state.fail(mapRationalError(parsed.error()), fieldPath(path, parsed.field()));
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+[[nodiscard]] bool decodeFrameRate(const JsonValue& node, DecodeState& state,
+                                   const std::string& path, FrameRate& out) {
+    std::string_view numeratorText;
+    std::string_view denominatorText;
+    if (!decodeRationalStrings(node, state, path, numeratorText, denominatorText)) {
+        return false;
+    }
+    const auto parsed = parseCanonicalPositiveRatio(numeratorText, denominatorText);
+    if (!parsed) {
+        state.fail(mapRationalError(parsed.error()), fieldPath(path, parsed.field()));
+        return false;
+    }
+    const auto created = FrameRate::create(parsed.value()->numerator, parsed.value()->denominator);
+    if (!created.has_value()) {
+        // Unreachable given parseCanonicalPositiveRatio already proved a reduced, positive,
+        // uint32-bounded pair; kept as a defensive typed failure rather than trusting silently.
+        state.fail(DocumentDecodeError::DomainViolation, path);
+        return false;
+    }
+    out = *created;
+    return true;
+}
+
+[[nodiscard]] bool decodeFormat(const JsonValue& node, DecodeState& state, const std::string& path,
+                                CompositionFormat& out) {
+    static constexpr std::array<std::string_view, 4> kKeys{"width", "height", "pixelAspect",
+                                                           "frameRate"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    const auto widthPath = joinPath(path, "width");
+    std::uint32_t width = 0;
+    if (!decodeUInt32Member(*members[0], state, widthPath, CompositionFormat::kMaximumDimension,
+                            width)) {
+        return false;
+    }
+    if (width == 0) {
+        state.fail(DocumentDecodeError::DomainViolation, widthPath);
+        return false;
+    }
+
+    const auto heightPath = joinPath(path, "height");
+    std::uint32_t height = 0;
+    if (!decodeUInt32Member(*members[1], state, heightPath, CompositionFormat::kMaximumDimension,
+                            height)) {
+        return false;
+    }
+    if (height == 0) {
+        state.fail(DocumentDecodeError::DomainViolation, heightPath);
+        return false;
+    }
+
+    const auto product = static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height);
+    if (product > CompositionFormat::kMaximumPixelCount) {
+        state.fail(DocumentDecodeError::DomainViolation, path);
+        return false;
+    }
+
+    // Neither core::PixelAspectRatio nor FrameRate has a default constructor (both are built only
+    // through their checked static factories), so these locals are seeded with a valid factory
+    // value and then overwritten by the decode below.
+    core::PixelAspectRatio pixelAspect = core::PixelAspectRatio::square();
+    if (!decodePixelAspect(*members[2], state, joinPath(path, "pixelAspect"), pixelAspect)) {
+        return false;
+    }
+    FrameRate frameRate = FrameRate::framesPerSecond24();
+    if (!decodeFrameRate(*members[3], state, joinPath(path, "frameRate"), frameRate)) {
+        return false;
+    }
+
+    const auto created = CompositionFormat::create(width, height, pixelAspect, frameRate);
+    if (!created.has_value()) {
+        // Unreachable given the width/height/product pre-checks above mirror
+        // CompositionFormat::isValidExtent exactly; kept as a defensive typed failure.
+        state.fail(DocumentDecodeError::DomainViolation, path);
+        return false;
+    }
+    out = *created;
+    return true;
+}
+
+[[nodiscard]] bool decodeComposition(const JsonValue& node, DecodeState& state,
+                                     const std::string& path, DecodedComposition& out) {
+    static constexpr std::array<std::string_view, 4> kKeys{"id", "name", "duration", "format"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, false, state, path, members)) {
+        return false;
+    }
+
+    const auto idPath = joinPath(path, "id");
+    std::string_view idText;
+    if (!decodeStringMember(*members[0], state, idPath, idText)) {
+        return false;
+    }
+    const auto idParsed = parseCanonicalObjectId(idText);
+    if (!idParsed) {
+        state.fail(DocumentDecodeError::InvalidId, idPath);
+        return false;
+    }
+    out.id = CompositionId::fromRaw(*idParsed.value());
+
+    std::string_view nameText;
+    if (!decodeStringMember(*members[1], state, joinPath(path, "name"), nameText)) {
+        return false;
+    }
+    out.name = std::string(nameText);
+
+    if (!decodeDuration(*members[2], state, joinPath(path, "duration"), out.duration)) {
+        return false;
+    }
+    return decodeFormat(*members[3], state, joinPath(path, "format"), out.format);
+}
+
+[[nodiscard]] bool decodeLocator(const JsonValue& node, DecodeState& state, const std::string& path,
+                                 OcioConfigLocator& out) {
+    if (node.kind() != JsonValueKind::Object) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto members = node.objectMembers();
+    const auto kindPath = joinPath(path, "kind");
+    if (members.empty()) {
+        state.fail(DocumentDecodeError::MissingMember, kindPath);
+        return false;
+    }
+    if (members[0].key() != "kind") {
+        state.fail(DocumentDecodeError::UnknownMember, joinPath(path, members[0].key()));
+        return false;
+    }
+    std::string_view kindText;
+    if (!decodeStringMember(members[0].value(), state, kindPath, kindText)) {
+        return false;
+    }
+
+    std::string_view secondKey;
+    if (kindText == "builtin" || kindText == "external-ocioz" || kindText == "external-config") {
+        secondKey = "uri";
+    } else if (kindText == "project-relative-ocioz") {
+        secondKey = "path";
+    } else {
+        state.fail(DocumentDecodeError::InvalidOcioLocatorKind, kindPath);
+        return false;
+    }
+
+    if (members.size() < 2) {
+        state.fail(DocumentDecodeError::MissingMember, joinPath(path, secondKey));
+        return false;
+    }
+    if (members[1].key() != secondKey) {
+        state.fail(DocumentDecodeError::UnknownMember, joinPath(path, members[1].key()));
+        return false;
+    }
+    if (members.size() > 2) {
+        state.fail(DocumentDecodeError::UnknownMember, joinPath(path, members[2].key()));
+        return false;
+    }
+
+    std::string_view valueText;
+    if (!decodeStringMember(members[1].value(), state, joinPath(path, secondKey), valueText)) {
+        return false;
+    }
+
+    if (kindText == "builtin") {
+        out = document::BuiltInOcioConfigLocator{std::string(valueText)};
+    } else if (kindText == "project-relative-ocioz") {
+        out = document::ProjectRelativeOciozLocator{std::string(valueText)};
+    } else if (kindText == "external-ocioz") {
+        out = document::ExternalOciozLocator{std::string(valueText)};
+    } else {
+        out = document::ExternalOcioConfigLocator{std::string(valueText)};
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeExpectedRevision(const JsonValue& node, DecodeState& state,
+                                          const std::string& path, OcioConfigRevision& out) {
+    static constexpr std::array<std::string_view, 2> kKeys{"algorithm", "digest"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    std::string_view algorithmText;
+    if (!decodeStringMember(*members[0], state, joinPath(path, "algorithm"), algorithmText)) {
+        return false;
+    }
+    out.algorithm =
+        algorithmText == "sha256" ? OcioRevisionAlgorithm::Sha256 : OcioRevisionAlgorithm::Unknown;
+
+    const auto digestPath = joinPath(path, "digest");
+    std::string_view digestText;
+    if (!decodeStringMember(*members[1], state, digestPath, digestText)) {
+        return false;
+    }
+    const auto digest = core::Sha256Digest::fromLowercaseHex(digestText);
+    if (!digest.has_value()) {
+        state.fail(DocumentDecodeError::InvalidDigestSpelling, digestPath);
+        return false;
+    }
+    out.digest = *digest;
+    return true;
+}
+
+[[nodiscard]] bool decodeContextVariables(const JsonValue& node, DecodeState& state,
+                                          const std::string& path,
+                                          std::vector<OcioContextVariable>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    static constexpr std::array<std::string_view, 2> kKeys{"name", "value"};
+    out.clear();
+    const auto elements = node.arrayElements();
+    out.reserve(elements.size());
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        const auto elementPath = joinPathIndex(path, index);
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(elements[index], kKeys, true, state, elementPath, members)) {
+            return false;
+        }
+        std::string_view nameText;
+        if (!decodeStringMember(*members[0], state, joinPath(elementPath, "name"), nameText)) {
+            return false;
+        }
+        std::string_view valueText;
+        if (!decodeStringMember(*members[1], state, joinPath(elementPath, "value"), valueText)) {
+            return false;
+        }
+        out.push_back({std::string(nameText), std::string(valueText)});
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeOcioConfig(const JsonValue& node, DecodeState& state,
+                                    const std::string& path, OcioConfigReference& out) {
+    static constexpr std::array<std::string_view, 5> kKeys{
+        "schemaVersion", "locator", "expectedRevision", "portability", "contextVariables"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    if (!decodeSchemaVersionField(*members[0], state, joinPath(path, "schemaVersion"),
+                                  out.schemaVersion)) {
+        return false;
+    }
+    if (!decodeLocator(*members[1], state, joinPath(path, "locator"), out.locator)) {
+        return false;
+    }
+    if (!decodeExpectedRevision(*members[2], state, joinPath(path, "expectedRevision"),
+                                out.expectedRevision)) {
+        return false;
+    }
+
+    const auto portabilityPath = joinPath(path, "portability");
+    std::string_view portabilityText;
+    if (!decodeStringMember(*members[3], state, portabilityPath, portabilityText)) {
+        return false;
+    }
+    if (portabilityText == "builtin") {
+        out.portability = OcioConfigPortability::BuiltIn;
+    } else if (portabilityText == "project-relative") {
+        out.portability = OcioConfigPortability::ProjectRelative;
+    } else if (portabilityText == "external") {
+        out.portability = OcioConfigPortability::External;
+    } else {
+        out.portability = OcioConfigPortability::Unknown;
+    }
+
+    return decodeContextVariables(*members[4], state, joinPath(path, "contextVariables"),
+                                  out.contextVariables);
+}
+
+[[nodiscard]] bool decodeColorSettings(const JsonValue& node, DecodeState& state,
+                                       const std::string& path, ColorSettings& out) {
+    static constexpr std::array<std::string_view, 3> kKeys{"schemaVersion", "processColorSpaceId",
+                                                           "ocioConfig"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    if (!decodeSchemaVersionField(*members[0], state, joinPath(path, "schemaVersion"),
+                                  out.schemaVersion)) {
+        return false;
+    }
+
+    std::string_view processColorSpaceIdText;
+    if (!decodeStringMember(*members[1], state, joinPath(path, "processColorSpaceId"),
+                            processColorSpaceIdText)) {
+        return false;
+    }
+    out.processColorSpaceId = std::string(processColorSpaceIdText);
+
+    if (!decodeOcioConfig(*members[2], state, joinPath(path, "ocioConfig"), out.ocioConfig)) {
+        return false;
+    }
+
+    const auto validation = out.validate();
+    if (!validation.ok()) {
+        const auto& issue = validation.issues().front();
+        state.fail(DocumentDecodeError::DomainViolation,
+                   joinPath(path, translateValidationPath(issue.path)));
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeProject(const JsonValue& node, DecodeState& state, const std::string& path,
+                                 DecodedDocumentEnvelope& out) {
+    static constexpr std::array<std::string_view, 4> kKeys{"id", "name", "colorSettings",
+                                                           "compositions"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    const auto idPath = joinPath(path, "id");
+    std::string_view idText;
+    if (!decodeStringMember(*members[0], state, idPath, idText)) {
+        return false;
+    }
+    const auto idParsed = parseCanonicalObjectId(idText);
+    if (!idParsed) {
+        state.fail(DocumentDecodeError::InvalidId, idPath);
+        return false;
+    }
+    out.projectId = ProjectId::fromRaw(*idParsed.value());
+
+    std::string_view nameText;
+    if (!decodeStringMember(*members[1], state, joinPath(path, "name"), nameText)) {
+        return false;
+    }
+    out.projectName = std::string(nameText);
+
+    if (!decodeColorSettings(*members[2], state, joinPath(path, "colorSettings"),
+                             out.colorSettings)) {
+        return false;
+    }
+
+    const auto compositionsPath = joinPath(path, "compositions");
+    if (members[3]->kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, compositionsPath);
+        return false;
+    }
+    const auto elements = members[3]->arrayElements();
+    out.compositions.clear();
+    out.compositions.reserve(elements.size());
+    std::uint64_t previousId = 0;
+    bool hasPrevious = false;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        DecodedComposition composition;
+        if (!decodeComposition(elements[index], state, joinPathIndex(compositionsPath, index),
+                               composition)) {
+            return false;
+        }
+        const auto currentId = composition.id.value();
+        if (hasPrevious) {
+            if (currentId == previousId) {
+                state.fail(DocumentDecodeError::DuplicateComposition,
+                           joinPath(joinPathIndex(compositionsPath, index), "id"));
+                return false;
+            }
+            if (currentId < previousId) {
+                state.fail(DocumentDecodeError::UnsortedCompositions,
+                           joinPath(joinPathIndex(compositionsPath, index), "id"));
+                return false;
+            }
+        }
+        previousId = currentId;
+        hasPrevious = true;
+        out.compositions.push_back(std::move(composition));
+    }
+    return true;
+}
+
+} // namespace
+
+DocumentDecodePathText DocumentDecodePathText::from(const std::string_view text) noexcept {
+    DocumentDecodePathText result;
+    const auto copySize = std::min(text.size(), result.chars_.size());
+    for (std::size_t index = 0; index < copySize; ++index) {
+        result.chars_[index] = text[index];
+    }
+    result.size_ = static_cast<std::uint16_t>(copySize);
+    result.truncated_ = text.size() > copySize;
+    return result;
+}
+
+DocumentDecodeResult DocumentDecodeResult::success(DecodedDocumentEnvelope envelope) {
+    DocumentDecodeResult result;
+    result.envelope_ = std::move(envelope);
+    result.error_ = DocumentDecodeError::None;
+    return result;
+}
+
+DocumentDecodeResult DocumentDecodeResult::failure(const DocumentDecodeError error,
+                                                   const std::string_view path) {
+    DocumentDecodeResult result;
+    result.error_ = error;
+    result.path_ = DocumentDecodePathText::from(path);
+    return result;
+}
+
+DocumentDecodeResult decodeDocumentEnvelope(const JsonValue& root) {
+    static constexpr std::array<std::string_view, 4> kKeys{"schemaVersion", "project",
+                                                           "idAllocation", "extensions"};
+    DecodeState state;
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(root, kKeys, true, state, std::string{}, members)) {
+        return DocumentDecodeResult::failure(state.error, state.path);
+    }
+
+    document::SchemaVersion schemaVersion;
+    if (!decodeSchemaVersionField(*members[0], state, "/schemaVersion", schemaVersion)) {
+        return DocumentDecodeResult::failure(state.error, state.path);
+    }
+    if (schemaVersion != kCanonicalDocumentSchemaVersionV1) {
+        return DocumentDecodeResult::failure(DocumentDecodeError::DomainViolation,
+                                             "/schemaVersion");
+    }
+
+    DecodedDocumentEnvelope envelope;
+    if (!decodeProject(*members[1], state, "/project", envelope)) {
+        return DocumentDecodeResult::failure(state.error, state.path);
+    }
+
+    if (members[2]->kind() != JsonValueKind::Object) {
+        return DocumentDecodeResult::failure(DocumentDecodeError::WrongValueKind, "/idAllocation");
+    }
+    if (members[3]->kind() != JsonValueKind::Array) {
+        return DocumentDecodeResult::failure(DocumentDecodeError::WrongValueKind, "/extensions");
+    }
+
+    return DocumentDecodeResult::success(std::move(envelope));
+}
+
+} // namespace bloom::project

--- a/src/project/include/bloom/project/document_decode.hpp
+++ b/src/project/include/bloom/project/document_decode.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/composition_settings.hpp>
+#include <bloom/document/ids.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Typed decode of the document.json envelope from a parsed strict JSON DOM (see
+// docs/architecture/project-format.md, "Canonical Document Shape", "Project And Composition", and
+// "Project Color Settings And OCIO Reference"). This is the schema-specific validation layer the
+// format contract requires: a generic JSON Schema validator can check structure and lexical
+// bounds, but only typed decode establishes canonical acceptance (exact member order, canonical
+// decimal/rational spellings, frozen v1 value domains, and cross-field agreement such as
+// portability/locator family).
+//
+// Scope (R1): the document envelope and its non-graph durable values only -- schemaVersion,
+// project id/name/colorSettings, and per-composition id/name/duration/format. Parameters,
+// animation curves, the canonical graph, idAllocation content, and extension records are not
+// decoded here; composition objects are matched only on their required id/name/duration/format
+// prefix so a real writer-produced document (which always continues with parameters,
+// animationCurves, graph) still decodes. idAllocation and extensions are checked only for
+// presence, position, and JSON kind. This module deliberately does not construct
+// bloom::document::Project or bloom::document::Document: reassembling the live model and
+// restoring the id allocator from idAllocation.highestIssued is a later slice. The unknown-member
+// round-trip overlay is also a later slice, so an unrecognized root member is a typed decode
+// error rather than being preserved.
+//
+// Decoding constructs every typed value through its existing checked surface: canonical_decimal.hpp
+// parsers for decimal-string ids/rationals and canonical JSON-number uint32 fields,
+// core::RationalTime::create (via parseCanonicalRationalTime), core::PixelAspectRatio::create (via
+// parseCanonicalPositiveRatio/parseCanonicalPixelAspectRatio), bloom::document::FrameRate::create,
+// bloom::document::CompositionFormat::create, bloom::core::Sha256Digest::fromLowercaseHex, and
+// bloom::document::ColorSettings::validate()/OcioConfigReference::validate() for the OCIO
+// locator-family, portability-agreement, process-color-space, and context-variable domain rules.
+// No value is bypassed by hand-rolling a duplicate domain check where a checked surface already
+// exists.
+//
+// decodeDocumentEnvelope() is not noexcept: its intermediate std::string/std::vector-backed
+// results can throw std::bad_alloc on allocation failure. Marking it noexcept while it allocates
+// through a throwing surface would be an untruthful noexcept claim; callers that need a
+// termination-free boundary should wrap the call themselves.
+
+namespace bloom::project {
+
+// One decoded composition's non-graph durable values.
+struct DecodedComposition final {
+    document::CompositionId id;
+    std::string name;
+    core::RationalTime duration;
+    document::CompositionFormat format;
+
+    friend bool operator==(const DecodedComposition&, const DecodedComposition&) = default;
+};
+
+// The decoded document.json envelope's non-graph durable values. Deliberately not a
+// bloom::document::Project: reconstructing the live model (graph, parameters, animation curves,
+// extension records) and restoring the id allocator are out of scope for this package.
+struct DecodedDocumentEnvelope final {
+    document::ProjectId projectId;
+    std::string projectName;
+    document::ColorSettings colorSettings;
+    std::vector<DecodedComposition> compositions;
+
+    friend bool operator==(const DecodedDocumentEnvelope&,
+                           const DecodedDocumentEnvelope&) = default;
+};
+
+enum class DocumentDecodeError : std::uint8_t {
+    None,
+    // A member's JSON value kind did not match the schema (e.g. a number where a string was
+    // required, or an object where an array was required).
+    WrongValueKind,
+    // A required member was absent from an otherwise well-formed object.
+    MissingMember,
+    // An object member's key is not a member this schema/position recognizes.
+    UnknownMember,
+    // An object member's key is known to this schema but appeared in the wrong position; exact
+    // member order is part of canonical acceptance.
+    MemberOutOfOrder,
+    // A typed 64-bit object id's decimal-string spelling is non-canonical (leading zero, a `+`
+    // sign, non-digit characters, out of uint64 range) or is the invalid zero value.
+    InvalidId,
+    // A JSON-number uint32 field's token is not a canonical non-negative integer spelling
+    // (fraction, exponent, leading zero, or a `+`/`-` sign).
+    InvalidJsonUInt32,
+    // A rational component's decimal-string spelling is non-canonical or does not fit its
+    // declared signed/unsigned range.
+    InvalidRationalComponent,
+    // A rational pair's terms are not already reduced (gcd != 1).
+    UnreducedRational,
+    // A composition duration parsed successfully but is zero or negative.
+    NonPositiveDuration,
+    // An OCIO content-revision digest is not exactly 64 lowercase hexadecimal ASCII characters.
+    InvalidDigestSpelling,
+    // An OCIO locator's `kind` discriminator is not one of the four known v1 locator families.
+    InvalidOcioLocatorKind,
+    // Compositions are not sorted by strictly ascending numeric CompositionId.
+    UnsortedCompositions,
+    // Two compositions declare the same numeric CompositionId.
+    DuplicateComposition,
+    // A value is lexically well-formed but violates a frozen v1 domain or cross-field rule:
+    // schemaVersion != 1.0, composition width/height out of 1..1048576 or zero, checked pixel
+    // product > 2^32, processColorSpaceId != "lin_rec709_scene", a built-in OCIO URI other than
+    // the exact immutable identity, a malformed project-relative or external OCIO locator,
+    // portability disagreeing with the locator family, an OCIO revision algorithm other than
+    // "sha256", or an OCIO context variable with an invalid name/value or an unsorted/duplicate
+    // name. These are reported through bloom::document::ColorSettings::validate() and
+    // OcioConfigReference::validate() rather than being re-implemented here.
+    DomainViolation,
+};
+
+// A bounded diagnostic path to one JSON member, formatted as `/key/0/key`, mirroring
+// StrictJsonDomPathText's shape and truncation contract.
+class DocumentDecodePathText final {
+  public:
+    constexpr DocumentDecodePathText() noexcept = default;
+
+    [[nodiscard]] static DocumentDecodePathText from(std::string_view text) noexcept;
+
+    [[nodiscard]] std::string_view view() const& noexcept { return {chars_.data(), size_}; }
+    [[nodiscard]] std::string_view view() const&& = delete;
+    [[nodiscard]] bool truncated() const noexcept { return truncated_; }
+
+  private:
+    std::array<char, 512> chars_{};
+    std::uint16_t size_ = 0;
+    bool truncated_ = false;
+};
+
+// [[nodiscard]] failure-aware result. On success, value() names the decoded envelope; on
+// failure, error() names the typed cause and path() names the exact offending member.
+class [[nodiscard]] DocumentDecodeResult final {
+  public:
+    [[nodiscard]] static DocumentDecodeResult success(DecodedDocumentEnvelope envelope);
+    [[nodiscard]] static DocumentDecodeResult failure(DocumentDecodeError error,
+                                                      std::string_view path);
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error_ == DocumentDecodeError::None;
+    }
+    [[nodiscard]] DocumentDecodeError error() const noexcept { return error_; }
+    [[nodiscard]] std::string_view path() const noexcept { return path_.view(); }
+    [[nodiscard]] bool pathTruncated() const noexcept { return path_.truncated(); }
+    [[nodiscard]] const DecodedDocumentEnvelope* value() const& noexcept {
+        return envelope_.has_value() ? &*envelope_ : nullptr;
+    }
+    [[nodiscard]] const DecodedDocumentEnvelope* value() const&& = delete;
+
+  private:
+    DocumentDecodeResult() = default;
+
+    std::optional<DecodedDocumentEnvelope> envelope_;
+    DocumentDecodeError error_ = DocumentDecodeError::None;
+    DocumentDecodePathText path_;
+};
+
+// Decodes `root` (the document.json root value from a parsed StrictJsonDomDocument) into a
+// DecodedDocumentEnvelope. `root` must outlive the call; nothing is retained past return. See the
+// file-level comment above for exact scope. May throw std::bad_alloc; never throws otherwise.
+[[nodiscard]] DocumentDecodeResult decodeDocumentEnvelope(const JsonValue& root);
+
+} // namespace bloom::project

--- a/src/project/tests/document_decode_tests.cpp
+++ b/src/project/tests/document_decode_tests.cpp
@@ -1,0 +1,672 @@
+#include <bloom/project/document_decode.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <numeric>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using bloom::project::DecodedDocumentEnvelope;
+using bloom::project::DocumentDecodeError;
+using bloom::project::DocumentDecodeResult;
+using bloom::project::JsonValue;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::StrictJsonDomResult;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 8ULL << 20U; // 8 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = bloom::project::ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+// ---------------------------------------------------------------------------------------------
+// Minimal hand-assembled document.json fixtures. parseStrictJsonDom accepts any insignificant
+// whitespace and member order (canonical layout is only a writer requirement), so these compact,
+// non-canonically-ordered literals are valid input; document_decode.cpp's own order checks are
+// exercised deliberately by the "wrong member order" fixtures below. Composition objects below
+// carry only id/name/duration/format: the decoder matches composition members as a prefix (see
+// document_decode.hpp's scope comment), so parameters/animationCurves/graph need not be present.
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::string_view kSchemaVersion10 = R"({"major":1,"minor":0})";
+constexpr std::string_view kValidDigest =
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+[[nodiscard]] std::string colorSettingsJson(const std::string_view digest,
+                                            const std::string_view portability,
+                                            const std::string_view contextVariablesJson) {
+    std::string result =
+        R"({"schemaVersion":{"major":1,"minor":0},"processColorSpaceId":"lin_rec709_scene",)"
+        R"("ocioConfig":{"schemaVersion":{"major":1,"minor":0},)"
+        R"("locator":{"kind":"builtin","uri":"bloom://ocio/neutral-v1/config.ocio"},)"
+        R"("expectedRevision":{"algorithm":"sha256","digest":")";
+    result += digest;
+    result += R"("},"portability":")";
+    result += portability;
+    result += R"(","contextVariables":[)";
+    result += contextVariablesJson;
+    result += "]}}";
+    return result;
+}
+
+[[nodiscard]] std::string defaultColorSettingsJson() {
+    return colorSettingsJson(kValidDigest, "builtin", "");
+}
+
+[[nodiscard]] std::string compositionJson(
+    const std::string_view idJson, const std::string_view name,
+    const std::string_view durationNumerator, const std::string_view durationDenominator,
+    const std::string_view widthJson, const std::string_view heightJson,
+    const std::string_view pixelAspectNumerator, const std::string_view pixelAspectDenominator,
+    const std::string_view frameRateNumerator, const std::string_view frameRateDenominator) {
+    std::string result = "{\"id\":";
+    result += idJson;
+    result += ",\"name\":\"";
+    result += name;
+    result += "\",\"duration\":{\"numerator\":\"";
+    result += durationNumerator;
+    result += "\",\"denominator\":\"";
+    result += durationDenominator;
+    result += "\"},\"format\":{\"width\":";
+    result += widthJson;
+    result += ",\"height\":";
+    result += heightJson;
+    result += ",\"pixelAspect\":{\"numerator\":\"";
+    result += pixelAspectNumerator;
+    result += "\",\"denominator\":\"";
+    result += pixelAspectDenominator;
+    result += "\"},\"frameRate\":{\"numerator\":\"";
+    result += frameRateNumerator;
+    result += "\",\"denominator\":\"";
+    result += frameRateDenominator;
+    result += "\"}}}";
+    return result;
+}
+
+[[nodiscard]] std::string defaultCompositionJson(const std::string_view idJson = R"("1")") {
+    return compositionJson(idJson, "Comp", "10", "1", "1920", "1080", "1", "1", "24", "1");
+}
+
+[[nodiscard]] std::string documentJson(const std::string_view schemaVersionJson,
+                                       const std::string_view projectIdJson,
+                                       const std::string_view projectNameJson,
+                                       const std::string_view colorSettingsJsonText,
+                                       const std::string_view compositionsArrayBody) {
+    std::string result = "{\"schemaVersion\":";
+    result += schemaVersionJson;
+    result += ",\"project\":{\"id\":";
+    result += projectIdJson;
+    result += ",\"name\":";
+    result += projectNameJson;
+    result += ",\"colorSettings\":";
+    result += colorSettingsJsonText;
+    result += ",\"compositions\":[";
+    result += compositionsArrayBody;
+    result += "]},\"idAllocation\":{},\"extensions\":[]}";
+    return result;
+}
+
+[[nodiscard]] std::string baselineDocument() {
+    return documentJson(kSchemaVersion10, R"("1")", R"("Untitled")", defaultColorSettingsJson(),
+                        defaultCompositionJson());
+}
+
+[[nodiscard]] std::string documentWithComposition(const std::string_view compositionJsonText) {
+    return documentJson(kSchemaVersion10, R"("1")", R"("Untitled")", defaultColorSettingsJson(),
+                        compositionJsonText);
+}
+
+[[nodiscard]] std::string documentWithColorSettings(const std::string_view colorSettingsJsonText) {
+    return documentJson(kSchemaVersion10, R"("1")", R"("Untitled")", colorSettingsJsonText,
+                        defaultCompositionJson());
+}
+
+// ---------------------------------------------------------------------------------------------
+// Decode helpers
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] DocumentDecodeResult decodeText(const std::string& text) {
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(text), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    if (!parsed) {
+        // Every fixture below is constructed to be syntactically valid strict JSON; a parse
+        // failure means the fixture itself is broken, not the decoder under test. Fail loudly
+        // rather than reporting a misleading decode mismatch.
+        std::cerr << "fixture failed to parse as strict JSON (error="
+                  << static_cast<int>(parsed.error()) << ")\n";
+        std::abort();
+    }
+    return bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+}
+
+void expectDecodeFailure(Expectations& expectations, const std::string& text,
+                         const DocumentDecodeError expectedError,
+                         const std::string_view expectedPath, const std::string_view message) {
+    const auto decoded = decodeText(text);
+    expectations.expect(
+        !decoded && decoded.error() == expectedError && decoded.path() == expectedPath, message);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Success path sanity and full round trip
+// ---------------------------------------------------------------------------------------------
+
+void testBaselineDecodesSuccessfully(Expectations& expectations) {
+    const auto decoded = decodeText(baselineDocument());
+    expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr,
+                        "the hand-assembled baseline fixture decodes without error");
+    if (decoded.value() != nullptr) {
+        const auto& envelope = *decoded.value();
+        expectations.expect(envelope.projectId.value() == 1,
+                            "the baseline project id decodes to 1");
+        expectations.expect(envelope.projectName == "Untitled",
+                            "the baseline project name decodes exactly");
+        expectations.expect(envelope.compositions.size() == 1,
+                            "the baseline fixture decodes exactly one composition");
+    }
+}
+
+void testFullRoundTrip(Expectations& expectations) {
+    using bloom::core::RationalTime;
+    using bloom::document::Document;
+
+    const auto duration = RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    std::array<std::uint8_t, 32> digestBytes{};
+    std::iota(digestBytes.begin(), digestBytes.end(), std::uint8_t{0});
+    const auto settings = bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(digestBytes));
+
+    std::array<char, 256> payloadScratch{};
+    std::array<std::size_t, 256> sortScratch{};
+    const bloom::project::CanonicalDocumentV1 request{
+        .snapshot = &snapshot,
+        .colorSettings = &settings,
+        .payloadScratch = payloadScratch,
+        .sortScratch = sortScratch,
+    };
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    if (!size.hasValue()) {
+        expectations.expect(false, "the round-trip snapshot sizes successfully");
+        return;
+    }
+    std::vector<char> output(*size.value());
+    const auto written = bloom::project::encodeCanonicalDocument(request, output);
+    if (!written) {
+        expectations.expect(false, "the round-trip snapshot encodes successfully");
+        return;
+    }
+
+    const std::string_view encodedText(output.data(), output.size());
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(encodedText), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    expectations.expect(static_cast<bool>(parsed),
+                        "the canonical writer's own bytes parse as strict JSON");
+    if (!parsed) {
+        return;
+    }
+
+    const auto decoded = bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+    expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr,
+                        "the canonical writer's own bytes decode without error");
+    if (decoded.value() == nullptr) {
+        return;
+    }
+
+    const auto& envelope = *decoded.value();
+    const auto& sourceProject = snapshot.project();
+    expectations.expect(envelope.projectId == sourceProject.id(),
+                        "round trip: decoded project id equals the source project id");
+    expectations.expect(envelope.projectName == sourceProject.name(),
+                        "round trip: decoded project name equals the source project name");
+    expectations.expect(envelope.colorSettings == settings,
+                        "round trip: decoded color settings equal the source color settings");
+    expectations.expect(
+        envelope.compositions.size() == sourceProject.compositions().size(),
+        "round trip: decoded composition count equals the source composition count");
+    if (envelope.compositions.size() == sourceProject.compositions().size()) {
+        for (std::size_t index = 0; index < envelope.compositions.size(); ++index) {
+            const auto& decodedComposition = envelope.compositions[index];
+            const auto& sourceComposition = sourceProject.compositions()[index];
+            expectations.expect(
+                decodedComposition.id == sourceComposition.id(),
+                "round trip: decoded composition id equals the source composition id");
+            expectations.expect(
+                decodedComposition.name == sourceComposition.name(),
+                "round trip: decoded composition name equals the source composition name");
+            expectations.expect(
+                decodedComposition.duration == sourceComposition.duration(),
+                "round trip: decoded composition duration equals the source duration");
+            expectations.expect(decodedComposition.format == sourceComposition.format(),
+                                "round trip: decoded composition format equals the source format");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Structural rejection: exact member order and unknown members
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsRootMemberOrder(Expectations& expectations) {
+    const std::string project =
+        std::string("{\"id\":\"1\",\"name\":\"Untitled\",\"colorSettings\":") +
+        defaultColorSettingsJson() + ",\"compositions\":[" + defaultCompositionJson() + "]}";
+    const std::string json = std::string("{\"schemaVersion\":") + std::string(kSchemaVersion10) +
+                             ",\"idAllocation\":{},\"project\":" + project + ",\"extensions\":[]}";
+    expectDecodeFailure(
+        expectations, json, DocumentDecodeError::MemberOutOfOrder, "/idAllocation",
+        "a root object with idAllocation before project reports member-out-of-order "
+        "at the exact offending key");
+}
+
+void testRejectsRootUnknownMember(Expectations& expectations) {
+    const std::string json =
+        baselineDocument().substr(0, baselineDocument().size() - 1) + ",\"bogus\":null}";
+    expectDecodeFailure(expectations, json, DocumentDecodeError::UnknownMember, "/bogus",
+                        "an unrecognized trailing root member is rejected with its exact path");
+}
+
+void testRejectsProjectMemberOrder(Expectations& expectations) {
+    const std::string project =
+        std::string("{\"name\":\"Untitled\",\"id\":\"1\",\"colorSettings\":") +
+        defaultColorSettingsJson() + ",\"compositions\":[" + defaultCompositionJson() + "]}";
+    const std::string json = std::string("{\"schemaVersion\":") + std::string(kSchemaVersion10) +
+                             ",\"project\":" + project + ",\"idAllocation\":{},\"extensions\":[]}";
+    expectDecodeFailure(expectations, json, DocumentDecodeError::MemberOutOfOrder, "/project/name",
+                        "a project object with name before id reports member-out-of-order at the "
+                        "exact offending key");
+}
+
+void testRejectsCompositionMemberOrder(Expectations& expectations) {
+    const std::string composition =
+        R"({"name":"Comp","id":"1","duration":{"numerator":"10","denominator":"1"},)"
+        R"("format":{"width":1920,"height":1080,"pixelAspect":{"numerator":"1","denominator":"1"},)"
+        R"("frameRate":{"numerator":"24","denominator":"1"}}})";
+    expectDecodeFailure(
+        expectations, documentWithComposition(composition), DocumentDecodeError::MemberOutOfOrder,
+        "/project/compositions/0/name",
+        "a composition object with name before id reports member-out-of-order at the "
+        "exact offending key");
+}
+
+void testRejectsFormatMemberOrder(Expectations& expectations) {
+    const std::string composition =
+        R"({"id":"1","name":"Comp","duration":{"numerator":"10","denominator":"1"},)"
+        R"("format":{"height":1080,"width":1920,"pixelAspect":{"numerator":"1","denominator":"1"},)"
+        R"("frameRate":{"numerator":"24","denominator":"1"}}})";
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::MemberOutOfOrder,
+                        "/project/compositions/0/format/height",
+                        "a format object with height before width reports member-out-of-order at "
+                        "the exact offending key");
+}
+
+void testRejectsCompositionMissingFormat(Expectations& expectations) {
+    const std::string composition =
+        R"({"id":"1","name":"Comp","duration":{"numerator":"10","denominator":"1"}})";
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::MissingMember, "/project/compositions/0/format",
+                        "a composition missing its format member reports the exact missing path");
+}
+
+void testRejectsProjectIdWrongKind(Expectations& expectations) {
+    const std::string json = documentJson(kSchemaVersion10, "1", R"("Untitled")",
+                                          defaultColorSettingsJson(), defaultCompositionJson());
+    expectDecodeFailure(expectations, json, DocumentDecodeError::WrongValueKind, "/project/id",
+                        "a project id encoded as a JSON number instead of a string is rejected");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Schema version
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsSchemaVersionMinor11(Expectations& expectations) {
+    const std::string json = documentJson(R"({"major":1,"minor":1})", R"("1")", R"("Untitled")",
+                                          defaultColorSettingsJson(), defaultCompositionJson());
+    expectDecodeFailure(expectations, json, DocumentDecodeError::DomainViolation, "/schemaVersion",
+                        "document schemaVersion 1.1 is rejected as not exactly 1.0");
+}
+
+void testRejectsSchemaVersionMajor2(Expectations& expectations) {
+    const std::string json = documentJson(R"({"major":2,"minor":0})", R"("1")", R"("Untitled")",
+                                          defaultColorSettingsJson(), defaultCompositionJson());
+    expectDecodeFailure(expectations, json, DocumentDecodeError::DomainViolation, "/schemaVersion",
+                        "document schemaVersion 2.0 is rejected as not exactly 1.0");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Object id canonical spelling
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsProjectIdSpellings(Expectations& expectations) {
+    for (const auto& [spelling, label] :
+         {std::pair<std::string_view, std::string_view>{"0", "zero"},
+          std::pair<std::string_view, std::string_view>{"01", "leading-zero"},
+          std::pair<std::string_view, std::string_view>{"+1", "leading-plus"}}) {
+        const std::string idJson = std::string("\"") + std::string(spelling) + "\"";
+        const std::string json = documentJson(kSchemaVersion10, idJson, R"("Untitled")",
+                                              defaultColorSettingsJson(), defaultCompositionJson());
+        expectDecodeFailure(expectations, json, DocumentDecodeError::InvalidId, "/project/id",
+                            std::string("a project id spelled '") + std::string(spelling) + "' (" +
+                                std::string(label) + ") is rejected as non-canonical");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Duration
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnreducedDuration(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "20", "2", "1920", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::UnreducedRational, "/project/compositions/0/duration",
+                        "an unreduced duration 20/2 is rejected");
+}
+
+void testRejectsZeroDuration(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "0", "1", "1920", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::NonPositiveDuration,
+                        "/project/compositions/0/duration",
+                        "a zero duration is rejected as non-positive");
+}
+
+void testRejectsNegativeDuration(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "-5", "1", "1920", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::NonPositiveDuration,
+                        "/project/compositions/0/duration",
+                        "a negative duration is rejected as non-positive");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Pixel aspect
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnreducedPixelAspect(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "1920", "1080", "2", "2", "24", "1");
+    expectDecodeFailure(
+        expectations, documentWithComposition(composition), DocumentDecodeError::UnreducedRational,
+        "/project/compositions/0/format/pixelAspect", "an unreduced pixel aspect 2/2 is rejected");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Composition format domain: width/height/pixel product
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsZeroWidth(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "0", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::DomainViolation,
+                        "/project/compositions/0/format/width", "a zero width is rejected");
+}
+
+void testRejectsWidthOverCeiling(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "1048577", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::DomainViolation,
+                        "/project/compositions/0/format/width",
+                        "a width above the frozen 1048576 ceiling is rejected");
+}
+
+void testRejectsZeroHeight(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "1920", "0", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::DomainViolation,
+                        "/project/compositions/0/format/height", "a zero height is rejected");
+}
+
+void testRejectsHeightOverCeiling(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "1920", "1048577", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::DomainViolation,
+                        "/project/compositions/0/format/height",
+                        "a height above the frozen 1048576 ceiling is rejected");
+}
+
+void testRejectsPixelProductOverCeiling(Expectations& expectations) {
+    // Both terms individually satisfy 1..1048576, but 65536 * 65537 = 4295032832 > 2^32.
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "65536", "65537", "1", "1", "24", "1");
+    expectDecodeFailure(
+        expectations, documentWithComposition(composition), DocumentDecodeError::DomainViolation,
+        "/project/compositions/0/format",
+        "a checked pixel product over 2^32 is rejected even though width and height "
+        "each satisfy the per-dimension ceiling");
+}
+
+// ---------------------------------------------------------------------------------------------
+// JSON-number uint32 spelling
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsWidthFractionSpelling(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "1920.0", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::InvalidJsonUInt32,
+                        "/project/compositions/0/format/width",
+                        "a width spelled with a fraction (1920.0) is rejected as non-canonical");
+}
+
+void testRejectsWidthExponentSpelling(Expectations& expectations) {
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "192e1", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::InvalidJsonUInt32,
+                        "/project/compositions/0/format/width",
+                        "a width spelled with an exponent (192e1) is rejected as non-canonical");
+}
+
+void testRejectsWidthNegativeZeroSpelling(Expectations& expectations) {
+    // "-0" is valid RFC 8259 JSON number syntax (unlike a genuine multi-digit leading zero such as
+    // "01920", which the mandatory strict JSON preflight layer rejects before typed decode ever
+    // sees it -- see strict_json_preflight_tests.cpp's InvalidNumber{"01", ...} case). Negative
+    // zero is the reachable member of the same non-canonical-sign spelling family the contract
+    // calls out explicitly: "JSON negative zero is invalid for an integer field."
+    const auto composition =
+        compositionJson(R"("1")", "Comp", "10", "1", "-0", "1080", "1", "1", "24", "1");
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::InvalidJsonUInt32,
+                        "/project/compositions/0/format/width",
+                        "a width spelled as negative zero (-0) is rejected as non-canonical");
+}
+
+// ---------------------------------------------------------------------------------------------
+// OCIO digest spelling
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsDigestWrongLength(Expectations& expectations) {
+    const std::string shortDigest(kValidDigest.substr(0, kValidDigest.size() - 1));
+    const std::string colorSettings = colorSettingsJson(shortDigest, "builtin", "");
+    expectDecodeFailure(expectations, documentWithColorSettings(colorSettings),
+                        DocumentDecodeError::InvalidDigestSpelling,
+                        "/project/colorSettings/ocioConfig/expectedRevision/digest",
+                        "a 63-character digest is rejected for its wrong length");
+}
+
+void testRejectsDigestUppercaseHex(Expectations& expectations) {
+    std::string upperDigest(kValidDigest.substr(0, kValidDigest.size() - 2));
+    upperDigest += "1F";
+    const std::string colorSettings = colorSettingsJson(upperDigest, "builtin", "");
+    expectDecodeFailure(expectations, documentWithColorSettings(colorSettings),
+                        DocumentDecodeError::InvalidDigestSpelling,
+                        "/project/colorSettings/ocioConfig/expectedRevision/digest",
+                        "a digest containing an uppercase hex character is rejected");
+}
+
+// ---------------------------------------------------------------------------------------------
+// OCIO portability/locator agreement
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsPortabilityLocatorMismatch(Expectations& expectations) {
+    const std::string colorSettings = colorSettingsJson(kValidDigest, "external", "");
+    expectDecodeFailure(expectations, documentWithColorSettings(colorSettings),
+                        DocumentDecodeError::DomainViolation,
+                        "/project/colorSettings/ocioConfig/portability",
+                        "portability 'external' disagreeing with a builtin locator is rejected");
+}
+
+// ---------------------------------------------------------------------------------------------
+// OCIO context variables
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnsortedContextVariables(Expectations& expectations) {
+    const std::string colorSettings = colorSettingsJson(
+        kValidDigest, "builtin", R"({"name":"b","value":"1"},{"name":"a","value":"2"})");
+    expectDecodeFailure(expectations, documentWithColorSettings(colorSettings),
+                        DocumentDecodeError::DomainViolation,
+                        "/project/colorSettings/ocioConfig/contextVariables/1/name",
+                        "context variables out of UTF-8 name order are rejected");
+}
+
+void testRejectsDuplicateContextVariables(Expectations& expectations) {
+    const std::string colorSettings = colorSettingsJson(
+        kValidDigest, "builtin", R"({"name":"a","value":"1"},{"name":"a","value":"2"})");
+    expectDecodeFailure(expectations, documentWithColorSettings(colorSettings),
+                        DocumentDecodeError::DomainViolation,
+                        "/project/colorSettings/ocioConfig/contextVariables/1/name",
+                        "a duplicate context variable name is rejected");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Compositions collection ordering
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnsortedCompositions(Expectations& expectations) {
+    const std::string compositions =
+        defaultCompositionJson(R"("2")") + "," + defaultCompositionJson(R"("1")");
+    expectDecodeFailure(expectations, documentWithComposition(compositions),
+                        DocumentDecodeError::UnsortedCompositions, "/project/compositions/1/id",
+                        "compositions out of ascending numeric id order are rejected");
+}
+
+void testRejectsDuplicateCompositions(Expectations& expectations) {
+    const std::string compositions =
+        defaultCompositionJson(R"("1")") + "," + defaultCompositionJson(R"("1")");
+    expectDecodeFailure(expectations, documentWithComposition(compositions),
+                        DocumentDecodeError::DuplicateComposition, "/project/compositions/1/id",
+                        "two compositions declaring the same numeric id are rejected");
+}
+
+} // namespace
+
+int main() try {
+    Expectations expectations;
+
+    testBaselineDecodesSuccessfully(expectations);
+    testFullRoundTrip(expectations);
+
+    testRejectsRootMemberOrder(expectations);
+    testRejectsRootUnknownMember(expectations);
+    testRejectsProjectMemberOrder(expectations);
+    testRejectsCompositionMemberOrder(expectations);
+    testRejectsFormatMemberOrder(expectations);
+    testRejectsCompositionMissingFormat(expectations);
+    testRejectsProjectIdWrongKind(expectations);
+
+    testRejectsSchemaVersionMinor11(expectations);
+    testRejectsSchemaVersionMajor2(expectations);
+
+    testRejectsProjectIdSpellings(expectations);
+
+    testRejectsUnreducedDuration(expectations);
+    testRejectsZeroDuration(expectations);
+    testRejectsNegativeDuration(expectations);
+
+    testRejectsUnreducedPixelAspect(expectations);
+
+    testRejectsZeroWidth(expectations);
+    testRejectsWidthOverCeiling(expectations);
+    testRejectsZeroHeight(expectations);
+    testRejectsHeightOverCeiling(expectations);
+    testRejectsPixelProductOverCeiling(expectations);
+
+    testRejectsWidthFractionSpelling(expectations);
+    testRejectsWidthExponentSpelling(expectations);
+    testRejectsWidthNegativeZeroSpelling(expectations);
+
+    testRejectsDigestWrongLength(expectations);
+    testRejectsDigestUppercaseHex(expectations);
+
+    testRejectsPortabilityLocatorMismatch(expectations);
+
+    testRejectsUnsortedContextVariables(expectations);
+    testRejectsDuplicateContextVariables(expectations);
+
+    testRejectsUnsortedCompositions(expectations);
+    testRejectsDuplicateCompositions(expectations);
+
+    if (expectations.failures() != 0) {
+        std::cerr << expectations.failures() << " expectation(s) failed\n";
+        return 1;
+    }
+    return 0;
+} catch (const std::exception& exception) {
+    std::cerr << "Unexpected test exception: " << exception.what() << '\n';
+    return 1;
+} catch (...) {
+    std::cerr << "Unexpected non-standard test exception\n";
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #30. Batch 6 reader work, slice R1: the schema-specific validation layer over the strict JSON DOM.

- `decodeDocumentEnvelope`: exact-order member matching (unknown vs out-of-order distinguished), canonical spellings enforced through the existing decimal parsers, values built only through checked factories, OCIO domain and cross-field rules delegated to `ColorSettings::validate()` with validation paths translated to the module's path convention
- compositions verified strictly sorted by numeric id and duplicate-free; typed errors with exact bounded member paths
- deliberately produces decoded-value structs, not `document::Project` — live-model reconstruction and allocator restore need model-side surfaces and land as a coordinated later slice (documented in the header)
- staging note: composition objects are matched on their required id/name/duration/format prefix; trailing members (parameters/animationCurves/graph) pass unvalidated until R2 decodes them
- honest exception stance: the decoder allocates through throwing surfaces and is documented non-noexcept, per the prior review lesson

## Testing

- Full round trip against the canonical writer's minimal golden document, every decoded value compared to source
- 30 test functions / 42 expectations covering member order at every level, wrong versions, non-canonical spellings (including the contract's negative-zero integer rule, substituted with documented reasoning for the preflight-unreachable leading-zero case), domain violations, digest and locator rules, unsorted/duplicate collections
- Full `ci-linux-native` suite 56/56 and format check green, independently re-verified

Implemented by a Claude Sonnet subagent from the bounded task specification; reviewed in full by the supervising session (validation-delegation coverage verified against `color_settings.cpp`).