### PR TITLE
feat: decode composition interior wire shapes

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(
         canonical_json_writer.cpp
         canonical_manifest.cpp
         document_decode.cpp
+        document_decode_composition.cpp
+        document_decode_internal.hpp
         manifest_requirements.cpp
         project_io_memory.cpp
         project_io_memory_resource.cpp

--- a/src/project/document_decode.cpp
+++ b/src/project/document_decode.cpp
@@ -1,5 +1,7 @@
 #include <bloom/project/document_decode.hpp>
 
+#include "document_decode_internal.hpp"
+
 #include <bloom/core/sha256.hpp>
 #include <bloom/project/canonical_decimal.hpp>
 #include <bloom/project/canonical_document.hpp>
@@ -18,35 +20,24 @@
 namespace bloom::project {
 
 namespace {
+// TU-local only: mapUInt32Error is never called outside detail::decodeUInt32Member's own
+// definition below, so unlike the primitives in document_decode_internal.hpp it keeps internal
+// linkage rather than becoming part of the cross-file decode seam.
+[[nodiscard]] DocumentDecodeError mapUInt32Error(const CanonicalDecimalError error) noexcept {
+    return error == CanonicalDecimalError::InvalidLexicalForm
+               ? DocumentDecodeError::InvalidJsonUInt32
+               : DocumentDecodeError::DomainViolation;
+}
+} // namespace
 
-using document::ColorSettings;
-using document::CompositionFormat;
-using document::CompositionId;
-using document::FrameRate;
-using document::OcioConfigLocator;
-using document::OcioConfigPortability;
-using document::OcioConfigReference;
-using document::OcioConfigRevision;
-using document::OcioContextVariable;
-using document::OcioRevisionAlgorithm;
-using document::ProjectId;
-using document::SchemaVersion;
+// ------------------------------------------------------------------------------------------
+// Shared decode plumbing (declared in document_decode_internal.hpp; also used by
+// document_decode_composition.cpp).
+// ------------------------------------------------------------------------------------------
 
-// Threads a first-failure-wins typed error and its exact member path through the recursive
-// decode walk, mirroring the WalkState/EmitState pattern used by the canonical document writer.
-struct DecodeState final {
-    DocumentDecodeError error = DocumentDecodeError::None;
-    std::string path;
+namespace detail {
 
-    void fail(const DocumentDecodeError newError, std::string newPath) noexcept {
-        if (error == DocumentDecodeError::None) {
-            error = newError;
-            path = std::move(newPath);
-        }
-    }
-};
-
-[[nodiscard]] std::string joinPath(const std::string& base, std::string_view segment) {
+std::string joinPath(const std::string& base, const std::string_view segment) {
     std::string result;
     result.reserve(base.size() + 1 + segment.size());
     result.append(base);
@@ -55,21 +46,18 @@ struct DecodeState final {
     return result;
 }
 
-[[nodiscard]] std::string joinPathIndex(const std::string& base, const std::size_t index) {
+std::string joinPathIndex(const std::string& base, const std::size_t index) {
     return joinPath(base, std::to_string(index));
 }
 
 // Checks that `object` is a JSON object whose leading members exactly match `expectedKeys` in
 // order, filling `outValues` with pointers to each matched member's value. When
 // `rejectExtraMembers` is true the object must contain exactly `expectedKeys.size()` members;
-// otherwise trailing members beyond the matched prefix are accepted without inspection (used for
-// composition, whose parameters/animationCurves/graph members are outside this package's scope
-// but always present in a writer-produced document).
-[[nodiscard]] bool matchOrderedMembers(const JsonValue& object,
-                                       const std::span<const std::string_view> expectedKeys,
-                                       const bool rejectExtraMembers, DecodeState& state,
-                                       const std::string& basePath,
-                                       std::vector<const JsonValue*>& outValues) {
+// otherwise trailing members beyond the matched prefix are accepted without inspection.
+bool matchOrderedMembers(const JsonValue& object,
+                         const std::span<const std::string_view> expectedKeys,
+                         const bool rejectExtraMembers, DecodeState& state,
+                         const std::string& basePath, std::vector<const JsonValue*>& outValues) {
     if (object.kind() != JsonValueKind::Object) {
         state.fail(DocumentDecodeError::WrongValueKind, basePath);
         return false;
@@ -102,19 +90,13 @@ struct DecodeState final {
     return true;
 }
 
-[[nodiscard]] DocumentDecodeError mapUInt32Error(const CanonicalDecimalError error) noexcept {
-    return error == CanonicalDecimalError::InvalidLexicalForm
-               ? DocumentDecodeError::InvalidJsonUInt32
-               : DocumentDecodeError::DomainViolation;
-}
-
-[[nodiscard]] DocumentDecodeError mapRationalError(const CanonicalDecimalError error) noexcept {
+DocumentDecodeError mapRationalError(const CanonicalDecimalError error) noexcept {
     return error == CanonicalDecimalError::NotReduced
                ? DocumentDecodeError::UnreducedRational
                : DocumentDecodeError::InvalidRationalComponent;
 }
 
-[[nodiscard]] std::string fieldPath(const std::string& base, const CanonicalDecimalField field) {
+std::string fieldPath(const std::string& base, const CanonicalDecimalField field) {
     switch (field) {
     case CanonicalDecimalField::Numerator:
         return joinPath(base, "numerator");
@@ -126,6 +108,129 @@ struct DecodeState final {
     }
     return base;
 }
+
+bool decodeStringMember(const JsonValue& value, DecodeState& state, const std::string& path,
+                        std::string_view& out) noexcept {
+    if (value.kind() != JsonValueKind::String) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto text = value.asString();
+    if (!text.has_value()) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    out = *text;
+    return true;
+}
+
+// asNumberToken()/asString() are documented to return a value whenever kind() already matches, but
+// that invariant is not visible to static analysis; every caller re-checks has_value() immediately
+// before dereferencing rather than trusting the prior kind() check alone.
+bool decodeUInt32Member(const JsonValue& value, DecodeState& state, const std::string& path,
+                        const std::uint32_t maximum, std::uint32_t& out) {
+    if (value.kind() != JsonValueKind::Number) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto token = value.asNumberToken();
+    if (!token.has_value()) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto parsed = parseCanonicalJsonUInt32(*token, maximum);
+    if (!parsed) {
+        state.fail(mapUInt32Error(parsed.error()), path);
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+// Reads an object's first member, requires it to be literally named "kind", and decodes its string
+// value as the discriminator for a branch the caller resolves afterward (constant value, parameter
+// source, edge destination, OCIO locator). The branch-specific full key set (and therefore whether
+// a mis-first key is "known elsewhere") is not knowable until `kindText` is read, so this cannot go
+// through matchOrderedMembers itself.
+bool decodeKindDiscriminator(const JsonValue& node, DecodeState& state, const std::string& path,
+                             std::string_view& kindText) {
+    if (node.kind() != JsonValueKind::Object) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto members = node.objectMembers();
+    const auto kindPath = joinPath(path, "kind");
+    if (members.empty()) {
+        state.fail(DocumentDecodeError::MissingMember, kindPath);
+        return false;
+    }
+    if (members[0].key() != "kind") {
+        state.fail(DocumentDecodeError::UnknownMember, joinPath(path, members[0].key()));
+        return false;
+    }
+    return decodeStringMember(members[0].value(), state, kindPath, kindText);
+}
+
+namespace {
+[[nodiscard]] bool decodeRationalStrings(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, std::string_view& numeratorText,
+                                         std::string_view& denominatorText) {
+    static constexpr std::array<std::string_view, 2> kKeys{"numerator", "denominator"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+    if (!decodeStringMember(*members[0], state, joinPath(path, "numerator"), numeratorText)) {
+        return false;
+    }
+    return decodeStringMember(*members[1], state, joinPath(path, "denominator"), denominatorText);
+}
+} // namespace
+
+bool decodeRationalTimeValue(const JsonValue& node, DecodeState& state, const std::string& path,
+                             core::RationalTime& out) {
+    std::string_view numeratorText;
+    std::string_view denominatorText;
+    if (!decodeRationalStrings(node, state, path, numeratorText, denominatorText)) {
+        return false;
+    }
+    const auto parsed = parseCanonicalRationalTime(numeratorText, denominatorText);
+    if (!parsed) {
+        state.fail(mapRationalError(parsed.error()), fieldPath(path, parsed.field()));
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+} // namespace detail
+
+namespace {
+
+using detail::decodeKindDiscriminator;
+using detail::decodeObjectId;
+using detail::decodeRationalTimeValue;
+using detail::DecodeState;
+using detail::decodeStringMember;
+using detail::decodeUInt32Member;
+using detail::fieldPath;
+using detail::joinPath;
+using detail::joinPathIndex;
+using detail::mapRationalError;
+using detail::matchOrderedMembers;
+
+using document::ColorSettings;
+using document::CompositionFormat;
+using document::CompositionId;
+using document::FrameRate;
+using document::OcioConfigLocator;
+using document::OcioConfigPortability;
+using document::OcioConfigReference;
+using document::OcioConfigRevision;
+using document::OcioContextVariable;
+using document::OcioRevisionAlgorithm;
+using document::ProjectId;
+using document::SchemaVersion;
 
 // Translates a bloom::document::ValidationIssue path (dot/bracket notation, e.g.
 // "ocioConfig.contextVariables[3].name") into this module's slash-separated path convention
@@ -156,45 +261,6 @@ struct DecodeState final {
     return result;
 }
 
-[[nodiscard]] bool decodeStringMember(const JsonValue& value, DecodeState& state,
-                                      const std::string& path, std::string_view& out) noexcept {
-    if (value.kind() != JsonValueKind::String) {
-        state.fail(DocumentDecodeError::WrongValueKind, path);
-        return false;
-    }
-    const auto text = value.asString();
-    if (!text.has_value()) {
-        state.fail(DocumentDecodeError::WrongValueKind, path);
-        return false;
-    }
-    out = *text;
-    return true;
-}
-
-// asNumberToken()/asString() are documented to return a value whenever kind() already matches, but
-// that invariant is not visible to static analysis; every caller re-checks has_value() immediately
-// before dereferencing rather than trusting the prior kind() check alone.
-[[nodiscard]] bool decodeUInt32Member(const JsonValue& value, DecodeState& state,
-                                      const std::string& path, const std::uint32_t maximum,
-                                      std::uint32_t& out) {
-    if (value.kind() != JsonValueKind::Number) {
-        state.fail(DocumentDecodeError::WrongValueKind, path);
-        return false;
-    }
-    const auto token = value.asNumberToken();
-    if (!token.has_value()) {
-        state.fail(DocumentDecodeError::WrongValueKind, path);
-        return false;
-    }
-    const auto parsed = parseCanonicalJsonUInt32(*token, maximum);
-    if (!parsed) {
-        state.fail(mapUInt32Error(parsed.error()), path);
-        return false;
-    }
-    out = *parsed.value();
-    return true;
-}
-
 [[nodiscard]] bool decodeSchemaVersionField(const JsonValue& node, DecodeState& state,
                                             const std::string& path, SchemaVersion& out) {
     static constexpr std::array<std::string_view, 2> kKeys{"major", "minor"};
@@ -219,45 +285,36 @@ struct DecodeState final {
     return true;
 }
 
-[[nodiscard]] bool decodeRationalStrings(const JsonValue& node, DecodeState& state,
-                                         const std::string& path, std::string_view& numeratorText,
-                                         std::string_view& denominatorText) {
-    static constexpr std::array<std::string_view, 2> kKeys{"numerator", "denominator"};
-    std::vector<const JsonValue*> members;
-    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
-        return false;
-    }
-    if (!decodeStringMember(*members[0], state, joinPath(path, "numerator"), numeratorText)) {
-        return false;
-    }
-    return decodeStringMember(*members[1], state, joinPath(path, "denominator"), denominatorText);
-}
-
 [[nodiscard]] bool decodeDuration(const JsonValue& node, DecodeState& state,
                                   const std::string& path, core::RationalTime& out) {
-    std::string_view numeratorText;
-    std::string_view denominatorText;
-    if (!decodeRationalStrings(node, state, path, numeratorText, denominatorText)) {
+    if (!decodeRationalTimeValue(node, state, path, out)) {
         return false;
     }
-    const auto parsed = parseCanonicalRationalTime(numeratorText, denominatorText);
-    if (!parsed) {
-        state.fail(mapRationalError(parsed.error()), fieldPath(path, parsed.field()));
-        return false;
-    }
-    if (parsed.value()->numerator() <= 0) {
+    if (out.numerator() <= 0) {
         state.fail(DocumentDecodeError::NonPositiveDuration, path);
         return false;
     }
-    out = *parsed.value();
     return true;
 }
 
 [[nodiscard]] bool decodePixelAspect(const JsonValue& node, DecodeState& state,
                                      const std::string& path, core::PixelAspectRatio& out) {
+    // decodePixelAspect/decodeFrameRate below intentionally re-decode their {numerator,denominator}
+    // pair through the domain-specific parseCanonicalPixelAspectRatio/parseCanonicalPositiveRatio
+    // surfaces rather than the general detail::decodeRationalTimeValue used by duration/keyframe
+    // time/rational constants: pixel aspect and frame rate additionally require an unsigned
+    // (never-negative) domain, which those two dedicated parsers enforce.
+    static constexpr std::array<std::string_view, 2> kKeys{"numerator", "denominator"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
     std::string_view numeratorText;
+    if (!decodeStringMember(*members[0], state, joinPath(path, "numerator"), numeratorText)) {
+        return false;
+    }
     std::string_view denominatorText;
-    if (!decodeRationalStrings(node, state, path, numeratorText, denominatorText)) {
+    if (!decodeStringMember(*members[1], state, joinPath(path, "denominator"), denominatorText)) {
         return false;
     }
     const auto parsed = parseCanonicalPixelAspectRatio(numeratorText, denominatorText);
@@ -271,9 +328,17 @@ struct DecodeState final {
 
 [[nodiscard]] bool decodeFrameRate(const JsonValue& node, DecodeState& state,
                                    const std::string& path, FrameRate& out) {
+    static constexpr std::array<std::string_view, 2> kKeys{"numerator", "denominator"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
     std::string_view numeratorText;
+    if (!decodeStringMember(*members[0], state, joinPath(path, "numerator"), numeratorText)) {
+        return false;
+    }
     std::string_view denominatorText;
-    if (!decodeRationalStrings(node, state, path, numeratorText, denominatorText)) {
+    if (!decodeStringMember(*members[1], state, joinPath(path, "denominator"), denominatorText)) {
         return false;
     }
     const auto parsed = parseCanonicalPositiveRatio(numeratorText, denominatorText);
@@ -352,25 +417,23 @@ struct DecodeState final {
     return true;
 }
 
+// A composition object is closed: exactly id/name/duration/format/parameters/animationCurves/graph
+// in exact order (see docs/architecture/project-format.md, "Project And Composition"). The
+// composition interior -- parameters, animationCurves, and the graph, plus the cross-reference
+// checks that span them -- is decoded by detail::decodeCompositionInterior in
+// document_decode_composition.cpp.
 [[nodiscard]] bool decodeComposition(const JsonValue& node, DecodeState& state,
                                      const std::string& path, DecodedComposition& out) {
-    static constexpr std::array<std::string_view, 4> kKeys{"id", "name", "duration", "format"};
+    static constexpr std::array<std::string_view, 7> kKeys{
+        "id", "name", "duration", "format", "parameters", "animationCurves", "graph"};
     std::vector<const JsonValue*> members;
-    if (!matchOrderedMembers(node, kKeys, false, state, path, members)) {
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
         return false;
     }
 
-    const auto idPath = joinPath(path, "id");
-    std::string_view idText;
-    if (!decodeStringMember(*members[0], state, idPath, idText)) {
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), out.id)) {
         return false;
     }
-    const auto idParsed = parseCanonicalObjectId(idText);
-    if (!idParsed) {
-        state.fail(DocumentDecodeError::InvalidId, idPath);
-        return false;
-    }
-    out.id = CompositionId::fromRaw(*idParsed.value());
 
     std::string_view nameText;
     if (!decodeStringMember(*members[1], state, joinPath(path, "name"), nameText)) {
@@ -381,27 +444,20 @@ struct DecodeState final {
     if (!decodeDuration(*members[2], state, joinPath(path, "duration"), out.duration)) {
         return false;
     }
-    return decodeFormat(*members[3], state, joinPath(path, "format"), out.format);
+    if (!decodeFormat(*members[3], state, joinPath(path, "format"), out.format)) {
+        return false;
+    }
+
+    return detail::decodeCompositionInterior(
+        *members[4], *members[5], *members[6], state, joinPath(path, "parameters"),
+        joinPath(path, "animationCurves"), joinPath(path, "graph"), out.parameters,
+        out.animationCurves, out.graph);
 }
 
 [[nodiscard]] bool decodeLocator(const JsonValue& node, DecodeState& state, const std::string& path,
                                  OcioConfigLocator& out) {
-    if (node.kind() != JsonValueKind::Object) {
-        state.fail(DocumentDecodeError::WrongValueKind, path);
-        return false;
-    }
-    const auto members = node.objectMembers();
-    const auto kindPath = joinPath(path, "kind");
-    if (members.empty()) {
-        state.fail(DocumentDecodeError::MissingMember, kindPath);
-        return false;
-    }
-    if (members[0].key() != "kind") {
-        state.fail(DocumentDecodeError::UnknownMember, joinPath(path, members[0].key()));
-        return false;
-    }
     std::string_view kindText;
-    if (!decodeStringMember(members[0].value(), state, kindPath, kindText)) {
+    if (!decodeKindDiscriminator(node, state, path, kindText)) {
         return false;
     }
 
@@ -411,25 +467,18 @@ struct DecodeState final {
     } else if (kindText == "project-relative-ocioz") {
         secondKey = "path";
     } else {
-        state.fail(DocumentDecodeError::InvalidOcioLocatorKind, kindPath);
+        state.fail(DocumentDecodeError::InvalidOcioLocatorKind, joinPath(path, "kind"));
         return false;
     }
 
-    if (members.size() < 2) {
-        state.fail(DocumentDecodeError::MissingMember, joinPath(path, secondKey));
-        return false;
-    }
-    if (members[1].key() != secondKey) {
-        state.fail(DocumentDecodeError::UnknownMember, joinPath(path, members[1].key()));
-        return false;
-    }
-    if (members.size() > 2) {
-        state.fail(DocumentDecodeError::UnknownMember, joinPath(path, members[2].key()));
+    const std::array<std::string_view, 2> keys{"kind", secondKey};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
         return false;
     }
 
     std::string_view valueText;
-    if (!decodeStringMember(members[1].value(), state, joinPath(path, secondKey), valueText)) {
+    if (!decodeStringMember(*members[1], state, joinPath(path, secondKey), valueText)) {
         return false;
     }
 
@@ -588,17 +637,9 @@ struct DecodeState final {
         return false;
     }
 
-    const auto idPath = joinPath(path, "id");
-    std::string_view idText;
-    if (!decodeStringMember(*members[0], state, idPath, idText)) {
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), out.projectId)) {
         return false;
     }
-    const auto idParsed = parseCanonicalObjectId(idText);
-    if (!idParsed) {
-        state.fail(DocumentDecodeError::InvalidId, idPath);
-        return false;
-    }
-    out.projectId = ProjectId::fromRaw(*idParsed.value());
 
     std::string_view nameText;
     if (!decodeStringMember(*members[1], state, joinPath(path, "name"), nameText)) {
@@ -678,9 +719,9 @@ DocumentDecodeResult DocumentDecodeResult::failure(const DocumentDecodeError err
 DocumentDecodeResult decodeDocumentEnvelope(const JsonValue& root) {
     static constexpr std::array<std::string_view, 4> kKeys{"schemaVersion", "project",
                                                            "idAllocation", "extensions"};
-    DecodeState state;
+    detail::DecodeState state;
     std::vector<const JsonValue*> members;
-    if (!matchOrderedMembers(root, kKeys, true, state, std::string{}, members)) {
+    if (!detail::matchOrderedMembers(root, kKeys, true, state, std::string{}, members)) {
         return DocumentDecodeResult::failure(state.error, state.path);
     }
 

--- a/src/project/document_decode_composition.cpp
+++ b/src/project/document_decode_composition.cpp
@@ -1,0 +1,1159 @@
+// Composition-interior typed decode: parameters, animation curves, and the canonical graph (see
+// docs/architecture/project-format.md, "Parameters", "Animation", and "Canonical Graph"). Split
+// out of document_decode.cpp -- which owns the document envelope, project, and composition scalar
+// members -- purely to keep one translation unit from growing past this codebase's file-size
+// convention; document_decode_internal.hpp is the private cross-file seam shared by both. The
+// single entry point bloom::project::detail::decodeCompositionInterior() is called from
+// document_decode.cpp's decodeComposition() once the composition object's exact seven-member shape
+// (id/name/duration/format/parameters/animationCurves/graph) is confirmed.
+//
+// Every constant value and graph value is constructed through document's own plain
+// aggregate/variant types (ParameterRecord, AnimationCurveRecord, NodeRecord, EdgeRecord,
+// LayerOutputBoundary, ...) rather than through ParameterStore/AnimationCurveStore/CanonicalGraph:
+// those store/graph types apply live-document invariants (schema/value agreement, curve ownership,
+// expected node bindings, cycle freedom, ...) that are a later document-construction concern (see
+// document_decode.hpp's DecodedComposition/DecodedGraph comments). This module's own
+// cross-reference checks are narrower and explicit: every parameter binding's parameterId, every
+// animation-curve source's curveId, and every edge/layerOutput/layerStack/compositionOutput node id
+// must each name a record decoded elsewhere in this same composition; an unresolved reference is
+// DanglingReference.
+
+#include "document_decode_internal.hpp"
+
+#include <bloom/core/color.hpp>
+#include <bloom/document/animation.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/project/canonical_decimal.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace bloom::project {
+
+namespace {
+
+using detail::decodeKindDiscriminator;
+using detail::decodeObjectId;
+using detail::decodeRationalTimeValue;
+using detail::DecodeState;
+using detail::decodeStringMember;
+using detail::decodeUInt32Member;
+using detail::fieldPath;
+using detail::joinPath;
+using detail::joinPathIndex;
+using detail::mapRationalError;
+using detail::matchOrderedMembers;
+
+using document::AnimationCurveId;
+using document::AnimationCurveRecord;
+using document::EdgeId;
+using document::EdgeRecord;
+using document::InputPortRef;
+using document::KeyframeInterpolation;
+using document::LayerId;
+using document::LayerOutputBoundary;
+using document::LayerSlotId;
+using document::LayerStackEntry;
+using document::LayerStackInputRef;
+using document::NodeId;
+using document::NodeInputRef;
+using document::NodeRecord;
+using document::OutputPortRef;
+using document::ParameterBinding;
+using document::ParameterId;
+using document::ParameterRecord;
+using document::ParameterValue;
+using document::ScalarAnimationCurve;
+using document::ScalarKeyframe;
+using document::Vec2AnimationCurve;
+using document::Vec2d;
+using document::Vec2Keyframe;
+
+[[nodiscard]] bool decodeBooleanMember(const JsonValue& value, DecodeState& state,
+                                       const std::string& path, bool& out) noexcept {
+    if (value.kind() != JsonValueKind::Boolean) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto parsed = value.asBoolean();
+    if (!parsed.has_value()) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    out = *parsed;
+    return true;
+}
+
+// Known Float64 fields (constant float64/vec2/color4 values and keyframe values) accept every
+// RFC 8259 number spelling that rounds to a finite binary64 value; parseKnownFloat64 is the same
+// checked surface the format contract's "Float64" section requires. No hand-rolled std::isfinite
+// check duplicates that surface, and overflow to infinity is reported as InvalidFloat64.
+[[nodiscard]] bool decodeFloat64Member(const JsonValue& value, DecodeState& state,
+                                       const std::string& path, double& out) {
+    if (value.kind() != JsonValueKind::Number) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto token = value.asNumberToken();
+    if (!token.has_value()) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto parsed = parseKnownFloat64(*token);
+    if (!parsed) {
+        state.fail(DocumentDecodeError::InvalidFloat64, path);
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+// ------------------------------------------------------------------------------------------
+// Parameters (docs/architecture/project-format.md, "Parameters")
+// ------------------------------------------------------------------------------------------
+
+[[nodiscard]] bool decodeConstantValue(const JsonValue& node, DecodeState& state,
+                                       const std::string& path, ParameterValue& out) {
+    std::string_view kindText;
+    if (!decodeKindDiscriminator(node, state, path, kindText)) {
+        return false;
+    }
+
+    if (kindText == "bool") {
+        static constexpr std::array<std::string_view, 2> keys{"kind", "value"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        bool value = false;
+        if (!decodeBooleanMember(*members[1], state, joinPath(path, "value"), value)) {
+            return false;
+        }
+        out = value;
+        return true;
+    }
+    if (kindText == "int64") {
+        static constexpr std::array<std::string_view, 2> keys{"kind", "value"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        const auto valuePath = joinPath(path, "value");
+        std::string_view text;
+        if (!decodeStringMember(*members[1], state, valuePath, text)) {
+            return false;
+        }
+        const auto parsed = parseCanonicalInt64(text);
+        if (!parsed) {
+            state.fail(DocumentDecodeError::InvalidInt64Value, valuePath);
+            return false;
+        }
+        out = *parsed.value();
+        return true;
+    }
+    if (kindText == "float64") {
+        static constexpr std::array<std::string_view, 2> keys{"kind", "value"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        double value = 0.0;
+        if (!decodeFloat64Member(*members[1], state, joinPath(path, "value"), value)) {
+            return false;
+        }
+        out = value;
+        return true;
+    }
+    if (kindText == "vec2") {
+        static constexpr std::array<std::string_view, 3> keys{"kind", "x", "y"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        Vec2d value;
+        if (!decodeFloat64Member(*members[1], state, joinPath(path, "x"), value.x)) {
+            return false;
+        }
+        if (!decodeFloat64Member(*members[2], state, joinPath(path, "y"), value.y)) {
+            return false;
+        }
+        out = value;
+        return true;
+    }
+    if (kindText == "color4") {
+        static constexpr std::array<std::string_view, 5> keys{"kind", "red", "green", "blue",
+                                                              "alpha"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        core::Color4d value;
+        if (!decodeFloat64Member(*members[1], state, joinPath(path, "red"), value.red)) {
+            return false;
+        }
+        if (!decodeFloat64Member(*members[2], state, joinPath(path, "green"), value.green)) {
+            return false;
+        }
+        if (!decodeFloat64Member(*members[3], state, joinPath(path, "blue"), value.blue)) {
+            return false;
+        }
+        if (!decodeFloat64Member(*members[4], state, joinPath(path, "alpha"), value.alpha)) {
+            return false;
+        }
+        out = value;
+        return true;
+    }
+    if (kindText == "string") {
+        static constexpr std::array<std::string_view, 2> keys{"kind", "value"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        std::string_view text;
+        if (!decodeStringMember(*members[1], state, joinPath(path, "value"), text)) {
+            return false;
+        }
+        out = std::string(text);
+        return true;
+    }
+    if (kindText == "rational") {
+        static constexpr std::array<std::string_view, 3> keys{"kind", "numerator", "denominator"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        std::string_view numeratorText;
+        if (!decodeStringMember(*members[1], state, joinPath(path, "numerator"), numeratorText)) {
+            return false;
+        }
+        std::string_view denominatorText;
+        if (!decodeStringMember(*members[2], state, joinPath(path, "denominator"),
+                                denominatorText)) {
+            return false;
+        }
+        const auto parsed = parseCanonicalRationalTime(numeratorText, denominatorText);
+        if (!parsed) {
+            state.fail(mapRationalError(parsed.error()), fieldPath(path, parsed.field()));
+            return false;
+        }
+        out = *parsed.value();
+        return true;
+    }
+
+    state.fail(DocumentDecodeError::InvalidConstantValueKind, joinPath(path, "kind"));
+    return false;
+}
+
+[[nodiscard]] bool decodeParameterSource(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, document::ParameterSource& out) {
+    std::string_view kindText;
+    if (!decodeKindDiscriminator(node, state, path, kindText)) {
+        return false;
+    }
+
+    if (kindText == "constant") {
+        static constexpr std::array<std::string_view, 2> keys{"kind", "value"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        ParameterValue value{};
+        if (!decodeConstantValue(*members[1], state, joinPath(path, "value"), value)) {
+            return false;
+        }
+        out = document::ConstantValueSource{std::move(value)};
+        return true;
+    }
+    if (kindText == "animation-curve") {
+        static constexpr std::array<std::string_view, 2> keys{"kind", "curveId"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        AnimationCurveId curveId;
+        if (!decodeObjectId(*members[1], state, joinPath(path, "curveId"), curveId)) {
+            return false;
+        }
+        out = document::AnimationCurveSource{curveId};
+        return true;
+    }
+
+    state.fail(DocumentDecodeError::UnsupportedParameterSource, joinPath(path, "kind"));
+    return false;
+}
+
+[[nodiscard]] bool decodeParameter(const JsonValue& node, DecodeState& state,
+                                   const std::string& path, ParameterRecord& out) {
+    static constexpr std::array<std::string_view, 3> keys{"id", "schemaKey", "source"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+
+    ParameterId id;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), id)) {
+        return false;
+    }
+    std::string_view schemaKeyText;
+    if (!decodeStringMember(*members[1], state, joinPath(path, "schemaKey"), schemaKeyText)) {
+        return false;
+    }
+    document::ParameterSource source;
+    if (!decodeParameterSource(*members[2], state, joinPath(path, "source"), source)) {
+        return false;
+    }
+
+    out.id = id;
+    out.schemaKey = std::string(schemaKeyText);
+    out.source = std::move(source);
+    return true;
+}
+
+[[nodiscard]] bool decodeParameters(const JsonValue& node, DecodeState& state,
+                                    const std::string& path, std::vector<ParameterRecord>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    std::uint64_t previousId = 0;
+    bool hasPrevious = false;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        ParameterRecord record;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeParameter(elements[index], state, elementPath, record)) {
+            return false;
+        }
+        const auto currentId = record.id.value();
+        if (hasPrevious) {
+            if (currentId == previousId) {
+                state.fail(DocumentDecodeError::DuplicateParameter, joinPath(elementPath, "id"));
+                return false;
+            }
+            if (currentId < previousId) {
+                state.fail(DocumentDecodeError::UnsortedParameters, joinPath(elementPath, "id"));
+                return false;
+            }
+        }
+        previousId = currentId;
+        hasPrevious = true;
+        out.push_back(std::move(record));
+    }
+    return true;
+}
+
+// ------------------------------------------------------------------------------------------
+// Animation curves (docs/architecture/project-format.md, "Animation")
+// ------------------------------------------------------------------------------------------
+
+[[nodiscard]] bool decodeInterpolation(const JsonValue& value, DecodeState& state,
+                                       const std::string& path, KeyframeInterpolation& out) {
+    std::string_view text;
+    if (!decodeStringMember(value, state, path, text)) {
+        return false;
+    }
+    if (text == "hold") {
+        out = KeyframeInterpolation::Hold;
+        return true;
+    }
+    if (text == "linear") {
+        out = KeyframeInterpolation::Linear;
+        return true;
+    }
+    state.fail(DocumentDecodeError::InvalidInterpolation, path);
+    return false;
+}
+
+[[nodiscard]] bool decodeScalarKeyframe(const JsonValue& node, DecodeState& state,
+                                        const std::string& path, ScalarKeyframe& out) {
+    static constexpr std::array<std::string_view, 4> keys{"id", "time", "value",
+                                                          "outgoingInterpolation"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+
+    document::KeyframeId id;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), id)) {
+        return false;
+    }
+    core::RationalTime time;
+    if (!decodeRationalTimeValue(*members[1], state, joinPath(path, "time"), time)) {
+        return false;
+    }
+    double value = 0.0;
+    if (!decodeFloat64Member(*members[2], state, joinPath(path, "value"), value)) {
+        return false;
+    }
+    KeyframeInterpolation interpolation = KeyframeInterpolation::Linear;
+    if (!decodeInterpolation(*members[3], state, joinPath(path, "outgoingInterpolation"),
+                             interpolation)) {
+        return false;
+    }
+
+    out.id = id;
+    out.time = time;
+    out.value = value;
+    out.outgoingInterpolation = interpolation;
+    return true;
+}
+
+[[nodiscard]] bool decodeVec2Keyframe(const JsonValue& node, DecodeState& state,
+                                      const std::string& path, Vec2Keyframe& out) {
+    static constexpr std::array<std::string_view, 4> keys{"id", "time", "value",
+                                                          "outgoingInterpolation"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+
+    document::KeyframeId id;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), id)) {
+        return false;
+    }
+    core::RationalTime time;
+    if (!decodeRationalTimeValue(*members[1], state, joinPath(path, "time"), time)) {
+        return false;
+    }
+
+    const auto valuePath = joinPath(path, "value");
+    static constexpr std::array<std::string_view, 2> valueKeys{"x", "y"};
+    std::vector<const JsonValue*> valueMembers;
+    if (!matchOrderedMembers(*members[2], valueKeys, true, state, valuePath, valueMembers)) {
+        return false;
+    }
+    Vec2d value;
+    if (!decodeFloat64Member(*valueMembers[0], state, joinPath(valuePath, "x"), value.x)) {
+        return false;
+    }
+    if (!decodeFloat64Member(*valueMembers[1], state, joinPath(valuePath, "y"), value.y)) {
+        return false;
+    }
+
+    KeyframeInterpolation interpolation = KeyframeInterpolation::Linear;
+    if (!decodeInterpolation(*members[3], state, joinPath(path, "outgoingInterpolation"),
+                             interpolation)) {
+        return false;
+    }
+
+    out.id = id;
+    out.time = time;
+    out.value = value;
+    out.outgoingInterpolation = interpolation;
+    return true;
+}
+
+// Shared keyframe-array shape: non-empty, strictly increasing exact rational time, and a
+// canonical Linear final interpolation (docs/architecture/project-format.md, "Animation").
+template <typename Keyframe, typename DecodeOne>
+[[nodiscard]] bool decodeKeyframeArray(const JsonValue& node, DecodeState& state,
+                                       const std::string& path, std::vector<Keyframe>& out,
+                                       DecodeOne decodeOne) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    if (elements.empty()) {
+        state.fail(DocumentDecodeError::EmptyKeyframes, path);
+        return false;
+    }
+    out.clear();
+    out.reserve(elements.size());
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        Keyframe keyframe;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeOne(elements[index], state, elementPath, keyframe)) {
+            return false;
+        }
+        if (!out.empty() && !(out.back().time < keyframe.time)) {
+            state.fail(DocumentDecodeError::NonIncreasingKeyframeTime,
+                       joinPath(elementPath, "time"));
+            return false;
+        }
+        out.push_back(std::move(keyframe));
+    }
+    if (out.back().outgoingInterpolation != KeyframeInterpolation::Linear) {
+        const auto finalElementPath = joinPathIndex(path, elements.size() - 1);
+        state.fail(DocumentDecodeError::FinalKeyframeNotLinear,
+                   joinPath(finalElementPath, "outgoingInterpolation"));
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeAnimationCurve(const JsonValue& node, DecodeState& state,
+                                        const std::string& path, AnimationCurveRecord& out) {
+    static constexpr std::array<std::string_view, 2> prefixKeys{"id", "kind"};
+    std::vector<const JsonValue*> prefix;
+    if (!matchOrderedMembers(node, prefixKeys, false, state, path, prefix)) {
+        return false;
+    }
+    document::AnimationCurveId id;
+    if (!decodeObjectId(*prefix[0], state, joinPath(path, "id"), id)) {
+        return false;
+    }
+    std::string_view kindText;
+    if (!decodeStringMember(*prefix[1], state, joinPath(path, "kind"), kindText)) {
+        return false;
+    }
+
+    if (kindText == "scalar") {
+        static constexpr std::array<std::string_view, 3> keys{"id", "kind", "keyframes"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        ScalarAnimationCurve curve;
+        curve.id = id;
+        if (!decodeKeyframeArray(*members[2], state, joinPath(path, "keyframes"), curve.keyframes,
+                                 decodeScalarKeyframe)) {
+            return false;
+        }
+        out = std::move(curve);
+        return true;
+    }
+    if (kindText == "vec2") {
+        static constexpr std::array<std::string_view, 3> keys{"id", "kind", "keyframes"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        Vec2AnimationCurve curve;
+        curve.id = id;
+        if (!decodeKeyframeArray(*members[2], state, joinPath(path, "keyframes"), curve.keyframes,
+                                 decodeVec2Keyframe)) {
+            return false;
+        }
+        out = std::move(curve);
+        return true;
+    }
+
+    state.fail(DocumentDecodeError::InvalidAnimationCurveKind, joinPath(path, "kind"));
+    return false;
+}
+
+[[nodiscard]] bool decodeAnimationCurves(const JsonValue& node, DecodeState& state,
+                                         const std::string& path,
+                                         std::vector<AnimationCurveRecord>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    std::uint64_t previousId = 0;
+    bool hasPrevious = false;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        AnimationCurveRecord record;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeAnimationCurve(elements[index], state, elementPath, record)) {
+            return false;
+        }
+        const auto currentId = document::animationCurveId(record).value();
+        if (hasPrevious) {
+            if (currentId == previousId) {
+                state.fail(DocumentDecodeError::DuplicateAnimationCurve,
+                           joinPath(elementPath, "id"));
+                return false;
+            }
+            if (currentId < previousId) {
+                state.fail(DocumentDecodeError::UnsortedAnimationCurves,
+                           joinPath(elementPath, "id"));
+                return false;
+            }
+        }
+        previousId = currentId;
+        hasPrevious = true;
+        out.push_back(std::move(record));
+    }
+    return true;
+}
+
+// A parameter's AnimationCurveSource.curveId can name a curve declared anywhere in the
+// composition's animationCurves array, including after the referencing parameter -- both arrays
+// must be fully decoded before this check runs.
+[[nodiscard]] bool checkParameterCurveReferences(DecodeState& state,
+                                                 const std::string& parametersPath,
+                                                 const std::vector<ParameterRecord>& parameters,
+                                                 const std::vector<AnimationCurveRecord>& curves) {
+    for (std::size_t index = 0; index < parameters.size(); ++index) {
+        const auto* source = std::get_if<document::AnimationCurveSource>(&parameters[index].source);
+        if (source == nullptr) {
+            continue;
+        }
+        const bool found = std::ranges::any_of(curves, [&](const AnimationCurveRecord& record) {
+            return document::animationCurveId(record) == source->curveId;
+        });
+        if (!found) {
+            const auto elementPath = joinPathIndex(parametersPath, index);
+            state.fail(DocumentDecodeError::DanglingReference,
+                       joinPath(joinPath(elementPath, "source"), "curveId"));
+            return false;
+        }
+    }
+    return true;
+}
+
+// ------------------------------------------------------------------------------------------
+// Canonical graph (docs/architecture/project-format.md, "Canonical Graph")
+// ------------------------------------------------------------------------------------------
+
+[[nodiscard]] bool nodeExists(const std::vector<NodeRecord>& nodes, const NodeId id) noexcept {
+    return std::ranges::any_of(nodes, [id](const NodeRecord& node) { return node.id == id; });
+}
+
+[[nodiscard]] bool parameterExists(const std::vector<ParameterRecord>& parameters,
+                                   const ParameterId id) noexcept {
+    return std::ranges::any_of(parameters,
+                               [id](const ParameterRecord& record) { return record.id == id; });
+}
+
+[[nodiscard]] bool decodeOutputPortRef(const JsonValue& node, DecodeState& state,
+                                       const std::string& path, OutputPortRef& out) {
+    static constexpr std::array<std::string_view, 2> keys{"nodeId", "port"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+    NodeId nodeId;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "nodeId"), nodeId)) {
+        return false;
+    }
+    std::string_view portText;
+    if (!decodeStringMember(*members[1], state, joinPath(path, "port"), portText)) {
+        return false;
+    }
+    out.nodeId = nodeId;
+    out.port = std::string(portText);
+    return true;
+}
+
+[[nodiscard]] bool decodeEdgeDestination(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, InputPortRef& out) {
+    std::string_view kindText;
+    if (!decodeKindDiscriminator(node, state, path, kindText)) {
+        return false;
+    }
+
+    if (kindText == "node-input") {
+        static constexpr std::array<std::string_view, 3> keys{"kind", "nodeId", "port"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        NodeId nodeId;
+        if (!decodeObjectId(*members[1], state, joinPath(path, "nodeId"), nodeId)) {
+            return false;
+        }
+        std::string_view portText;
+        if (!decodeStringMember(*members[2], state, joinPath(path, "port"), portText)) {
+            return false;
+        }
+        out = NodeInputRef{nodeId, std::string(portText)};
+        return true;
+    }
+    if (kindText == "layer-stack-input") {
+        static constexpr std::array<std::string_view, 4> keys{"kind", "stackNodeId", "slotId",
+                                                              "role"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        NodeId stackNodeId;
+        if (!decodeObjectId(*members[1], state, joinPath(path, "stackNodeId"), stackNodeId)) {
+            return false;
+        }
+        LayerSlotId slotId;
+        if (!decodeObjectId(*members[2], state, joinPath(path, "slotId"), slotId)) {
+            return false;
+        }
+        std::string_view roleText;
+        if (!decodeStringMember(*members[3], state, joinPath(path, "role"), roleText)) {
+            return false;
+        }
+        out = LayerStackInputRef{stackNodeId, slotId, std::string(roleText)};
+        return true;
+    }
+
+    state.fail(DocumentDecodeError::InvalidEdgeDestinationKind, joinPath(path, "kind"));
+    return false;
+}
+
+[[nodiscard]] bool decodeEdge(const JsonValue& node, DecodeState& state, const std::string& path,
+                              EdgeRecord& out) {
+    static constexpr std::array<std::string_view, 3> keys{"id", "source", "destination"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+
+    EdgeId id;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), id)) {
+        return false;
+    }
+    OutputPortRef source;
+    if (!decodeOutputPortRef(*members[1], state, joinPath(path, "source"), source)) {
+        return false;
+    }
+    InputPortRef destination;
+    if (!decodeEdgeDestination(*members[2], state, joinPath(path, "destination"), destination)) {
+        return false;
+    }
+
+    out.id = id;
+    out.source = std::move(source);
+    out.destination = std::move(destination);
+    return true;
+}
+
+[[nodiscard]] bool decodeEdges(const JsonValue& node, DecodeState& state, const std::string& path,
+                               std::vector<EdgeRecord>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    std::uint64_t previousId = 0;
+    bool hasPrevious = false;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        EdgeRecord record;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeEdge(elements[index], state, elementPath, record)) {
+            return false;
+        }
+        const auto currentId = record.id.value();
+        if (hasPrevious) {
+            if (currentId == previousId) {
+                state.fail(DocumentDecodeError::DuplicateEdge, joinPath(elementPath, "id"));
+                return false;
+            }
+            if (currentId < previousId) {
+                state.fail(DocumentDecodeError::UnsortedEdges, joinPath(elementPath, "id"));
+                return false;
+            }
+        }
+        previousId = currentId;
+        hasPrevious = true;
+        out.push_back(std::move(record));
+    }
+    return true;
+}
+
+[[nodiscard]] bool checkEdgeNodeReferences(DecodeState& state, const std::string& edgesPath,
+                                           const std::vector<EdgeRecord>& edges,
+                                           const std::vector<NodeRecord>& nodes) {
+    for (std::size_t index = 0; index < edges.size(); ++index) {
+        const auto& edge = edges[index];
+        const auto edgePath = joinPathIndex(edgesPath, index);
+        if (!nodeExists(nodes, edge.source.nodeId)) {
+            state.fail(DocumentDecodeError::DanglingReference,
+                       joinPath(joinPath(edgePath, "source"), "nodeId"));
+            return false;
+        }
+        if (const auto* nodeInput = std::get_if<NodeInputRef>(&edge.destination)) {
+            if (!nodeExists(nodes, nodeInput->nodeId)) {
+                state.fail(DocumentDecodeError::DanglingReference,
+                           joinPath(joinPath(edgePath, "destination"), "nodeId"));
+                return false;
+            }
+        } else {
+            const auto& stackInput = std::get<LayerStackInputRef>(edge.destination);
+            if (!nodeExists(nodes, stackInput.stackNodeId)) {
+                state.fail(DocumentDecodeError::DanglingReference,
+                           joinPath(joinPath(edgePath, "destination"), "stackNodeId"));
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeParameterBinding(const JsonValue& node, DecodeState& state,
+                                          const std::string& path, ParameterBinding& out) {
+    static constexpr std::array<std::string_view, 2> keys{"role", "parameterId"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+    std::string_view roleText;
+    if (!decodeStringMember(*members[0], state, joinPath(path, "role"), roleText)) {
+        return false;
+    }
+    ParameterId parameterId;
+    if (!decodeObjectId(*members[1], state, joinPath(path, "parameterId"), parameterId)) {
+        return false;
+    }
+    out.role = std::string(roleText);
+    out.parameterId = parameterId;
+    return true;
+}
+
+[[nodiscard]] bool decodeBindings(const JsonValue& node, DecodeState& state,
+                                  const std::string& path, std::vector<ParameterBinding>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    bool hasPrevious = false;
+    std::string previousRole;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        ParameterBinding binding;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeParameterBinding(elements[index], state, elementPath, binding)) {
+            return false;
+        }
+        if (hasPrevious) {
+            if (binding.role == previousRole) {
+                state.fail(DocumentDecodeError::DuplicateBinding, joinPath(elementPath, "role"));
+                return false;
+            }
+            if (!(previousRole < binding.role)) {
+                state.fail(DocumentDecodeError::UnsortedBindings, joinPath(elementPath, "role"));
+                return false;
+            }
+        }
+        previousRole = binding.role;
+        hasPrevious = true;
+        out.push_back(std::move(binding));
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeNode(const JsonValue& node, DecodeState& state, const std::string& path,
+                              NodeRecord& out) {
+    static constexpr std::array<std::string_view, 4> keys{"id", "typeId", "schemaVersion",
+                                                          "parameters"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+
+    NodeId id;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), id)) {
+        return false;
+    }
+    std::string_view typeIdText;
+    if (!decodeStringMember(*members[1], state, joinPath(path, "typeId"), typeIdText)) {
+        return false;
+    }
+    const auto schemaVersionPath = joinPath(path, "schemaVersion");
+    std::uint32_t schemaVersion = 0;
+    if (!decodeUInt32Member(*members[2], state, schemaVersionPath,
+                            std::numeric_limits<std::uint32_t>::max(), schemaVersion)) {
+        return false;
+    }
+    if (schemaVersion == 0) {
+        state.fail(DocumentDecodeError::DomainViolation, schemaVersionPath);
+        return false;
+    }
+    std::vector<ParameterBinding> bindings;
+    if (!decodeBindings(*members[3], state, joinPath(path, "parameters"), bindings)) {
+        return false;
+    }
+
+    out.id = id;
+    out.typeId = std::string(typeIdText);
+    out.schemaVersion = schemaVersion;
+    out.parameters = std::move(bindings);
+    return true;
+}
+
+[[nodiscard]] bool decodeNodes(const JsonValue& node, DecodeState& state, const std::string& path,
+                               std::vector<NodeRecord>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    std::uint64_t previousId = 0;
+    bool hasPrevious = false;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        NodeRecord record;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeNode(elements[index], state, elementPath, record)) {
+            return false;
+        }
+        const auto currentId = record.id.value();
+        if (hasPrevious) {
+            if (currentId == previousId) {
+                state.fail(DocumentDecodeError::DuplicateNode, joinPath(elementPath, "id"));
+                return false;
+            }
+            if (currentId < previousId) {
+                state.fail(DocumentDecodeError::UnsortedNodes, joinPath(elementPath, "id"));
+                return false;
+            }
+        }
+        previousId = currentId;
+        hasPrevious = true;
+        out.push_back(std::move(record));
+    }
+    return true;
+}
+
+[[nodiscard]] bool checkNodeParameterBindings(DecodeState& state, const std::string& nodesPath,
+                                              const std::vector<NodeRecord>& nodes,
+                                              const std::vector<ParameterRecord>& parameters) {
+    for (std::size_t nodeIndex = 0; nodeIndex < nodes.size(); ++nodeIndex) {
+        const auto& node = nodes[nodeIndex];
+        const auto bindingsPath = joinPath(joinPathIndex(nodesPath, nodeIndex), "parameters");
+        for (std::size_t bindingIndex = 0; bindingIndex < node.parameters.size(); ++bindingIndex) {
+            if (!parameterExists(parameters, node.parameters[bindingIndex].parameterId)) {
+                state.fail(DocumentDecodeError::DanglingReference,
+                           joinPath(joinPathIndex(bindingsPath, bindingIndex), "parameterId"));
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeLayerOutputBoundary(const JsonValue& node, DecodeState& state,
+                                             const std::string& path, LayerOutputBoundary& out) {
+    static constexpr std::array<std::string_view, 4> keys{"nodeId", "layerId", "name",
+                                                          "outputPort"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+    NodeId nodeId;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "nodeId"), nodeId)) {
+        return false;
+    }
+    LayerId layerId;
+    if (!decodeObjectId(*members[1], state, joinPath(path, "layerId"), layerId)) {
+        return false;
+    }
+    std::string_view nameText;
+    if (!decodeStringMember(*members[2], state, joinPath(path, "name"), nameText)) {
+        return false;
+    }
+    std::string_view outputPortText;
+    if (!decodeStringMember(*members[3], state, joinPath(path, "outputPort"), outputPortText)) {
+        return false;
+    }
+    out.nodeId = nodeId;
+    out.layerId = layerId;
+    out.name = std::string(nameText);
+    out.outputPort = std::string(outputPortText);
+    return true;
+}
+
+[[nodiscard]] bool decodeLayerOutputs(const JsonValue& node, DecodeState& state,
+                                      const std::string& path,
+                                      std::vector<LayerOutputBoundary>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    bool hasPrevious = false;
+    std::pair<std::uint64_t, std::uint64_t> previousKey{0, 0};
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        LayerOutputBoundary boundary;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeLayerOutputBoundary(elements[index], state, elementPath, boundary)) {
+            return false;
+        }
+        const std::pair<std::uint64_t, std::uint64_t> currentKey{boundary.layerId.value(),
+                                                                 boundary.nodeId.value()};
+        if (hasPrevious) {
+            if (currentKey == previousKey) {
+                state.fail(DocumentDecodeError::DuplicateLayerOutput,
+                           joinPath(elementPath, "layerId"));
+                return false;
+            }
+            if (currentKey < previousKey) {
+                state.fail(DocumentDecodeError::UnsortedLayerOutputs,
+                           joinPath(elementPath, "layerId"));
+                return false;
+            }
+        }
+        previousKey = currentKey;
+        hasPrevious = true;
+        out.push_back(std::move(boundary));
+    }
+    return true;
+}
+
+[[nodiscard]] bool
+checkLayerOutputNodeReferences(DecodeState& state, const std::string& layerOutputsPath,
+                               const std::vector<LayerOutputBoundary>& boundaries,
+                               const std::vector<NodeRecord>& nodes) {
+    for (std::size_t index = 0; index < boundaries.size(); ++index) {
+        if (!nodeExists(nodes, boundaries[index].nodeId)) {
+            state.fail(DocumentDecodeError::DanglingReference,
+                       joinPath(joinPathIndex(layerOutputsPath, index), "nodeId"));
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeLayerStackEntry(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, LayerStackEntry& out) {
+    static constexpr std::array<std::string_view, 2> keys{"slotId", "layerId"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+    LayerSlotId slotId;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "slotId"), slotId)) {
+        return false;
+    }
+    LayerId layerId;
+    if (!decodeObjectId(*members[1], state, joinPath(path, "layerId"), layerId)) {
+        return false;
+    }
+    out.slotId = slotId;
+    out.layerId = layerId;
+    return true;
+}
+
+// Layer Stack entries are canonical SOURCE order, never numerically sorted (see
+// docs/architecture/project-format.md, "Canonical Graph": "Layer Stack entries remain in semantic
+// top-to-bottom authoring order and are never ID-sorted"), so this deliberately applies no order or
+// duplicate check beyond each entry's own wire shape.
+[[nodiscard]] bool decodeLayerStackEntries(const JsonValue& node, DecodeState& state,
+                                           const std::string& path,
+                                           std::vector<LayerStackEntry>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        LayerStackEntry entry;
+        if (!decodeLayerStackEntry(elements[index], state, joinPathIndex(path, index), entry)) {
+            return false;
+        }
+        out.push_back(entry);
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeLayerStack(const JsonValue& node, DecodeState& state,
+                                    const std::string& path, DecodedLayerStack& out) {
+    static constexpr std::array<std::string_view, 2> keys{"nodeId", "entries"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+    NodeId nodeId;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "nodeId"), nodeId)) {
+        return false;
+    }
+    std::vector<LayerStackEntry> entries;
+    if (!decodeLayerStackEntries(*members[1], state, joinPath(path, "entries"), entries)) {
+        return false;
+    }
+    out.nodeId = nodeId;
+    out.entries = std::move(entries);
+    return true;
+}
+
+[[nodiscard]] bool decodeGraph(const JsonValue& node, DecodeState& state, const std::string& path,
+                               const std::vector<ParameterRecord>& parameters, DecodedGraph& out) {
+    static constexpr std::array<std::string_view, 5> keys{"nodes", "edges", "layerOutputs",
+                                                          "layerStack", "compositionOutput"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+
+    const auto nodesPath = joinPath(path, "nodes");
+    if (!decodeNodes(*members[0], state, nodesPath, out.nodes)) {
+        return false;
+    }
+    if (!checkNodeParameterBindings(state, nodesPath, out.nodes, parameters)) {
+        return false;
+    }
+
+    const auto edgesPath = joinPath(path, "edges");
+    if (!decodeEdges(*members[1], state, edgesPath, out.edges)) {
+        return false;
+    }
+    if (!checkEdgeNodeReferences(state, edgesPath, out.edges, out.nodes)) {
+        return false;
+    }
+
+    const auto layerOutputsPath = joinPath(path, "layerOutputs");
+    if (!decodeLayerOutputs(*members[2], state, layerOutputsPath, out.layerOutputs)) {
+        return false;
+    }
+    if (!checkLayerOutputNodeReferences(state, layerOutputsPath, out.layerOutputs, out.nodes)) {
+        return false;
+    }
+
+    const auto layerStackPath = joinPath(path, "layerStack");
+    if (!decodeLayerStack(*members[3], state, layerStackPath, out.layerStack)) {
+        return false;
+    }
+    if (!nodeExists(out.nodes, out.layerStack.nodeId)) {
+        state.fail(DocumentDecodeError::DanglingReference, joinPath(layerStackPath, "nodeId"));
+        return false;
+    }
+
+    const auto compositionOutputPath = joinPath(path, "compositionOutput");
+    if (!decodeOutputPortRef(*members[4], state, compositionOutputPath, out.compositionOutput)) {
+        return false;
+    }
+    if (!nodeExists(out.nodes, out.compositionOutput.nodeId)) {
+        state.fail(DocumentDecodeError::DanglingReference,
+                   joinPath(compositionOutputPath, "nodeId"));
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+namespace detail {
+
+bool decodeCompositionInterior(const JsonValue& parametersNode,
+                               const JsonValue& animationCurvesNode, const JsonValue& graphNode,
+                               DecodeState& state, const std::string& parametersPath,
+                               const std::string& curvesPath, const std::string& graphPath,
+                               std::vector<document::ParameterRecord>& parameters,
+                               std::vector<document::AnimationCurveRecord>& curves,
+                               DecodedGraph& graph) {
+    if (!decodeParameters(parametersNode, state, parametersPath, parameters)) {
+        return false;
+    }
+    if (!decodeAnimationCurves(animationCurvesNode, state, curvesPath, curves)) {
+        return false;
+    }
+    if (!checkParameterCurveReferences(state, parametersPath, parameters, curves)) {
+        return false;
+    }
+    return decodeGraph(graphNode, state, graphPath, parameters, graph);
+}
+
+} // namespace detail
+
+} // namespace bloom::project

--- a/src/project/document_decode_internal.hpp
+++ b/src/project/document_decode_internal.hpp
@@ -1,0 +1,114 @@
+#ifndef BLOOM_PROJECT_DOCUMENT_DECODE_INTERNAL_HPP
+#define BLOOM_PROJECT_DOCUMENT_DECODE_INTERNAL_HPP
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/project/canonical_decimal.hpp>
+#include <bloom/project/document_decode.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Decode plumbing shared between document_decode.cpp (the document envelope, project, and
+// composition scalar members) and document_decode_composition.cpp (the composition interior:
+// parameters, animation curves, and the canonical graph -- split out because document_decode.cpp
+// would otherwise exceed this codebase's file-size convention). Not a public Project I/O contract:
+// only these two translation units include this header, matching the existing
+// canonical_json_string_detail.hpp precedent for a private cross-file implementation seam.
+namespace bloom::project::detail {
+
+// Threads a first-failure-wins typed error and its exact member path through the recursive decode
+// walk, mirroring the WalkState/EmitState pattern used by the canonical document writer.
+struct DecodeState final {
+    DocumentDecodeError error = DocumentDecodeError::None;
+    std::string path;
+
+    void fail(DocumentDecodeError newError, std::string newPath) noexcept {
+        if (error == DocumentDecodeError::None) {
+            error = newError;
+            path = std::move(newPath);
+        }
+    }
+};
+
+[[nodiscard]] std::string joinPath(const std::string& base, std::string_view segment);
+[[nodiscard]] std::string joinPathIndex(const std::string& base, std::size_t index);
+
+// Translates a bloom::project::CanonicalDecimalField into this module's slash-separated path
+// convention, appended to `base`.
+[[nodiscard]] std::string fieldPath(const std::string& base, CanonicalDecimalField field);
+[[nodiscard]] DocumentDecodeError mapRationalError(CanonicalDecimalError error) noexcept;
+
+// Checks that `object` is a JSON object whose leading members exactly match `expectedKeys` in
+// order, filling `outValues` with pointers to each matched member's value. When
+// `rejectExtraMembers` is true the object must contain exactly `expectedKeys.size()` members;
+// otherwise trailing members beyond the matched prefix are accepted without inspection.
+[[nodiscard]] bool matchOrderedMembers(const JsonValue& object,
+                                       std::span<const std::string_view> expectedKeys,
+                                       bool rejectExtraMembers, DecodeState& state,
+                                       const std::string& basePath,
+                                       std::vector<const JsonValue*>& outValues);
+
+[[nodiscard]] bool decodeStringMember(const JsonValue& value, DecodeState& state,
+                                      const std::string& path, std::string_view& out) noexcept;
+
+[[nodiscard]] bool decodeUInt32Member(const JsonValue& value, DecodeState& state,
+                                      const std::string& path, std::uint32_t maximum,
+                                      std::uint32_t& out);
+
+// The general canonical rational-time wire shape ({"numerator","denominator"} signed decimal
+// strings, reduced, positive denominator, canonical zero) used both by a composition's `duration`
+// and, unadorned, by a `rational` constant value and a keyframe's `time` (see
+// docs/architecture/project-format.md, "Decimal Strings And JSON Integers" and "Animation").
+[[nodiscard]] bool decodeRationalTimeValue(const JsonValue& node, DecodeState& state,
+                                           const std::string& path, core::RationalTime& out);
+
+// Reads an object's first member, requires it to be literally named "kind", and decodes its
+// string value as the discriminator for a branch the caller resolves afterward (constant value,
+// parameter source, edge destination, OCIO locator).
+[[nodiscard]] bool decodeKindDiscriminator(const JsonValue& node, DecodeState& state,
+                                           const std::string& path, std::string_view& kindText);
+
+// Every typed 64-bit object id in schema `1.0` shares one wire shape: an unsigned decimal string
+// matching `[1-9][0-9]*` that fits uint64, with zero invalid (see
+// docs/architecture/project-format.md, "Decimal Strings And JSON Integers"). One template covers
+// every ProjectId/CompositionId/NodeId/EdgeId/LayerId/LayerSlotId/ParameterId/AnimationCurveId/
+// KeyframeId decode site.
+template <typename IdType>
+[[nodiscard]] bool decodeObjectId(const JsonValue& value, DecodeState& state,
+                                  const std::string& path, IdType& out) {
+    std::string_view text;
+    if (!decodeStringMember(value, state, path, text)) {
+        return false;
+    }
+    const auto parsed = parseCanonicalObjectId(text);
+    if (!parsed) {
+        state.fail(DocumentDecodeError::InvalidId, path);
+        return false;
+    }
+    out = IdType::fromRaw(*parsed.value());
+    return true;
+}
+
+// Decodes a composition's already-order-checked `parameters`, `animationCurves`, and `graph`
+// members (see document_decode.cpp's decodeComposition, which matches the composition object's
+// exact seven-member shape before delegating here). Cross-reference checks that need more than
+// one decoded collection (a parameter's curveId, a node binding's parameterId, and every
+// edge/layerOutput/layerStack/compositionOutput node id) run here too, once every collection they
+// reference is fully decoded. Defined in document_decode_composition.cpp.
+[[nodiscard]] bool
+decodeCompositionInterior(const JsonValue& parametersNode, const JsonValue& animationCurvesNode,
+                          const JsonValue& graphNode, DecodeState& state,
+                          const std::string& parametersPath, const std::string& curvesPath,
+                          const std::string& graphPath,
+                          std::vector<document::ParameterRecord>& parameters,
+                          std::vector<document::AnimationCurveRecord>& curves, DecodedGraph& graph);
+
+} // namespace bloom::project::detail
+
+#endif // BLOOM_PROJECT_DOCUMENT_DECODE_INTERNAL_HPP

--- a/src/project/include/bloom/project/document_decode.hpp
+++ b/src/project/include/bloom/project/document_decode.hpp
@@ -2,9 +2,12 @@
 
 #include <bloom/core/pixel_aspect_ratio.hpp>
 #include <bloom/core/rational_time.hpp>
+#include <bloom/document/animation.hpp>
 #include <bloom/document/color_settings.hpp>
 #include <bloom/document/composition_settings.hpp>
+#include <bloom/document/graph.hpp>
 #include <bloom/document/ids.hpp>
+#include <bloom/document/parameter.hpp>
 #include <bloom/project/strict_json_dom.hpp>
 
 #include <array>
@@ -15,28 +18,36 @@
 #include <vector>
 
 // Typed decode of the document.json envelope from a parsed strict JSON DOM (see
-// docs/architecture/project-format.md, "Canonical Document Shape", "Project And Composition", and
-// "Project Color Settings And OCIO Reference"). This is the schema-specific validation layer the
-// format contract requires: a generic JSON Schema validator can check structure and lexical
-// bounds, but only typed decode establishes canonical acceptance (exact member order, canonical
-// decimal/rational spellings, frozen v1 value domains, and cross-field agreement such as
-// portability/locator family).
+// docs/architecture/project-format.md, "Canonical Document Shape", "Project And Composition",
+// "Project Color Settings And OCIO Reference", "Parameters", "Animation", and "Canonical Graph").
+// This is the schema-specific validation layer the format contract requires: a generic JSON
+// Schema validator can check structure and lexical bounds, but only typed decode establishes
+// canonical acceptance (exact member order, canonical decimal/rational spellings, frozen v1 value
+// domains, and cross-field agreement such as portability/locator family).
 //
-// Scope (R1): the document envelope and its non-graph durable values only -- schemaVersion,
-// project id/name/colorSettings, and per-composition id/name/duration/format. Parameters,
-// animation curves, the canonical graph, idAllocation content, and extension records are not
-// decoded here; composition objects are matched only on their required id/name/duration/format
-// prefix so a real writer-produced document (which always continues with parameters,
-// animationCurves, graph) still decodes. idAllocation and extensions are checked only for
-// presence, position, and JSON kind. This module deliberately does not construct
-// bloom::document::Project or bloom::document::Document: reassembling the live model and
-// restoring the id allocator from idAllocation.highestIssued is a later slice. The unknown-member
-// round-trip overlay is also a later slice, so an unrecognized root member is a typed decode
-// error rather than being preserved.
+// Scope (R2): the document envelope and every durable value inside a composition -- schemaVersion,
+// project id/name/colorSettings, and per-composition id/name/duration/format/parameters/
+// animationCurves/graph. A composition object is now closed: it must contain exactly those seven
+// members in exact order, and an unrecognized or trailing member is a typed decode error. Within a
+// composition, cross-references are checked against records decoded elsewhere in that same
+// composition -- a parameter binding's parameterId, an animation-curve source's curveId, and every
+// edge/Layer Output/Layer Stack/compositionOutput node id must each name a record this module
+// itself decoded; an unresolved reference is DanglingReference. Cross-composition and
+// project-level references (e.g. a future extension-record subject) remain out of scope.
+// idAllocation content and extension records are still checked only for presence, position, and
+// JSON kind. This module deliberately does not construct bloom::document::Project or
+// bloom::document::Document: reassembling the live model (which additionally enforces
+// document-construction invariants such as expected node/schema bindings, Layer Stack membership,
+// and cycle freedom -- see bloom::document::CanonicalGraph::validate()) and restoring the id
+// allocator from idAllocation.highestIssued is a later slice. The unknown-member round-trip
+// overlay is also a later slice, so an unrecognized root member is a typed decode error rather
+// than being preserved.
 //
 // Decoding constructs every typed value through its existing checked surface: canonical_decimal.hpp
-// parsers for decimal-string ids/rationals and canonical JSON-number uint32 fields,
-// core::RationalTime::create (via parseCanonicalRationalTime), core::PixelAspectRatio::create (via
+// parsers for decimal-string ids/rationals/int64s, canonical JSON-number uint32 fields, and known
+// Float64 members (parseKnownFloat64, which accepts every RFC 8259 spelling that rounds to a
+// finite binary64 value and rejects overflow to infinity); core::RationalTime::create (via
+// parseCanonicalRationalTime), core::PixelAspectRatio::create (via
 // parseCanonicalPositiveRatio/parseCanonicalPixelAspectRatio), bloom::document::FrameRate::create,
 // bloom::document::CompositionFormat::create, bloom::core::Sha256Digest::fromLowercaseHex, and
 // bloom::document::ColorSettings::validate()/OcioConfigReference::validate() for the OCIO
@@ -51,19 +62,59 @@
 
 namespace bloom::project {
 
-// One decoded composition's non-graph durable values.
+// One decoded composition's canonical graph's Layer Stack: the stable node id owning it, and its
+// entries in exact source order (Layer Stack entries are never canonically sorted; see
+// docs/architecture/project-format.md, "Canonical Graph"). Deliberately a plain mirror of
+// bloom::document::LayerStack rather than that class: LayerStack's constructor and append() apply
+// live-document invariants (duplicate slot/layer rejection) that are a later
+// document-construction concern, not this package's wire-shape decode.
+struct DecodedLayerStack final {
+    document::NodeId nodeId;
+    std::vector<document::LayerStackEntry> entries;
+
+    friend bool operator==(const DecodedLayerStack&, const DecodedLayerStack&) = default;
+};
+
+// One decoded composition's canonical graph. A plain mirror of bloom::document::CanonicalGraph
+// rather than that class: CanonicalGraph has no default constructor (it always owns a Layer Stack
+// node id) and its addNode()/addEdge()/addLayerOutput() apply live-document invariants
+// (schema-specific expected bindings, Layer Stack/Layer Output membership, cycle freedom, ...)
+// that are a later document-construction concern. bloom::document::NodeRecord, EdgeRecord, and
+// LayerOutputBoundary are plain aggregate structs with no such invariants in their own
+// construction, so they are reused directly.
+struct DecodedGraph final {
+    std::vector<document::NodeRecord> nodes;
+    std::vector<document::EdgeRecord> edges;
+    std::vector<document::LayerOutputBoundary> layerOutputs;
+    DecodedLayerStack layerStack;
+    document::OutputPortRef compositionOutput;
+
+    friend bool operator==(const DecodedGraph&, const DecodedGraph&) = default;
+};
+
+// One decoded composition's durable values.
 struct DecodedComposition final {
     document::CompositionId id;
     std::string name;
     core::RationalTime duration;
     document::CompositionFormat format;
+    // bloom::document::ParameterRecord and bloom::document::AnimationCurveRecord are plain
+    // aggregate/variant value types with no invariant-enforcing constructor of their own, so they
+    // are reused directly rather than through bloom::document::ParameterStore/AnimationCurveStore
+    // (whose insert() applies live-document invariants -- schema/value agreement, curve ownership,
+    // ... -- that are a later document-construction concern).
+    std::vector<document::ParameterRecord> parameters;
+    std::vector<document::AnimationCurveRecord> animationCurves;
+    DecodedGraph graph;
 
     friend bool operator==(const DecodedComposition&, const DecodedComposition&) = default;
 };
 
-// The decoded document.json envelope's non-graph durable values. Deliberately not a
-// bloom::document::Project: reconstructing the live model (graph, parameters, animation curves,
-// extension records) and restoring the id allocator are out of scope for this package.
+// The decoded document.json envelope's durable values. Deliberately not a
+// bloom::document::Project: reconstructing the live model (restoring the id allocator, and
+// applying document-construction invariants beyond this module's wire-shape and
+// within-composition cross-reference checks) and decoding extension records are out of scope for
+// this package.
 struct DecodedDocumentEnvelope final {
     document::ProjectId projectId;
     std::string projectName;
@@ -112,10 +163,62 @@ enum class DocumentDecodeError : std::uint8_t {
     // product > 2^32, processColorSpaceId != "lin_rec709_scene", a built-in OCIO URI other than
     // the exact immutable identity, a malformed project-relative or external OCIO locator,
     // portability disagreeing with the locator family, an OCIO revision algorithm other than
-    // "sha256", or an OCIO context variable with an invalid name/value or an unsorted/duplicate
-    // name. These are reported through bloom::document::ColorSettings::validate() and
-    // OcioConfigReference::validate() rather than being re-implemented here.
+    // "sha256", an OCIO context variable with an invalid name/value or an unsorted/duplicate name,
+    // or a graph node schemaVersion of zero. These are reported through
+    // bloom::document::ColorSettings::validate()/OcioConfigReference::validate() or an inline
+    // domain check rather than being re-implemented as a dedicated typed error.
     DomainViolation,
+    // A constant value's numeric JSON number does not round to a finite binary64 value (exact
+    // overflow to infinity) or is otherwise not an accepted Float64 spelling.
+    InvalidFloat64,
+    // A constant int64 value's decimal-string spelling is non-canonical or does not fit int64.
+    InvalidInt64Value,
+    // A parameter source's `kind` discriminator is not "constant" or "animation-curve" -- for
+    // example the deferred "driver-binding" wire vocabulary (see
+    // docs/architecture/project-format.md, "Parameters").
+    UnsupportedParameterSource,
+    // A constant value's `kind` discriminator is not one of the seven known v1 value kinds.
+    InvalidConstantValueKind,
+    // Parameters are not sorted by strictly ascending numeric ParameterId.
+    UnsortedParameters,
+    // Two parameters declare the same numeric ParameterId.
+    DuplicateParameter,
+    // Animation curves are not sorted by strictly ascending numeric AnimationCurveId.
+    UnsortedAnimationCurves,
+    // Two animation curves declare the same numeric AnimationCurveId.
+    DuplicateAnimationCurve,
+    // An animation curve's `kind` discriminator is not "scalar" or "vec2".
+    InvalidAnimationCurveKind,
+    // An animation curve's keyframes array is empty.
+    EmptyKeyframes,
+    // Consecutive keyframes are not in strictly increasing exact rational time.
+    NonIncreasingKeyframeTime,
+    // A keyframe's `outgoingInterpolation` is not "hold" or "linear".
+    InvalidInterpolation,
+    // An animation curve's final keyframe interpolation is not canonical "linear".
+    FinalKeyframeNotLinear,
+    // Graph nodes are not sorted by strictly ascending numeric NodeId.
+    UnsortedNodes,
+    // Two graph nodes declare the same numeric NodeId.
+    DuplicateNode,
+    // A node's parameter bindings are not sorted by UTF-8 role then numeric ParameterId.
+    UnsortedBindings,
+    // Two parameter bindings on the same node declare the same role.
+    DuplicateBinding,
+    // Graph edges are not sorted by strictly ascending numeric EdgeId.
+    UnsortedEdges,
+    // Two graph edges declare the same numeric EdgeId.
+    DuplicateEdge,
+    // An edge destination's `kind` discriminator is not "node-input" or "layer-stack-input".
+    InvalidEdgeDestinationKind,
+    // Layer Output boundaries are not sorted by numeric LayerId then numeric NodeId.
+    UnsortedLayerOutputs,
+    // Two Layer Output boundaries declare the same (LayerId, NodeId) pair.
+    DuplicateLayerOutput,
+    // A parameter binding's parameterId, an animation-curve source's curveId, or an
+    // edge/Layer Output/Layer Stack/compositionOutput node id does not name a record decoded
+    // elsewhere in this same composition.
+    DanglingReference,
 };
 
 // A bounded diagnostic path to one JSON member, formatted as `/key/0/key`, mirroring

--- a/src/project/tests/document_decode_tests.cpp
+++ b/src/project/tests/document_decode_tests.cpp
@@ -1,14 +1,20 @@
 #include <bloom/project/document_decode.hpp>
 
+#include <bloom/core/color.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
 #include <bloom/core/rational_time.hpp>
 #include <bloom/core/sha256.hpp>
+#include <bloom/document/animation.hpp>
 #include <bloom/document/color_settings.hpp>
 #include <bloom/document/document.hpp>
+#include <bloom/document/graph.hpp>
 #include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
 #include <bloom/project/canonical_document.hpp>
 #include <bloom/project/project_io_memory.hpp>
 #include <bloom/project/strict_json_dom.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -79,6 +85,15 @@ constexpr std::string_view kSchemaVersion10 = R"({"major":1,"minor":0})";
 constexpr std::string_view kValidDigest =
     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 
+// A minimal closed composition interior: exactly one node (used both as the required Layer Stack
+// owner and the required compositionOutput target, which R2 permits -- CanonicalGraph's stricter
+// node-type/role invariants are a later document-construction concern). Used by every fixture
+// below that is not itself exercising parameters/animationCurves/graph.
+constexpr std::string_view kMinimalGraphJson =
+    R"({"nodes":[{"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+    R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+    R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+
 [[nodiscard]] std::string colorSettingsJson(const std::string_view digest,
                                             const std::string_view portability,
                                             const std::string_view contextVariablesJson) {
@@ -126,12 +141,33 @@ constexpr std::string_view kValidDigest =
     result += frameRateNumerator;
     result += "\",\"denominator\":\"";
     result += frameRateDenominator;
-    result += "\"}}}";
+    result += "\"}},\"parameters\":[],\"animationCurves\":[],\"graph\":";
+    result += kMinimalGraphJson;
+    result += "}";
     return result;
 }
 
 [[nodiscard]] std::string defaultCompositionJson(const std::string_view idJson = R"("1")") {
     return compositionJson(idJson, "Comp", "10", "1", "1920", "1080", "1", "1", "24", "1");
+}
+
+// Builds a full composition object with id "1"/name "Comp"/a fixed valid duration and format, and
+// caller-supplied parameters/animationCurves/graph bodies -- used by every R2 composition-interior
+// rejection and acceptance test below.
+[[nodiscard]] std::string compositionWithInterior(const std::string_view parametersJson,
+                                                  const std::string_view animationCurvesJson,
+                                                  const std::string_view graphJson) {
+    std::string result =
+        R"({"id":"1","name":"Comp","duration":{"numerator":"10","denominator":"1"},)"
+        R"("format":{"width":1920,"height":1080,"pixelAspect":{"numerator":"1","denominator":"1"},)"
+        R"("frameRate":{"numerator":"24","denominator":"1"}},"parameters":)";
+    result += parametersJson;
+    result += R"(,"animationCurves":)";
+    result += animationCurvesJson;
+    result += R"(,"graph":)";
+    result += graphJson;
+    result += "}";
+    return result;
 }
 
 [[nodiscard]] std::string documentJson(const std::string_view schemaVersionJson,
@@ -293,8 +329,243 @@ void testFullRoundTrip(Expectations& expectations) {
                 "round trip: decoded composition duration equals the source duration");
             expectations.expect(decodedComposition.format == sourceComposition.format(),
                                 "round trip: decoded composition format equals the source format");
+            expectations.expect(
+                decodedComposition.parameters.empty() &&
+                    sourceComposition.parameters().records().empty(),
+                "round trip: the minimal new-project composition has no parameters on either side");
+            expectations.expect(
+                decodedComposition.animationCurves.empty() &&
+                    sourceComposition.animationCurves().records().empty(),
+                "round trip: the minimal new-project composition has no animation curves on "
+                "either side");
+            expectations.expect(
+                decodedComposition.graph.nodes.size() == 2 &&
+                    decodedComposition.graph.edges.size() == 1 &&
+                    decodedComposition.graph.layerOutputs.empty(),
+                "round trip: the minimal new-project graph decodes its Layer Stack node, "
+                "composition-output node, and connecting edge");
+            expectations.expect(
+                decodedComposition.graph.layerStack.nodeId ==
+                        sourceComposition.graph().layerStack().nodeId() &&
+                    decodedComposition.graph.layerStack.entries.empty(),
+                "round trip: decoded Layer Stack node id matches and has no entries");
+            expectations.expect(
+                sourceComposition.graph().compositionOutput().has_value() &&
+                    decodedComposition.graph.compositionOutput ==
+                        *sourceComposition.graph().compositionOutput(),
+                "round trip: decoded compositionOutput matches the source graph's output");
         }
     }
+}
+
+void testComposedRoundTrip(Expectations& expectations) {
+    using namespace bloom::document;
+    using bloom::core::Color4d;
+    using bloom::core::PixelAspectRatio;
+    using bloom::core::RationalTime;
+
+    // Mirrors canonical_document_tests.cpp's testComposedGoldenBytes fixture (solid layer, one
+    // animated scalar opacity curve, one constant vec2 position, one constant color4) so this test
+    // exercises the exact composed shape the writer emits and this decoder must invert.
+    const auto duration = RationalTime::create(48, 24);
+    const auto frameRate = FrameRate::create(24000, 1001);
+    const auto pixelAspect = PixelAspectRatio::create(2, 1);
+    const auto format =
+        CompositionFormat::create(1280, 720, pixelAspect.value_or(PixelAspectRatio::square()),
+                                  frameRate.value_or(FrameRate::framesPerSecond24()));
+    if (!duration.has_value() || !format.has_value()) {
+        expectations.expect(false, "the composed fixture values are constructible");
+        return;
+    }
+
+    CanonicalGraph graph{NodeId::fromRaw(1)};
+    const NodeRecord layerOutputNode{
+        NodeId::fromRaw(3),
+        std::string(kLayerOutputNodeType),
+        {{"opacity", ParameterId::fromRaw(3)}, {"position", ParameterId::fromRaw(5)}},
+        kLayerOutputNodeSchemaVersion};
+    const NodeRecord layerStackNode{
+        NodeId::fromRaw(1), std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion};
+    const NodeRecord compositionOutputNode{NodeId::fromRaw(4),
+                                           std::string(kCompositionOutputNodeType),
+                                           {},
+                                           kCompositionOutputNodeSchemaVersion};
+    const NodeRecord solidSourceNode{NodeId::fromRaw(2),
+                                     std::string(kSolidSourceNodeType),
+                                     {{"color", ParameterId::fromRaw(7)}},
+                                     kSolidSourceNodeSchemaVersion};
+    const bool nodesAdded = graph.addNode(layerOutputNode) && graph.addNode(layerStackNode) &&
+                            graph.addNode(compositionOutputNode) && graph.addNode(solidSourceNode);
+    const EdgeRecord stackToOutputEdge{
+        EdgeId::fromRaw(3),
+        {NodeId::fromRaw(1), std::string(kLayerStackOutputPort)},
+        NodeInputRef{NodeId::fromRaw(4), std::string(kCompositionOutputInputPort)}};
+    const EdgeRecord solidToLayerEdge{
+        EdgeId::fromRaw(1),
+        {NodeId::fromRaw(2), std::string(kSolidSourceOutputPort)},
+        NodeInputRef{NodeId::fromRaw(3), std::string(kLayerOutputContentInputPort)}};
+    const EdgeRecord layerToStackEdge{EdgeId::fromRaw(2),
+                                      {NodeId::fromRaw(3), std::string(kLayerOutputOutputPort)},
+                                      LayerStackInputRef{NodeId::fromRaw(1),
+                                                         LayerSlotId::fromRaw(1),
+                                                         std::string(kLayerStackContentInputRole)}};
+    const bool edgesAdded = graph.addEdge(stackToOutputEdge) && graph.addEdge(solidToLayerEdge) &&
+                            graph.addEdge(layerToStackEdge);
+    const bool boundariesAdded =
+        graph.addLayerOutput({NodeId::fromRaw(3), LayerId::fromRaw(1), "Hero Plate",
+                              std::string(kLayerOutputOutputPort)});
+    expectations.expect(
+        nodesAdded && edgesAdded && boundariesAdded &&
+            graph.layerStack().append({LayerSlotId::fromRaw(1), LayerId::fromRaw(1)}),
+        "the composed fixture graph accepts its deliberately scrambled parts");
+
+    graph.setCompositionOutput({NodeId::fromRaw(4), std::string(kCompositionOutputOutputPort)});
+    Composition composition{CompositionId::fromRaw(1), "Hero Shot", *duration, std::move(graph),
+                            *format};
+    expectations.expect(composition.parameters().insert(
+                            {ParameterId::fromRaw(7), std::string(kSolidColorParameterSchemaKey),
+                             ConstantValueSource{Color4d{0.0, 0.5, 1.0, 1.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(5), std::string(kPositionParameterSchemaKey),
+                                 ConstantValueSource{Vec2d{96.0, -48.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(3), std::string(kOpacityParameterSchemaKey),
+                                 AnimationCurveSource{AnimationCurveId::fromRaw(9)}}),
+                        "the composed fixture parameters insert out of numeric ID order");
+
+    ScalarAnimationCurve curve;
+    curve.id = AnimationCurveId::fromRaw(9);
+    curve.keyframes.push_back(
+        {KeyframeId::fromRaw(21), RationalTime{}, 0.25, KeyframeInterpolation::Hold});
+    curve.keyframes.push_back({KeyframeId::fromRaw(22), RationalTime::fromInteger(48), 1.0,
+                               KeyframeInterpolation::Linear});
+    expectations.expect(composition.animationCurves().insert(curve),
+                        "the composed fixture animation curve inserts");
+
+    Project project{ProjectId::fromRaw(1), "Spot Check"};
+    expectations.expect(project.addComposition(std::move(composition)),
+                        "the composed fixture composition adds");
+
+    const IdAllocatorHighWater highWater{.composition = 1,
+                                         .node = 4,
+                                         .edge = 3,
+                                         .layer = 1,
+                                         .layerSlot = 1,
+                                         .parameter = 7,
+                                         .animationCurve = 9,
+                                         .keyframe = 22,
+                                         .driverBinding = 0,
+                                         .extensionRecord = 0};
+    Document document{std::move(project), highWater};
+    auto snapshot = document.snapshot();
+
+    std::array<char, 256> payloadScratch{};
+    std::array<std::size_t, 256> sortScratch{};
+    const auto settings =
+        bloom::document::makeBloomNeutralColorSettingsV1(bloom::core::Sha256Digest::fromBytes([] {
+            std::array<std::uint8_t, 32> bytes{};
+            std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+            return bytes;
+        }()));
+    const bloom::project::CanonicalDocumentV1 request{
+        .snapshot = &snapshot,
+        .colorSettings = &settings,
+        .payloadScratch = payloadScratch,
+        .sortScratch = sortScratch,
+    };
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    if (!size.hasValue()) {
+        expectations.expect(false, "the composed fixture sizes successfully");
+        return;
+    }
+    std::vector<char> output(*size.value());
+    const auto written = bloom::project::encodeCanonicalDocument(request, output);
+    if (!written) {
+        expectations.expect(false, "the composed fixture encodes successfully");
+        return;
+    }
+
+    const std::string_view encodedText(output.data(), output.size());
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(encodedText), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    expectations.expect(static_cast<bool>(parsed), "the composed fixture parses as strict JSON");
+    if (!parsed) {
+        return;
+    }
+
+    const auto decoded = bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+    expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr,
+                        "the composed fixture decodes without error");
+    if (decoded.value() == nullptr) {
+        return;
+    }
+
+    expectations.expect(decoded.value()->compositions.size() == 1,
+                        "the composed fixture decodes exactly one composition");
+    if (decoded.value()->compositions.empty()) {
+        return;
+    }
+    const auto& decodedComposition = decoded.value()->compositions.front();
+    const auto& sourceComposition = snapshot.project().compositions().front();
+
+    // Parameters: source insertion order is 7,5,3 (out-of-order on purpose); decoded order is
+    // strictly ascending numeric ParameterId.
+    std::vector<ParameterRecord> sourceParameters(sourceComposition.parameters().records().begin(),
+                                                  sourceComposition.parameters().records().end());
+    std::ranges::sort(sourceParameters,
+                      [](const auto& left, const auto& right) { return left.id < right.id; });
+    expectations.expect(decodedComposition.parameters == sourceParameters,
+                        "composed round trip: decoded parameters equal the source parameters, "
+                        "sorted by numeric id");
+
+    // Animation curves: AnimationCurveStore already keeps sorted order.
+    const std::vector<AnimationCurveRecord> sourceCurves(
+        sourceComposition.animationCurves().records().begin(),
+        sourceComposition.animationCurves().records().end());
+    expectations.expect(decodedComposition.animationCurves == sourceCurves,
+                        "composed round trip: decoded animation curves equal the source curves");
+
+    // Graph: nodes/edges/layerOutputs were inserted out of id order on purpose; sort copies to
+    // match the decoder's canonical numeric order before comparing.
+    std::vector<NodeRecord> sourceNodes(sourceComposition.graph().nodes().begin(),
+                                        sourceComposition.graph().nodes().end());
+    std::ranges::sort(sourceNodes,
+                      [](const auto& left, const auto& right) { return left.id < right.id; });
+    expectations.expect(decodedComposition.graph.nodes == sourceNodes,
+                        "composed round trip: decoded nodes equal the source nodes, sorted by id");
+
+    std::vector<EdgeRecord> sourceEdges(sourceComposition.graph().edges().begin(),
+                                        sourceComposition.graph().edges().end());
+    std::ranges::sort(sourceEdges,
+                      [](const auto& left, const auto& right) { return left.id < right.id; });
+    expectations.expect(decodedComposition.graph.edges == sourceEdges,
+                        "composed round trip: decoded edges equal the source edges, sorted by id");
+
+    std::vector<LayerOutputBoundary> sourceLayerOutputs(
+        sourceComposition.graph().layerOutputs().begin(),
+        sourceComposition.graph().layerOutputs().end());
+    std::ranges::sort(sourceLayerOutputs, [](const auto& left, const auto& right) {
+        return std::pair{left.layerId.value(), left.nodeId.value()} <
+               std::pair{right.layerId.value(), right.nodeId.value()};
+    });
+    expectations.expect(decodedComposition.graph.layerOutputs == sourceLayerOutputs,
+                        "composed round trip: decoded layer outputs equal the source layer "
+                        "outputs, sorted by (layerId, nodeId)");
+
+    expectations.expect(decodedComposition.graph.layerStack.nodeId ==
+                            sourceComposition.graph().layerStack().nodeId(),
+                        "composed round trip: decoded Layer Stack node id equals the source");
+    const std::vector<LayerStackEntry> sourceEntries(
+        sourceComposition.graph().layerStack().entries().begin(),
+        sourceComposition.graph().layerStack().entries().end());
+    expectations.expect(decodedComposition.graph.layerStack.entries == sourceEntries,
+                        "composed round trip: decoded Layer Stack entries equal the source "
+                        "entries in source order");
+
+    expectations.expect(sourceComposition.graph().compositionOutput().has_value() &&
+                            decodedComposition.graph.compositionOutput ==
+                                *sourceComposition.graph().compositionOutput(),
+                        "composed round trip: decoded compositionOutput equals the source");
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -344,10 +615,17 @@ void testRejectsCompositionMemberOrder(Expectations& expectations) {
 }
 
 void testRejectsFormatMemberOrder(Expectations& expectations) {
+    // Unlike testRejectsCompositionMissingFormat/testRejectsCompositionMemberOrder above (whose
+    // failure is detected while matching the composition object's own seven-key shape, before
+    // format's content is ever inspected), this test exercises decodeFormat's own internal member
+    // order, so the composition must otherwise be fully closed (parameters/animationCurves/graph
+    // present) for control to reach format's content decode at all.
     const std::string composition =
         R"({"id":"1","name":"Comp","duration":{"numerator":"10","denominator":"1"},)"
         R"("format":{"height":1080,"width":1920,"pixelAspect":{"numerator":"1","denominator":"1"},)"
-        R"("frameRate":{"numerator":"24","denominator":"1"}}})";
+        R"("frameRate":{"numerator":"24","denominator":"1"}},"parameters":[],)"
+        R"("animationCurves":[],"graph":)" +
+        std::string(kMinimalGraphJson) + "}";
     expectDecodeFailure(expectations, documentWithComposition(composition),
                         DocumentDecodeError::MemberOutOfOrder,
                         "/project/compositions/0/format/height",
@@ -610,6 +888,598 @@ void testRejectsDuplicateCompositions(Expectations& expectations) {
                         "two compositions declaring the same numeric id are rejected");
 }
 
+// ---------------------------------------------------------------------------------------------
+// R2: the composition object is now closed (the R1 staging gap)
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsClosedCompositionTrailingMember(Expectations& expectations) {
+    const std::string valid = compositionWithInterior("[]", "[]", std::string(kMinimalGraphJson));
+    const std::string composition = valid.substr(0, valid.size() - 1) + R"(,"bogus":null})";
+    expectDecodeFailure(expectations, documentWithComposition(composition),
+                        DocumentDecodeError::UnknownMember, "/project/compositions/0/bogus",
+                        "a fully-formed composition with a trailing unrecognized member is now "
+                        "rejected -- R1 accepted trailing members unvalidated");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Parameters: collection ordering and source discriminator
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] std::string boolConstantParameterJson(const std::string_view idJson) {
+    std::string result = R"({"id":)";
+    result += idJson;
+    result += R"(,"schemaKey":"bloom.test","source":{"kind":"constant",)"
+              R"("value":{"kind":"bool","value":true}}})";
+    return result;
+}
+
+void testRejectsUnsortedParameters(Expectations& expectations) {
+    const std::string parameters =
+        "[" + boolConstantParameterJson(R"("2")") + "," + boolConstantParameterJson(R"("1")") + "]";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior(
+                            parameters, "[]", std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::UnsortedParameters,
+                        "/project/compositions/0/parameters/1/id",
+                        "parameters out of ascending numeric id order are rejected");
+}
+
+void testRejectsDuplicateParameters(Expectations& expectations) {
+    const std::string parameters =
+        "[" + boolConstantParameterJson(R"("1")") + "," + boolConstantParameterJson(R"("1")") + "]";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior(
+                            parameters, "[]", std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::DuplicateParameter,
+                        "/project/compositions/0/parameters/1/id",
+                        "two parameters declaring the same numeric id are rejected");
+}
+
+void testRejectsUnsupportedParameterSourceKind(Expectations& expectations) {
+    const std::string parameters =
+        R"([{"id":"1","schemaKey":"bloom.test","source":{"kind":"driver-binding",)"
+        R"("driverId":"1"}}])";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior(
+                            parameters, "[]", std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::UnsupportedParameterSource,
+                        "/project/compositions/0/parameters/0/source/kind",
+                        "a spelled-out 'driver-binding' parameter source kind is the deferred wire "
+                        "vocabulary, reported as an unsupported source rather than fabricated");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Constant values: exact member order and kind
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] std::string parameterWithConstantValueJson(const std::string_view valueJson) {
+    std::string result = R"({"id":"1","schemaKey":"bloom.test","source":{"kind":"constant",)"
+                         R"("value":)";
+    result += valueJson;
+    result += "}}";
+    return result;
+}
+
+void expectConstantValueRejected(Expectations& expectations, const std::string_view valueJson,
+                                 const DocumentDecodeError expectedError,
+                                 const std::string_view expectedPath,
+                                 const std::string_view message) {
+    const std::string parameters = "[" + parameterWithConstantValueJson(valueJson) + "]";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior(
+                            parameters, "[]", std::string(kMinimalGraphJson))),
+                        expectedError, expectedPath, message);
+}
+
+void testRejectsBoolValueWrongOrder(Expectations& expectations) {
+    expectConstantValueRejected(
+        expectations, R"({"value":true,"kind":"bool"})", DocumentDecodeError::UnknownMember,
+        "/project/compositions/0/parameters/0/source/value/value",
+        "a bool constant value spelled with 'value' before 'kind' is rejected -- 'kind' must "
+        "be literally first");
+}
+
+void testRejectsInt64ValueWrongOrder(Expectations& expectations) {
+    expectConstantValueRejected(
+        expectations, R"({"value":"1","kind":"int64"})", DocumentDecodeError::UnknownMember,
+        "/project/compositions/0/parameters/0/source/value/value",
+        "an int64 constant value spelled with 'value' before 'kind' is rejected");
+}
+
+void testRejectsFloat64ValueWrongOrder(Expectations& expectations) {
+    expectConstantValueRejected(
+        expectations, R"({"value":1.0,"kind":"float64"})", DocumentDecodeError::UnknownMember,
+        "/project/compositions/0/parameters/0/source/value/value",
+        "a float64 constant value spelled with 'value' before 'kind' is rejected");
+}
+
+void testRejectsStringValueWrongOrder(Expectations& expectations) {
+    expectConstantValueRejected(
+        expectations, R"({"value":"text","kind":"string"})", DocumentDecodeError::UnknownMember,
+        "/project/compositions/0/parameters/0/source/value/value",
+        "a string constant value spelled with 'value' before 'kind' is rejected");
+}
+
+void testRejectsVec2ValueWrongOrder(Expectations& expectations) {
+    expectConstantValueRejected(expectations, R"({"kind":"vec2","y":0.0,"x":0.0})",
+                                DocumentDecodeError::MemberOutOfOrder,
+                                "/project/compositions/0/parameters/0/source/value/y",
+                                "a vec2 constant value spelled with 'y' before 'x' is rejected");
+}
+
+void testRejectsColor4ValueWrongOrder(Expectations& expectations) {
+    expectConstantValueRejected(
+        expectations, R"({"kind":"color4","green":0.0,"red":0.0,"blue":0.0,"alpha":1.0})",
+        DocumentDecodeError::MemberOutOfOrder,
+        "/project/compositions/0/parameters/0/source/value/green",
+        "a color4 constant value spelled with 'green' before 'red' is rejected");
+}
+
+void testRejectsRationalValueWrongOrder(Expectations& expectations) {
+    expectConstantValueRejected(
+        expectations, R"({"kind":"rational","denominator":"1","numerator":"0"})",
+        DocumentDecodeError::MemberOutOfOrder,
+        "/project/compositions/0/parameters/0/source/value/denominator",
+        "a rational constant value spelled with 'denominator' before 'numerator' is rejected");
+}
+
+void testRejectsUnknownConstantValueKind(Expectations& expectations) {
+    expectConstantValueRejected(expectations, R"({"kind":"bogus","value":true})",
+                                DocumentDecodeError::InvalidConstantValueKind,
+                                "/project/compositions/0/parameters/0/source/value/kind",
+                                "an unrecognized constant value kind is rejected");
+}
+
+void testRejectsNonFiniteFloat64(Expectations& expectations) {
+    expectConstantValueRejected(expectations, R"({"kind":"float64","value":1e309})",
+                                DocumentDecodeError::InvalidFloat64,
+                                "/project/compositions/0/parameters/0/source/value/value",
+                                "a float64 constant value that overflows to infinity is rejected");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Animation curves: collection ordering, kind, and keyframe shape
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnsortedAnimationCurves(Expectations& expectations) {
+    const std::string curves = R"([{"id":"2","kind":"scalar","keyframes":[{"id":"1",)"
+                               R"("time":{"numerator":"0","denominator":"1"},"value":0.0,)"
+                               R"("outgoingInterpolation":"linear"}]},)"
+                               R"({"id":"1","kind":"scalar","keyframes":[{"id":"2",)"
+                               R"("time":{"numerator":"0","denominator":"1"},"value":0.0,)"
+                               R"("outgoingInterpolation":"linear"}]}])";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(
+                            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::UnsortedAnimationCurves,
+                        "/project/compositions/0/animationCurves/1/id",
+                        "animation curves out of ascending numeric id order are rejected");
+}
+
+void testRejectsDuplicateAnimationCurves(Expectations& expectations) {
+    const std::string curveJson = R"({"id":"1","kind":"scalar","keyframes":[{"id":"1",)"
+                                  R"("time":{"numerator":"0","denominator":"1"},"value":0.0,)"
+                                  R"("outgoingInterpolation":"linear"}]})";
+    const std::string curves = "[" + curveJson + "," + curveJson + "]";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(
+                            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::DuplicateAnimationCurve,
+                        "/project/compositions/0/animationCurves/1/id",
+                        "two animation curves declaring the same numeric id are rejected");
+}
+
+void testRejectsUnknownAnimationCurveKind(Expectations& expectations) {
+    const std::string curves = R"([{"id":"1","kind":"bogus","keyframes":[]}])";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(
+                            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::InvalidAnimationCurveKind,
+                        "/project/compositions/0/animationCurves/0/kind",
+                        "an unrecognized animation curve kind is rejected");
+}
+
+void testRejectsEmptyKeyframes(Expectations& expectations) {
+    const std::string curves = R"([{"id":"1","kind":"scalar","keyframes":[]}])";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(
+                            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::EmptyKeyframes,
+                        "/project/compositions/0/animationCurves/0/keyframes",
+                        "an animation curve with no keyframes is rejected");
+}
+
+void testRejectsEqualKeyframeTimes(Expectations& expectations) {
+    const std::string curves =
+        R"([{"id":"1","kind":"scalar","keyframes":[)"
+        R"({"id":"1","time":{"numerator":"0","denominator":"1"},"value":0.0,)"
+        R"("outgoingInterpolation":"hold"},)"
+        R"({"id":"2","time":{"numerator":"0","denominator":"1"},"value":1.0,)"
+        R"("outgoingInterpolation":"linear"}]}])";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(
+                            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::NonIncreasingKeyframeTime,
+                        "/project/compositions/0/animationCurves/0/keyframes/1/time",
+                        "two keyframes with an equal exact rational time are rejected");
+}
+
+void testRejectsDecreasingKeyframeTimes(Expectations& expectations) {
+    const std::string curves =
+        R"([{"id":"1","kind":"scalar","keyframes":[)"
+        R"({"id":"1","time":{"numerator":"10","denominator":"1"},"value":0.0,)"
+        R"("outgoingInterpolation":"hold"},)"
+        R"({"id":"2","time":{"numerator":"5","denominator":"1"},"value":1.0,)"
+        R"("outgoingInterpolation":"linear"}]}])";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(
+                            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::NonIncreasingKeyframeTime,
+                        "/project/compositions/0/animationCurves/0/keyframes/1/time",
+                        "a keyframe time that decreases from the previous keyframe is rejected");
+}
+
+void testRejectsFinalKeyframeNotLinear(Expectations& expectations) {
+    const std::string curves =
+        R"([{"id":"1","kind":"scalar","keyframes":[)"
+        R"({"id":"1","time":{"numerator":"0","denominator":"1"},"value":0.0,)"
+        R"("outgoingInterpolation":"linear"},)"
+        R"({"id":"2","time":{"numerator":"10","denominator":"1"},"value":1.0,)"
+        R"("outgoingInterpolation":"hold"}]}])";
+    expectDecodeFailure(
+        expectations,
+        documentWithComposition(
+            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+        DocumentDecodeError::FinalKeyframeNotLinear,
+        "/project/compositions/0/animationCurves/0/keyframes/1/outgoingInterpolation",
+        "a final keyframe interpolation other than canonical linear is rejected");
+}
+
+void testRejectsUnknownInterpolation(Expectations& expectations) {
+    const std::string curves =
+        R"([{"id":"1","kind":"scalar","keyframes":[)"
+        R"({"id":"1","time":{"numerator":"0","denominator":"1"},"value":0.0,)"
+        R"("outgoingInterpolation":"bogus"}]}])";
+    expectDecodeFailure(
+        expectations,
+        documentWithComposition(
+            compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))),
+        DocumentDecodeError::InvalidInterpolation,
+        "/project/compositions/0/animationCurves/0/keyframes/0/outgoingInterpolation",
+        "an unrecognized interpolation spelling is rejected");
+}
+
+void testAcceptsVec2AnimationCurve(Expectations& expectations) {
+    // An unreferenced vec2 curve is valid wire shape at this decode layer: curve ownership by
+    // exactly one parameter is a later document-construction invariant, not checked here.
+    const std::string curves = R"([{"id":"1","kind":"vec2","keyframes":[)"
+                               R"({"id":"1","time":{"numerator":"0","denominator":"1"},)"
+                               R"("value":{"x":0.0,"y":0.0},"outgoingInterpolation":"linear"}]}])";
+    const auto decoded = decodeText(documentWithComposition(
+        compositionWithInterior("[]", curves, std::string(kMinimalGraphJson))));
+    expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr,
+                        "a well-formed vec2 animation curve decodes successfully");
+    if (decoded.value() != nullptr) {
+        expectations.expect(decoded.value()->compositions.front().animationCurves.size() == 1,
+                            "the decoded composition has exactly the one vec2 curve");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Graph: node/edge/binding/layerOutput ordering, discriminators, and schemaVersion domain
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnsortedNodes(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"2","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(
+        expectations, documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+        DocumentDecodeError::UnsortedNodes, "/project/compositions/0/graph/nodes/1/id",
+        "graph nodes out of ascending numeric id order are rejected");
+}
+
+void testRejectsDuplicateNodes(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(
+        expectations, documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+        DocumentDecodeError::DuplicateNode, "/project/compositions/0/graph/nodes/1/id",
+        "two graph nodes declaring the same numeric id are rejected");
+}
+
+void testRejectsSchemaVersionZero(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":0,"parameters":[]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(
+        expectations, documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+        DocumentDecodeError::DomainViolation, "/project/compositions/0/graph/nodes/0/schemaVersion",
+        "a node schemaVersion of zero is rejected");
+}
+
+void testRejectsUnsortedBindings(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[)"
+        R"({"role":"position","parameterId":"1"},{"role":"color","parameterId":"2"}]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::UnsortedBindings,
+                        "/project/compositions/0/graph/nodes/0/parameters/1/role",
+                        "parameter bindings out of UTF-8 role order are rejected");
+}
+
+void testRejectsDuplicateBindings(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[)"
+        R"({"role":"color","parameterId":"1"},{"role":"color","parameterId":"2"}]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DuplicateBinding,
+                        "/project/compositions/0/graph/nodes/0/parameters/1/role",
+                        "two parameter bindings on the same node declaring the same role are "
+                        "rejected");
+}
+
+void testRejectsUnsortedEdges(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"2","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[)"
+        R"({"id":"2","source":{"nodeId":"1","port":"image"},)"
+        R"("destination":{"kind":"node-input","nodeId":"2","port":"image"}},)"
+        R"({"id":"1","source":{"nodeId":"1","port":"image"},)"
+        R"("destination":{"kind":"node-input","nodeId":"2","port":"image"}}],)"
+        R"("layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(
+        expectations, documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+        DocumentDecodeError::UnsortedEdges, "/project/compositions/0/graph/edges/1/id",
+        "graph edges out of ascending numeric id order are rejected");
+}
+
+void testRejectsDuplicateEdges(Expectations& expectations) {
+    const std::string edgeJson =
+        R"({"id":"1","source":{"nodeId":"1","port":"image"},)"
+        R"("destination":{"kind":"node-input","nodeId":"2","port":"image"}})";
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"2","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[)" +
+        edgeJson + "," + edgeJson +
+        R"(],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(
+        expectations, documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+        DocumentDecodeError::DuplicateEdge, "/project/compositions/0/graph/edges/1/id",
+        "two graph edges declaring the same numeric id are rejected");
+}
+
+void testRejectsUnknownEdgeDestinationKind(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"2","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[)"
+        R"({"id":"1","source":{"nodeId":"1","port":"image"},)"
+        R"("destination":{"kind":"bogus","nodeId":"2","port":"image"}}],)"
+        R"("layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::InvalidEdgeDestinationKind,
+                        "/project/compositions/0/graph/edges/0/destination/kind",
+                        "an unrecognized edge destination kind is rejected");
+}
+
+void testRejectsUnsortedLayerOutputs(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.layer-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],)"
+        R"("layerOutputs":[)"
+        R"({"nodeId":"1","layerId":"2","name":"B","outputPort":"image"},)"
+        R"({"nodeId":"1","layerId":"1","name":"A","outputPort":"image"}],)"
+        R"("layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::UnsortedLayerOutputs,
+                        "/project/compositions/0/graph/layerOutputs/1/layerId",
+                        "Layer Output boundaries out of (layerId, nodeId) order are rejected");
+}
+
+void testRejectsDuplicateLayerOutputs(Expectations& expectations) {
+    const std::string boundaryJson =
+        R"({"nodeId":"1","layerId":"1","name":"A","outputPort":"image"})";
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.layer-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],)"
+        R"("layerOutputs":[)" +
+        boundaryJson + "," + boundaryJson +
+        R"(],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DuplicateLayerOutput,
+                        "/project/compositions/0/graph/layerOutputs/1/layerId",
+                        "two Layer Output boundaries declaring the same (layerId, nodeId) pair "
+                        "are rejected");
+}
+
+void testAcceptsUnsortedLayerStackEntries(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.layer-stack","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"2","typeId":"bloom.layer-output","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"3","typeId":"bloom.layer-output","schemaVersion":1,"parameters":[]},)"
+        R"({"id":"4","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],)"
+        R"("layerOutputs":[)"
+        R"({"nodeId":"2","layerId":"1","name":"A","outputPort":"image"},)"
+        R"({"nodeId":"3","layerId":"2","name":"B","outputPort":"image"}],)"
+        R"("layerStack":{"nodeId":"1","entries":[)"
+        R"({"slotId":"2","layerId":"2"},{"slotId":"1","layerId":"1"}]},)"
+        R"("compositionOutput":{"nodeId":"4","port":"image"}})";
+    const auto decoded =
+        decodeText(documentWithComposition(compositionWithInterior("[]", "[]", graph)));
+    expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr,
+                        "Layer Stack entries in reversed (non-ascending) slot order decode "
+                        "successfully -- entries are never sorted");
+    if (decoded.value() != nullptr) {
+        const auto& entries = decoded.value()->compositions.front().graph.layerStack.entries;
+        expectations.expect(entries.size() == 2 && entries[0].slotId.value() == 2 &&
+                                entries[1].slotId.value() == 1,
+                            "the decoded Layer Stack entries preserve exact source order, not "
+                            "ascending slot order");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Cross-reference checks within one decoded composition
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsDanglingCurveId(Expectations& expectations) {
+    const std::string parameters =
+        R"([{"id":"1","schemaKey":"bloom.test","source":{"kind":"animation-curve",)"
+        R"("curveId":"99"}}])";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior(
+                            parameters, "[]", std::string(kMinimalGraphJson))),
+                        DocumentDecodeError::DanglingReference,
+                        "/project/compositions/0/parameters/0/source/curveId",
+                        "a parameter's animation-curve source naming a curve id absent from "
+                        "animationCurves is rejected");
+}
+
+void testRejectsDanglingParameterId(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[)"
+        R"({"role":"color","parameterId":"99"}]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DanglingReference,
+                        "/project/compositions/0/graph/nodes/0/parameters/0/parameterId",
+                        "a node parameter binding naming a parameter id absent from parameters "
+                        "is rejected");
+}
+
+void testRejectsDanglingEdgeSourceNode(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[)"
+        R"({"id":"1","source":{"nodeId":"99","port":"image"},)"
+        R"("destination":{"kind":"node-input","nodeId":"1","port":"image"}}],)"
+        R"("layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DanglingReference,
+                        "/project/compositions/0/graph/edges/0/source/nodeId",
+                        "an edge source naming a node id absent from graph.nodes is rejected");
+}
+
+void testRejectsDanglingEdgeDestinationNode(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[)"
+        R"({"id":"1","source":{"nodeId":"1","port":"image"},)"
+        R"("destination":{"kind":"node-input","nodeId":"99","port":"image"}}],)"
+        R"("layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DanglingReference,
+                        "/project/compositions/0/graph/edges/0/destination/nodeId",
+                        "a node-input edge destination naming a node id absent from graph.nodes "
+                        "is rejected");
+}
+
+void testRejectsDanglingEdgeDestinationStackNode(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[)"
+        R"({"id":"1","source":{"nodeId":"1","port":"image"},)"
+        R"("destination":{"kind":"layer-stack-input","stackNodeId":"99","slotId":"1",)"
+        R"("role":"content"}}],)"
+        R"("layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DanglingReference,
+                        "/project/compositions/0/graph/edges/0/destination/stackNodeId",
+                        "a layer-stack-input edge destination naming a stack node id absent from "
+                        "graph.nodes is rejected");
+}
+
+void testRejectsDanglingLayerOutputNode(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],)"
+        R"("layerOutputs":[)"
+        R"({"nodeId":"99","layerId":"1","name":"A","outputPort":"image"}],)"
+        R"("layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DanglingReference,
+                        "/project/compositions/0/graph/layerOutputs/0/nodeId",
+                        "a Layer Output boundary naming a node id absent from graph.nodes is "
+                        "rejected");
+}
+
+void testRejectsDanglingLayerStackNode(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"99","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+    expectDecodeFailure(
+        expectations, documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+        DocumentDecodeError::DanglingReference, "/project/compositions/0/graph/layerStack/nodeId",
+        "a Layer Stack naming an owning node id absent from graph.nodes is "
+        "rejected");
+}
+
+void testRejectsDanglingCompositionOutputNode(Expectations& expectations) {
+    const std::string graph =
+        R"({"nodes":[)"
+        R"({"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+        R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+        R"("compositionOutput":{"nodeId":"99","port":"image"}})";
+    expectDecodeFailure(expectations,
+                        documentWithComposition(compositionWithInterior("[]", "[]", graph)),
+                        DocumentDecodeError::DanglingReference,
+                        "/project/compositions/0/graph/compositionOutput/nodeId",
+                        "a compositionOutput naming a node id absent from graph.nodes is "
+                        "rejected");
+}
+
 } // namespace
 
 int main() try {
@@ -657,6 +1527,55 @@ int main() try {
 
     testRejectsUnsortedCompositions(expectations);
     testRejectsDuplicateCompositions(expectations);
+
+    testComposedRoundTrip(expectations);
+
+    testRejectsClosedCompositionTrailingMember(expectations);
+
+    testRejectsUnsortedParameters(expectations);
+    testRejectsDuplicateParameters(expectations);
+    testRejectsUnsupportedParameterSourceKind(expectations);
+
+    testRejectsBoolValueWrongOrder(expectations);
+    testRejectsInt64ValueWrongOrder(expectations);
+    testRejectsFloat64ValueWrongOrder(expectations);
+    testRejectsStringValueWrongOrder(expectations);
+    testRejectsVec2ValueWrongOrder(expectations);
+    testRejectsColor4ValueWrongOrder(expectations);
+    testRejectsRationalValueWrongOrder(expectations);
+    testRejectsUnknownConstantValueKind(expectations);
+    testRejectsNonFiniteFloat64(expectations);
+
+    testRejectsUnsortedAnimationCurves(expectations);
+    testRejectsDuplicateAnimationCurves(expectations);
+    testRejectsUnknownAnimationCurveKind(expectations);
+    testRejectsEmptyKeyframes(expectations);
+    testRejectsEqualKeyframeTimes(expectations);
+    testRejectsDecreasingKeyframeTimes(expectations);
+    testRejectsFinalKeyframeNotLinear(expectations);
+    testRejectsUnknownInterpolation(expectations);
+    testAcceptsVec2AnimationCurve(expectations);
+
+    testRejectsUnsortedNodes(expectations);
+    testRejectsDuplicateNodes(expectations);
+    testRejectsSchemaVersionZero(expectations);
+    testRejectsUnsortedBindings(expectations);
+    testRejectsDuplicateBindings(expectations);
+    testRejectsUnsortedEdges(expectations);
+    testRejectsDuplicateEdges(expectations);
+    testRejectsUnknownEdgeDestinationKind(expectations);
+    testRejectsUnsortedLayerOutputs(expectations);
+    testRejectsDuplicateLayerOutputs(expectations);
+    testAcceptsUnsortedLayerStackEntries(expectations);
+
+    testRejectsDanglingCurveId(expectations);
+    testRejectsDanglingParameterId(expectations);
+    testRejectsDanglingEdgeSourceNode(expectations);
+    testRejectsDanglingEdgeDestinationNode(expectations);
+    testRejectsDanglingEdgeDestinationStackNode(expectations);
+    testRejectsDanglingLayerOutputNode(expectations);
+    testRejectsDanglingLayerStackNode(expectations);
+    testRejectsDanglingCompositionOutputNode(expectations);
 
     if (expectations.failures() != 0) {
         std::cerr << expectations.failures() << " expectation(s) failed\n";


### PR DESCRIPTION
## Summary

Closes #32. Batch 6 reader slice R2: the composition interior, closing the R1 staging gap.

- composition objects now decode exactly id/name/duration/format/parameters/animationCurves/graph in order — the unvalidated-suffix acceptance from R1 is gone, with a test proving it
- parameters: sorted/duplicate-free by numeric id; sources discriminated exactly constant/animation-curve, with deferred driver vocabulary reported as a typed `UnsupportedParameterSource`; all seven constant-value shapes with exact member orders; Float64 through the checked finite-parsing surface
- animation: curves sorted/duplicate-free, non-empty keyframes in strictly increasing exact rational time, final interpolation canonically linear, interpolation vocabulary closed
- graph: exact five-member shape; nodes/edges sorted by id, bindings by role (duplicate roles rejected — verified against the live model's own unique-role invariant in `graph.cpp`), layer outputs by (layerId, nodeId); discriminated destinations; layer-stack entries kept in source order with a positive test that reversed entries decode; `schemaVersion >= 1`
- in-composition reference integrity: curve sources, parameter bindings, edge endpoints, layer outputs, layer stack, and composition output must name decoded records — typed `DanglingReference` with exact paths
- interior decode split into its own translation unit behind a private detail header, following the `canonical_json_string_detail` precedent
- implementor-flagged interpretations reviewed and upheld: layer-output duplicates checked on the wire sort key (broader uniqueness belongs to model construction), text-domain validation and keyframe-id uniqueness deferred to model construction with the rest of the live invariants

## Testing

- Round trip of the composed golden fixture (solid layer + animated scalar curve) with every interior value compared to source; 42 new test functions
- Full `ci-linux-native` suite 56/56 and format check (275 files) green, independently re-verified

## Deferred cleanup noted in review

A few decode helpers are `noexcept` while their failure paths allocate small path strings on the global heap (pre-existing in R1's `decodeStringMember`, repeated in `decodeBooleanMember`). Unreachable through the bounded budget — global-heap exhaustion at that point is process-fatal anyway — but inconsistent with the truthful-noexcept principle; queued as a cleanup with R3.

Implemented by a Claude Sonnet subagent; reviewed in full by the supervising session (binding-role strictness verified against the live model).