### PR TITLE
feat: reconstruct documents from decoded values

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
         document_decode.cpp
         document_decode_composition.cpp
         document_decode_internal.hpp
+        document_reconstruct.cpp
         manifest_requirements.cpp
         project_io_memory.cpp
         project_io_memory_resource.cpp
@@ -33,6 +34,7 @@ target_sources(
             include/bloom/project/canonical_json_writer.hpp
             include/bloom/project/canonical_manifest.hpp
             include/bloom/project/document_decode.hpp
+            include/bloom/project/document_reconstruct.hpp
             include/bloom/project/manifest_requirements.hpp
             include/bloom/project/project_io_memory.hpp
             include/bloom/project/project_io_memory_resource.hpp
@@ -85,6 +87,15 @@ if(BUILD_TESTING)
     bloom_add_test(
         NAME bloom.project.document_decode
         COMMAND bloom_project_document_decode_test
+        LABELS unit project persistence document
+    )
+
+    add_executable(bloom_project_document_reconstruct_test tests/document_reconstruct_tests.cpp)
+    target_link_libraries(bloom_project_document_reconstruct_test PRIVATE bloom_project)
+    bloom_enable_warnings(bloom_project_document_reconstruct_test)
+    bloom_add_test(
+        NAME bloom.project.document_reconstruct
+        COMMAND bloom_project_document_reconstruct_test
         LABELS unit project persistence document
     )
 

--- a/src/project/document_decode.cpp
+++ b/src/project/document_decode.cpp
@@ -3,6 +3,7 @@
 #include "document_decode_internal.hpp"
 
 #include <bloom/core/sha256.hpp>
+#include <bloom/project/canonical_base64.hpp>
 #include <bloom/project/canonical_decimal.hpp>
 #include <bloom/project/canonical_document.hpp>
 
@@ -11,6 +12,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -110,7 +112,7 @@ std::string fieldPath(const std::string& base, const CanonicalDecimalField field
 }
 
 bool decodeStringMember(const JsonValue& value, DecodeState& state, const std::string& path,
-                        std::string_view& out) noexcept {
+                        std::string_view& out) {
     if (value.kind() != JsonValueKind::String) {
         state.fail(DocumentDecodeError::WrongValueKind, path);
         return false;
@@ -222,13 +224,23 @@ using detail::matchOrderedMembers;
 using document::ColorSettings;
 using document::CompositionFormat;
 using document::CompositionId;
+using document::ExtensionHostReference;
+using document::ExtensionHostReferenceTable;
+using document::ExtensionOwnerRemapper;
+using document::ExtensionRecord;
+using document::ExtensionRecordId;
+using document::ExtensionReferencePolicy;
+using document::ExtensionTarget;
 using document::FrameRate;
+using document::IdAllocatorHighWater;
+using document::NoExtensionReferences;
 using document::OcioConfigLocator;
 using document::OcioConfigPortability;
 using document::OcioConfigReference;
 using document::OcioConfigRevision;
 using document::OcioContextVariable;
 using document::OcioRevisionAlgorithm;
+using document::OpaqueExtensionPayload;
 using document::ProjectId;
 using document::SchemaVersion;
 
@@ -688,6 +700,399 @@ using document::SchemaVersion;
     return true;
 }
 
+// ------------------------------------------------------------------------------------------
+// idAllocation.highestIssued (docs/architecture/project-format.md, "Inclusive Allocator State")
+// ------------------------------------------------------------------------------------------
+
+// Unlike a typed object id (detail::decodeObjectId, [1-9][0-9]* only), an inclusive allocator
+// high-water value uses 0|[1-9][0-9]* -- zero is a valid "never issued" spelling -- so this decodes
+// through parseCanonicalAllocatorHighWater rather than parseCanonicalObjectId.
+[[nodiscard]] bool decodeAllocatorHighWaterMember(const JsonValue& value, DecodeState& state,
+                                                  const std::string& path, std::uint64_t& out) {
+    std::string_view text;
+    if (!decodeStringMember(value, state, path, text)) {
+        return false;
+    }
+    const auto parsed = parseCanonicalAllocatorHighWater(text);
+    if (!parsed) {
+        state.fail(DocumentDecodeError::InvalidAllocatorHighWater, path);
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+// The closed ten-member highestIssued object in exact order (see
+// docs/architecture/project-format.md, "Inclusive Allocator State"):
+// composition/node/edge/layer/layerSlot/parameter/animationCurve/
+// keyframe/driverBinding/extensionRecord.
+[[nodiscard]] bool decodeHighestIssued(const JsonValue& node, DecodeState& state,
+                                       const std::string& path, IdAllocatorHighWater& out) {
+    static constexpr std::array<std::string_view, 10> kKeys{
+        "composition", "node",           "edge",     "layer",         "layerSlot",
+        "parameter",   "animationCurve", "keyframe", "driverBinding", "extensionRecord"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+    if (!decodeAllocatorHighWaterMember(*members[0], state, joinPath(path, "composition"),
+                                        out.composition) ||
+        !decodeAllocatorHighWaterMember(*members[1], state, joinPath(path, "node"), out.node) ||
+        !decodeAllocatorHighWaterMember(*members[2], state, joinPath(path, "edge"), out.edge) ||
+        !decodeAllocatorHighWaterMember(*members[3], state, joinPath(path, "layer"), out.layer) ||
+        !decodeAllocatorHighWaterMember(*members[4], state, joinPath(path, "layerSlot"),
+                                        out.layerSlot) ||
+        !decodeAllocatorHighWaterMember(*members[5], state, joinPath(path, "parameter"),
+                                        out.parameter) ||
+        !decodeAllocatorHighWaterMember(*members[6], state, joinPath(path, "animationCurve"),
+                                        out.animationCurve) ||
+        !decodeAllocatorHighWaterMember(*members[7], state, joinPath(path, "keyframe"),
+                                        out.keyframe) ||
+        !decodeAllocatorHighWaterMember(*members[8], state, joinPath(path, "driverBinding"),
+                                        out.driverBinding)) {
+        return false;
+    }
+    return decodeAllocatorHighWaterMember(*members[9], state, joinPath(path, "extensionRecord"),
+                                          out.extensionRecord);
+}
+
+[[nodiscard]] bool decodeIdAllocation(const JsonValue& node, DecodeState& state,
+                                      const std::string& path, IdAllocatorHighWater& out) {
+    static constexpr std::array<std::string_view, 1> kKeys{"highestIssued"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+    return decodeHighestIssued(*members[0], state, joinPath(path, "highestIssued"), out);
+}
+
+// ------------------------------------------------------------------------------------------
+// extensions (docs/architecture/project-format.md, "Opaque Extension Envelope")
+// ------------------------------------------------------------------------------------------
+
+// A typed target {"kind": ..., "id": ...} used both by a record's `subject` (once null is ruled
+// out by the caller) and by a host-table reference `target`. Inverts extensionTargetKind's nine
+// wire strings from canonical_document.cpp exactly: project, composition, node, edge, layer,
+// layer-slot, parameter, animation-curve, keyframe.
+[[nodiscard]] bool decodeExtensionTarget(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, ExtensionTarget& out) {
+    std::string_view kindText;
+    if (!decodeKindDiscriminator(node, state, path, kindText)) {
+        return false;
+    }
+    static constexpr std::array<std::string_view, 2> keys{"kind", "id"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+    const auto idPath = joinPath(path, "id");
+    if (kindText == "project") {
+        document::ProjectId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "composition") {
+        CompositionId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "node") {
+        document::NodeId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "edge") {
+        document::EdgeId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "layer") {
+        document::LayerId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "layer-slot") {
+        document::LayerSlotId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "parameter") {
+        document::ParameterId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "animation-curve") {
+        document::AnimationCurveId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+    if (kindText == "keyframe") {
+        document::KeyframeId id;
+        if (!decodeObjectId(*members[1], state, idPath, id)) {
+            return false;
+        }
+        out = id;
+        return true;
+    }
+
+    state.fail(DocumentDecodeError::InvalidExtensionTargetKind, joinPath(path, "kind"));
+    return false;
+}
+
+// `subject` is always present and is either JSON null or a typed target (see
+// docs/architecture/project-format.md, "Opaque Extension Envelope").
+[[nodiscard]] bool decodeExtensionSubject(const JsonValue& node, DecodeState& state,
+                                          const std::string& path,
+                                          std::optional<ExtensionTarget>& out) {
+    if (node.isNull()) {
+        out.reset();
+        return true;
+    }
+    ExtensionTarget target;
+    if (!decodeExtensionTarget(node, state, path, target)) {
+        return false;
+    }
+    out = target;
+    return true;
+}
+
+[[nodiscard]] bool decodeHostReference(const JsonValue& node, DecodeState& state,
+                                       const std::string& path, ExtensionHostReference& out) {
+    static constexpr std::array<std::string_view, 2> keys{"key", "target"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+    std::string_view keyText;
+    if (!decodeStringMember(*members[0], state, joinPath(path, "key"), keyText)) {
+        return false;
+    }
+    ExtensionTarget target;
+    if (!decodeExtensionTarget(*members[1], state, joinPath(path, "target"), target)) {
+        return false;
+    }
+    out.key = std::string(keyText);
+    out.target = target;
+    return true;
+}
+
+// One of the three exact reference-policy shapes (see docs/architecture/project-format.md, "Opaque
+// Extension Envelope"): {"kind":"none"}, {"kind":"host-table","references":[...]}, or
+// {"kind":"owner-remapper","remapperId":...,"version":...}. Host-table reference ordering/duplicate
+// keys and every cross-reference target's existence are left to
+// bloom::document::validateExtensionRecords() during reconstruction, matching this module's
+// existing policy of deferring cross-collection/project-level invariants past wire-shape decode.
+[[nodiscard]] bool decodeReferencePolicy(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, ExtensionReferencePolicy& out) {
+    std::string_view kindText;
+    if (!decodeKindDiscriminator(node, state, path, kindText)) {
+        return false;
+    }
+
+    if (kindText == "none") {
+        static constexpr std::array<std::string_view, 1> keys{"kind"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        out = NoExtensionReferences{};
+        return true;
+    }
+    if (kindText == "host-table") {
+        static constexpr std::array<std::string_view, 2> keys{"kind", "references"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        const auto referencesPath = joinPath(path, "references");
+        if (members[1]->kind() != JsonValueKind::Array) {
+            state.fail(DocumentDecodeError::WrongValueKind, referencesPath);
+            return false;
+        }
+        const auto elements = members[1]->arrayElements();
+        ExtensionHostReferenceTable table;
+        table.references.reserve(elements.size());
+        for (std::size_t index = 0; index < elements.size(); ++index) {
+            ExtensionHostReference reference;
+            if (!decodeHostReference(elements[index], state, joinPathIndex(referencesPath, index),
+                                     reference)) {
+                return false;
+            }
+            table.references.push_back(std::move(reference));
+        }
+        out = std::move(table);
+        return true;
+    }
+    if (kindText == "owner-remapper") {
+        static constexpr std::array<std::string_view, 3> keys{"kind", "remapperId", "version"};
+        std::vector<const JsonValue*> members;
+        if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+            return false;
+        }
+        std::string_view remapperIdText;
+        if (!decodeStringMember(*members[1], state, joinPath(path, "remapperId"), remapperIdText)) {
+            return false;
+        }
+        SchemaVersion version;
+        if (!decodeSchemaVersionField(*members[2], state, joinPath(path, "version"), version)) {
+            return false;
+        }
+        out = ExtensionOwnerRemapper{std::string(remapperIdText), version};
+        return true;
+    }
+
+    state.fail(DocumentDecodeError::InvalidReferencePolicyKind, joinPath(path, "kind"));
+    return false;
+}
+
+// `payload` is canonical RFC 4648 base64 (standard alphabet, required `=` padding, no whitespace);
+// decoded bytes are preserved exactly through canonical_base64.hpp's checked decode surface (see
+// docs/architecture/project-format.md, "Opaque Extension Envelope").
+[[nodiscard]] bool decodePayload(const JsonValue& node, DecodeState& state, const std::string& path,
+                                 OpaqueExtensionPayload& out) {
+    std::string_view encodedText;
+    if (!decodeStringMember(node, state, path, encodedText)) {
+        return false;
+    }
+    const auto decodedSize = canonicalBase64DecodedSize(encodedText);
+    if (!decodedSize) {
+        state.fail(DocumentDecodeError::InvalidBase64Payload, path);
+        return false;
+    }
+    std::vector<std::byte> bytes(*decodedSize.value());
+    const auto written = decodeCanonicalBase64(encodedText, bytes);
+    if (!written) {
+        state.fail(DocumentDecodeError::InvalidBase64Payload, path);
+        return false;
+    }
+    out = OpaqueExtensionPayload(std::move(bytes));
+    return true;
+}
+
+// The closed eight-member extension record shape in exact order (see
+// docs/architecture/project-format.md, "Opaque Extension Envelope"): id/ownerId/typeId/
+// schemaVersion/subject/mediaType/referencePolicy/payload. Lexical domain rules owned by the
+// document model (namespaced owner/type ID grammar, schema major nonzero, media type/host-reference
+// key structural-text bounds) are left to bloom::document::validateExtensionRecords() during
+// reconstruction, matching this module's existing policy for parameter schemaKey/node typeId/etc.
+[[nodiscard]] bool decodeExtensionRecord(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, ExtensionRecord& out) {
+    static constexpr std::array<std::string_view, 8> keys{
+        "id",      "ownerId",   "typeId",          "schemaVersion",
+        "subject", "mediaType", "referencePolicy", "payload"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, keys, true, state, path, members)) {
+        return false;
+    }
+
+    ExtensionRecordId id;
+    if (!decodeObjectId(*members[0], state, joinPath(path, "id"), id)) {
+        return false;
+    }
+    std::string_view ownerIdText;
+    if (!decodeStringMember(*members[1], state, joinPath(path, "ownerId"), ownerIdText)) {
+        return false;
+    }
+    std::string_view typeIdText;
+    if (!decodeStringMember(*members[2], state, joinPath(path, "typeId"), typeIdText)) {
+        return false;
+    }
+    SchemaVersion schemaVersion;
+    if (!decodeSchemaVersionField(*members[3], state, joinPath(path, "schemaVersion"),
+                                  schemaVersion)) {
+        return false;
+    }
+    std::optional<ExtensionTarget> subject;
+    if (!decodeExtensionSubject(*members[4], state, joinPath(path, "subject"), subject)) {
+        return false;
+    }
+    std::string_view mediaTypeText;
+    if (!decodeStringMember(*members[5], state, joinPath(path, "mediaType"), mediaTypeText)) {
+        return false;
+    }
+    ExtensionReferencePolicy referencePolicy{NoExtensionReferences{}};
+    if (!decodeReferencePolicy(*members[6], state, joinPath(path, "referencePolicy"),
+                               referencePolicy)) {
+        return false;
+    }
+    OpaqueExtensionPayload payload;
+    if (!decodePayload(*members[7], state, joinPath(path, "payload"), payload)) {
+        return false;
+    }
+
+    out.id = id;
+    out.ownerId = std::string(ownerIdText);
+    out.typeId = std::string(typeIdText);
+    out.schemaVersion = schemaVersion;
+    out.subject = subject;
+    out.mediaType = std::string(mediaTypeText);
+    out.referencePolicy = std::move(referencePolicy);
+    out.payload = std::move(payload);
+    return true;
+}
+
+[[nodiscard]] bool decodeExtensionRecords(const JsonValue& node, DecodeState& state,
+                                          const std::string& path,
+                                          std::vector<ExtensionRecord>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(DocumentDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+    std::uint64_t previousId = 0;
+    bool hasPrevious = false;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        ExtensionRecord record;
+        const auto elementPath = joinPathIndex(path, index);
+        if (!decodeExtensionRecord(elements[index], state, elementPath, record)) {
+            return false;
+        }
+        const auto currentId = record.id.value();
+        if (hasPrevious) {
+            if (currentId == previousId) {
+                state.fail(DocumentDecodeError::DuplicateExtensionRecord,
+                           joinPath(elementPath, "id"));
+                return false;
+            }
+            if (currentId < previousId) {
+                state.fail(DocumentDecodeError::UnsortedExtensionRecords,
+                           joinPath(elementPath, "id"));
+                return false;
+            }
+        }
+        previousId = currentId;
+        hasPrevious = true;
+        out.push_back(std::move(record));
+    }
+    return true;
+}
+
 } // namespace
 
 DocumentDecodePathText DocumentDecodePathText::from(const std::string_view text) noexcept {
@@ -739,11 +1144,12 @@ DocumentDecodeResult decodeDocumentEnvelope(const JsonValue& root) {
         return DocumentDecodeResult::failure(state.error, state.path);
     }
 
-    if (members[2]->kind() != JsonValueKind::Object) {
-        return DocumentDecodeResult::failure(DocumentDecodeError::WrongValueKind, "/idAllocation");
+    if (!decodeIdAllocation(*members[2], state, "/idAllocation", envelope.highWater)) {
+        return DocumentDecodeResult::failure(state.error, state.path);
     }
-    if (members[3]->kind() != JsonValueKind::Array) {
-        return DocumentDecodeResult::failure(DocumentDecodeError::WrongValueKind, "/extensions");
+
+    if (!decodeExtensionRecords(*members[3], state, "/extensions", envelope.extensionRecords)) {
+        return DocumentDecodeResult::failure(state.error, state.path);
     }
 
     return DocumentDecodeResult::success(std::move(envelope));

--- a/src/project/document_decode_composition.cpp
+++ b/src/project/document_decode_composition.cpp
@@ -78,8 +78,13 @@ using document::Vec2AnimationCurve;
 using document::Vec2d;
 using document::Vec2Keyframe;
 
+// Not noexcept: DecodeState::fail() takes its path argument by value, so a failing call here copies
+// `path` into that by-value parameter -- an allocation that can throw std::bad_alloc. Marking this
+// noexcept while it allocates on the failure path would be an untruthful noexcept claim (the same
+// pattern fixed for detail::decodeStringMember in
+// document_decode_internal.hpp/document_decode.cpp).
 [[nodiscard]] bool decodeBooleanMember(const JsonValue& value, DecodeState& state,
-                                       const std::string& path, bool& out) noexcept {
+                                       const std::string& path, bool& out) {
     if (value.kind() != JsonValueKind::Boolean) {
         state.fail(DocumentDecodeError::WrongValueKind, path);
         return false;

--- a/src/project/document_decode_internal.hpp
+++ b/src/project/document_decode_internal.hpp
@@ -54,8 +54,11 @@ struct DecodeState final {
                                        const std::string& basePath,
                                        std::vector<const JsonValue*>& outValues);
 
+// Not noexcept: DecodeState::fail() takes its path argument by value, so a failing call here copies
+// `path` into that by-value parameter -- an allocation that can throw std::bad_alloc. Marking this
+// noexcept while it allocates on the failure path would be an untruthful noexcept claim.
 [[nodiscard]] bool decodeStringMember(const JsonValue& value, DecodeState& state,
-                                      const std::string& path, std::string_view& out) noexcept;
+                                      const std::string& path, std::string_view& out);
 
 [[nodiscard]] bool decodeUInt32Member(const JsonValue& value, DecodeState& state,
                                       const std::string& path, std::uint32_t maximum,

--- a/src/project/document_reconstruct.cpp
+++ b/src/project/document_reconstruct.cpp
@@ -1,0 +1,173 @@
+#include <bloom/project/document_reconstruct.hpp>
+
+#include <bloom/document/animation.hpp>
+#include <bloom/document/extension_records.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/layer_stack.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace bloom::project {
+
+namespace {
+
+// Internal signal for the per-composition assembly helpers below: nullopt means "keep going",
+// otherwise the exact typed rejection to return from reconstructDocument(). Kept distinct from
+// ReconstructDocumentResult itself because these helpers never produce a real ReconstructedDocument
+// on success -- only reconstructDocument() constructs the final Document.
+using StepResult = std::optional<ReconstructionRejected>;
+
+[[nodiscard]] StepResult compositionRejection(const ReconstructionStage stage,
+                                              const document::CompositionId compositionId,
+                                              const std::uint64_t recordId) noexcept {
+    return ReconstructionRejected{
+        .stage = stage, .compositionId = compositionId, .recordId = recordId};
+}
+
+[[nodiscard]] ReconstructionRejected projectRejection(const ReconstructionStage stage) noexcept {
+    return {.stage = stage, .compositionId = {}, .recordId = 0};
+}
+
+// Assembles one composition's canonical graph through CanonicalGraph's own checked adders, moving
+// every decoded record in. Every rejection is reported with the owning composition id and the
+// specific node/edge/layer/slot id the offending adder was given.
+[[nodiscard]] StepResult buildGraph(const document::CompositionId compositionId,
+                                    DecodedGraph& decodedGraph, document::CanonicalGraph& graph) {
+    for (auto& node : decodedGraph.nodes) {
+        const auto nodeId = node.id;
+        if (!graph.addNode(std::move(node))) {
+            return compositionRejection(ReconstructionStage::GraphNode, compositionId,
+                                        nodeId.value());
+        }
+    }
+    for (auto& edge : decodedGraph.edges) {
+        const auto edgeId = edge.id;
+        if (!graph.addEdge(std::move(edge))) {
+            return compositionRejection(ReconstructionStage::GraphEdge, compositionId,
+                                        edgeId.value());
+        }
+    }
+    for (auto& boundary : decodedGraph.layerOutputs) {
+        const auto layerId = boundary.layerId;
+        if (!graph.addLayerOutput(std::move(boundary))) {
+            return compositionRejection(ReconstructionStage::LayerOutput, compositionId,
+                                        layerId.value());
+        }
+    }
+    for (const auto& entry : decodedGraph.layerStack.entries) {
+        if (!graph.layerStack().append(entry)) {
+            return compositionRejection(ReconstructionStage::LayerStackEntry, compositionId,
+                                        entry.slotId.value());
+        }
+    }
+    graph.setCompositionOutput(std::move(decodedGraph.compositionOutput));
+    return std::nullopt;
+}
+
+// Assembles one composition's parameters and animation curves through ParameterStore::insert() and
+// AnimationCurveStore::insert() -- the stores' own checked adders, applying curve ownership and
+// schema/value agreement that this function does not duplicate.
+[[nodiscard]] StepResult buildStores(const document::CompositionId compositionId,
+                                     DecodedComposition& decodedComposition,
+                                     document::Composition& composition) {
+    for (auto& parameter : decodedComposition.parameters) {
+        const auto parameterId = parameter.id;
+        if (!composition.parameters().insert(std::move(parameter))) {
+            return compositionRejection(ReconstructionStage::ParameterStore, compositionId,
+                                        parameterId.value());
+        }
+    }
+    for (auto& curve : decodedComposition.animationCurves) {
+        const auto curveId = document::animationCurveId(curve);
+        if (!composition.animationCurves().insert(std::move(curve))) {
+            return compositionRejection(ReconstructionStage::AnimationCurveStore, compositionId,
+                                        curveId.value());
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+ReconstructDocumentResult ReconstructDocumentResult::success(ReconstructedDocument result) {
+    ReconstructDocumentResult out;
+    out.succeeded_ = true;
+    out.result_ = std::move(result);
+    return out;
+}
+
+ReconstructDocumentResult ReconstructDocumentResult::failure(ReconstructionRejected rejection) {
+    ReconstructDocumentResult out;
+    out.succeeded_ = false;
+    out.rejection_ = rejection;
+    return out;
+}
+
+ReconstructDocumentResult reconstructDocument(DecodedDocumentEnvelope envelope) {
+    document::Project project(envelope.projectId, std::move(envelope.projectName));
+
+    for (auto& decodedComposition : envelope.compositions) {
+        const auto compositionId = decodedComposition.id;
+
+        document::CanonicalGraph graph(decodedComposition.graph.layerStack.nodeId);
+        if (const auto rejection = buildGraph(compositionId, decodedComposition.graph, graph);
+            rejection.has_value()) {
+            return ReconstructDocumentResult::failure(*rejection);
+        }
+
+        document::Composition composition(compositionId, std::move(decodedComposition.name),
+                                          decodedComposition.duration, std::move(graph),
+                                          decodedComposition.format);
+
+        if (const auto rejection = buildStores(compositionId, decodedComposition, composition);
+            rejection.has_value()) {
+            return ReconstructDocumentResult::failure(*rejection);
+        }
+
+        if (!project.addComposition(std::move(composition))) {
+            return ReconstructDocumentResult::failure({.stage = ReconstructionStage::CompositionAdd,
+                                                       .compositionId = compositionId,
+                                                       .recordId = 0});
+        }
+    }
+
+    for (auto& record : envelope.extensionRecords) {
+        const auto recordId = record.id;
+        if (!project.addExtensionRecord(std::move(record))) {
+            return ReconstructDocumentResult::failure(
+                {.stage = ReconstructionStage::ExtensionRecordAdd,
+                 .compositionId = {},
+                 .recordId = recordId.value()});
+        }
+    }
+
+    const auto validation = project.validate();
+    if (!validation.ok()) {
+        return ReconstructDocumentResult::failure(
+            projectRejection(ReconstructionStage::ProjectValidate));
+    }
+
+    // Document(Project, IdAllocatorHighWater) re-validates the project (already known-valid above)
+    // and then checks the contract's inclusive-watermark rule: every declared id must already be
+    // covered by its namespace's persisted high water (see docs/architecture/project-format.md,
+    // "Inclusive Allocator State"). Both failure paths throw plain std::invalid_argument --
+    // DocumentProvenanceError (thrown only by Document::draft() for a foreign snapshot) derives
+    // from it but is not itself thrown here; catching the base class is still the correct, and
+    // only, truthful boundary so no document-model exception ever escapes reconstruction.
+    try {
+        auto document =
+            std::make_unique<document::Document>(std::move(project), envelope.highWater);
+        return ReconstructDocumentResult::success(
+            {std::move(document), std::move(envelope.colorSettings)});
+    } catch (const std::invalid_argument&) {
+        return ReconstructDocumentResult::failure(
+            projectRejection(ReconstructionStage::DocumentConstruct));
+    }
+}
+
+} // namespace bloom::project

--- a/src/project/include/bloom/project/document_decode.hpp
+++ b/src/project/include/bloom/project/document_decode.hpp
@@ -5,6 +5,7 @@
 #include <bloom/document/animation.hpp>
 #include <bloom/document/color_settings.hpp>
 #include <bloom/document/composition_settings.hpp>
+#include <bloom/document/extension_records.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/ids.hpp>
 #include <bloom/document/parameter.hpp>
@@ -34,14 +35,18 @@
 // edge/Layer Output/Layer Stack/compositionOutput node id must each name a record this module
 // itself decoded; an unresolved reference is DanglingReference. Cross-composition and
 // project-level references (e.g. a future extension-record subject) remain out of scope.
-// idAllocation content and extension records are still checked only for presence, position, and
-// JSON kind. This module deliberately does not construct bloom::document::Project or
-// bloom::document::Document: reassembling the live model (which additionally enforces
-// document-construction invariants such as expected node/schema bindings, Layer Stack membership,
-// and cycle freedom -- see bloom::document::CanonicalGraph::validate()) and restoring the id
-// allocator from idAllocation.highestIssued is a later slice. The unknown-member round-trip
-// overlay is also a later slice, so an unrecognized root member is a typed decode error rather
-// than being preserved.
+// idAllocation.highestIssued and every extension record are also fully decoded (R3): the closed
+// ten-member highestIssued object into document::IdAllocatorHighWater, and the extensions array --
+// sorted, duplicate-free by numeric ExtensionRecordId -- into document::ExtensionRecord values
+// (typed subject/target kinds, all three reference-policy shapes, and the base64 payload decoded
+// through canonical_base64.hpp). This module still deliberately does not construct
+// bloom::document::Project or bloom::document::Document: reassembling the live model (which
+// additionally enforces document-construction invariants such as expected node/schema bindings,
+// Layer Stack membership, cycle freedom, extension subject/reference-target existence -- see
+// bloom::document::CanonicalGraph::validate() and bloom::document::validateExtensionRecords() --
+// and restoring the id allocator from the decoded highWater) is bloom::project::reconstructDocument
+// in document_reconstruct.hpp. The unknown-member round-trip overlay is also a later slice, so an
+// unrecognized root member is a typed decode error rather than being preserved.
 //
 // Decoding constructs every typed value through its existing checked surface: canonical_decimal.hpp
 // parsers for decimal-string ids/rationals/int64s, canonical JSON-number uint32 fields, and known
@@ -111,15 +116,24 @@ struct DecodedComposition final {
 };
 
 // The decoded document.json envelope's durable values. Deliberately not a
-// bloom::document::Project: reconstructing the live model (restoring the id allocator, and
-// applying document-construction invariants beyond this module's wire-shape and
-// within-composition cross-reference checks) and decoding extension records are out of scope for
-// this package.
+// bloom::document::Project: reconstructing the live model (restoring the id allocator and applying
+// document-construction invariants beyond this module's wire-shape and within-composition
+// cross-reference checks) is bloom::project::reconstructDocument's job (see
+// document_reconstruct.hpp), not this module's. idAllocation.highestIssued and every extension
+// record are fully decoded here (R3): highWater mirrors document::IdAllocatorHighWater exactly, and
+// extensionRecords reuses document::ExtensionRecord directly -- like
+// ParameterRecord/NodeRecord/..., ExtensionRecord is a plain aggregate/variant value type with no
+// invariant-enforcing constructor of its own, so this module's decode only checks wire shape
+// (closed member order, canonical id/base64 spelling, sorted+unique record ids) and leaves
+// cross-reference/subject-existence/reference-policy target-existence checks to
+// bloom::document::Project::validate() during reconstruction.
 struct DecodedDocumentEnvelope final {
     document::ProjectId projectId;
     std::string projectName;
     document::ColorSettings colorSettings;
     std::vector<DecodedComposition> compositions;
+    document::IdAllocatorHighWater highWater;
+    std::vector<document::ExtensionRecord> extensionRecords;
 
     friend bool operator==(const DecodedDocumentEnvelope&,
                            const DecodedDocumentEnvelope&) = default;
@@ -219,6 +233,24 @@ enum class DocumentDecodeError : std::uint8_t {
     // edge/Layer Output/Layer Stack/compositionOutput node id does not name a record decoded
     // elsewhere in this same composition.
     DanglingReference,
+    // An idAllocation.highestIssued member's decimal-string spelling is non-canonical (leading
+    // zero, a `+`/`-` sign, non-digit characters) or out of uint64 range. Unlike InvalidId, zero is
+    // a valid high-water spelling here (see docs/architecture/project-format.md, "Inclusive
+    // Allocator State").
+    InvalidAllocatorHighWater,
+    // Extension records are not sorted by strictly ascending numeric ExtensionRecordId.
+    UnsortedExtensionRecords,
+    // Two extension records declare the same numeric ExtensionRecordId.
+    DuplicateExtensionRecord,
+    // An extension record subject's or a host-table reference target's `kind` discriminator is not
+    // one of the nine known v1 typed target kinds.
+    InvalidExtensionTargetKind,
+    // An extension record's `referencePolicy.kind` discriminator is not "none", "host-table", or
+    // "owner-remapper".
+    InvalidReferencePolicyKind,
+    // An extension record's `payload` is not a canonical RFC 4648 standard-alphabet base64 spelling
+    // with required `=` padding, correct length, and zero tail bits.
+    InvalidBase64Payload,
 };
 
 // A bounded diagnostic path to one JSON member, formatted as `/key/0/key`, mirroring

--- a/src/project/include/bloom/project/document_reconstruct.hpp
+++ b/src/project/include/bloom/project/document_reconstruct.hpp
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/ids.hpp>
+#include <bloom/project/document_decode.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+// Reconstructs a live bloom::document::Document from a bloom::project::DecodedDocumentEnvelope (see
+// document_decode.hpp): the R3 slice named in docs/architecture/project-format.md's "Canonical
+// Document Shape", "Inclusive Allocator State", and "Opaque Extension Envelope" sections that
+// document_decode.hpp's own file comment defers -- restoring the id allocator and applying every
+// document-construction invariant beyond decode's wire-shape and within-composition
+// cross-reference checks.
+//
+// reconstructDocument() never adds, bypasses, or weakens a document-model surface: every decoded
+// value is installed through the exact checked adder the live model already exposes --
+// bloom::document::CanonicalGraph::addNode()/addEdge()/addLayerOutput(),
+// bloom::document::LayerStack::append(), bloom::document::ParameterStore::insert(),
+// bloom::document::AnimationCurveStore::insert(), bloom::document::Project::addComposition()/
+// addExtensionRecord(), bloom::document::Project::validate(), and finally
+// bloom::document::Document's two-argument constructor, which is the sole place that checks the
+// contract's inclusive-watermark rule: every decoded id must already be covered by its namespace's
+// persisted high water (see "Inclusive Allocator State" -- deleted and undone allocations stay
+// permanently consumed). Any rejection from one of those surfaces is reported as a typed
+// ReconstructionRejected value naming the offending record by id; it is never silently downgraded,
+// retried, or patched around by hand-rolling a parallel check in this module.
+namespace bloom::project {
+
+// Coarse stage identifying which checked document-model surface rejected reconstruction. Ordered to
+// match the reconstruction walk: per-composition graph assembly, per-composition store assembly,
+// composition admission, extension admission, whole-project validation, and finally Document
+// construction (the inclusive-watermark check).
+enum class ReconstructionStage : std::uint8_t {
+    // Reserved zero value for a default-constructed (never-failed) ReconstructionRejected; never
+    // returned by reconstructDocument() itself.
+    None,
+    // bloom::document::CanonicalGraph::addNode() rejected a decoded node.
+    GraphNode,
+    // bloom::document::CanonicalGraph::addEdge() rejected a decoded edge.
+    GraphEdge,
+    // bloom::document::CanonicalGraph::addLayerOutput() rejected a decoded Layer Output boundary.
+    LayerOutput,
+    // bloom::document::LayerStack::append() rejected a decoded Layer Stack entry (for example a
+    // duplicate slot or layer id within one composition's stack).
+    LayerStackEntry,
+    // bloom::document::ParameterStore::insert() rejected a decoded parameter.
+    ParameterStore,
+    // bloom::document::AnimationCurveStore::insert() rejected a decoded animation curve.
+    AnimationCurveStore,
+    // bloom::document::Project::addComposition() rejected the fully assembled composition (for
+    // example an invalid human-facing name).
+    CompositionAdd,
+    // bloom::document::Project::addExtensionRecord() rejected a decoded extension record (for
+    // example a duplicate id -- unreachable given decode's own sort/uniqueness check, but still a
+    // typed possibility of that checked surface).
+    ExtensionRecordAdd,
+    // bloom::document::Project::validate() reported at least one issue after every composition and
+    // extension record was added: a whole-project or cross-composition invariant (schema/role
+    // agreement, orphan extension subject or host-table target, cross-composition id collision, an
+    // unowned or multiply-owned animation curve, ...) that a single checked adder cannot see in
+    // isolation.
+    ProjectValidate,
+    // bloom::document::Document's two-argument constructor rejected the validated project against
+    // the decoded idAllocation.highestIssued state: at least one declared id is not covered by its
+    // namespace's persisted high water.
+    DocumentConstruct,
+};
+
+// Names the offending record by id where the failing stage is scoped to one. `compositionId` is
+// invalid (zero) for a stage that is not composition-scoped (CompositionAdd names the composition
+// being added through compositionId itself; ExtensionRecordAdd/ProjectValidate/DocumentConstruct
+// are project-wide and leave both ids zero). `recordId` holds the raw value of whichever typed id
+// the stage's own checked adder was given -- a ParameterId, AnimationCurveId, NodeId, EdgeId,
+// LayerId, or LayerSlotId depending on `stage` -- and is zero when not applicable. Exact JSON
+// member paths are intentionally not reproduced here: reconstruction operates on already-decoded
+// values, and the decode-time DocumentDecodeResult path remains the place that names JSON
+// structure.
+struct ReconstructionRejected final {
+    ReconstructionStage stage = ReconstructionStage::None;
+    document::CompositionId compositionId;
+    std::uint64_t recordId = 0;
+
+    friend bool operator==(const ReconstructionRejected&,
+                           const ReconstructionRejected&) noexcept = default;
+};
+
+// A successfully reconstructed document plus its caller-owned color settings, mirroring
+// CanonicalDocumentV1's split: bloom::document::Project does not itself own color settings (see
+// canonical_document.hpp), so the decoded value travels alongside the live Document rather than
+// inside it.
+struct ReconstructedDocument final {
+    std::unique_ptr<document::Document> document;
+    document::ColorSettings colorSettings;
+};
+
+// [[nodiscard]] failure-aware result, mirroring DocumentDecodeResult's value()/error() shape
+// (document_decode.hpp): value() returns a pointer, null on failure, and is deleted on an rvalue
+// receiver so a caller can never hold a pointer into a temporary about to be destroyed. Document is
+// move-only (see document.hpp), so this result type is itself move-only; a caller that wants to
+// keep the reconstructed Document past the result's own lifetime moves it out of value()->document.
+class [[nodiscard]] ReconstructDocumentResult final {
+  public:
+    ReconstructDocumentResult(ReconstructDocumentResult&&) noexcept = default;
+    ReconstructDocumentResult& operator=(ReconstructDocumentResult&&) noexcept = default;
+    ReconstructDocumentResult(const ReconstructDocumentResult&) = delete;
+    ReconstructDocumentResult& operator=(const ReconstructDocumentResult&) = delete;
+    ~ReconstructDocumentResult() = default;
+
+    [[nodiscard]] static ReconstructDocumentResult success(ReconstructedDocument result);
+    [[nodiscard]] static ReconstructDocumentResult failure(ReconstructionRejected rejection);
+
+    [[nodiscard]] explicit operator bool() const noexcept { return succeeded_; }
+    [[nodiscard]] ReconstructionRejected rejection() const noexcept { return rejection_; }
+
+    [[nodiscard]] ReconstructedDocument* value() & noexcept {
+        return result_.has_value() ? &*result_ : nullptr;
+    }
+    [[nodiscard]] const ReconstructedDocument* value() const& noexcept {
+        return result_.has_value() ? &*result_ : nullptr;
+    }
+    [[nodiscard]] const ReconstructedDocument* value() const&& = delete;
+
+  private:
+    ReconstructDocumentResult() = default;
+
+    bool succeeded_ = false;
+    std::optional<ReconstructedDocument> result_;
+    ReconstructionRejected rejection_;
+};
+
+// Reconstructs a live Document from `envelope` (moved from, so nothing is retained past return on
+// success or failure). See the file-level comment above for the exact checked surfaces this walks
+// through and the ordering ReconstructionStage documents. May throw std::bad_alloc; every
+// document-model rejection is reported through the returned result rather than thrown.
+[[nodiscard]] ReconstructDocumentResult reconstructDocument(DecodedDocumentEnvelope envelope);
+
+} // namespace bloom::project

--- a/src/project/tests/document_decode_tests.cpp
+++ b/src/project/tests/document_decode_tests.cpp
@@ -185,7 +185,9 @@ constexpr std::string_view kMinimalGraphJson =
     result += colorSettingsJsonText;
     result += ",\"compositions\":[";
     result += compositionsArrayBody;
-    result += "]},\"idAllocation\":{},\"extensions\":[]}";
+    result += R"(]},"idAllocation":{"highestIssued":{"composition":"0","node":"0","edge":"0",)"
+              R"("layer":"0","layerSlot":"0","parameter":"0","animationCurve":"0","keyframe":"0",)"
+              R"("driverBinding":"0","extensionRecord":"0"}},"extensions":[]})";
     return result;
 }
 

--- a/src/project/tests/document_reconstruct_tests.cpp
+++ b/src/project/tests/document_reconstruct_tests.cpp
@@ -1,0 +1,793 @@
+#include <bloom/project/document_reconstruct.hpp>
+
+#include <bloom/core/color.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/animation.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/extension_records.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/ids.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/document_decode.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace {
+
+using bloom::project::DecodedDocumentEnvelope;
+using bloom::project::DocumentDecodeError;
+using bloom::project::DocumentDecodeResult;
+using bloom::project::JsonValue;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::ReconstructDocumentResult;
+using bloom::project::ReconstructionRejected;
+using bloom::project::ReconstructionStage;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 8ULL << 20U; // 8 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = bloom::project::ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+// ---------------------------------------------------------------------------------------------
+// Shared round-trip plumbing: encode a live snapshot, parse+decode the bytes back, and expose the
+// pieces so each fixture-specific test can drive reconstructDocument() and compare.
+// ---------------------------------------------------------------------------------------------
+
+struct EncodedDocument final {
+    bool ok = false;
+    std::string bytes;
+};
+
+[[nodiscard]] EncodedDocument encodeSnapshot(const bloom::document::Snapshot& snapshot,
+                                             const bloom::document::ColorSettings& colorSettings) {
+    EncodedDocument encoded;
+    std::vector<char> payloadScratch(1024, '\0');
+    std::vector<std::size_t> sortScratch(1024, 0);
+    const bloom::project::CanonicalDocumentV1 request{
+        .snapshot = &snapshot,
+        .colorSettings = &colorSettings,
+        .payloadScratch = payloadScratch,
+        .sortScratch = sortScratch,
+    };
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    if (!size.hasValue()) {
+        return encoded;
+    }
+    std::vector<char> output(*size.value());
+    const auto written = bloom::project::encodeCanonicalDocument(request, output);
+    if (!written) {
+        return encoded;
+    }
+    encoded.ok = true;
+    encoded.bytes.assign(output.data(), output.size());
+    return encoded;
+}
+
+[[nodiscard]] DocumentDecodeResult decodeText(const std::string& text) {
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(text), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    if (!parsed) {
+        std::cerr << "fixture failed to parse as strict JSON (error="
+                  << static_cast<int>(parsed.error()) << ")\n";
+        std::abort();
+    }
+    return bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+}
+
+// Runs the complete determinism round trip for one already-constructed source document: encode,
+// parse, decode, reconstruct, re-encode, and assert byte equality plus high-water equality. Returns
+// early (after recording a failure) on the first broken link so later assertions never dereference
+// a null/absent value.
+void expectDeterminismRoundTrip(Expectations& expectations, const bloom::document::Document& source,
+                                const bloom::document::ColorSettings& colorSettings,
+                                const std::string_view label) {
+    auto sourceSnapshot = source.snapshot();
+    const auto firstEncoded = encodeSnapshot(sourceSnapshot, colorSettings);
+    expectations.expect(firstEncoded.ok, label);
+    if (!firstEncoded.ok) {
+        return;
+    }
+
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(firstEncoded.bytes), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    expectations.expect(static_cast<bool>(parsed), label);
+    if (!parsed) {
+        return;
+    }
+
+    const auto decoded = bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+    expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr, label);
+    if (decoded.value() == nullptr) {
+        return;
+    }
+
+    auto reconstructed = bloom::project::reconstructDocument(*decoded.value());
+    expectations.expect(static_cast<bool>(reconstructed), label);
+    if (!reconstructed) {
+        return;
+    }
+
+    auto* reconstructedValue = reconstructed.value();
+    expectations.expect(reconstructedValue != nullptr && reconstructedValue->document != nullptr,
+                        label);
+    if (reconstructedValue == nullptr || reconstructedValue->document == nullptr) {
+        return;
+    }
+    auto reconstructedSnapshot = reconstructedValue->document->snapshot();
+    expectations.expect(reconstructedSnapshot.ids().highWater() == sourceSnapshot.ids().highWater(),
+                        label);
+
+    const auto secondEncoded =
+        encodeSnapshot(reconstructedSnapshot, reconstructedValue->colorSettings);
+    expectations.expect(secondEncoded.ok, label);
+    if (!secondEncoded.ok) {
+        return;
+    }
+    expectations.expect(firstEncoded.bytes == secondEncoded.bytes, label);
+}
+
+// ---------------------------------------------------------------------------------------------
+// THE determinism round trip -- minimal fixture.
+// ---------------------------------------------------------------------------------------------
+
+void testMinimalDeterminismRoundTrip(Expectations& expectations) {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        expectations.expect(false, "minimal round trip: fixture duration is constructible");
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto settings = neutralColorSettings();
+
+    expectDeterminismRoundTrip(expectations, document, settings,
+                               "minimal fixture: determinism round trip (encode/decode/"
+                               "reconstruct/re-encode/highWater) holds at every step");
+}
+
+// ---------------------------------------------------------------------------------------------
+// THE determinism round trip -- composed fixture (mirrors canonical_document_tests.cpp's
+// testComposedGoldenBytes: solid layer, one animated scalar opacity curve, one constant vec2
+// position, one constant color4).
+// ---------------------------------------------------------------------------------------------
+
+void testComposedDeterminismRoundTrip(Expectations& expectations) {
+    using namespace bloom::document;
+    using bloom::core::Color4d;
+    using bloom::core::PixelAspectRatio;
+    using bloom::core::RationalTime;
+
+    const auto duration = RationalTime::create(48, 24);
+    const auto frameRate = FrameRate::create(24000, 1001);
+    const auto pixelAspect = PixelAspectRatio::create(2, 1);
+    const auto format =
+        CompositionFormat::create(1280, 720, pixelAspect.value_or(PixelAspectRatio::square()),
+                                  frameRate.value_or(FrameRate::framesPerSecond24()));
+    if (!duration.has_value() || !format.has_value()) {
+        expectations.expect(false, "composed round trip: fixture values are constructible");
+        return;
+    }
+
+    CanonicalGraph graph{NodeId::fromRaw(1)};
+    const NodeRecord layerOutputNode{
+        NodeId::fromRaw(3),
+        std::string(kLayerOutputNodeType),
+        {{"opacity", ParameterId::fromRaw(3)}, {"position", ParameterId::fromRaw(5)}},
+        kLayerOutputNodeSchemaVersion};
+    const NodeRecord layerStackNode{
+        NodeId::fromRaw(1), std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion};
+    const NodeRecord compositionOutputNode{NodeId::fromRaw(4),
+                                           std::string(kCompositionOutputNodeType),
+                                           {},
+                                           kCompositionOutputNodeSchemaVersion};
+    const NodeRecord solidSourceNode{NodeId::fromRaw(2),
+                                     std::string(kSolidSourceNodeType),
+                                     {{"color", ParameterId::fromRaw(7)}},
+                                     kSolidSourceNodeSchemaVersion};
+    const bool nodesAdded = graph.addNode(layerOutputNode) && graph.addNode(layerStackNode) &&
+                            graph.addNode(compositionOutputNode) && graph.addNode(solidSourceNode);
+    const EdgeRecord stackToOutputEdge{
+        EdgeId::fromRaw(3),
+        {NodeId::fromRaw(1), std::string(kLayerStackOutputPort)},
+        NodeInputRef{NodeId::fromRaw(4), std::string(kCompositionOutputInputPort)}};
+    const EdgeRecord solidToLayerEdge{
+        EdgeId::fromRaw(1),
+        {NodeId::fromRaw(2), std::string(kSolidSourceOutputPort)},
+        NodeInputRef{NodeId::fromRaw(3), std::string(kLayerOutputContentInputPort)}};
+    const EdgeRecord layerToStackEdge{EdgeId::fromRaw(2),
+                                      {NodeId::fromRaw(3), std::string(kLayerOutputOutputPort)},
+                                      LayerStackInputRef{NodeId::fromRaw(1),
+                                                         LayerSlotId::fromRaw(1),
+                                                         std::string(kLayerStackContentInputRole)}};
+    const bool edgesAdded = graph.addEdge(stackToOutputEdge) && graph.addEdge(solidToLayerEdge) &&
+                            graph.addEdge(layerToStackEdge);
+    const bool boundariesAdded =
+        graph.addLayerOutput({NodeId::fromRaw(3), LayerId::fromRaw(1), "Hero Plate",
+                              std::string(kLayerOutputOutputPort)});
+    expectations.expect(
+        nodesAdded && edgesAdded && boundariesAdded &&
+            graph.layerStack().append({LayerSlotId::fromRaw(1), LayerId::fromRaw(1)}),
+        "composed round trip: fixture graph accepts its parts");
+
+    graph.setCompositionOutput({NodeId::fromRaw(4), std::string(kCompositionOutputOutputPort)});
+    Composition composition{CompositionId::fromRaw(1), "Hero Shot", *duration, std::move(graph),
+                            *format};
+    expectations.expect(composition.parameters().insert(
+                            {ParameterId::fromRaw(7), std::string(kSolidColorParameterSchemaKey),
+                             ConstantValueSource{Color4d{0.0, 0.5, 1.0, 1.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(5), std::string(kPositionParameterSchemaKey),
+                                 ConstantValueSource{Vec2d{96.0, -48.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(3), std::string(kOpacityParameterSchemaKey),
+                                 AnimationCurveSource{AnimationCurveId::fromRaw(9)}}),
+                        "composed round trip: fixture parameters insert");
+
+    ScalarAnimationCurve curve;
+    curve.id = AnimationCurveId::fromRaw(9);
+    curve.keyframes.push_back(
+        {KeyframeId::fromRaw(21), RationalTime{}, 0.25, KeyframeInterpolation::Hold});
+    curve.keyframes.push_back({KeyframeId::fromRaw(22), RationalTime::fromInteger(48), 1.0,
+                               KeyframeInterpolation::Linear});
+    expectations.expect(composition.animationCurves().insert(curve),
+                        "composed round trip: fixture animation curve inserts");
+
+    Project project{ProjectId::fromRaw(1), "Spot Check"};
+    expectations.expect(project.addComposition(std::move(composition)),
+                        "composed round trip: fixture composition adds");
+
+    const IdAllocatorHighWater highWater{.composition = 1,
+                                         .node = 4,
+                                         .edge = 3,
+                                         .layer = 1,
+                                         .layerSlot = 1,
+                                         .parameter = 7,
+                                         .animationCurve = 9,
+                                         .keyframe = 22,
+                                         .driverBinding = 0,
+                                         .extensionRecord = 0};
+    Document document{std::move(project), highWater};
+    const auto settings = neutralColorSettings();
+
+    expectDeterminismRoundTrip(expectations, document, settings,
+                               "composed fixture: determinism round trip (encode/decode/"
+                               "reconstruct/re-encode/highWater) holds at every step");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Extension round trip -- all three reference policies plus a typed-subject record (mirrors
+// canonical_document_tests.cpp's testExtensionGoldenBytes fixture).
+// ---------------------------------------------------------------------------------------------
+
+void testExtensionDeterminismRoundTrip(Expectations& expectations) {
+    using namespace bloom::document;
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        expectations.expect(false, "extension round trip: fixture duration is constructible");
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+
+    const ExtensionRecord linkTableRecord{
+        ExtensionRecordId::fromRaw(9),
+        "vendor.module",
+        "vendor.module.link-table",
+        {1, 0},
+        std::nullopt,
+        "application/x-vendor-table",
+        ExtensionHostReferenceTable{{{std::string("primary-comp"), CompositionId::fromRaw(1)}}},
+        OpaqueExtensionPayload{}};
+    const ExtensionRecord markerRecord{
+        ExtensionRecordId::fromRaw(5), "vendor.module",
+        "vendor.module.marker",        {1, 0},
+        CompositionId::fromRaw(1),     "application/octet-stream",
+        NoExtensionReferences{},       OpaqueExtensionPayload{std::byte{0x00}}};
+    const ExtensionRecord remapperRecord{
+        ExtensionRecordId::fromRaw(2),
+        "vendor.module",
+        "vendor.module.record-type",
+        {1, 0},
+        std::nullopt,
+        "text/x-vendor-note",
+        ExtensionOwnerRemapper{"vendor.module.record-remapper", {1, 0}},
+        OpaqueExtensionPayload{std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE}, std::byte{0xEF}}};
+    expectations.expect(newProject.project.addExtensionRecord(linkTableRecord) &&
+                            newProject.project.addExtensionRecord(markerRecord) &&
+                            newProject.project.addExtensionRecord(remapperRecord),
+                        "extension round trip: fixture records add out of numeric ID order");
+
+    Document document{std::move(newProject.project)};
+    const auto settings = neutralColorSettings();
+
+    // Confirm the shape decode/reconstruct must invert before checking the round trip itself:
+    // three records, three distinct reference-policy kinds, one typed subject.
+    auto sourceSnapshot = document.snapshot();
+    const auto encoded = encodeSnapshot(sourceSnapshot, settings);
+    expectations.expect(encoded.ok, "extension round trip: source snapshot encodes");
+    if (encoded.ok) {
+        auto parsed = bloom::project::parseStrictJsonDom(asBytes(encoded.bytes), {},
+                                                         makeOperation(kGenerousOperationBudget));
+        expectations.expect(static_cast<bool>(parsed), "extension round trip: source bytes parse");
+        if (parsed) {
+            const auto decoded = bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+            expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr,
+                                "extension round trip: source snapshot decodes");
+            if (decoded.value() != nullptr) {
+                const auto& records = decoded.value()->extensionRecords;
+                expectations.expect(records.size() == 3,
+                                    "extension round trip: three extension records decode");
+                expectations.expect(
+                    records.size() == 3 &&
+                        std::holds_alternative<ExtensionOwnerRemapper>(
+                            records[0].referencePolicy) &&
+                        !records[0].subject.has_value(),
+                    "extension round trip: the owner-remapper record decodes with a null subject");
+                bool markerSubjectIsComposition = false;
+                if (records.size() == 3) {
+                    const std::optional<ExtensionTarget>& markerSubject = records[1].subject;
+                    if (markerSubject.has_value()) {
+                        markerSubjectIsComposition =
+                            std::holds_alternative<CompositionId>(markerSubject.value());
+                    }
+                }
+                expectations.expect(
+                    records.size() == 3 &&
+                        std::holds_alternative<NoExtensionReferences>(records[1].referencePolicy) &&
+                        markerSubjectIsComposition,
+                    "extension round trip: the none-policy record decodes with a typed "
+                    "composition subject");
+                expectations.expect(
+                    records.size() == 3 && std::holds_alternative<ExtensionHostReferenceTable>(
+                                               records[2].referencePolicy),
+                    "extension round trip: the host-table record decodes its reference policy "
+                    "kind");
+            }
+        }
+    }
+
+    expectDeterminismRoundTrip(expectations, document, settings,
+                               "extension fixture: determinism round trip (encode/decode/"
+                               "reconstruct/re-encode/highWater) holds at every step");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Decode-layer rejections: idAllocation.highestIssued and extensions (R3 additions).
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::string_view kValidDigest =
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+[[nodiscard]] std::string defaultColorSettingsJson() {
+    std::string result =
+        R"({"schemaVersion":{"major":1,"minor":0},"processColorSpaceId":"lin_rec709_scene",)"
+        R"("ocioConfig":{"schemaVersion":{"major":1,"minor":0},)"
+        R"("locator":{"kind":"builtin","uri":"bloom://ocio/neutral-v1/config.ocio"},)"
+        R"("expectedRevision":{"algorithm":"sha256","digest":")";
+    result += kValidDigest;
+    result += R"("},"portability":"builtin","contextVariables":[]}})";
+    return result;
+}
+
+constexpr std::string_view kMinimalGraphJson =
+    R"({"nodes":[{"id":"1","typeId":"bloom.composition-output","schemaVersion":1,"parameters":[]}],)"
+    R"("edges":[],"layerOutputs":[],"layerStack":{"nodeId":"1","entries":[]},)"
+    R"("compositionOutput":{"nodeId":"1","port":"image"}})";
+
+[[nodiscard]] std::string defaultCompositionJson() {
+    std::string result =
+        R"({"id":"1","name":"Comp","duration":{"numerator":"10","denominator":"1"},)"
+        R"("format":{"width":1920,"height":1080,"pixelAspect":{"numerator":"1","denominator":"1"},)"
+        R"("frameRate":{"numerator":"24","denominator":"1"}},"parameters":[],"animationCurves":[],)"
+        R"("graph":)";
+    result += kMinimalGraphJson;
+    result += "}";
+    return result;
+}
+
+[[nodiscard]] std::string documentJson(const std::string_view idAllocationJson,
+                                       const std::string_view extensionsJson) {
+    std::string result =
+        R"({"schemaVersion":{"major":1,"minor":0},"project":{"id":"1","name":"Untitled",)"
+        R"("colorSettings":)";
+    result += defaultColorSettingsJson();
+    result += R"(,"compositions":[)";
+    result += defaultCompositionJson();
+    result += R"(]},"idAllocation":)";
+    result += idAllocationJson;
+    result += R"(,"extensions":)";
+    result += extensionsJson;
+    result += "}";
+    return result;
+}
+
+constexpr std::string_view kDefaultHighestIssued =
+    R"({"highestIssued":{"composition":"0","node":"0","edge":"0","layer":"0","layerSlot":"0",)"
+    R"("parameter":"0","animationCurve":"0","keyframe":"0","driverBinding":"0",)"
+    R"("extensionRecord":"0"}})";
+
+void expectDecodeFailure(Expectations& expectations, const std::string& text,
+                         const DocumentDecodeError expectedError,
+                         const std::string_view expectedPath, const std::string_view message) {
+    const auto decoded = decodeText(text);
+    expectations.expect(
+        !decoded && decoded.error() == expectedError && decoded.path() == expectedPath, message);
+}
+
+void testHighestIssuedRejections(Expectations& expectations) {
+    expectDecodeFailure(
+        expectations,
+        documentJson(R"({"highestIssued":{"node":"0","composition":"0","edge":"0","layer":"0",)"
+                     R"("layerSlot":"0","parameter":"0","animationCurve":"0","keyframe":"0",)"
+                     R"("driverBinding":"0","extensionRecord":"0"}})",
+                     "[]"),
+        DocumentDecodeError::MemberOutOfOrder, "/idAllocation/highestIssued/node",
+        "highestIssued members out of order report MemberOutOfOrder at the misplaced key");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(R"({"highestIssued":{"composition":"0","node":"0","edge":"0","layer":"0",)"
+                     R"("layerSlot":"0","parameter":"0","animationCurve":"0","keyframe":"0",)"
+                     R"("driverBinding":"0"}})",
+                     "[]"),
+        DocumentDecodeError::MissingMember, "/idAllocation/highestIssued/extensionRecord",
+        "a highestIssued object missing its trailing member reports MissingMember");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(R"({"highestIssued":{"composition":"0","node":"0","edge":"0","layer":"0",)"
+                     R"("layerSlot":"0","parameter":"0","animationCurve":"0","keyframe":"0",)"
+                     R"("driverBinding":"0","extensionRecord":"0","extra":"0"}})",
+                     "[]"),
+        DocumentDecodeError::UnknownMember, "/idAllocation/highestIssued/extra",
+        "a highestIssued object with an eleventh member reports UnknownMember");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(R"({"highestIssued":{"composition":"+1","node":"0","edge":"0","layer":"0",)"
+                     R"("layerSlot":"0","parameter":"0","animationCurve":"0","keyframe":"0",)"
+                     R"("driverBinding":"0","extensionRecord":"0"}})",
+                     "[]"),
+        DocumentDecodeError::InvalidAllocatorHighWater, "/idAllocation/highestIssued/composition",
+        "a leading-plus highestIssued spelling is rejected as non-canonical");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(R"({"highestIssued":{"composition":"01","node":"0","edge":"0","layer":"0",)"
+                     R"("layerSlot":"0","parameter":"0","animationCurve":"0","keyframe":"0",)"
+                     R"("driverBinding":"0","extensionRecord":"0"}})",
+                     "[]"),
+        DocumentDecodeError::InvalidAllocatorHighWater, "/idAllocation/highestIssued/composition",
+        "a leading-zero highestIssued spelling is rejected as non-canonical");
+
+    const auto acceptedZero = decodeText(documentJson(std::string(kDefaultHighestIssued), "[]"));
+    expectations.expect(static_cast<bool>(acceptedZero) && acceptedZero.value() != nullptr,
+                        "a highestIssued of all \"0\" is accepted (0 is a valid high-water value)");
+    if (acceptedZero.value() != nullptr) {
+        expectations.expect(acceptedZero.value()->highWater ==
+                                bloom::document::IdAllocatorHighWater{},
+                            "an all-zero highestIssued decodes to a default-valued high water");
+    }
+}
+
+[[nodiscard]] std::string extensionRecordJson(const std::string_view id,
+                                              const std::string_view subject,
+                                              const std::string_view referencePolicy,
+                                              const std::string_view payload) {
+    std::string result = R"({"id":")";
+    result += id;
+    result += R"(","ownerId":"vendor.module","typeId":"vendor.module.record-type",)"
+              R"("schemaVersion":{"major":1,"minor":0},"subject":)";
+    result += subject;
+    result += R"(,"mediaType":"application/octet-stream","referencePolicy":)";
+    result += referencePolicy;
+    result += R"(,"payload":")";
+    result += payload;
+    result += "\"}";
+    return result;
+}
+
+void testExtensionRejections(Expectations& expectations) {
+    const auto highestIssued = std::string(kDefaultHighestIssued);
+    const auto noneRecord = [](const std::string_view id) {
+        return extensionRecordJson(id, "null", R"({"kind":"none"})", "AA==");
+    };
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(highestIssued, "[" + noneRecord("2") + "," + noneRecord("1") + "]"),
+        DocumentDecodeError::UnsortedExtensionRecords, "/extensions/1/id",
+        "extension records out of numeric ID order report UnsortedExtensionRecords");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(highestIssued, "[" + noneRecord("1") + "," + noneRecord("1") + "]"),
+        DocumentDecodeError::DuplicateExtensionRecord, "/extensions/1/id",
+        "two extension records sharing one numeric ID report DuplicateExtensionRecord");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(highestIssued, "[" +
+                                        extensionRecordJson("1", R"({"kind":"widget","id":"1"})",
+                                                            R"({"kind":"none"})", "AA==") +
+                                        "]"),
+        DocumentDecodeError::InvalidExtensionTargetKind, "/extensions/0/subject/kind",
+        "an unknown typed-subject kind reports InvalidExtensionTargetKind");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(highestIssued,
+                     "[" + extensionRecordJson("1", "null", R"({"kind":"mystery"})", "AA==") + "]"),
+        DocumentDecodeError::InvalidReferencePolicyKind, "/extensions/0/referencePolicy/kind",
+        "an unknown referencePolicy kind reports InvalidReferencePolicyKind");
+
+    expectDecodeFailure(
+        expectations,
+        documentJson(highestIssued,
+                     "[" + extensionRecordJson("1", "null", R"({"kind":"none"})", "***") + "]"),
+        DocumentDecodeError::InvalidBase64Payload, "/extensions/0/payload",
+        "a malformed base64 payload spelling reports InvalidBase64Payload");
+
+    const auto valid = decodeText(documentJson(highestIssued, "[" + noneRecord("1") + "]"));
+    expectations.expect(static_cast<bool>(valid) && valid.value() != nullptr &&
+                            valid.value()->extensionRecords.size() == 1,
+                        "a single well-formed extension record decodes successfully");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Reconstruction-layer rejections: hand-built decoded envelopes exercise the checked document-model
+// adders and the Document constructor's inclusive-watermark check directly (no JSON round trip
+// needed -- reconstructDocument() takes an already-decoded envelope).
+// ---------------------------------------------------------------------------------------------
+
+// A minimal well-formed envelope: one composition with a Layer Stack node (also the graph's stable
+// owner) wired straight to a composition-output node -- mirrors document_decode_tests.cpp's minimal
+// shape. Callers mutate the returned envelope to provoke one specific rejection.
+[[nodiscard]] DecodedDocumentEnvelope minimalEnvelope() {
+    using namespace bloom::document;
+    DecodedDocumentEnvelope envelope;
+    envelope.projectId = ProjectId::fromRaw(1);
+    envelope.projectName = "Untitled";
+    envelope.colorSettings = bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+
+    const auto duration = bloom::core::RationalTime::create(10, 1);
+    const auto format = CompositionFormat::create(1920, 1080);
+    if (!duration.has_value() || !format.has_value()) {
+        std::abort();
+    }
+
+    bloom::project::DecodedComposition composition;
+    composition.id = CompositionId::fromRaw(1);
+    composition.name = "Comp";
+    composition.duration = *duration;
+    composition.format = *format;
+
+    composition.graph.layerStack.nodeId = NodeId::fromRaw(1);
+    composition.graph.nodes.push_back(
+        {NodeId::fromRaw(1), std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion});
+    composition.graph.nodes.push_back({NodeId::fromRaw(2),
+                                       std::string(kCompositionOutputNodeType),
+                                       {},
+                                       kCompositionOutputNodeSchemaVersion});
+    composition.graph.edges.push_back(
+        {EdgeId::fromRaw(1),
+         {NodeId::fromRaw(1), std::string(kLayerStackOutputPort)},
+         NodeInputRef{NodeId::fromRaw(2), std::string(kCompositionOutputInputPort)}});
+    composition.graph.compositionOutput = {NodeId::fromRaw(2),
+                                           std::string(kCompositionOutputOutputPort)};
+
+    envelope.compositions.push_back(std::move(composition));
+    envelope.highWater.composition = 1;
+    envelope.highWater.node = 2;
+    envelope.highWater.edge = 1;
+    return envelope;
+}
+
+void testGraphStoreRejections(Expectations& expectations) {
+    using namespace bloom::document;
+
+    // CanonicalGraph::addNode() rejects a structurally invalid parameter-binding role even though
+    // decode itself (which does not apply grammar rules to role text) accepted it.
+    {
+        auto envelope = minimalEnvelope();
+        envelope.compositions.front().graph.nodes.front().parameters.push_back(
+            {"", ParameterId::fromRaw(1)});
+        auto reconstructed = bloom::project::reconstructDocument(envelope);
+        expectations.expect(!reconstructed,
+                            "a node with a structurally invalid binding role is rejected");
+        if (!reconstructed) {
+            expectations.expect(
+                reconstructed.rejection().stage == ReconstructionStage::GraphNode &&
+                    reconstructed.rejection().compositionId == CompositionId::fromRaw(1) &&
+                    reconstructed.rejection().recordId == 1,
+                "the rejection names GraphNode, the owning composition, and the offending node id");
+        }
+    }
+
+    // LayerStack::append() rejects a second entry that duplicates an already-appended slot/layer --
+    // decode itself does not check Layer Stack entry duplicates (they are canonical source order,
+    // never sorted).
+    {
+        auto envelope = minimalEnvelope();
+        auto& composition = envelope.compositions.front();
+        composition.graph.layerStack.entries.push_back(
+            {LayerSlotId::fromRaw(1), LayerId::fromRaw(1)});
+        composition.graph.layerStack.entries.push_back(
+            {LayerSlotId::fromRaw(1), LayerId::fromRaw(1)});
+        auto reconstructed = bloom::project::reconstructDocument(envelope);
+        expectations.expect(!reconstructed, "a duplicated Layer Stack entry is rejected");
+        if (!reconstructed) {
+            expectations.expect(
+                reconstructed.rejection().stage == ReconstructionStage::LayerStackEntry &&
+                    reconstructed.rejection().compositionId == CompositionId::fromRaw(1) &&
+                    reconstructed.rejection().recordId == 1,
+                "the rejection names LayerStackEntry, the owning composition, and the slot id");
+        }
+    }
+}
+
+void testProjectValidateRejection(Expectations& expectations) {
+    // A layer-output node whose "position"/"opacity" bindings are swapped: each parameter is
+    // individually valid against its own declared schemaKey (so ParameterStore::insert() and
+    // CanonicalGraph::addNode() both accept it), but the wrong parameter is bound to each role,
+    // which only bloom::document::CanonicalGraph::validate()'s expected-binding check (reached
+    // through Project::validate()) detects.
+    using namespace bloom::document;
+    auto envelope = minimalEnvelope();
+    auto& composition = envelope.compositions.front();
+
+    composition.graph.nodes.front() = {
+        NodeId::fromRaw(1), std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion};
+    NodeRecord layerOutputNode{
+        NodeId::fromRaw(3), std::string(kLayerOutputNodeType), {}, kLayerOutputNodeSchemaVersion};
+    // Swapped on purpose: "position" is bound to the opacity-schema parameter and vice versa.
+    layerOutputNode.parameters = {{"opacity", ParameterId::fromRaw(5)},
+                                  {"position", ParameterId::fromRaw(3)}};
+    composition.graph.nodes.push_back(std::move(layerOutputNode));
+    composition.graph.compositionOutput = {NodeId::fromRaw(2),
+                                           std::string(kCompositionOutputOutputPort)};
+    composition.graph.edges.push_back(
+        {EdgeId::fromRaw(2),
+         {NodeId::fromRaw(3), std::string(kLayerOutputOutputPort)},
+         LayerStackInputRef{NodeId::fromRaw(1), LayerSlotId::fromRaw(1),
+                            std::string(kLayerStackContentInputRole)}});
+    composition.graph.layerOutputs.push_back(
+        {NodeId::fromRaw(3), LayerId::fromRaw(1), "Layer", std::string(kLayerOutputOutputPort)});
+    composition.graph.layerStack.entries.push_back({LayerSlotId::fromRaw(1), LayerId::fromRaw(1)});
+
+    composition.parameters.push_back({ParameterId::fromRaw(3),
+                                      std::string(kOpacityParameterSchemaKey),
+                                      ConstantValueSource{0.5}});
+    composition.parameters.push_back({ParameterId::fromRaw(5),
+                                      std::string(kPositionParameterSchemaKey),
+                                      ConstantValueSource{Vec2d{0.0, 0.0}}});
+
+    envelope.highWater.node = 3;
+    envelope.highWater.edge = 2;
+    envelope.highWater.layer = 1;
+    envelope.highWater.layerSlot = 1;
+    envelope.highWater.parameter = 5;
+
+    auto reconstructed = bloom::project::reconstructDocument(envelope);
+    expectations.expect(!reconstructed,
+                        "a layer-output node bound to mismatched-schema parameters is rejected");
+    if (!reconstructed) {
+        expectations.expect(reconstructed.rejection().stage == ReconstructionStage::ProjectValidate,
+                            "the rejection surfaces through the whole-project validate() stage");
+    }
+}
+
+void testDocumentConstructRejection(Expectations& expectations) {
+    // The graph/store/composition/extension admission and Project::validate() all succeed; only the
+    // decoded high water is wrong (below the highest declared node id), so the failure can only
+    // come from Document's own inclusive-watermark check.
+    auto envelope = minimalEnvelope();
+    envelope.highWater.node = 1; // node 2 (compositionOutput) is declared but not covered.
+
+    auto reconstructed = bloom::project::reconstructDocument(envelope);
+    expectations.expect(!reconstructed,
+                        "a decoded id above its namespace's persisted high water is rejected");
+    if (!reconstructed) {
+        expectations.expect(
+            reconstructed.rejection().stage == ReconstructionStage::DocumentConstruct,
+            "the rejection surfaces through the Document constructor's provenance check");
+    }
+}
+
+void testWellFormedEnvelopeReconstructs(Expectations& expectations) {
+    auto envelope = minimalEnvelope();
+    auto reconstructed = bloom::project::reconstructDocument(envelope);
+    expectations.expect(static_cast<bool>(reconstructed),
+                        "a well-formed hand-built envelope reconstructs successfully");
+    if (reconstructed) {
+        expectations.expect(reconstructed.value() != nullptr &&
+                                reconstructed.value()->document != nullptr,
+                            "a successful reconstruction owns a live Document");
+    }
+}
+
+} // namespace
+
+int main() {
+    try {
+        Expectations expectations;
+        testMinimalDeterminismRoundTrip(expectations);
+        testComposedDeterminismRoundTrip(expectations);
+        testExtensionDeterminismRoundTrip(expectations);
+        testHighestIssuedRejections(expectations);
+        testExtensionRejections(expectations);
+        testGraphStoreRejections(expectations);
+        testProjectValidateRejection(expectations);
+        testDocumentConstructRejection(expectations);
+        testWellFormedEnvelopeReconstructs(expectations);
+        return expectations.failures() == 0 ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "Unexpected test exception: " << error.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #34. Batch 6 reader slice R3 — the decode surface completed and closed into a live document, proving the determinism promise.

- `highestIssued`: closed ten-member object in exact order through the existing allocator high-water parsing surface (zero legal, non-canonical spellings rejected)
- extension records: sorted duplicate-free by id; typed subjects across all nine target kinds; the three reference policies; payloads through the checked canonical base64 surfaces into `OpaqueExtensionPayload`
- `reconstructDocument`: decoded values feed only through existing checked model surfaces (graph adders, store inserts, `addComposition`/`addExtensionRecord`, `Project::validate`), each rejection typed with stage and record context; `Document(Project, IdAllocatorHighWater)` enforces the contract's inclusive-watermark rule with its exception converted at a truthful boundary — no model surface added, bypassed, or weakened
- host-table reference key sort/uniqueness deliberately left to model validation — verified present in `extension_records.cpp` (UTF-8 sort, uniqueness, target resolution)
- review-queued cleanup landed: untruthful `noexcept` removed from allocating-failure-path decode helpers

## The determinism result

**Encode → parse → decode → reconstruct → re-encode yields byte-identical canonical output for both the minimal and composed golden fixtures, with reconstructed allocator state equal to source.** This is the Batch 6 merge-gate property "same snapshot produces identical canonical document.json bytes" extended through a full reopen cycle, now executable in the test suite.

## Testing

- 37 new expectations: both determinism round trips; extension round trip across all three policies with a typed subject; decode rejections for every malformed allocator/extension shape; reconstruction rejections asserting exact stage, composition id, and record id for graph, layer-stack, store, validation, and watermark-provenance failures
- Full `ci-linux-native` suite 57/57 and format check (278 files) green, independently re-verified

Implemented by a Claude Sonnet subagent; reviewed in full by the supervising session (model-delegation claims verified in source).