### PR TITLE
feat: overlay round-trip state onto writes

### DIFF
--- a/src/project/canonical_document.cpp
+++ b/src/project/canonical_document.cpp
@@ -7,7 +7,9 @@
 #include <bloom/document/persisted_text.hpp>
 #include <bloom/project/canonical_base64.hpp>
 #include <bloom/project/canonical_decimal.hpp>
+#include <bloom/project/round_trip_state.hpp>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
@@ -16,6 +18,7 @@
 #include <string_view>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace {
 
@@ -30,6 +33,12 @@ using bloom::project::CanonicalJsonWriter;
 using bloom::project::CanonicalJsonWriterError;
 using bloom::project::CanonicalJsonWriterResult;
 using bloom::project::kCanonicalDocumentNoIndex;
+using bloom::project::RetainedJsonMember;
+using bloom::project::RetainedJsonValue;
+using bloom::project::RetainedJsonValueKind;
+using bloom::project::RoundTripAttachmentPath;
+using bloom::project::RoundTripCollectionKind;
+using bloom::project::RoundTripState;
 
 constexpr auto kV1SchemaVersion = bloom::project::kCanonicalDocumentSchemaVersionV1;
 
@@ -115,6 +124,25 @@ template <typename Range, typename KeyOf>
     return true;
 }
 
+// RT2: a lightweight, allocation-free mirror of one bloom::project::RoundTripPathSegment used only
+// to build the *current* attachment path during emission (see round_trip_state.hpp's file comment
+// for the path/identity model this walk reproduces). `text` never owns storage: for a named
+// segment it points at a string literal or an already-alive live-document string (e.g. a parameter
+// binding's `role`); for a collection element it points at a caller-local decimal spelling
+// (bloom::project::formatCanonicalUInt64's fixed-buffer result) that outlives the PathScope
+// referencing it. Kept trivially copyable/assignable so a fixed std::array can hold the whole path
+// with no heap allocation at any point in RT2's overlay walk.
+struct EmitPathSegment final {
+    bool isCollectionElement = false;
+    RoundTripCollectionKind kind{};
+    std::string_view text;
+};
+
+// Deepest attachment path in the fixed v1 schema tree is five segments (for example a vec2
+// keyframe's own "value" object: project/Composition/AnimationCurve/Keyframe/value). This budget
+// keeps generous headroom without needing a heap-backed path.
+constexpr std::size_t kMaxAttachmentDepth = 12;
+
 struct WalkState final {
     CanonicalDocumentError error = CanonicalDocumentError::None;
     std::size_t compositionIndex = kCanonicalDocumentNoIndex;
@@ -139,6 +167,19 @@ struct EmitState final {
     SortWindows sort;
     std::span<char> payloadScratch;
     WalkState walk{};
+    // RT2 overlay: null (the default) reproduces the plain writer exactly -- findRetained() below
+    // short-circuits before ever touching attachmentPath, so a plain write pushes/pops path
+    // segments but never performs a lookup or allocates.
+    const RoundTripState* roundTrip = nullptr;
+    std::uint32_t schemaMinor = 0;
+    std::array<EmitPathSegment, kMaxAttachmentDepth> attachmentPath{};
+    std::size_t attachmentDepth = 0;
+    // Count of attachment points this walk actually found and re-emitted from *roundTrip. Compared
+    // against roundTrip->entries().size() once the walk finishes successfully (see
+    // emitDocumentRoot): every entry in a RoundTripState captured against this exact document is
+    // visited exactly once by construction, so a leftover entry means the caller passed state that
+    // does not describe the document actually being written.
+    std::size_t retainedConsumed = 0;
 
     [[nodiscard]] bool ok(const CanonicalJsonWriterResult result) noexcept {
         if (result) {
@@ -161,8 +202,153 @@ struct EmitState final {
     }
 };
 
-[[nodiscard]] bool emitVersion(EmitState& state,
-                               const bloom::document::SchemaVersion version) noexcept {
+// RAII scope that pushes one attachment-path segment for the duration of emitting one nested
+// singleton member or collection element, and pops it back off on destruction -- the writer-side
+// mirror of document_decode_internal.hpp's detail::AttachmentScope. Pushing/popping is
+// unconditional (cheap array writes) regardless of whether an overlay is active; only
+// findRetained() below is conditioned on state.roundTrip being non-null.
+class PathScope final {
+  public:
+    PathScope(EmitState& state, const std::string_view name) noexcept : state_(state) {
+        push(EmitPathSegment{false, {}, name});
+    }
+    PathScope(EmitState& state, const RoundTripCollectionKind kind,
+              const std::string_view identity) noexcept
+        : state_(state) {
+        push(EmitPathSegment{true, kind, identity});
+    }
+    PathScope(const PathScope&) = delete;
+    PathScope& operator=(const PathScope&) = delete;
+    PathScope(PathScope&&) = delete;
+    PathScope& operator=(PathScope&&) = delete;
+    ~PathScope() { --state_.attachmentDepth; }
+
+  private:
+    void push(const EmitPathSegment segment) noexcept {
+        // The fixed v1 schema tree never nests this deep (see kMaxAttachmentDepth's comment); a
+        // request that somehow did would be a programming error in this file, not a document
+        // condition to report through a typed CanonicalDocumentError.
+        if (state_.attachmentDepth >= kMaxAttachmentDepth) {
+            std::terminate();
+        }
+        state_.attachmentPath[state_.attachmentDepth] = segment;
+        ++state_.attachmentDepth;
+    }
+
+    EmitState& state_;
+};
+
+[[nodiscard]] bool pathsMatch(const std::span<const EmitPathSegment> current,
+                              const RoundTripAttachmentPath& entryPath) noexcept {
+    if (current.size() != entryPath.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < current.size(); ++index) {
+        const auto& a = current[index];
+        const auto& b = entryPath[index];
+        if (a.isCollectionElement != b.isCollectionElement()) {
+            return false;
+        }
+        if (a.isCollectionElement) {
+            if (a.kind != b.collectionKind() || a.text != b.identity()) {
+                return false;
+            }
+        } else if (a.text != b.name()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Linear scan over the (bounded) retained-entry list, mirroring RoundTripState::find()'s own
+// linear lookup but comparing against the caller-local EmitPathSegment path rather than
+// constructing a heap-owned RoundTripAttachmentPath -- keeping every RT2 overlay lookup
+// allocation-free.
+[[nodiscard]] const std::vector<RetainedJsonMember>* findRetained(EmitState& state) noexcept {
+    if (state.roundTrip == nullptr) {
+        return nullptr;
+    }
+    const std::span<const EmitPathSegment> current(state.attachmentPath.data(),
+                                                   state.attachmentDepth);
+    for (const auto& entry : state.roundTrip->entries()) {
+        if (pathsMatch(current, entry.path)) {
+            return &entry.members;
+        }
+    }
+    return nullptr;
+}
+
+// Recursively re-emits one retained value exactly as RT1 captured it: null/bool as literals,
+// strings through the ordinary canonical string writer, numbers through UnknownJsonNumber's
+// canonical spelling surface, and arrays/objects recursively with retained member order preserved
+// verbatim (opaque content -- see round_trip_state.hpp's documented rule that a value nested
+// inside an already-unknown member carries no schema of its own and is never re-sorted).
+[[nodiscard]] bool emitRetainedValue(EmitState& state, const RetainedJsonValue& value) noexcept {
+    auto& writer = state.writer;
+    switch (value.kind()) {
+    case RetainedJsonValueKind::Null:
+        return state.ok(writer.nullValue());
+    case RetainedJsonValueKind::Boolean:
+        return state.ok(writer.booleanValue(value.asBoolean()));
+    case RetainedJsonValueKind::Number:
+        return state.ok(writer.unknownNumberValue(value.asNumber()));
+    case RetainedJsonValueKind::String:
+        return state.ok(writer.stringValue(value.asString()));
+    case RetainedJsonValueKind::Array: {
+        if (!state.ok(writer.beginArray())) {
+            return false;
+        }
+        for (const auto& element : value.elements()) {
+            if (!emitRetainedValue(state, element)) {
+                return false;
+            }
+        }
+        return state.ok(writer.endArray());
+    }
+    case RetainedJsonValueKind::Object: {
+        if (!state.ok(writer.beginObject())) {
+            return false;
+        }
+        for (const auto& member : value.members()) {
+            if (!state.ok(writer.memberName(member.key())) ||
+                !emitRetainedValue(state, member.value())) {
+                return false;
+            }
+        }
+        return state.ok(writer.endObject());
+    }
+    }
+    return false;
+}
+
+// Looks up the current attachment path and, if RoundTripState retained members there, re-emits
+// each one (key then recursively its value) in the stored order -- already ascending UTF-8 by
+// RT1's capture guarantee, so no re-sort happens here. A no-op (returns true without writing
+// anything) when there is no overlay or no entry at this exact path, which is the overwhelmingly
+// common case for every attachment point in a plain or lightly-annotated document.
+[[nodiscard]] bool emitRetainedTrailing(EmitState& state) noexcept {
+    const auto* members = findRetained(state);
+    if (members == nullptr) {
+        return true;
+    }
+    ++state.retainedConsumed;
+    for (const auto& member : *members) {
+        if (!state.ok(state.writer.memberName(member.key())) ||
+            !emitRetainedValue(state, member.value())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// `attach` is true only at the four attachment-point schemaVersion sites (colorSettings.
+// schemaVersion, ocioConfig.schemaVersion, an extension record's schemaVersion, and an
+// owner-remapper's version); the document root's own schemaVersion is written with the default
+// `attach = false` and no PathScope pushed, matching the decode-side bootstrap constraint that the
+// root schemaVersion object is always decoded before documentMinor/roundTrip are established and so
+// can never itself retain a trailing member (see document_decode.cpp's decodeDocumentEnvelope).
+[[nodiscard]] bool emitVersion(EmitState& state, const bloom::document::SchemaVersion version,
+                               const bool attach = false) noexcept {
     auto& writer = state.writer;
     if (!state.ok(writer.beginObject())) {
         return false;
@@ -171,6 +357,9 @@ struct EmitState final {
         return false;
     }
     if (!state.ok(writer.memberName("minor")) || !state.ok(writer.integerValue(version.minor))) {
+        return false;
+    }
+    if (attach && !emitRetainedTrailing(state)) {
         return false;
     }
     return state.ok(writer.endObject());
@@ -190,6 +379,9 @@ struct EmitState final {
            state.ok(state.writer.stringValue(text.view()));
 }
 
+// Every call site of this shape (composition duration, format pixelAspect/frameRate, a keyframe's
+// time) is a genuine attachment point -- unlike emitVersion, there is no "never attach" caller --
+// so the caller only needs to push the right PathScope first; this always looks up and re-emits.
 [[nodiscard]] bool emitRational(EmitState& state, const std::int64_t numerator,
                                 const std::int64_t denominator) noexcept {
     if (!state.ok(state.writer.beginObject())) {
@@ -201,9 +393,14 @@ struct EmitState final {
     if (!emitNamedSigned(state, "denominator", denominator)) {
         return false;
     }
+    if (!emitRetainedTrailing(state)) {
+        return false;
+    }
     return state.ok(state.writer.endObject());
 }
 
+// Every call site (edge source, compositionOutput) is a genuine attachment point; the caller pushes
+// the right PathScope first.
 [[nodiscard]] bool emitOutputPortRef(EmitState& state,
                                      const bloom::document::OutputPortRef& reference) noexcept {
     if (!state.ok(state.writer.beginObject())) {
@@ -214,6 +411,9 @@ struct EmitState final {
     }
     if (!state.ok(state.writer.memberName("port")) ||
         !state.ok(state.writer.stringValue(reference.port))) {
+        return false;
+    }
+    if (!emitRetainedTrailing(state)) {
         return false;
     }
     return state.ok(state.writer.endObject());
@@ -279,6 +479,8 @@ extensionTargetValue(const bloom::document::ExtensionTarget& target) noexcept {
     return keyframeId == nullptr ? 0 : keyframeId->value();
 }
 
+// Every call site (an extension record's non-null subject, a host reference's target) is a genuine
+// attachment point; the caller pushes the right PathScope first.
 [[nodiscard]] bool emitTypedTarget(EmitState& state,
                                    const bloom::document::ExtensionTarget& target) noexcept {
     if (!state.ok(state.writer.beginObject())) {
@@ -289,6 +491,9 @@ extensionTargetValue(const bloom::document::ExtensionTarget& target) noexcept {
         return false;
     }
     if (!emitNamedId(state, "id", extensionTargetValue(target))) {
+        return false;
+    }
+    if (!emitRetainedTrailing(state)) {
         return false;
     }
     return state.ok(state.writer.endObject());
@@ -304,22 +509,23 @@ extensionTargetValue(const bloom::document::ExtensionTarget& target) noexcept {
     if (const auto* boolean = std::get_if<bool>(&value)) {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("bool")) &&
                state.ok(writer.memberName("value")) && state.ok(writer.booleanValue(*boolean)) &&
-               state.ok(writer.endObject());
+               emitRetainedTrailing(state) && state.ok(writer.endObject());
     }
     if (const auto* integer = std::get_if<std::int64_t>(&value)) {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("int64")) &&
-               emitNamedSigned(state, "value", *integer) && state.ok(writer.endObject());
+               emitNamedSigned(state, "value", *integer) && emitRetainedTrailing(state) &&
+               state.ok(writer.endObject());
     }
     if (const auto* floating = std::get_if<double>(&value)) {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("float64")) &&
                state.ok(writer.memberName("value")) && state.ok(writer.float64Value(*floating)) &&
-               state.ok(writer.endObject());
+               emitRetainedTrailing(state) && state.ok(writer.endObject());
     }
     if (const auto* vector = std::get_if<Vec2d>(&value)) {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("vec2")) &&
                state.ok(writer.memberName("x")) && state.ok(writer.float64Value(vector->x)) &&
                state.ok(writer.memberName("y")) && state.ok(writer.float64Value(vector->y)) &&
-               state.ok(writer.endObject());
+               emitRetainedTrailing(state) && state.ok(writer.endObject());
     }
     if (const auto* color = std::get_if<bloom::core::Color4d>(&value)) {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("color4")) &&
@@ -327,18 +533,19 @@ extensionTargetValue(const bloom::document::ExtensionTarget& target) noexcept {
                state.ok(writer.memberName("green")) &&
                state.ok(writer.float64Value(color->green)) && state.ok(writer.memberName("blue")) &&
                state.ok(writer.float64Value(color->blue)) && state.ok(writer.memberName("alpha")) &&
-               state.ok(writer.float64Value(color->alpha)) && state.ok(writer.endObject());
+               state.ok(writer.float64Value(color->alpha)) && emitRetainedTrailing(state) &&
+               state.ok(writer.endObject());
     }
     if (const auto* text = std::get_if<std::string>(&value)) {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("string")) &&
                state.ok(writer.memberName("value")) && state.ok(writer.stringValue(*text)) &&
-               state.ok(writer.endObject());
+               emitRetainedTrailing(state) && state.ok(writer.endObject());
     }
     if (const auto* rational = std::get_if<bloom::core::RationalTime>(&value)) {
         return state.ok(writer.memberName("kind")) && state.ok(writer.stringValue("rational")) &&
                emitNamedSigned(state, "numerator", rational->numerator()) &&
                emitNamedSigned(state, "denominator", rational->denominator()) &&
-               state.ok(writer.endObject());
+               emitRetainedTrailing(state) && state.ok(writer.endObject());
     }
     return false;
 }
@@ -347,6 +554,8 @@ extensionTargetValue(const bloom::document::ExtensionTarget& target) noexcept {
                                  const std::size_t parameterRank) noexcept {
     using namespace bloom::document;
     auto& writer = state.writer;
+    const auto idText = bloom::project::formatCanonicalUInt64(record.id.value());
+    const PathScope parameterScope(state, RoundTripCollectionKind::Parameter, idText.view());
     if (!state.ok(writer.beginObject())) {
         return false;
     }
@@ -360,38 +569,47 @@ extensionTargetValue(const bloom::document::ExtensionTarget& target) noexcept {
     if (!state.ok(writer.memberName("source")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    if (const auto* constant = std::get_if<ConstantValueSource>(&record.source)) {
-        if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("constant"))) {
-            return false;
-        }
-        if (!state.ok(writer.memberName("value"))) {
-            return false;
-        }
-        if (!emitConstantValue(state, constant->value)) {
-            {
+    {
+        const PathScope sourceScope(state, "source");
+        if (const auto* constant = std::get_if<ConstantValueSource>(&record.source)) {
+            if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("constant"))) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("value"))) {
+                return false;
+            }
+            const PathScope valueScope(state, "value");
+            if (!emitConstantValue(state, constant->value)) {
                 state.walk.fail(CanonicalDocumentError::InvalidParameter,
                                 state.walk.compositionIndex, parameterRank);
                 return false;
             }
-        }
-    } else if (const auto* curve = std::get_if<AnimationCurveSource>(&record.source)) {
-        if (!state.ok(writer.memberName("kind")) ||
-            !state.ok(writer.stringValue("animation-curve"))) {
-            return false;
-        }
-        if (!emitNamedId(state, "curveId", curve->curveId.value())) {
-            return false;
-        }
-    } else {
-        // Admission rejected live driver sources before staging; reaching this path means the
-        // caller bypassed canonicalDocumentSize.
-        {
+        } else if (const auto* curve = std::get_if<AnimationCurveSource>(&record.source)) {
+            if (!state.ok(writer.memberName("kind")) ||
+                !state.ok(writer.stringValue("animation-curve"))) {
+                return false;
+            }
+            if (!emitNamedId(state, "curveId", curve->curveId.value())) {
+                return false;
+            }
+        } else {
+            // Admission rejected live driver sources before staging; reaching this path means the
+            // caller bypassed canonicalDocumentSize.
             state.walk.fail(CanonicalDocumentError::UnsupportedDriverBindingSource,
                             state.walk.compositionIndex, parameterRank);
             return false;
         }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
     }
-    return state.ok(writer.endObject()) && state.ok(writer.endObject());
+    if (!state.ok(writer.endObject())) {
+        return false;
+    }
+    if (!emitRetainedTrailing(state)) {
+        return false;
+    }
+    return state.ok(writer.endObject());
 }
 
 [[nodiscard]] bool
@@ -409,6 +627,8 @@ emitInterpolation(EmitState& state,
 [[nodiscard]] bool emitScalarKeyframe(EmitState& state,
                                       const bloom::document::ScalarKeyframe& key) noexcept {
     auto& writer = state.writer;
+    const auto idText = bloom::project::formatCanonicalUInt64(key.id.value());
+    const PathScope keyframeScope(state, RoundTripCollectionKind::Keyframe, idText.view());
     if (!state.ok(writer.beginObject())) {
         return false;
     }
@@ -418,8 +638,11 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("time"))) {
         return false;
     }
-    if (!emitRational(state, key.time.numerator(), key.time.denominator())) {
-        return false;
+    {
+        const PathScope timeScope(state, "time");
+        if (!emitRational(state, key.time.numerator(), key.time.denominator())) {
+            return false;
+        }
     }
     if (!state.ok(writer.memberName("value"))) {
         return false;
@@ -433,12 +656,17 @@ emitInterpolation(EmitState& state,
     if (!emitInterpolation(state, key.outgoingInterpolation)) {
         return false;
     }
+    if (!emitRetainedTrailing(state)) {
+        return false;
+    }
     return state.ok(writer.endObject());
 }
 
 [[nodiscard]] bool emitVec2Keyframe(EmitState& state,
                                     const bloom::document::Vec2Keyframe& key) noexcept {
     auto& writer = state.writer;
+    const auto idText = bloom::project::formatCanonicalUInt64(key.id.value());
+    const PathScope keyframeScope(state, RoundTripCollectionKind::Keyframe, idText.view());
     if (!state.ok(writer.beginObject())) {
         return false;
     }
@@ -448,17 +676,26 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("time"))) {
         return false;
     }
-    if (!emitRational(state, key.time.numerator(), key.time.denominator())) {
-        return false;
+    {
+        const PathScope timeScope(state, "time");
+        if (!emitRational(state, key.time.numerator(), key.time.denominator())) {
+            return false;
+        }
     }
     if (!state.ok(writer.memberName("value")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    if (!state.ok(writer.memberName("x")) || !state.ok(writer.float64Value(key.value.x))) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("y")) || !state.ok(writer.float64Value(key.value.y))) {
-        return false;
+    {
+        const PathScope valueScope(state, "value");
+        if (!state.ok(writer.memberName("x")) || !state.ok(writer.float64Value(key.value.x))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("y")) || !state.ok(writer.float64Value(key.value.y))) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
     }
     if (!state.ok(writer.endObject())) {
         return false;
@@ -467,6 +704,9 @@ emitInterpolation(EmitState& state,
         return false;
     }
     if (!emitInterpolation(state, key.outgoingInterpolation)) {
+        return false;
+    }
+    if (!emitRetainedTrailing(state)) {
         return false;
     }
     return state.ok(writer.endObject());
@@ -494,6 +734,8 @@ emitInterpolation(EmitState& state,
     }
     for (const auto recordIndex : order) {
         const auto& record = records[recordIndex];
+        const auto idText = bloom::project::formatCanonicalUInt64(animationCurveId(record).value());
+        const PathScope curveScope(state, RoundTripCollectionKind::AnimationCurve, idText.view());
         if (!state.ok(writer.beginObject())) {
             return false;
         }
@@ -554,7 +796,13 @@ emitInterpolation(EmitState& state,
                 return false;
             }
         }
-        if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+        if (!state.ok(writer.endArray())) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
+        if (!state.ok(writer.endObject())) {
             return false;
         }
     }
@@ -594,6 +842,7 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("graph")) || !state.ok(writer.beginObject())) {
         return false;
     }
+    const PathScope graphScope(state, "graph");
 
     if (!state.ok(writer.memberName("nodes")) || !state.ok(writer.beginArray())) {
         return false;
@@ -609,6 +858,8 @@ emitInterpolation(EmitState& state,
     }
     for (const auto nodeIndex : nodeOrder) {
         const auto& node = graph.nodes()[nodeIndex];
+        const auto nodeIdText = bloom::project::formatCanonicalUInt64(node.id.value());
+        const PathScope nodeScope(state, RoundTripCollectionKind::Node, nodeIdText.view());
         if (!state.ok(writer.beginObject())) {
             return false;
         }
@@ -641,6 +892,8 @@ emitInterpolation(EmitState& state,
         }
         for (const auto bindingIndex : bindingOrder) {
             const auto& binding = node.parameters[bindingIndex];
+            const PathScope bindingScope(state, RoundTripCollectionKind::ParameterBinding,
+                                         std::string_view(binding.role));
             if (!state.ok(writer.beginObject())) {
                 return false;
             }
@@ -651,11 +904,20 @@ emitInterpolation(EmitState& state,
             if (!emitNamedId(state, "parameterId", binding.parameterId.value())) {
                 return false;
             }
+            if (!emitRetainedTrailing(state)) {
+                return false;
+            }
             if (!state.ok(writer.endObject())) {
                 return false;
             }
         }
-        if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+        if (!state.ok(writer.endArray())) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
+        if (!state.ok(writer.endObject())) {
             return false;
         }
     }
@@ -677,52 +939,71 @@ emitInterpolation(EmitState& state,
     }
     for (const auto edgeIndex : edgeOrder) {
         const auto& edge = graph.edges()[edgeIndex];
+        const auto edgeIdText = bloom::project::formatCanonicalUInt64(edge.id.value());
+        const PathScope edgeScope(state, RoundTripCollectionKind::Edge, edgeIdText.view());
         if (!state.ok(writer.beginObject())) {
             return false;
         }
         if (!emitNamedId(state, "id", edge.id.value())) {
             return false;
         }
-        if (!state.ok(writer.memberName("source")) || !emitOutputPortRef(state, edge.source)) {
+        if (!state.ok(writer.memberName("source"))) {
             return false;
+        }
+        {
+            const PathScope sourceScope(state, "source");
+            if (!emitOutputPortRef(state, edge.source)) {
+                return false;
+            }
         }
         if (!state.ok(writer.memberName("destination")) || !state.ok(writer.beginObject())) {
             return false;
         }
-        if (const auto* nodeInput = std::get_if<NodeInputRef>(&edge.destination)) {
-            if (!state.ok(writer.memberName("kind")) ||
-                !state.ok(writer.stringValue("node-input"))) {
-                return false;
-            }
-            if (!emitNamedId(state, "nodeId", nodeInput->nodeId.value())) {
-                return false;
-            }
-            if (!state.ok(writer.memberName("port")) ||
-                !state.ok(writer.stringValue(nodeInput->port))) {
-                return false;
-            }
-        } else if (const auto* stackInput = std::get_if<LayerStackInputRef>(&edge.destination)) {
-            if (!state.ok(writer.memberName("kind")) ||
-                !state.ok(writer.stringValue("layer-stack-input"))) {
-                return false;
-            }
-            if (!emitNamedId(state, "stackNodeId", stackInput->stackNodeId.value())) {
-                return false;
-            }
-            if (!emitNamedId(state, "slotId", stackInput->slotId.value())) {
-                return false;
-            }
-            if (!state.ok(writer.memberName("role")) ||
-                !state.ok(writer.stringValue(stackInput->role))) {
-                return false;
-            }
-        } else {
-            {
+        {
+            const PathScope destinationScope(state, "destination");
+            if (const auto* nodeInput = std::get_if<NodeInputRef>(&edge.destination)) {
+                if (!state.ok(writer.memberName("kind")) ||
+                    !state.ok(writer.stringValue("node-input"))) {
+                    return false;
+                }
+                if (!emitNamedId(state, "nodeId", nodeInput->nodeId.value())) {
+                    return false;
+                }
+                if (!state.ok(writer.memberName("port")) ||
+                    !state.ok(writer.stringValue(nodeInput->port))) {
+                    return false;
+                }
+            } else if (const auto* stackInput =
+                           std::get_if<LayerStackInputRef>(&edge.destination)) {
+                if (!state.ok(writer.memberName("kind")) ||
+                    !state.ok(writer.stringValue("layer-stack-input"))) {
+                    return false;
+                }
+                if (!emitNamedId(state, "stackNodeId", stackInput->stackNodeId.value())) {
+                    return false;
+                }
+                if (!emitNamedId(state, "slotId", stackInput->slotId.value())) {
+                    return false;
+                }
+                if (!state.ok(writer.memberName("role")) ||
+                    !state.ok(writer.stringValue(stackInput->role))) {
+                    return false;
+                }
+            } else {
                 state.walk.fail(CanonicalDocumentError::InvalidGraph, compositionIndex);
                 return false;
             }
+            if (!emitRetainedTrailing(state)) {
+                return false;
+            }
         }
-        if (!state.ok(writer.endObject()) || !state.ok(writer.endObject())) {
+        if (!state.ok(writer.endObject())) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
+        if (!state.ok(writer.endObject())) {
             return false;
         }
     }
@@ -748,6 +1029,9 @@ emitInterpolation(EmitState& state,
     }
     for (const auto boundaryIndex : boundaryOrder) {
         const auto& boundary = graph.layerOutputs()[boundaryIndex];
+        const auto layerIdText = bloom::project::formatCanonicalUInt64(boundary.layerId.value());
+        const PathScope layerOutputScope(state, RoundTripCollectionKind::LayerOutput,
+                                         layerIdText.view());
         if (!state.ok(writer.beginObject())) {
             return false;
         }
@@ -764,6 +1048,9 @@ emitInterpolation(EmitState& state,
             !state.ok(writer.stringValue(boundary.outputPort))) {
             return false;
         }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
         if (!state.ok(writer.endObject())) {
             return false;
         }
@@ -775,27 +1062,42 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("layerStack")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    if (!emitNamedId(state, "nodeId", graph.layerStack().nodeId().value())) {
-        return false;
+    {
+        const PathScope layerStackScope(state, "layerStack");
+        if (!emitNamedId(state, "nodeId", graph.layerStack().nodeId().value())) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("entries")) || !state.ok(writer.beginArray())) {
+            return false;
+        }
+        for (const auto& entry : graph.layerStack().entries()) {
+            const auto slotIdText = bloom::project::formatCanonicalUInt64(entry.slotId.value());
+            const PathScope entryScope(state, RoundTripCollectionKind::LayerStackEntry,
+                                       slotIdText.view());
+            if (!state.ok(writer.beginObject())) {
+                return false;
+            }
+            if (!emitNamedId(state, "slotId", entry.slotId.value())) {
+                return false;
+            }
+            if (!emitNamedId(state, "layerId", entry.layerId.value())) {
+                return false;
+            }
+            if (!emitRetainedTrailing(state)) {
+                return false;
+            }
+            if (!state.ok(writer.endObject())) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.endArray())) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
     }
-    if (!state.ok(writer.memberName("entries")) || !state.ok(writer.beginArray())) {
-        return false;
-    }
-    for (const auto& entry : graph.layerStack().entries()) {
-        if (!state.ok(writer.beginObject())) {
-            return false;
-        }
-        if (!emitNamedId(state, "slotId", entry.slotId.value())) {
-            return false;
-        }
-        if (!emitNamedId(state, "layerId", entry.layerId.value())) {
-            return false;
-        }
-        if (!state.ok(writer.endObject())) {
-            return false;
-        }
-    }
-    if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+    if (!state.ok(writer.endObject())) {
         return false;
     }
 
@@ -808,7 +1110,13 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("compositionOutput"))) {
         return false;
     }
-    if (!emitOutputPortRef(state, *graph.compositionOutput())) {
+    {
+        const PathScope compositionOutputScope(state, "compositionOutput");
+        if (!emitOutputPortRef(state, *graph.compositionOutput())) {
+            return false;
+        }
+    }
+    if (!emitRetainedTrailing(state)) {
         return false;
     }
     return state.ok(writer.endObject());
@@ -819,6 +1127,9 @@ emitInterpolation(EmitState& state,
     auto& writer = state.writer;
     state.walk.compositionIndex = compositionIndex;
     state.walk.elementIndex = kCanonicalDocumentNoIndex;
+    const auto compositionIdText = bloom::project::formatCanonicalUInt64(composition.id().value());
+    const PathScope compositionScope(state, RoundTripCollectionKind::Composition,
+                                     compositionIdText.view());
     if (!state.ok(writer.beginObject())) {
         return false;
     }
@@ -831,32 +1142,50 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("duration"))) {
         return false;
     }
-    if (!emitRational(state, composition.duration().numerator(),
-                      composition.duration().denominator())) {
-        return false;
+    {
+        const PathScope durationScope(state, "duration");
+        if (!emitRational(state, composition.duration().numerator(),
+                          composition.duration().denominator())) {
+            return false;
+        }
     }
     if (!state.ok(writer.memberName("format")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    const auto format = composition.format();
-    if (!state.ok(writer.memberName("width")) || !state.ok(writer.integerValue(format.width()))) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("height")) || !state.ok(writer.integerValue(format.height()))) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("pixelAspect"))) {
-        return false;
-    }
-    if (!emitRational(state, format.pixelAspect().numerator(),
-                      format.pixelAspect().denominator())) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("frameRate"))) {
-        return false;
-    }
-    if (!emitRational(state, format.frameRate().numerator(), format.frameRate().denominator())) {
-        return false;
+    {
+        const PathScope formatScope(state, "format");
+        const auto format = composition.format();
+        if (!state.ok(writer.memberName("width")) ||
+            !state.ok(writer.integerValue(format.width()))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("height")) ||
+            !state.ok(writer.integerValue(format.height()))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("pixelAspect"))) {
+            return false;
+        }
+        {
+            const PathScope pixelAspectScope(state, "pixelAspect");
+            if (!emitRational(state, format.pixelAspect().numerator(),
+                              format.pixelAspect().denominator())) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.memberName("frameRate"))) {
+            return false;
+        }
+        {
+            const PathScope frameRateScope(state, "frameRate");
+            if (!emitRational(state, format.frameRate().numerator(),
+                              format.frameRate().denominator())) {
+                return false;
+            }
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
     }
     if (!state.ok(writer.endObject())) {
         return false;
@@ -870,9 +1199,14 @@ emitInterpolation(EmitState& state,
     if (!emitGraph(state, composition, compositionIndex)) {
         return false;
     }
+    if (!emitRetainedTrailing(state)) {
+        return false;
+    }
     return state.ok(writer.endObject());
 }
 
+// Only call site (colorSettings.ocioConfig.locator) is a genuine attachment point; the caller
+// pushes the "locator" PathScope first.
 [[nodiscard]] bool emitLocator(EmitState& state,
                                const bloom::document::OcioConfigLocator& locator) noexcept {
     using namespace bloom::document;
@@ -902,6 +1236,9 @@ emitInterpolation(EmitState& state,
     if (!emitted) {
         return false;
     }
+    if (!emitRetainedTrailing(state)) {
+        return false;
+    }
     return state.ok(writer.endObject());
 }
 
@@ -915,8 +1252,11 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("schemaVersion"))) {
         return false;
     }
-    if (!emitVersion(state, settings.schemaVersion)) {
-        return false;
+    {
+        const PathScope schemaVersionScope(state, "schemaVersion");
+        if (!emitVersion(state, settings.schemaVersion, true)) {
+            return false;
+        }
     }
     if (!state.ok(writer.memberName("processColorSpaceId")) ||
         !state.ok(writer.stringValue(settings.processColorSpaceId))) {
@@ -925,70 +1265,97 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("ocioConfig")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    if (!state.ok(writer.memberName("schemaVersion"))) {
-        return false;
-    }
-    if (!emitVersion(state, settings.ocioConfig.schemaVersion)) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("locator"))) {
-        return false;
-    }
-    if (!emitLocator(state, settings.ocioConfig.locator)) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("expectedRevision")) || !state.ok(writer.beginObject())) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("algorithm")) || !state.ok(writer.stringValue("sha256"))) {
-        return false;
-    }
-    const auto hex = settings.ocioConfig.expectedRevision.digest.toLowercaseHex();
-    if (!state.ok(writer.memberName("digest")) ||
-        !state.ok(writer.stringValue(std::string_view(hex.data(), hex.size())))) {
-        return false;
-    }
-    if (!state.ok(writer.endObject())) {
-        return false;
-    }
-    std::string_view portability;
-    switch (settings.ocioConfig.portability) {
-    case OcioConfigPortability::BuiltIn:
-        portability = "builtin";
-        break;
-    case OcioConfigPortability::ProjectRelative:
-        portability = "project-relative";
-        break;
-    case OcioConfigPortability::External:
-        portability = "external";
-        break;
-    default: {
-        state.walk.fail(CanonicalDocumentError::OcioPortabilityMismatch);
-        return false;
-    }
-    }
-    if (!state.ok(writer.memberName("portability")) || !state.ok(writer.stringValue(portability))) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("contextVariables")) || !state.ok(writer.beginArray())) {
-        return false;
-    }
-    for (const auto& variable : settings.ocioConfig.contextVariables) {
-        if (!state.ok(writer.beginObject())) {
+    {
+        const PathScope ocioConfigScope(state, "ocioConfig");
+        if (!state.ok(writer.memberName("schemaVersion"))) {
             return false;
         }
-        if (!state.ok(writer.memberName("name")) || !state.ok(writer.stringValue(variable.name))) {
+        {
+            const PathScope ocioSchemaVersionScope(state, "schemaVersion");
+            if (!emitVersion(state, settings.ocioConfig.schemaVersion, true)) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.memberName("locator"))) {
             return false;
         }
-        if (!state.ok(writer.memberName("value")) ||
-            !state.ok(writer.stringValue(variable.value))) {
+        {
+            const PathScope locatorScope(state, "locator");
+            if (!emitLocator(state, settings.ocioConfig.locator)) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.memberName("expectedRevision")) || !state.ok(writer.beginObject())) {
             return false;
+        }
+        {
+            const PathScope expectedRevisionScope(state, "expectedRevision");
+            if (!state.ok(writer.memberName("algorithm")) ||
+                !state.ok(writer.stringValue("sha256"))) {
+                return false;
+            }
+            const auto hex = settings.ocioConfig.expectedRevision.digest.toLowercaseHex();
+            if (!state.ok(writer.memberName("digest")) ||
+                !state.ok(writer.stringValue(std::string_view(hex.data(), hex.size())))) {
+                return false;
+            }
+            if (!emitRetainedTrailing(state)) {
+                return false;
+            }
         }
         if (!state.ok(writer.endObject())) {
             return false;
         }
+        std::string_view portability;
+        switch (settings.ocioConfig.portability) {
+        case OcioConfigPortability::BuiltIn:
+            portability = "builtin";
+            break;
+        case OcioConfigPortability::ProjectRelative:
+            portability = "project-relative";
+            break;
+        case OcioConfigPortability::External:
+            portability = "external";
+            break;
+        default: {
+            state.walk.fail(CanonicalDocumentError::OcioPortabilityMismatch);
+            return false;
+        }
+        }
+        if (!state.ok(writer.memberName("portability")) ||
+            !state.ok(writer.stringValue(portability))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("contextVariables")) || !state.ok(writer.beginArray())) {
+            return false;
+        }
+        for (const auto& variable : settings.ocioConfig.contextVariables) {
+            if (!state.ok(writer.beginObject())) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("name")) ||
+                !state.ok(writer.stringValue(variable.name))) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("value")) ||
+                !state.ok(writer.stringValue(variable.value))) {
+                return false;
+            }
+            if (!state.ok(writer.endObject())) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.endArray())) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
     }
-    if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+    if (!state.ok(writer.endObject())) {
+        return false;
+    }
+    if (!emitRetainedTrailing(state)) {
         return false;
     }
     return state.ok(writer.endObject());
@@ -1018,6 +1385,8 @@ emitInterpolation(EmitState& state,
 [[nodiscard]] bool emitExtensionRecord(EmitState& state, const ExtensionRecord& record) noexcept {
     using namespace bloom::document;
     auto& writer = state.writer;
+    const auto idText = bloom::project::formatCanonicalUInt64(record.id.value());
+    const PathScope recordScope(state, RoundTripCollectionKind::ExtensionRecord, idText.view());
     if (!state.ok(writer.beginObject())) {
         return false;
     }
@@ -1033,16 +1402,21 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("schemaVersion"))) {
         return false;
     }
-    if (!emitVersion(state, record.schemaVersion)) {
-        return false;
+    {
+        const PathScope schemaVersionScope(state, "schemaVersion");
+        if (!emitVersion(state, record.schemaVersion, true)) {
+            return false;
+        }
     }
     if (!state.ok(writer.memberName("subject"))) {
         return false;
     }
-    if (record.subject.has_value() && !emitTypedTarget(state, *record.subject)) {
-        return false;
-    }
-    if (!record.subject.has_value() && !state.ok(writer.nullValue())) {
+    if (record.subject.has_value()) {
+        const PathScope subjectScope(state, "subject");
+        if (!emitTypedTarget(state, *record.subject)) {
+            return false;
+        }
+    } else if (!state.ok(writer.nullValue())) {
         return false;
     }
     if (!state.ok(writer.memberName("mediaType")) ||
@@ -1052,58 +1426,74 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("referencePolicy")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    if (std::holds_alternative<NoExtensionReferences>(record.referencePolicy)) {
-        if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("none"))) {
-            return false;
-        }
-    } else if (const auto* table =
-                   std::get_if<ExtensionHostReferenceTable>(&record.referencePolicy)) {
-        if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("host-table"))) {
-            return false;
-        }
-        if (!state.ok(writer.memberName("references")) || !state.ok(writer.beginArray())) {
-            return false;
-        }
-        for (const auto& reference : table->references) {
-            if (!state.ok(writer.beginObject())) {
+    {
+        const PathScope referencePolicyScope(state, "referencePolicy");
+        if (std::holds_alternative<NoExtensionReferences>(record.referencePolicy)) {
+            if (!state.ok(writer.memberName("kind")) || !state.ok(writer.stringValue("none"))) {
                 return false;
             }
-            if (!state.ok(writer.memberName("key")) ||
-                !state.ok(writer.stringValue(reference.key))) {
+        } else if (const auto* table =
+                       std::get_if<ExtensionHostReferenceTable>(&record.referencePolicy)) {
+            if (!state.ok(writer.memberName("kind")) ||
+                !state.ok(writer.stringValue("host-table"))) {
                 return false;
             }
-            if (!state.ok(writer.memberName("target"))) {
+            if (!state.ok(writer.memberName("references")) || !state.ok(writer.beginArray())) {
                 return false;
             }
-            if (!emitTypedTarget(state, reference.target)) {
+            for (const auto& reference : table->references) {
+                const PathScope hostReferenceScope(state, RoundTripCollectionKind::HostReference,
+                                                   std::string_view(reference.key));
+                if (!state.ok(writer.beginObject())) {
+                    return false;
+                }
+                if (!state.ok(writer.memberName("key")) ||
+                    !state.ok(writer.stringValue(reference.key))) {
+                    return false;
+                }
+                if (!state.ok(writer.memberName("target"))) {
+                    return false;
+                }
+                {
+                    const PathScope targetScope(state, "target");
+                    if (!emitTypedTarget(state, reference.target)) {
+                        return false;
+                    }
+                }
+                if (!emitRetainedTrailing(state)) {
+                    return false;
+                }
+                if (!state.ok(writer.endObject())) {
+                    return false;
+                }
+            }
+            if (!state.ok(writer.endArray())) {
                 return false;
             }
-            if (!state.ok(writer.endObject())) {
+        } else if (const auto* remapper =
+                       std::get_if<ExtensionOwnerRemapper>(&record.referencePolicy)) {
+            if (!state.ok(writer.memberName("kind")) ||
+                !state.ok(writer.stringValue("owner-remapper"))) {
                 return false;
             }
-        }
-        if (!state.ok(writer.endArray())) {
-            return false;
-        }
-    } else if (const auto* remapper =
-                   std::get_if<ExtensionOwnerRemapper>(&record.referencePolicy)) {
-        if (!state.ok(writer.memberName("kind")) ||
-            !state.ok(writer.stringValue("owner-remapper"))) {
-            return false;
-        }
-        if (!state.ok(writer.memberName("remapperId")) ||
-            !state.ok(writer.stringValue(remapper->remapperId))) {
-            return false;
-        }
-        if (!state.ok(writer.memberName("version"))) {
-            return false;
-        }
-        if (!emitVersion(state, remapper->version)) {
-            return false;
-        }
-    } else {
-        {
+            if (!state.ok(writer.memberName("remapperId")) ||
+                !state.ok(writer.stringValue(remapper->remapperId))) {
+                return false;
+            }
+            if (!state.ok(writer.memberName("version"))) {
+                return false;
+            }
+            {
+                const PathScope versionScope(state, "version");
+                if (!emitVersion(state, remapper->version, true)) {
+                    return false;
+                }
+            }
+        } else {
             state.walk.fail(CanonicalDocumentError::InvalidExtensionRecord);
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
             return false;
         }
     }
@@ -1114,6 +1504,9 @@ emitInterpolation(EmitState& state,
         return false;
     }
     if (!emitPayload(state, record.payload)) {
+        return false;
+    }
+    if (!emitRetainedTrailing(state)) {
         return false;
     }
     return state.ok(writer.endObject());
@@ -1133,66 +1526,100 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.memberName("schemaVersion"))) {
         return false;
     }
-    if (!emitVersion(state, kV1SchemaVersion)) {
+    // No PathScope pushed: the root schemaVersion object is never itself an attachment point (see
+    // emitVersion's own comment). {1, schemaMinor} lets an overlay rewrite of a {1, minor > 0}
+    // document reproduce the exact minor it was opened with; a plain write leaves schemaMinor at
+    // its default 0.
+    if (!emitVersion(state, SchemaVersion{kV1SchemaVersion.major, state.schemaMinor})) {
         return false;
     }
 
     if (!state.ok(writer.memberName("project")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    if (!emitNamedId(state, "id", state.project.id().value())) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("name")) ||
-        !state.ok(writer.stringValue(state.project.name()))) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("colorSettings")) || !emitColorSettings(state)) {
-        return false;
-    }
-    if (!state.ok(writer.memberName("compositions")) || !state.ok(writer.beginArray())) {
-        return false;
-    }
-    std::span<const std::size_t> compositionOrder;
-    if (!makeOrder(
-            state.project.compositions(),
-            [](const Composition& composition) noexcept { return composition.id().value(); },
-            state.sort.window0, compositionOrder, state.walk.error)) {
+    {
+        const PathScope projectScope(state, "project");
+        if (!emitNamedId(state, "id", state.project.id().value())) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("name")) ||
+            !state.ok(writer.stringValue(state.project.name()))) {
+            return false;
+        }
+        if (!state.ok(writer.memberName("colorSettings"))) {
+            return false;
+        }
         {
-            state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity);
+            const PathScope colorSettingsScope(state, "colorSettings");
+            if (!emitColorSettings(state)) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.memberName("compositions")) || !state.ok(writer.beginArray())) {
+            return false;
+        }
+        std::span<const std::size_t> compositionOrder;
+        if (!makeOrder(
+                state.project.compositions(),
+                [](const Composition& composition) noexcept { return composition.id().value(); },
+                state.sort.window0, compositionOrder, state.walk.error)) {
+            {
+                state.walk.fail(CanonicalDocumentError::InvalidCollectionIdentity);
+                return false;
+            }
+        }
+        for (const auto compositionIndex : compositionOrder) {
+            if (!emitComposition(state, state.project.compositions()[compositionIndex],
+                                 compositionIndex)) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.endArray())) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
             return false;
         }
     }
-    for (const auto compositionIndex : compositionOrder) {
-        if (!emitComposition(state, state.project.compositions()[compositionIndex],
-                             compositionIndex)) {
-            return false;
-        }
-    }
-    if (!state.ok(writer.endArray()) || !state.ok(writer.endObject())) {
+    if (!state.ok(writer.endObject())) {
         return false;
     }
 
     if (!state.ok(writer.memberName("idAllocation")) || !state.ok(writer.beginObject())) {
         return false;
     }
-    if (!state.ok(writer.memberName("highestIssued")) || !state.ok(writer.beginObject())) {
-        return false;
+    {
+        const PathScope idAllocationScope(state, "idAllocation");
+        if (!state.ok(writer.memberName("highestIssued")) || !state.ok(writer.beginObject())) {
+            return false;
+        }
+        {
+            const PathScope highestIssuedScope(state, "highestIssued");
+            const auto& water = state.highWater;
+            if (!emitHighWaterMember(state, "composition", water.composition) ||
+                !emitHighWaterMember(state, "node", water.node) ||
+                !emitHighWaterMember(state, "edge", water.edge) ||
+                !emitHighWaterMember(state, "layer", water.layer) ||
+                !emitHighWaterMember(state, "layerSlot", water.layerSlot) ||
+                !emitHighWaterMember(state, "parameter", water.parameter) ||
+                !emitHighWaterMember(state, "animationCurve", water.animationCurve) ||
+                !emitHighWaterMember(state, "keyframe", water.keyframe) ||
+                !emitHighWaterMember(state, "driverBinding", water.driverBinding) ||
+                !emitHighWaterMember(state, "extensionRecord", water.extensionRecord)) {
+                return false;
+            }
+            if (!emitRetainedTrailing(state)) {
+                return false;
+            }
+        }
+        if (!state.ok(writer.endObject())) {
+            return false;
+        }
+        if (!emitRetainedTrailing(state)) {
+            return false;
+        }
     }
-    const auto& water = state.highWater;
-    if (!emitHighWaterMember(state, "composition", water.composition) ||
-        !emitHighWaterMember(state, "node", water.node) ||
-        !emitHighWaterMember(state, "edge", water.edge) ||
-        !emitHighWaterMember(state, "layer", water.layer) ||
-        !emitHighWaterMember(state, "layerSlot", water.layerSlot) ||
-        !emitHighWaterMember(state, "parameter", water.parameter) ||
-        !emitHighWaterMember(state, "animationCurve", water.animationCurve) ||
-        !emitHighWaterMember(state, "keyframe", water.keyframe) ||
-        !emitHighWaterMember(state, "driverBinding", water.driverBinding) ||
-        !emitHighWaterMember(state, "extensionRecord", water.extensionRecord)) {
-        return false;
-    }
-    if (!state.ok(writer.endObject()) || !state.ok(writer.endObject())) {
+    if (!state.ok(writer.endObject())) {
         return false;
     }
 
@@ -1217,10 +1644,24 @@ emitInterpolation(EmitState& state,
     if (!state.ok(writer.endArray())) {
         return false;
     }
+    if (!emitRetainedTrailing(state)) {
+        return false;
+    }
     if (!state.ok(writer.endObject())) {
         return false;
     }
-    return state.ok(writer.finish());
+    if (!state.ok(writer.finish())) {
+        return false;
+    }
+    // RT2: every attachment point in an overlay's RoundTripState must be consumed exactly once by
+    // this walk (see docs/architecture/project-format.md, "Versions, Migrations, And
+    // Preservation"). A leftover entry is state captured against a different document (or a stale
+    // edit of this one), never silently dropped.
+    if (state.roundTrip != nullptr && state.retainedConsumed != state.roundTrip->entries().size()) {
+        state.walk.fail(CanonicalDocumentError::RoundTripStateMismatch);
+        return false;
+    }
+    return true;
 }
 
 [[nodiscard]] bloom::document::OcioConfigPortability
@@ -1368,7 +1809,9 @@ CanonicalDocumentSizeResult canonicalDocumentSize(const CanonicalDocumentV1& doc
                     *document.colorSettings,
                     splitSortScratch(document.sortScratch, plan),
                     document.payloadScratch,
-                    {}};
+                    {},
+                    document.roundTrip,
+                    document.schemaMinor};
     if (!emitDocumentRoot(state)) {
         return CanonicalDocumentSizeResult::failure(state.walk.error, state.walk.compositionIndex,
                                                     state.walk.elementIndex);
@@ -1406,7 +1849,9 @@ encodeCanonicalDocument(const CanonicalDocumentV1& document, const std::span<cha
                     *document.colorSettings,
                     splitSortScratch(document.sortScratch, measureSortPlan(snapshot.project())),
                     document.payloadScratch,
-                    {}};
+                    {},
+                    document.roundTrip,
+                    document.schemaMinor};
     if (!emitDocumentRoot(state) || writer.bytesWritten() != requiredSize) {
         std::terminate();
     }

--- a/src/project/include/bloom/project/canonical_document.hpp
+++ b/src/project/include/bloom/project/canonical_document.hpp
@@ -19,6 +19,11 @@ class Snapshot;
 
 namespace bloom::project {
 
+// Forward-declared only: CanonicalDocumentV1 below holds a plain observer pointer, so the
+// pointee's complete definition (round_trip_state.hpp) is not required by every translation unit
+// that merely names a CanonicalDocumentV1.
+class RoundTripState;
+
 inline constexpr document::SchemaVersion kCanonicalDocumentSchemaVersionV1{1, 0};
 // The v1 expanded document.json resource limit from docs/architecture/project-format.md.
 inline constexpr std::size_t kCanonicalDocumentMaximumBytes = 268'435'456;
@@ -40,11 +45,30 @@ inline constexpr std::size_t kCanonicalDocumentNoIndex = static_cast<std::size_t
 // one nested sub-order at a time (node parameter bindings, curve keyframes). The required total is
 // measured from live collection sizes; store-ordered collections (animation curves, keyframes,
 // extension records) are re-sorted defensively through the same windows rather than trusted.
+// RT2 overlay input is threaded directly onto the plain request rather than a parallel struct:
+// every field below (snapshot, colorSettings, both scratch spans) is still required exactly once
+// per encode, an overlay rewrite needs no field a plain write does not already carry, and the
+// counting/write two-pass discipline (canonicalDocumentSize/encodeCanonicalDocument) already
+// takes one CanonicalDocumentV1 by const reference -- a parallel struct would only duplicate that
+// plumbing for no behavioral gain. `roundTrip` and `schemaMinor` both default to their plain-write
+// values (null, 0), so every existing call site compiles and behaves unchanged.
 struct CanonicalDocumentV1 final {
     const bloom::document::Snapshot* snapshot = nullptr;
     const bloom::document::ColorSettings* colorSettings = nullptr;
     std::span<char> payloadScratch{};
     std::span<std::size_t> sortScratch{};
+    // Optional RT2 overlay (see docs/architecture/project-format.md, "Versions, Migrations, And
+    // Preservation"). Null (the default) reproduces the plain v1.0 writer exactly: no attachment
+    // lookup is ever performed, byte-identical to every pre-RT2 golden. When non-null, every
+    // retained attachment point in *roundTrip is re-emitted after the last known member of its
+    // corresponding object, and `schemaMinor` should name the exact minor this state was captured
+    // against (a mismatched minor still encodes, but the result would not describe the schema
+    // version it claims). The pointee must outlive the call.
+    const RoundTripState* roundTrip = nullptr;
+    // The document schema minor to emit at the document root ({1, schemaMinor}). Defaults to 0
+    // (the only schema `1.0` writes before RT2). An overlay rewrite of a {1, minor > 0} document
+    // must pass that same minor back so the emitted schemaVersion matches what was opened.
+    std::uint32_t schemaMinor = 0;
 };
 
 struct CanonicalDocumentLimits final {
@@ -77,6 +101,13 @@ enum class CanonicalDocumentError : std::uint8_t {
     ContainerEntryCountExceeded,
     DocumentSizeExceeded,
     OutputCapacityExceeded,
+    // RT2: the supplied RoundTripState has at least one attachment-point entry the emission walk
+    // never visited (see docs/architecture/project-format.md, "Versions, Migrations, And
+    // Preservation": preserved intent is never silently discarded). Every entry in a RoundTripState
+    // produced by decoding *this exact* document is visited exactly once by construction; a
+    // leftover entry means the caller passed state captured against a different document (or a
+    // stale edit of this one) than the one actually being written.
+    RoundTripStateMismatch,
 };
 
 class [[nodiscard]] CanonicalDocumentSizeResult final {

--- a/src/project/tests/canonical_document_tests.cpp
+++ b/src/project/tests/canonical_document_tests.cpp
@@ -10,7 +10,14 @@
 #include <bloom/document/extension_records.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
 #include <bloom/document/project.hpp>
+#include <bloom/project/document_decode.hpp>
+#include <bloom/project/document_reconstruct.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/round_trip_state.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+#include <bloom/project/unknown_json_number.hpp>
 
 #include <array>
 #include <cstddef>
@@ -44,6 +51,16 @@ using bloom::document::ScalarKeyframe;
 using bloom::project::CanonicalDocumentError;
 using bloom::project::CanonicalDocumentLimits;
 using bloom::project::CanonicalDocumentV1;
+using bloom::project::DocumentDecodeResult;
+using bloom::project::JsonValue;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::RetainedJsonMember;
+using bloom::project::RetainedJsonValue;
+using bloom::project::RoundTripAttachmentPath;
+using bloom::project::RoundTripCollectionKind;
+using bloom::project::RoundTripPathSegment;
+using bloom::project::RoundTripState;
+using bloom::project::UnknownJsonNumber;
 
 constexpr std::size_t kScratchSize = 64;
 
@@ -135,120 +152,129 @@ void expectRequestError(Expectations& expectations, const CanonicalDocumentV1& r
                         "the matching encode path reports the same typed failure");
 }
 
+// The exact canonical bytes for makeMinimalProject()'s live document at document schema {1, 0}
+// with no overlay. Factored out (rather than kept local to testMinimalGoldenBytes, as originally)
+// so RT2's overlay tests below can build on it: they take this known-good text and apply small,
+// explicit, verified-anchor edits (splicing retained members at exact known canonical positions)
+// rather than hand-transcribing a second, separately-error-prone multi-hundred-line literal. See
+// this file's RT2 section for why splicing was chosen over the alternative of building fixtures
+// straight from the writer plus a golden diff.
+constexpr std::string_view kMinimalDocumentGolden =
+    "{\n"
+    "  \"schemaVersion\": {\n"
+    "    \"major\": 1,\n"
+    "    \"minor\": 0\n"
+    "  },\n"
+    "  \"project\": {\n"
+    "    \"id\": \"1\",\n"
+    "    \"name\": \"Untitled Project\",\n"
+    "    \"colorSettings\": {\n"
+    "      \"schemaVersion\": {\n"
+    "        \"major\": 1,\n"
+    "        \"minor\": 0\n"
+    "      },\n"
+    "      \"processColorSpaceId\": \"lin_rec709_scene\",\n"
+    "      \"ocioConfig\": {\n"
+    "        \"schemaVersion\": {\n"
+    "          \"major\": 1,\n"
+    "          \"minor\": 0\n"
+    "        },\n"
+    "        \"locator\": {\n"
+    "          \"kind\": \"builtin\",\n"
+    "          \"uri\": \"bloom://ocio/neutral-v1/config.ocio\"\n"
+    "        },\n"
+    "        \"expectedRevision\": {\n"
+    "          \"algorithm\": \"sha256\",\n"
+    "          \"digest\": "
+    "\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"\n"
+    "        },\n"
+    "        \"portability\": \"builtin\",\n"
+    "        \"contextVariables\": []\n"
+    "      }\n"
+    "    },\n"
+    "    \"compositions\": [\n"
+    "      {\n"
+    "        \"id\": \"1\",\n"
+    "        \"name\": \"Main Composition\",\n"
+    "        \"duration\": {\n"
+    "          \"numerator\": \"10\",\n"
+    "          \"denominator\": \"1\"\n"
+    "        },\n"
+    "        \"format\": {\n"
+    "          \"width\": 1920,\n"
+    "          \"height\": 1080,\n"
+    "          \"pixelAspect\": {\n"
+    "            \"numerator\": \"1\",\n"
+    "            \"denominator\": \"1\"\n"
+    "          },\n"
+    "          \"frameRate\": {\n"
+    "            \"numerator\": \"24\",\n"
+    "            \"denominator\": \"1\"\n"
+    "          }\n"
+    "        },\n"
+    "        \"parameters\": [],\n"
+    "        \"animationCurves\": [],\n"
+    "        \"graph\": {\n"
+    "          \"nodes\": [\n"
+    "            {\n"
+    "              \"id\": \"1\",\n"
+    "              \"typeId\": \"bloom.layer-stack\",\n"
+    "              \"schemaVersion\": 1,\n"
+    "              \"parameters\": []\n"
+    "            },\n"
+    "            {\n"
+    "              \"id\": \"2\",\n"
+    "              \"typeId\": \"bloom.composition-output\",\n"
+    "              \"schemaVersion\": 1,\n"
+    "              \"parameters\": []\n"
+    "            }\n"
+    "          ],\n"
+    "          \"edges\": [\n"
+    "            {\n"
+    "              \"id\": \"1\",\n"
+    "              \"source\": {\n"
+    "                \"nodeId\": \"1\",\n"
+    "                \"port\": \"image\"\n"
+    "              },\n"
+    "              \"destination\": {\n"
+    "                \"kind\": \"node-input\",\n"
+    "                \"nodeId\": \"2\",\n"
+    "                \"port\": \"image\"\n"
+    "              }\n"
+    "            }\n"
+    "          ],\n"
+    "          \"layerOutputs\": [],\n"
+    "          \"layerStack\": {\n"
+    "            \"nodeId\": \"1\",\n"
+    "            \"entries\": []\n"
+    "          },\n"
+    "          \"compositionOutput\": {\n"
+    "            \"nodeId\": \"2\",\n"
+    "            \"port\": \"image\"\n"
+    "          }\n"
+    "        }\n"
+    "      }\n"
+    "    ]\n"
+    "  },\n"
+    "  \"idAllocation\": {\n"
+    "    \"highestIssued\": {\n"
+    "      \"composition\": \"1\",\n"
+    "      \"node\": \"2\",\n"
+    "      \"edge\": \"1\",\n"
+    "      \"layer\": \"0\",\n"
+    "      \"layerSlot\": \"0\",\n"
+    "      \"parameter\": \"0\",\n"
+    "      \"animationCurve\": \"0\",\n"
+    "      \"keyframe\": \"0\",\n"
+    "      \"driverBinding\": \"0\",\n"
+    "      \"extensionRecord\": \"0\"\n"
+    "    }\n"
+    "  },\n"
+    "  \"extensions\": []\n"
+    "}\n";
+
 void testMinimalGoldenBytes(Expectations& expectations) {
-    constexpr std::string_view expected =
-        "{\n"
-        "  \"schemaVersion\": {\n"
-        "    \"major\": 1,\n"
-        "    \"minor\": 0\n"
-        "  },\n"
-        "  \"project\": {\n"
-        "    \"id\": \"1\",\n"
-        "    \"name\": \"Untitled Project\",\n"
-        "    \"colorSettings\": {\n"
-        "      \"schemaVersion\": {\n"
-        "        \"major\": 1,\n"
-        "        \"minor\": 0\n"
-        "      },\n"
-        "      \"processColorSpaceId\": \"lin_rec709_scene\",\n"
-        "      \"ocioConfig\": {\n"
-        "        \"schemaVersion\": {\n"
-        "          \"major\": 1,\n"
-        "          \"minor\": 0\n"
-        "        },\n"
-        "        \"locator\": {\n"
-        "          \"kind\": \"builtin\",\n"
-        "          \"uri\": \"bloom://ocio/neutral-v1/config.ocio\"\n"
-        "        },\n"
-        "        \"expectedRevision\": {\n"
-        "          \"algorithm\": \"sha256\",\n"
-        "          \"digest\": "
-        "\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"\n"
-        "        },\n"
-        "        \"portability\": \"builtin\",\n"
-        "        \"contextVariables\": []\n"
-        "      }\n"
-        "    },\n"
-        "    \"compositions\": [\n"
-        "      {\n"
-        "        \"id\": \"1\",\n"
-        "        \"name\": \"Main Composition\",\n"
-        "        \"duration\": {\n"
-        "          \"numerator\": \"10\",\n"
-        "          \"denominator\": \"1\"\n"
-        "        },\n"
-        "        \"format\": {\n"
-        "          \"width\": 1920,\n"
-        "          \"height\": 1080,\n"
-        "          \"pixelAspect\": {\n"
-        "            \"numerator\": \"1\",\n"
-        "            \"denominator\": \"1\"\n"
-        "          },\n"
-        "          \"frameRate\": {\n"
-        "            \"numerator\": \"24\",\n"
-        "            \"denominator\": \"1\"\n"
-        "          }\n"
-        "        },\n"
-        "        \"parameters\": [],\n"
-        "        \"animationCurves\": [],\n"
-        "        \"graph\": {\n"
-        "          \"nodes\": [\n"
-        "            {\n"
-        "              \"id\": \"1\",\n"
-        "              \"typeId\": \"bloom.layer-stack\",\n"
-        "              \"schemaVersion\": 1,\n"
-        "              \"parameters\": []\n"
-        "            },\n"
-        "            {\n"
-        "              \"id\": \"2\",\n"
-        "              \"typeId\": \"bloom.composition-output\",\n"
-        "              \"schemaVersion\": 1,\n"
-        "              \"parameters\": []\n"
-        "            }\n"
-        "          ],\n"
-        "          \"edges\": [\n"
-        "            {\n"
-        "              \"id\": \"1\",\n"
-        "              \"source\": {\n"
-        "                \"nodeId\": \"1\",\n"
-        "                \"port\": \"image\"\n"
-        "              },\n"
-        "              \"destination\": {\n"
-        "                \"kind\": \"node-input\",\n"
-        "                \"nodeId\": \"2\",\n"
-        "                \"port\": \"image\"\n"
-        "              }\n"
-        "            }\n"
-        "          ],\n"
-        "          \"layerOutputs\": [],\n"
-        "          \"layerStack\": {\n"
-        "            \"nodeId\": \"1\",\n"
-        "            \"entries\": []\n"
-        "          },\n"
-        "          \"compositionOutput\": {\n"
-        "            \"nodeId\": \"2\",\n"
-        "            \"port\": \"image\"\n"
-        "          }\n"
-        "        }\n"
-        "      }\n"
-        "    ]\n"
-        "  },\n"
-        "  \"idAllocation\": {\n"
-        "    \"highestIssued\": {\n"
-        "      \"composition\": \"1\",\n"
-        "      \"node\": \"2\",\n"
-        "      \"edge\": \"1\",\n"
-        "      \"layer\": \"0\",\n"
-        "      \"layerSlot\": \"0\",\n"
-        "      \"parameter\": \"0\",\n"
-        "      \"animationCurve\": \"0\",\n"
-        "      \"keyframe\": \"0\",\n"
-        "      \"driverBinding\": \"0\",\n"
-        "      \"extensionRecord\": \"0\"\n"
-        "    }\n"
-        "  },\n"
-        "  \"extensions\": []\n"
-        "}\n";
+    const std::string_view expected = kMinimalDocumentGolden;
 
     auto newProject = makeMinimalProject();
     Document document{std::move(newProject.project)};
@@ -1072,6 +1098,806 @@ void testLimitsAndCapacityAdversarial(Expectations& expectations) {
                         "exact capacity emits the complete document ending in one LF");
 }
 
+// ---------------------------------------------------------------------------------------------
+// RT2: writer-side overlay (docs/architecture/project-format.md, "Versions, Migrations, And
+// Preservation"). Fixture strategy: rather than hand-transcribing a second large canonical-bytes
+// literal per test (error-prone at this size and hard to keep visibly correct), every test below
+// starts from an already-verified canonical text -- kMinimalDocumentGolden above, or a fixture's
+// own plain {1,0} encode (itself checked against the same writer this suite already trusts) --
+// and applies small, explicit, anchor-verified edits that splice one retained member at one exact
+// canonical position. requireReplace() aborts loudly on an anchor miss (a fixture bug, not a
+// condition this suite reports through Expectations) rather than silently building a wrong golden.
+// ---------------------------------------------------------------------------------------------
+
+using bloom::project::DocumentClassification;
+using bloom::project::DocumentDecodeOutcome;
+
+constexpr std::uint64_t kGenerousOperationBudget = 8ULL << 20U; // 8 MiB: ample for every fixture.
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = bloom::project::ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] DocumentDecodeResult decodeText(const std::string& text) {
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(text), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    if (!parsed) {
+        std::cerr << "RT2 fixture failed to parse as strict JSON (error="
+                  << static_cast<int>(parsed.error()) << ")\n";
+        std::abort();
+    }
+    return bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+}
+
+[[nodiscard]] UnknownJsonNumber unknownNumber(const std::string_view canonicalToken) {
+    const auto parsed = bloom::project::parseUnknownJsonNumber(canonicalToken);
+    if (!parsed.hasValue()) {
+        std::abort();
+    }
+    return *parsed.value();
+}
+
+// Replaces the first (and, at every call site below, only) occurrence of `anchor` in `text` with
+// `replacement`. Aborts immediately if `anchor` is missing: that means a fixture edit above it
+// already changed the text this call expected, or the anchor was never correct -- either way a
+// fixture-construction bug, not a runtime document condition.
+void requireReplace(std::string& text, const std::string_view anchor,
+                    const std::string_view replacement) {
+    const auto pos = text.find(anchor);
+    if (pos == std::string::npos) {
+        std::cerr << "RT2 fixture splice anchor not found:\n" << anchor << '\n';
+        std::abort();
+    }
+    text.replace(pos, anchor.size(), replacement);
+}
+
+// Byte-equality assertion that also prints the first differing offset on failure, since a wrong
+// splice/indent among these large fixtures is otherwise tedious to localize from a bare pass/fail.
+void expectBytesEqual(Expectations& expectations, const std::string_view actual,
+                      const std::string_view expected, const std::string_view message) {
+    if (actual == expected) {
+        expectations.expect(true, message);
+        return;
+    }
+    std::size_t mismatch = 0;
+    while (mismatch < actual.size() && mismatch < expected.size() &&
+           actual[mismatch] == expected[mismatch]) {
+        ++mismatch;
+    }
+    std::cerr << "RT2 byte mismatch for \"" << message << "\" at offset " << mismatch
+              << " (actual size " << actual.size() << ", expected size " << expected.size()
+              << ")\n  actual:   ..." << actual.substr(mismatch, 80) << "...\n  expected: ..."
+              << expected.substr(mismatch, 80) << "...\n";
+    expectations.expect(false, message);
+}
+
+// Plain writes (null RoundTripState) reproduce every pre-RT2 golden byte-for-byte with the new
+// CanonicalDocumentV1 fields explicitly at their plain-write defaults.
+void testPlainWriteExplicitDefaultsUnchanged(Expectations& expectations) {
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = nullptr,
+                                      .schemaMinor = 0};
+    const auto encoded = encodeWithSlack(request);
+    expectations.expect(encoded.ok && encoded.bytes == kMinimalDocumentGolden,
+                        "explicit null overlay and minor 0 reproduce the exact pre-RT2 golden");
+}
+
+// Version parameterization: schemaMinor alone (no overlay) changes only the root schemaVersion.
+void testSchemaMinorParameterization(Expectations& expectations) {
+    std::string expected(kMinimalDocumentGolden);
+    requireReplace(expected, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = nullptr,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "schemaMinor=1 with no overlay sizes exactly with the golden");
+    const auto encoded = encodeWithSlack(request);
+    expectBytesEqual(expectations,
+                     encoded.ok ? std::string_view(encoded.bytes) : std::string_view{}, expected,
+                     "schemaMinor=1 with no overlay emits {1, 1} and is otherwise "
+                     "byte-identical");
+}
+
+// The document root itself is an attachment point (its schema path is the empty path).
+void testOverlayRootAttachmentPoint(Expectations& expectations) {
+    std::string expected(kMinimalDocumentGolden);
+    requireReplace(expected, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+    requireReplace(expected, "  \"extensions\": []\n}\n",
+                   "  \"extensions\": [],\n  \"zzzRoot\": true\n}\n");
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> rootMembers;
+    rootMembers.emplace_back("zzzRoot", RetainedJsonValue(true));
+    roundTrip.attach({}, std::move(rootMembers));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "a root-attached retained member sizes exactly with the golden");
+    const auto encoded = encodeWithSlack(request);
+    expectBytesEqual(expectations,
+                     encoded.ok ? std::string_view(encoded.bytes) : std::string_view{}, expected,
+                     "a root-attached retained member re-emits after every known root member");
+}
+
+// A singleton schema-path attachment point nested one level in (project).
+void testOverlayProjectAttachmentPoint(Expectations& expectations) {
+    std::string expected(kMinimalDocumentGolden);
+    requireReplace(expected, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+    requireReplace(expected, "    ]\n  },\n  \"idAllocation\"",
+                   "    ],\n    \"zzzProject\": \"hello\"\n  },\n  \"idAllocation\"");
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> members;
+    members.emplace_back("zzzProject", RetainedJsonValue(std::string("hello")));
+    roundTrip.attach({RoundTripPathSegment::named("project")}, std::move(members));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "a project-attached retained member sizes exactly with the golden");
+    const auto encoded = encodeWithSlack(request);
+    expectBytesEqual(expectations,
+                     encoded.ok ? std::string_view(encoded.bytes) : std::string_view{}, expected,
+                     "a project-attached retained member re-emits after compositions");
+}
+
+// A collection-element attachment point (Composition:"1") and its nested singleton (format),
+// combined so this test also covers a retained deep subtree (an object whose member is an array
+// mixing numbers and a string) and a retained lossless integer whose input spelling is already
+// canonical (byte equality proves no re-derivation/renormalization happened).
+void testOverlayCompositionAndFormatAttachmentPoints(Expectations& expectations) {
+    std::string expected(kMinimalDocumentGolden);
+    requireReplace(expected, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+    requireReplace(expected,
+                   "          \"frameRate\": {\n"
+                   "            \"numerator\": \"24\",\n"
+                   "            \"denominator\": \"1\"\n"
+                   "          }\n"
+                   "        },\n"
+                   "        \"parameters\"",
+                   "          \"frameRate\": {\n"
+                   "            \"numerator\": \"24\",\n"
+                   "            \"denominator\": \"1\"\n"
+                   "          },\n"
+                   "          \"zzzFormat\": {\n"
+                   "            \"list\": [\n"
+                   "              1,\n"
+                   "              2,\n"
+                   "              \"three\"\n"
+                   "            ],\n"
+                   "            \"note\": \"deep\"\n"
+                   "          }\n"
+                   "        },\n"
+                   "        \"parameters\"");
+    requireReplace(expected,
+                   "          }\n"
+                   "        }\n"
+                   "      }\n"
+                   "    ]\n"
+                   "  },\n"
+                   "  \"idAllocation\"",
+                   "          }\n"
+                   "        },\n"
+                   "        \"zzzComp\": -7\n"
+                   "      }\n"
+                   "    ]\n"
+                   "  },\n"
+                   "  \"idAllocation\"");
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> compositionMembers;
+    compositionMembers.emplace_back("zzzComp", RetainedJsonValue(unknownNumber("-7")));
+    roundTrip.attach(
+        {RoundTripPathSegment::named("project"),
+         RoundTripPathSegment::collectionElement(RoundTripCollectionKind::Composition, "1")},
+        std::move(compositionMembers));
+
+    std::vector<RetainedJsonValue> listElements;
+    listElements.emplace_back(unknownNumber("1"));
+    listElements.emplace_back(unknownNumber("2"));
+    listElements.emplace_back(std::string("three"));
+    std::vector<RetainedJsonMember> formatValueMembers;
+    formatValueMembers.emplace_back("list", RetainedJsonValue::makeArray(std::move(listElements)));
+    formatValueMembers.emplace_back("note", RetainedJsonValue(std::string("deep")));
+    std::vector<RetainedJsonMember> formatMembers;
+    formatMembers.emplace_back("zzzFormat",
+                               RetainedJsonValue::makeObject(std::move(formatValueMembers)));
+    roundTrip.attach(
+        {RoundTripPathSegment::named("project"),
+         RoundTripPathSegment::collectionElement(RoundTripCollectionKind::Composition, "1"),
+         RoundTripPathSegment::named("format")},
+        std::move(formatMembers));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "composition- and format-attached retained members size exactly with the "
+                        "golden");
+    const auto encoded = encodeWithSlack(request);
+    expectBytesEqual(
+        expectations, encoded.ok ? std::string_view(encoded.bytes) : std::string_view{}, expected,
+        "a retained deep subtree and a canonical-spelling lossless integer both re-emit "
+        "byte-identically");
+}
+
+// A collection-element attachment point nested two levels in (a graph node).
+void testOverlayNodeAttachmentPoint(Expectations& expectations) {
+    std::string expected(kMinimalDocumentGolden);
+    requireReplace(expected, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+    requireReplace(expected,
+                   "              \"parameters\": []\n"
+                   "            },\n"
+                   "            {\n"
+                   "              \"id\": \"2\"",
+                   "              \"parameters\": [],\n"
+                   "              \"zzzNode\": null\n"
+                   "            },\n"
+                   "            {\n"
+                   "              \"id\": \"2\"");
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> members;
+    members.emplace_back("zzzNode", RetainedJsonValue{});
+    roundTrip.attach(
+        {RoundTripPathSegment::named("project"),
+         RoundTripPathSegment::collectionElement(RoundTripCollectionKind::Composition, "1"),
+         RoundTripPathSegment::named("graph"),
+         RoundTripPathSegment::collectionElement(RoundTripCollectionKind::Node, "1")},
+        std::move(members));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "a node-attached retained member sizes exactly with the golden");
+    const auto encoded = encodeWithSlack(request);
+    expectBytesEqual(expectations,
+                     encoded.ok ? std::string_view(encoded.bytes) : std::string_view{}, expected,
+                     "a null-valued retained member on a graph node re-emits exactly");
+}
+
+// A second collection kind under graph (Edge), demonstrating the identity model generalizes past
+// Composition/Node.
+void testOverlayEdgeAttachmentPoint(Expectations& expectations) {
+    std::string expected(kMinimalDocumentGolden);
+    requireReplace(expected, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+    requireReplace(expected,
+                   "              }\n"
+                   "            }\n"
+                   "          ],\n"
+                   "          \"layerOutputs\"",
+                   "              },\n"
+                   "              \"zzzEdge\": \"e\"\n"
+                   "            }\n"
+                   "          ],\n"
+                   "          \"layerOutputs\"");
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> members;
+    members.emplace_back("zzzEdge", RetainedJsonValue(std::string("e")));
+    roundTrip.attach(
+        {RoundTripPathSegment::named("project"),
+         RoundTripPathSegment::collectionElement(RoundTripCollectionKind::Composition, "1"),
+         RoundTripPathSegment::named("graph"),
+         RoundTripPathSegment::collectionElement(RoundTripCollectionKind::Edge, "1")},
+        std::move(members));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "an edge-attached retained member sizes exactly with the golden");
+    const auto encoded = encodeWithSlack(request);
+    expectBytesEqual(expectations,
+                     encoded.ok ? std::string_view(encoded.bytes) : std::string_view{}, expected,
+                     "an edge-attached retained member re-emits after destination");
+}
+
+// Two nested singleton attachment points (idAllocation, and highestIssued inside it), the second
+// carrying a retained array of booleans.
+void testOverlayIdAllocationAttachmentPoints(Expectations& expectations) {
+    std::string expected(kMinimalDocumentGolden);
+    requireReplace(expected, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+    requireReplace(expected,
+                   "      \"extensionRecord\": \"0\"\n"
+                   "    }\n"
+                   "  },\n"
+                   "  \"extensions\"",
+                   "      \"extensionRecord\": \"0\",\n"
+                   "      \"zzzHighWater\": 5\n"
+                   "    },\n"
+                   "    \"zzzIdAllocation\": [\n"
+                   "      true,\n"
+                   "      false\n"
+                   "    ]\n"
+                   "  },\n"
+                   "  \"extensions\"");
+
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> highWaterMembers;
+    highWaterMembers.emplace_back("zzzHighWater", RetainedJsonValue(unknownNumber("5")));
+    roundTrip.attach(
+        {RoundTripPathSegment::named("idAllocation"), RoundTripPathSegment::named("highestIssued")},
+        std::move(highWaterMembers));
+
+    std::vector<RetainedJsonValue> boolElements;
+    boolElements.emplace_back(true);
+    boolElements.emplace_back(false);
+    std::vector<RetainedJsonMember> idAllocationMembers;
+    idAllocationMembers.emplace_back("zzzIdAllocation",
+                                     RetainedJsonValue::makeArray(std::move(boolElements)));
+    roundTrip.attach({RoundTripPathSegment::named("idAllocation")}, std::move(idAllocationMembers));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(size.hasValue() && *size.value() == expected.size(),
+                        "idAllocation- and highestIssued-attached retained members size exactly "
+                        "with the golden");
+    const auto encoded = encodeWithSlack(request);
+    expectBytesEqual(expectations,
+                     encoded.ok ? std::string_view(encoded.bytes) : std::string_view{}, expected,
+                     "nested idAllocation/highestIssued retained members re-emit at their own "
+                     "exact positions");
+}
+
+// An attachment path naming a collection element the walk never visits (here, a Composition id
+// that does not exist in the live document being written) is a typed error, never silently
+// dropped -- the contract this suite must enforce for every RoundTripState an overlay accepts.
+void testOverlayLeftoverEntryIsTypedError(Expectations& expectations) {
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> members;
+    members.emplace_back("zzzGhost", RetainedJsonValue(true));
+    roundTrip.attach(
+        {RoundTripPathSegment::named("project"),
+         RoundTripPathSegment::collectionElement(RoundTripCollectionKind::Composition, "999")},
+        std::move(members));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(!size.hasValue() &&
+                            size.error() == CanonicalDocumentError::RoundTripStateMismatch,
+                        "an attachment point the walk never visits is a typed leftover error, "
+                        "never silently dropped");
+    expectations.expect(size.compositionIndex() == bloom::project::kCanonicalDocumentNoIndex &&
+                            size.elementIndex() == bloom::project::kCanonicalDocumentNoIndex,
+                        "the leftover-entry error carries no composition/element location -- it "
+                        "is a document-wide state mismatch, not a per-record failure");
+
+    std::array<char, 8> tinyOutput{};
+    tinyOutput.fill('?');
+    const auto encode = bloom::project::encodeCanonicalDocument(request, tinyOutput);
+    expectations.expect(!encode &&
+                            encode.error() == CanonicalDocumentError::RoundTripStateMismatch &&
+                            encode.bytesWritten() == 0 && tinyOutput.front() == '?',
+                        "the encode path reports the same leftover-entry error and writes "
+                        "nothing");
+}
+
+// Count-then-write byte-equality invariant exercised with an overlay present: an exact-size buffer
+// succeeds and repeated sizing is deterministic; one byte short fails cleanly and reports the
+// exact requirement, mirroring testLimitsAndCapacityAdversarial's plain-write coverage.
+void testOverlayCapacityBoundary(Expectations& expectations) {
+    auto newProject = makeMinimalProject();
+    Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+
+    RoundTripState roundTrip;
+    std::vector<RetainedJsonMember> members;
+    members.emplace_back("zzzProject", RetainedJsonValue(std::string("hello")));
+    roundTrip.attach({RoundTripPathSegment::named("project")}, std::move(members));
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &settings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch,
+                                      .roundTrip = &roundTrip,
+                                      .schemaMinor = 1};
+    const auto size = bloom::project::canonicalDocumentSize(request);
+    if (!size.hasValue()) {
+        expectations.expect(false, "the overlay capacity fixture preflights successfully");
+        return;
+    }
+    const auto exactSize = *size.value();
+    expectations.expect(exactSize > kMinimalDocumentGolden.size(),
+                        "the overlay-attached retained member adds bytes beyond the plain golden "
+                        "size");
+
+    std::vector<char> exactOutput(exactSize, '?');
+    const auto exactResult = bloom::project::encodeCanonicalDocument(request, exactOutput);
+    expectations.expect(exactResult && exactResult.bytesWritten() == exactSize &&
+                            exactOutput.back() == '\n',
+                        "an exact-size buffer succeeds with an overlay present");
+
+    std::vector<char> shortOutput(exactSize - 1, '?');
+    const auto shortResult = bloom::project::encodeCanonicalDocument(request, shortOutput);
+    expectations.expect(
+        !shortResult && shortResult.error() == CanonicalDocumentError::OutputCapacityExceeded &&
+            shortResult.requiredSize().has_value() && *shortResult.requiredSize() == exactSize &&
+            shortResult.bytesWritten() == 0 && shortOutput.front() == '?' &&
+            shortOutput.back() == '?',
+        "a one-byte-short buffer fails cleanly with the exact requirement reported, overlay "
+        "present");
+
+    const auto repeatSize = bloom::project::canonicalDocumentSize(request);
+    expectations.expect(repeatSize.hasValue() && *repeatSize.value() == exactSize,
+                        "repeated sizing with an overlay present is deterministic");
+}
+
+// ---------------------------------------------------------------------------------------------
+// THE preservation determinism cycle: canonical 1.1 bytes with unknown trailing members at seven
+// attachment kinds (root, project, a composition, that composition's format, a node, an extension
+// record, and a layer-stack entry) -> parse -> decode (EditableWithRoundTrip) -> reconstruct the
+// live document -> re-encode with the overlay and minor 1 -> byte-identical to the original input.
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] Document buildPreservationCycleFixtureDocument() {
+    using namespace bloom::document;
+
+    const auto duration = RationalTime::create(10, 1);
+    const auto pixelAspect = PixelAspectRatio::create(1, 1);
+    const auto frameRate = FrameRate::create(24, 1);
+    const auto format =
+        CompositionFormat::create(1920, 1080, pixelAspect.value_or(PixelAspectRatio::square()),
+                                  frameRate.value_or(FrameRate::framesPerSecond24()));
+    if (!duration.has_value() || !format.has_value()) {
+        std::abort();
+    }
+
+    CanonicalGraph graph{NodeId::fromRaw(1)};
+    const NodeRecord layerStackNode{
+        NodeId::fromRaw(1), std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion};
+    const NodeRecord layerOutputNode{
+        NodeId::fromRaw(2),
+        std::string(kLayerOutputNodeType),
+        {{"opacity", ParameterId::fromRaw(3)}, {"position", ParameterId::fromRaw(5)}},
+        kLayerOutputNodeSchemaVersion};
+    const NodeRecord compositionOutputNode{NodeId::fromRaw(3),
+                                           std::string(kCompositionOutputNodeType),
+                                           {},
+                                           kCompositionOutputNodeSchemaVersion};
+    const bool nodesAdded = graph.addNode(layerStackNode) && graph.addNode(layerOutputNode) &&
+                            graph.addNode(compositionOutputNode);
+    const EdgeRecord layerToStackEdge{EdgeId::fromRaw(1),
+                                      {NodeId::fromRaw(2), std::string(kLayerOutputOutputPort)},
+                                      LayerStackInputRef{NodeId::fromRaw(1),
+                                                         LayerSlotId::fromRaw(1),
+                                                         std::string(kLayerStackContentInputRole)}};
+    const EdgeRecord stackToOutputEdge{
+        EdgeId::fromRaw(2),
+        {NodeId::fromRaw(1), std::string(kLayerStackOutputPort)},
+        NodeInputRef{NodeId::fromRaw(3), std::string(kCompositionOutputInputPort)}};
+    const bool edgesAdded = graph.addEdge(layerToStackEdge) && graph.addEdge(stackToOutputEdge);
+    const bool boundaryAdded = graph.addLayerOutput(
+        {NodeId::fromRaw(2), LayerId::fromRaw(1), "Layer", std::string(kLayerOutputOutputPort)});
+    const bool entryAdded =
+        graph.layerStack().append({LayerSlotId::fromRaw(1), LayerId::fromRaw(1)});
+    if (!nodesAdded || !edgesAdded || !boundaryAdded || !entryAdded) {
+        std::abort();
+    }
+    graph.setCompositionOutput({NodeId::fromRaw(3), std::string(kCompositionOutputOutputPort)});
+
+    Composition composition{CompositionId::fromRaw(1), "Comp", *duration, std::move(graph),
+                            *format};
+    const bool paramsInserted =
+        composition.parameters().insert({ParameterId::fromRaw(3),
+                                         std::string(kOpacityParameterSchemaKey),
+                                         ConstantValueSource{1.0}}) &&
+        composition.parameters().insert({ParameterId::fromRaw(5),
+                                         std::string(kPositionParameterSchemaKey),
+                                         ConstantValueSource{Vec2d{0.0, 0.0}}});
+    if (!paramsInserted) {
+        std::abort();
+    }
+
+    Project project{ProjectId::fromRaw(1), "RT2 Fixture"};
+    if (!project.addComposition(std::move(composition))) {
+        std::abort();
+    }
+    const ExtensionRecord markerRecord{
+        ExtensionRecordId::fromRaw(1), "vendor.module",
+        "vendor.module.marker",        {1, 0},
+        CompositionId::fromRaw(1),     "application/octet-stream",
+        NoExtensionReferences{},       OpaqueExtensionPayload{std::byte{0x00}}};
+    if (!project.addExtensionRecord(markerRecord)) {
+        std::abort();
+    }
+
+    IdAllocatorHighWater highWater{};
+    highWater.composition = 1;
+    highWater.node = 3;
+    highWater.edge = 2;
+    highWater.layer = 1;
+    highWater.layerSlot = 1;
+    highWater.parameter = 5;
+    highWater.extensionRecord = 1;
+    return Document{std::move(project), highWater};
+}
+
+void testPreservationDeterminismCycle(Expectations& expectations) {
+    auto document = buildPreservationCycleFixtureDocument();
+    auto snapshot = document.snapshot();
+
+    std::array<char, kScratchSize> payloadScratch{};
+    std::array<std::size_t, kScratchSize> sortScratch{};
+    const auto settings = neutralColorSettings();
+    const CanonicalDocumentV1 plainRequest{.snapshot = &snapshot,
+                                           .colorSettings = &settings,
+                                           .payloadScratch = payloadScratch,
+                                           .sortScratch = sortScratch};
+    const auto plainEncoded = encodeWithSlack(plainRequest);
+    expectations.expect(plainEncoded.ok, "the RT2 cycle fixture's plain {1,0} encode succeeds");
+    if (!plainEncoded.ok) {
+        return;
+    }
+
+    std::string original(plainEncoded.bytes);
+
+    requireReplace(original, "\"minor\": 0\n  },\n  \"project\"",
+                   "\"minor\": 1\n  },\n  \"project\"");
+
+    requireReplace(original,
+                   "                \"slotId\": \"1\",\n"
+                   "                \"layerId\": \"1\"\n"
+                   "              }\n",
+                   "                \"slotId\": \"1\",\n"
+                   "                \"layerId\": \"1\",\n"
+                   "                \"zzzEntry\": \"slot-note\"\n"
+                   "              }\n");
+
+    requireReplace(original,
+                   "              \"typeId\": \"bloom.composition-output\",\n"
+                   "              \"schemaVersion\": 1,\n"
+                   "              \"parameters\": []\n"
+                   "            }\n",
+                   "              \"typeId\": \"bloom.composition-output\",\n"
+                   "              \"schemaVersion\": 1,\n"
+                   "              \"parameters\": [],\n"
+                   "              \"zzzNode\": null\n"
+                   "            }\n");
+
+    requireReplace(original,
+                   "          \"frameRate\": {\n"
+                   "            \"numerator\": \"24\",\n"
+                   "            \"denominator\": \"1\"\n"
+                   "          }\n"
+                   "        },\n"
+                   "        \"parameters\"",
+                   "          \"frameRate\": {\n"
+                   "            \"numerator\": \"24\",\n"
+                   "            \"denominator\": \"1\"\n"
+                   "          },\n"
+                   "          \"zzzFormat\": {\n"
+                   "            \"list\": [\n"
+                   "              1,\n"
+                   "              2,\n"
+                   "              \"three\",\n"
+                   "              [\n"
+                   "                4,\n"
+                   "                5\n"
+                   "              ]\n"
+                   "            ],\n"
+                   "            \"note\": \"deep\"\n"
+                   "          }\n"
+                   "        },\n"
+                   "        \"parameters\"");
+
+    requireReplace(original,
+                   "          \"compositionOutput\": {\n"
+                   "            \"nodeId\": \"3\",\n"
+                   "            \"port\": \"image\"\n"
+                   "          }\n"
+                   "        }\n"
+                   "      }\n"
+                   "    ]\n"
+                   "  },\n"
+                   "  \"idAllocation\"",
+                   "          \"compositionOutput\": {\n"
+                   "            \"nodeId\": \"3\",\n"
+                   "            \"port\": \"image\"\n"
+                   "          }\n"
+                   "        },\n"
+                   "        \"zzzComp\": true\n"
+                   "      }\n"
+                   "    ]\n"
+                   "  },\n"
+                   "  \"idAllocation\"");
+
+    requireReplace(original, "    ]\n  },\n  \"idAllocation\"",
+                   "    ],\n    \"zzzProject\": \"hello world\"\n  },\n  \"idAllocation\"");
+
+    requireReplace(original, "      \"payload\": \"AA==\"\n    }\n",
+                   "      \"payload\": \"AA==\",\n      \"zzzExt\": 1.5\n    }\n");
+
+    requireReplace(original, "      \"zzzExt\": 1.5\n    }\n  ]\n}\n",
+                   "      \"zzzExt\": 1.5\n    }\n  ],\n  \"zzzRoot\": 42\n}\n");
+
+    const auto decoded = decodeText(original);
+    expectations.expect(decoded.outcome() == DocumentDecodeOutcome::Decoded &&
+                            static_cast<bool>(decoded) && decoded.value() != nullptr,
+                        "the spliced 1.1 fixture decodes with a trusted envelope");
+    expectations.expect(decoded.classification() == DocumentClassification::EditableWithRoundTrip,
+                        "the spliced 1.1 fixture classifies EditableWithRoundTrip");
+    if (decoded.value() == nullptr || decoded.roundTrip() == nullptr) {
+        expectations.expect(false, "a RoundTripState is present for the spliced fixture");
+        return;
+    }
+    expectations.expect(decoded.roundTrip()->size() == 7,
+                        "exactly seven attachment points were captured (root, project, "
+                        "composition, format, node, extension record, layer-stack entry)");
+    {
+        const RoundTripAttachmentPath extensionPath{
+            RoundTripPathSegment::collectionElement(RoundTripCollectionKind::ExtensionRecord, "1")};
+        const auto* members = decoded.roundTrip()->find(extensionPath);
+        expectations.expect(
+            members != nullptr && members->size() == 1 && (*members)[0].key() == "zzzExt" &&
+                (*members)[0].value().kind() == bloom::project::RetainedJsonValueKind::Number,
+            "the extension record attachment point captured its exact retained member, keyed by "
+            "numeric ExtensionRecordId directly off the document root");
+    }
+
+    auto reconstructed = bloom::project::reconstructDocument(*decoded.value());
+    expectations.expect(static_cast<bool>(reconstructed), "the spliced fixture reconstructs");
+    if (!reconstructed) {
+        return;
+    }
+    auto* reconstructedValue = reconstructed.value();
+    if (reconstructedValue == nullptr || reconstructedValue->document == nullptr) {
+        expectations.expect(false, "reconstruction produced a live Document");
+        return;
+    }
+    auto reconstructedSnapshot = reconstructedValue->document->snapshot();
+    expectations.expect(reconstructedSnapshot.ids().highWater() == snapshot.ids().highWater(),
+                        "reconstruction from the spliced fixture preserves the exact allocator "
+                        "high-water state");
+
+    std::array<char, kScratchSize> overlayPayloadScratch{};
+    std::array<std::size_t, kScratchSize> overlaySortScratch{};
+    const CanonicalDocumentV1 overlayRequest{.snapshot = &reconstructedSnapshot,
+                                             .colorSettings = &reconstructedValue->colorSettings,
+                                             .payloadScratch = overlayPayloadScratch,
+                                             .sortScratch = overlaySortScratch,
+                                             .roundTrip = decoded.roundTrip(),
+                                             .schemaMinor = 1};
+    const auto overlaySize = bloom::project::canonicalDocumentSize(overlayRequest);
+    expectations.expect(overlaySize.hasValue() && *overlaySize.value() == original.size(),
+                        "the overlay re-encode sizes exactly to the spliced original's byte "
+                        "count");
+
+    const auto overlayEncoded = encodeWithSlack(overlayRequest);
+    expectBytesEqual(
+        expectations,
+        overlayEncoded.ok ? std::string_view(overlayEncoded.bytes) : std::string_view{}, original,
+        "the overlay re-encode is byte-identical to the spliced original: parse -> decode -> "
+        "reconstruct -> re-encode reproduces preserved intent exactly");
+}
+
 } // namespace
 
 int main() {
@@ -1083,6 +1909,17 @@ int main() {
         testInvalidColorSettingsRejections(expectations);
         testDriverSourceAdmission(expectations);
         testLimitsAndCapacityAdversarial(expectations);
+        testPlainWriteExplicitDefaultsUnchanged(expectations);
+        testSchemaMinorParameterization(expectations);
+        testOverlayRootAttachmentPoint(expectations);
+        testOverlayProjectAttachmentPoint(expectations);
+        testOverlayCompositionAndFormatAttachmentPoints(expectations);
+        testOverlayNodeAttachmentPoint(expectations);
+        testOverlayEdgeAttachmentPoint(expectations);
+        testOverlayIdAllocationAttachmentPoints(expectations);
+        testOverlayLeftoverEntryIsTypedError(expectations);
+        testOverlayCapacityBoundary(expectations);
+        testPreservationDeterminismCycle(expectations);
         return expectations.failures() == 0 ? 0 : 1;
     } catch (const std::exception& error) {
         std::cerr << "Unexpected test exception: " << error.what() << '\n';


### PR DESCRIPTION
## Summary

Closes #40. RT2 — the overlay half, completing the unknown-member preservation cycle.

- `CanonicalDocumentV1` gains `roundTrip` (optional, default null) and `schemaMinor` (default 0): existing call sites unchanged, all pre-existing goldens byte-identical
- attachment-path tracking through an allocation-free fixed-array path scope mirroring the decode side's model — the ~30 attachment points were derived from the decoder's actual capture sites, not re-guessed from the doc — keeping the writer allocation-free and truthfully `noexcept` with the overlay active
- retained members re-emit after known members in stored ascending order; numbers via the lossless subset's canonical spelling; nested structure verbatim as opaque content; the root `schemaVersion` correctly remains a non-attachment point (mirroring the decode bootstrap), while the four nested version objects attach
- consumed-exactly-once: a leftover entry after a successful walk is typed `RoundTripStateMismatch`, never a silent drop
- count-then-write parity holds with the overlay; capacity failures report the exact required size

## The preservation result

**The full cycle — canonical 1.1 bytes with unknown members at root/project/composition/format/node/extension-record/layer-stack-entry depths → parse → decode editable-with-round-trip → reconstruct the live document → re-encode with overlay and minor 1 — is byte-identical to the input**, alongside per-point splice tests including a deep subtree and a canonical negative number.

## Testing

26 new expectations across 10 test functions; fixtures built by splicing anchor-verified edits into already-proven canonical goldens rather than hand-transcribed literals (the approach caught a real minor-version mismatch immediately). The report explicitly flags its coverage boundary: eight points byte-verified individually plus seven through the cycle test; the remaining attachment points share the same uniform mechanism and are exercised structurally. Full `ci-linux-native` suite 57/57 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent (survived one account-limit termination mid-package; resumed with context intact); reviewed by the supervising session.