### PR TITLE
feat: read constrained zip containers

### DIFF
--- a/cmake/BloomDependencyPrefix.cmake
+++ b/cmake/BloomDependencyPrefix.cmake
@@ -108,9 +108,40 @@ function(bloom_find_dependency package)
     if(BLOOM_DEPENDENCY_MODE STREQUAL "qualified")
         set(CMAKE_FIND_USE_PACKAGE_REGISTRY OFF)
         set(CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY OFF)
+
+        # zlib 1.3.2's static-only install ships a package config (ZLIBConfig.cmake) whose
+        # component loop unconditionally includes ZLIB-shared.cmake, which a static-only build
+        # never installs -- Config-mode zlib resolution fails hard with a missing-file error.
+        # Module-mode FindZLIB.cmake is the working route (same reasoning as
+        # dependencies/superbuild/projects/libzip.cmake, which builds libzip against this same
+        # static-only zlib for the identical reason). A qualified package's own exported config,
+        # such as libzip's, may call plain find_dependency(ZLIB ...) internally; that call is not
+        # restricted by this function's own NO_DEFAULT_PATH/PATHS below (find_dependency does not
+        # inherit them), so left alone it would either hit the broken component loop or silently
+        # resolve a host zlib. Force module-mode search rooted at the prefix for the duration of
+        # this call (function-scoped: never leaks to the caller) so any transitively pulled ZLIB
+        # resolves from the prefix's static archive.
+        set(ZLIB_ROOT "${BLOOM_DEPENDENCY_PREFIX}")
+        set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
+
         find_package(${package} REQUIRED CONFIG
             PATHS "${BLOOM_DEPENDENCY_PREFIX}"
             NO_DEFAULT_PATH)
+
+        # Fail closed rather than silently linking an unqualified zlib into a qualified build: a
+        # transitive find_dependency(ZLIB) inside another package's config is not restricted by
+        # the NO_DEFAULT_PATH above, so nothing else stops module-mode search from falling through
+        # to a host zlib once the ZLIB_ROOT hint doesn't produce a match.
+        if(DEFINED ZLIB_LIBRARY AND NOT ZLIB_LIBRARY STREQUAL "")
+            cmake_path(IS_PREFIX BLOOM_DEPENDENCY_PREFIX "${ZLIB_LIBRARY}" NORMALIZE
+                bloom_zlib_under_prefix)
+            if(NOT bloom_zlib_under_prefix)
+                message(FATAL_ERROR
+                    "qualified mode: ZLIB resolved outside the dependency prefix "
+                    "(${ZLIB_LIBRARY}); a transitive dependency must never escape "
+                    "${BLOOM_DEPENDENCY_PREFIX}.")
+            endif()
+        endif()
     elseif(BLOOM_DEPENDENCY_MODE STREQUAL "developer-system")
         find_package(${package} REQUIRED CONFIG)
     else()

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -1,4 +1,5 @@
 bloom_find_dependency(yyjson)
+bloom_find_dependency(libzip)
 
 add_library(bloom_project STATIC)
 
@@ -24,6 +25,9 @@ target_sources(
         strict_json_preflight.cpp
         strict_json_preflight.hpp
         unknown_json_number.cpp
+        zip_container.cpp
+        zip_container_preflight.cpp
+        zip_container_preflight.hpp
     PUBLIC
         FILE_SET HEADERS
         BASE_DIRS include
@@ -42,11 +46,12 @@ target_sources(
             include/bloom/project/round_trip_state.hpp
             include/bloom/project/strict_json_dom.hpp
             include/bloom/project/unknown_json_number.hpp
+            include/bloom/project/zip_container.hpp
 )
 
 target_compile_features(bloom_project PUBLIC cxx_std_20)
 target_link_libraries(bloom_project PUBLIC bloom_core bloom_document)
-target_link_libraries(bloom_project PRIVATE yyjson::yyjson)
+target_link_libraries(bloom_project PRIVATE yyjson::yyjson libzip::zip)
 bloom_enable_warnings(bloom_project)
 
 if(BUILD_TESTING)
@@ -205,5 +210,36 @@ if(BUILD_TESTING)
         NAME bloom.project.io_memory_resource
         COMMAND bloom_project_io_memory_resource_test
         LABELS unit project persistence memory
+    )
+
+    add_executable(
+        bloom_project_zip_container_preflight_test
+        tests/zip_container_preflight_tests.cpp
+    )
+    target_include_directories(
+        bloom_project_zip_container_preflight_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_project_zip_container_preflight_test
+        PRIVATE bloom_project ZLIB::ZLIB
+    )
+    bloom_enable_warnings(bloom_project_zip_container_preflight_test)
+    bloom_add_test(
+        NAME bloom.project.zip_container_preflight
+        COMMAND bloom_project_zip_container_preflight_test
+        LABELS unit project persistence security
+    )
+
+    add_executable(bloom_project_zip_container_test tests/zip_container_tests.cpp)
+    target_link_libraries(
+        bloom_project_zip_container_test
+        PRIVATE bloom_project ZLIB::ZLIB
+    )
+    bloom_enable_warnings(bloom_project_zip_container_test)
+    bloom_add_test(
+        NAME bloom.project.zip_container
+        COMMAND bloom_project_zip_container_test
+        LABELS unit project persistence security
     )
 endif()

--- a/src/project/include/bloom/project/zip_container.hpp
+++ b/src/project/include/bloom/project/zip_container.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/project_io_memory_resource.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <memory_resource>
+#include <optional>
+#include <span>
+#include <vector>
+
+// The bounded Constrained ZIP Profile container reader, per
+// docs/architecture/project-format.md ("Constrained ZIP Profile" + "Resource Limits").
+// `readZipContainer()` first runs a raw, allocation-free preflight scan
+// (`bloom::project::detail::preflightZipContainer()`) that proves the archive bytes are a
+// conforming exactly-two-entry container before any qualified reader is invoked, then extracts
+// both entries with a qualified libzip 1.11 reader confined to zip_container.cpp, independently
+// re-verifies every libzip-reported fact against what the preflight established, and computes an
+// independent CRC-32 with the qualified zlib `crc32()` over each fully expanded buffer. No libzip
+// or zlib type, header, or macro appears here or in any other public Bloom contract. The reader
+// parses no JSON: on success it hands back the two expanded entry byte buffers untouched.
+
+namespace bloom::project {
+
+namespace detail {
+class ZipContainerBuilder;
+} // namespace detail
+
+// The v1 Constrained ZIP Profile resource limits table (docs/architecture/project-format.md,
+// "Resource Limits"). Limits apply before allocation where the size is declared, and during
+// streaming (expanded-size mismatch) otherwise.
+struct ZipContainerLimits final {
+    std::uint64_t maxArchiveBytes = 272629760;       // 260 MiB physical
+    std::uint64_t maxManifestBytes = 1048576;        // 1 MiB expanded
+    std::uint64_t maxDocumentBytes = 268435456;      // 256 MiB expanded
+    std::uint64_t maxTotalExpandedBytes = 269484032; // 257 MiB expanded total
+    std::uint64_t maxExpansionRatio = 1000;          // per entry, max(1, compressedSize)
+};
+
+enum class ZipContainerError : std::uint8_t {
+    None,
+    InvalidLimits,
+    ArchiveTooLarge,
+    ArchiveTruncated,
+    MissingOrMalformedEocd,
+    ArchiveCommentForbidden,
+    MultiDiskForbidden,
+    WrongEntryCount,
+    WrongEntryName,
+    WrongEntryOrder,
+    Utf8FlagMissing,
+    ForbiddenGeneralPurposeFlag,
+    UnsupportedCompressionMethod,
+    ExtraFieldForbidden,
+    EntryCommentForbidden,
+    Zip64Forbidden,
+    LocalCentralHeaderDisagreement,
+    OverlappingOrUnaccountedByteRange,
+    NonRegularEntry,
+    ExecutableEntry,
+    ExpandedSizeLimitExceeded,
+    ExpansionRatioExceeded,
+    StoredSizeMismatch,
+    // The fully expanded byte count of an entry, measured while streaming it out of the qualified
+    // reader, did not equal its declared uncompressed size -- including a stream that keeps
+    // producing bytes past the declared size (a decompression bomb caught before it can overrun
+    // the exactly-sized destination buffer, which is never given more capacity than declared).
+    ExpandedSizeMismatch,
+    CrcMismatch,
+    SizeOverflow,
+    ResourceExhausted,
+    // The qualified libzip reader disagreed with a fact the raw preflight already established
+    // (open failure after a passing preflight, a zip_stat_index mismatch, or a read that did not
+    // behave as the preflight-derived entry size predicted). Never trusted blindly.
+    QualifiedReaderDisagreement,
+};
+
+// A parsed container owning its PMR resource and both expanded entry buffers for as long as the
+// document lives. The resource lives behind a stable heap address so moving the document never
+// invalidates the buffers' allocator state (mirrors StrictJsonDomDocument).
+class ZipContainerDocument final {
+  public:
+    ZipContainerDocument(const ZipContainerDocument&) = delete;
+    ZipContainerDocument& operator=(const ZipContainerDocument&) = delete;
+    ZipContainerDocument(ZipContainerDocument&&) noexcept = default;
+    ZipContainerDocument& operator=(ZipContainerDocument&&) noexcept = default;
+    ~ZipContainerDocument() = default;
+
+    [[nodiscard]] std::span<const std::byte> manifestBytes() const noexcept {
+        return {manifest_.data(), manifest_.size()};
+    }
+    [[nodiscard]] std::span<const std::byte> documentBytes() const noexcept {
+        return {document_.data(), document_.size()};
+    }
+
+  private:
+    friend class detail::ZipContainerBuilder;
+
+    ZipContainerDocument(std::unique_ptr<ProjectIoMemoryResource> resource,
+                         std::pmr::vector<std::byte> manifest,
+                         std::pmr::vector<std::byte> document) noexcept;
+
+    std::unique_ptr<ProjectIoMemoryResource> resource_;
+    std::pmr::vector<std::byte> manifest_;
+    std::pmr::vector<std::byte> document_;
+};
+
+// [[nodiscard]] failure-aware result. On success, document() names the extracted buffers; on
+// failure, error() names the typed cause and byteOffset() names the offending archive byte
+// position where meaningful (0 otherwise).
+class [[nodiscard]] ZipContainerReadResult final {
+  public:
+    ZipContainerReadResult(const ZipContainerReadResult&) = delete;
+    ZipContainerReadResult& operator=(const ZipContainerReadResult&) = delete;
+    ZipContainerReadResult(ZipContainerReadResult&&) noexcept = default;
+    ZipContainerReadResult& operator=(ZipContainerReadResult&&) noexcept = default;
+    ~ZipContainerReadResult() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error_ == ZipContainerError::None;
+    }
+    [[nodiscard]] ZipContainerError error() const noexcept { return error_; }
+    [[nodiscard]] std::size_t byteOffset() const noexcept { return byteOffset_; }
+    [[nodiscard]] const ZipContainerDocument* document() const& noexcept {
+        return document_.has_value() ? &*document_ : nullptr;
+    }
+    [[nodiscard]] const ZipContainerDocument* document() const&& = delete;
+
+  private:
+    friend class detail::ZipContainerBuilder;
+
+    ZipContainerReadResult() noexcept = default;
+
+    std::optional<ZipContainerDocument> document_;
+    ZipContainerError error_ = ZipContainerError::InvalidLimits;
+    std::size_t byteOffset_ = 0;
+};
+
+// Runs the bounded raw preflight against `archive` with `limits`, then extracts both entries with
+// the qualified libzip/zlib pair, charging every allocation -- including a documented worst-case
+// dependency-working-memory reservation held for the duration of the libzip calls -- through
+// `operation`. Budget rejection is reported as ResourceExhausted rather than throwing or falling
+// back to unmetered heap allocation. `archive` must outlive neither the call nor any live libzip
+// handle it creates internally; no reference to it survives the call. Never throws.
+[[nodiscard]] ZipContainerReadResult readZipContainer(std::span<const std::byte> archive,
+                                                      const ZipContainerLimits& limits,
+                                                      ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::project

--- a/src/project/tests/zip_container_preflight_tests.cpp
+++ b/src/project/tests/zip_container_preflight_tests.cpp
@@ -1,0 +1,602 @@
+#include "zip_container_preflight.hpp"
+
+#include "zip_container_test_support.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using bloom::project::detail::preflightZipContainer;
+using bloom::project::detail::ZipContainerPreflightError;
+using bloom::project::detail::ZipContainerPreflightLimits;
+using bloom::project::detail::ZipContainerPreflightResult;
+using bloom::project::test::ArchiveWriter;
+using bloom::project::test::buildConformingArchive;
+using bloom::project::test::EntrySpec;
+using bloom::project::test::makeDeflateEntry;
+using bloom::project::test::makeStoredEntry;
+using bloom::project::test::toBytes;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] ZipContainerPreflightResult run(const std::vector<std::byte>& archive,
+                                              const ZipContainerPreflightLimits& limits = {}) {
+    return preflightZipContainer(std::span<const std::byte>(archive), limits);
+}
+
+[[nodiscard]] EntrySpec manifestEntry(const std::string_view payload = "{}") {
+    return makeStoredEntry("manifest.json", toBytes(payload));
+}
+
+[[nodiscard]] EntrySpec documentEntry(const std::string_view payload = "{}") {
+    return makeStoredEntry("document.json", toBytes(payload));
+}
+
+void testConformingArchives(Expectations& expectations) {
+    {
+        const auto archive =
+            buildConformingArchive(manifestEntry("{\"m\":1}"), documentEntry("{\"d\":2}"));
+        const auto result = run(archive);
+        expectations.expect(result.succeeded(), "a stored-only conforming archive is accepted");
+        expectations.expect(result.manifest.uncompressedSize == 7 &&
+                                result.document.uncompressedSize == 7,
+                            "declared sizes are captured exactly");
+        const auto second = run(archive);
+        expectations.expect(second.succeeded() &&
+                                second.manifest.crc32Value == result.manifest.crc32Value,
+                            "preflighting the same bytes twice is deterministic");
+    }
+    {
+        const std::string manifestPayload(2000, 'm');
+        const std::string documentPayload(3000, 'd');
+        const auto archive =
+            buildConformingArchive(makeDeflateEntry("manifest.json", toBytes(manifestPayload)),
+                                   makeDeflateEntry("document.json", toBytes(documentPayload)));
+        const auto result = run(archive);
+        expectations.expect(result.succeeded() && result.manifest.method == 8 &&
+                                result.document.method == 8,
+                            "a deflate-only conforming archive is accepted");
+    }
+    {
+        const auto archive = buildConformingArchive(
+            manifestEntry(), makeDeflateEntry("document.json", toBytes(std::string(500, 'x'))));
+        const auto result = run(archive);
+        expectations.expect(result.succeeded() && result.manifest.method == 0 &&
+                                result.document.method == 8,
+                            "a mixed stored/deflate archive is accepted");
+    }
+}
+
+void testEmptyPayloadEntry(Expectations& expectations) {
+    const auto archive = buildConformingArchive(manifestEntry(""), documentEntry("{}"));
+    const auto result = run(archive);
+    expectations.expect(result.succeeded() && result.manifest.uncompressedSize == 0 &&
+                            result.manifest.crc32Value == 0,
+                        "a zero-byte manifest entry is structurally accepted with CRC 0");
+}
+
+void testInvalidLimits(Expectations& expectations) {
+    ZipContainerPreflightLimits limits{};
+    limits.maxManifestBytes = 0;
+    const auto archive = buildConformingArchive(manifestEntry(), documentEntry());
+    const auto result = run(archive, limits);
+    expectations.expect(!result.succeeded() &&
+                            result.error == ZipContainerPreflightError::InvalidLimits,
+                        "a zeroed limit field is rejected before any byte is inspected");
+}
+
+void testArchiveTooLarge(Expectations& expectations) {
+    ZipContainerPreflightLimits limits{};
+    const auto archive = buildConformingArchive(manifestEntry(), documentEntry());
+    limits.maxArchiveBytes = archive.size() - 1;
+    const auto result = run(archive, limits);
+    expectations.expect(!result.succeeded() &&
+                            result.error == ZipContainerPreflightError::ArchiveTooLarge,
+                        "an archive one byte over the physical size ceiling is rejected");
+}
+
+void testTruncation(Expectations& expectations) {
+    const auto archive = buildConformingArchive(manifestEntry(), documentEntry());
+    {
+        std::vector<std::byte> truncated(archive.begin(), archive.begin() + 10);
+        const auto result = run(truncated);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ArchiveTruncated,
+                            "an archive shorter than one EOCD record is rejected as truncated");
+    }
+    {
+        // A local header whose declared compressed size claims more bytes than the whole
+        // (otherwise genuinely valid and self-consistent) archive contains: the central directory
+        // and EOCD honestly describe the true, small physical layout, so this is caught by the
+        // local-header data range walking past end-of-file, not by a missing EOCD.
+        auto manifest = manifestEntry();
+        manifest.localCompressedSize = manifest.centralCompressedSize = 1'000'000;
+        const auto truncated = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(truncated);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ArchiveTruncated,
+                            "a declared entry data range extending past the true end of the "
+                            "archive is rejected as truncated");
+    }
+    {
+        // Cutting bytes off the tail moves the EOCD's signature out of the scanner's fixed
+        // 22-byte window without leaving any other self-consistent EOCD candidate nearby, so this
+        // is indistinguishable from a genuinely missing/malformed EOCD rather than a distinct
+        // "structure truncated mid-record" case.
+        std::vector<std::byte> truncated(archive.begin(), archive.end() - 5);
+        const auto result = run(truncated);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::MissingOrMalformedEocd,
+                            "cutting bytes off the archive's tail is rejected as a malformed EOCD");
+    }
+    {
+        std::vector<std::byte> empty;
+        const auto result = run(empty);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ArchiveTruncated,
+                            "an empty archive is rejected as truncated");
+    }
+}
+
+void testEocdLocationAndComment(Expectations& expectations) {
+    {
+        auto archive = buildConformingArchive(manifestEntry(), documentEntry());
+        archive.push_back(std::byte{0xAB});
+        archive.push_back(std::byte{0xCD});
+        const auto result = run(archive);
+        expectations.expect(
+            !result.succeeded() &&
+                result.error == ZipContainerPreflightError::MissingOrMalformedEocd,
+            "trailing bytes after a well-formed EOCD are rejected as malformed EOCD");
+    }
+    {
+        ArchiveWriter writer;
+        const auto manifest = manifestEntry();
+        const auto document = documentEntry();
+        const auto manifestOffset = writer.appendLocal(manifest);
+        const auto documentOffset = writer.appendLocal(document);
+        const auto centralStart = writer.size();
+        writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+        writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+        const auto centralSize = writer.size() - centralStart;
+        writer.appendEocd(0, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                          static_cast<std::uint32_t>(centralStart), "hello");
+        const auto result = run(writer.bytes());
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ArchiveCommentForbidden,
+                            "a nonzero, self-consistent archive comment is rejected distinctly");
+    }
+}
+
+void testDiskNumbers(Expectations& expectations) {
+    {
+        ArchiveWriter writer;
+        const auto manifest = manifestEntry();
+        const auto document = documentEntry();
+        const auto manifestOffset = writer.appendLocal(manifest);
+        const auto documentOffset = writer.appendLocal(document);
+        const auto centralStart = writer.size();
+        writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+        writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+        const auto centralSize = writer.size() - centralStart;
+        writer.appendEocd(1, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                          static_cast<std::uint32_t>(centralStart));
+        const auto result = run(writer.bytes());
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::MultiDiskForbidden,
+                            "a nonzero EOCD disk number is rejected");
+    }
+    {
+        auto manifest = manifestEntry();
+        manifest.diskNumberStart = 1;
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::MultiDiskForbidden,
+                            "a nonzero per-entry central disk-number-start is rejected");
+    }
+}
+
+void testEntryCount(Expectations& expectations) {
+    for (const std::uint16_t count : {std::uint16_t{1}, std::uint16_t{3}}) {
+        ArchiveWriter writer;
+        const auto manifest = manifestEntry();
+        const auto document = documentEntry();
+        const auto manifestOffset = writer.appendLocal(manifest);
+        const auto documentOffset = writer.appendLocal(document);
+        const auto centralStart = writer.size();
+        writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+        writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+        const auto centralSize = writer.size() - centralStart;
+        writer.appendEocd(0, 0, count, count, static_cast<std::uint32_t>(centralSize),
+                          static_cast<std::uint32_t>(centralStart));
+        const auto result = run(writer.bytes());
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::WrongEntryCount,
+                            "an EOCD entry count other than exactly two is rejected");
+    }
+}
+
+void testEntryNames(Expectations& expectations) {
+    const std::vector<std::string> badNames{"Manifest.json", std::string("manifest.json") + '\0',
+                                            "./manifest.json", "manifest\\json", "/manifest.json"};
+    for (const auto& badName : badNames) {
+        auto manifest = manifestEntry();
+        manifest.localName = badName;
+        manifest.centralName = badName;
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::WrongEntryName,
+                            "an exact-name deviation is rejected as wrong entry name: " + badName);
+    }
+    {
+        // Reversed order in the central directory, local headers left untouched.
+        ArchiveWriter writer;
+        const auto manifest = manifestEntry();
+        const auto document = documentEntry();
+        const auto manifestOffset = writer.appendLocal(manifest);
+        const auto documentOffset = writer.appendLocal(document);
+        const auto centralStart = writer.size();
+        writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+        writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+        const auto centralSize = writer.size() - centralStart;
+        writer.appendEocd(0, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                          static_cast<std::uint32_t>(centralStart));
+        const auto result = run(writer.bytes());
+        expectations.expect(
+            !result.succeeded() && result.error == ZipContainerPreflightError::WrongEntryOrder,
+            "a reversed central directory order is rejected distinctly from a wrong name");
+    }
+    {
+        // Reversed order at the local-header level too (document physically first).
+        auto manifest = manifestEntry();
+        auto document = documentEntry();
+        const auto archive = buildConformingArchive(document, manifest);
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::WrongEntryOrder,
+                            "swapping both local headers (and their matching central records) is "
+                            "rejected as wrong order, detected at the local level");
+    }
+}
+
+void testGeneralPurposeFlags(Expectations& expectations) {
+    {
+        auto manifest = manifestEntry();
+        manifest.localFlags = manifest.centralFlags = 0;
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::Utf8FlagMissing,
+                            "flags == 0 is reported as a missing UTF-8 flag");
+    }
+    {
+        auto manifest = manifestEntry();
+        manifest.localFlags = manifest.centralFlags = 0x0808; // UTF-8 + data descriptor.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error ==
+                                    ZipContainerPreflightError::ForbiddenGeneralPurposeFlag,
+                            "the data-descriptor bit is a forbidden general-purpose flag");
+    }
+    {
+        auto manifest = manifestEntry();
+        manifest.localFlags = manifest.centralFlags = 0x0801; // UTF-8 + encryption.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error ==
+                                    ZipContainerPreflightError::ForbiddenGeneralPurposeFlag,
+                            "the encryption bit is a forbidden general-purpose flag");
+    }
+}
+
+void testCompressionMethod(Expectations& expectations) {
+    for (const std::uint16_t method : {std::uint16_t{1}, std::uint16_t{12}}) {
+        auto manifest = manifestEntry();
+        manifest.localMethod = manifest.centralMethod = method;
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error ==
+                                    ZipContainerPreflightError::UnsupportedCompressionMethod,
+                            "an unsupported compression method is rejected");
+    }
+}
+
+void testExtraField(Expectations& expectations) {
+    {
+        auto manifest = manifestEntry();
+        manifest.localExtra = {std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}};
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ExtraFieldForbidden,
+                            "a local-only extra field is rejected");
+    }
+    {
+        auto manifest = manifestEntry();
+        manifest.centralExtra = {std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}};
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ExtraFieldForbidden,
+                            "a central-only extra field is rejected");
+    }
+}
+
+void testEntryComment(Expectations& expectations) {
+    auto manifest = manifestEntry();
+    manifest.centralComment = "hi";
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+    const auto result = run(archive);
+    expectations.expect(!result.succeeded() &&
+                            result.error == ZipContainerPreflightError::EntryCommentForbidden,
+                        "a per-entry central directory comment is rejected");
+}
+
+void testZip64Sentinels(Expectations& expectations) {
+    auto manifest = manifestEntry();
+    manifest.localUncompressedSize = manifest.centralUncompressedSize = 0xFFFFFFFFU;
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+    const auto result = run(archive);
+    expectations.expect(!result.succeeded() &&
+                            result.error == ZipContainerPreflightError::Zip64Forbidden,
+                        "a ZIP64 uncompressed-size sentinel is rejected");
+}
+
+void testLocalCentralDisagreement(Expectations& expectations) {
+    {
+        auto manifest = manifestEntry();
+        manifest.centralMethod = 8; // local stays stored (0); central claims deflate.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error ==
+                                    ZipContainerPreflightError::LocalCentralHeaderDisagreement,
+                            "a local/central method disagreement is rejected");
+    }
+    {
+        auto manifest = manifestEntry();
+        manifest.centralCrc ^= 0xFFFFFFFFU;
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error ==
+                                    ZipContainerPreflightError::LocalCentralHeaderDisagreement,
+                            "a local/central CRC disagreement is rejected");
+    }
+}
+
+void testByteAccounting(Expectations& expectations) {
+    {
+        std::vector<std::byte> withPrefix{std::byte{'X'}, std::byte{'Y'}};
+        const auto archive = buildConformingArchive(manifestEntry(), documentEntry());
+        withPrefix.insert(withPrefix.end(), archive.begin(), archive.end());
+        const auto result = run(withPrefix);
+        expectations.expect(
+            !result.succeeded() &&
+                result.error == ZipContainerPreflightError::OverlappingOrUnaccountedByteRange,
+            "prepended bytes shifting the manifest local header off offset 0 are rejected");
+    }
+    {
+        ArchiveWriter writer;
+        const auto manifest = manifestEntry();
+        const auto document = documentEntry();
+        const auto manifestOffset = writer.appendLocal(manifest);
+        const auto documentOffset = writer.appendLocal(document);
+        const std::vector<std::byte> gap{std::byte{0}, std::byte{0}, std::byte{0}, std::byte{0}};
+        writer.appendRawBytes(gap);
+        const auto centralStart = writer.size();
+        writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+        writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+        const auto centralSize = writer.size() - centralStart;
+        writer.appendEocd(0, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                          static_cast<std::uint32_t>(centralStart));
+        const auto result = run(writer.bytes());
+        expectations.expect(
+            !result.succeeded() &&
+                result.error == ZipContainerPreflightError::OverlappingOrUnaccountedByteRange,
+            "a gap between the document data and the central directory is rejected");
+    }
+    {
+        // A deflate entry (so the stored-size-consistency check does not intervene) whose
+        // declared compressed size claims fewer bytes than are physically written: the next
+        // header is expected too early, landing inside the still-live payload bytes.
+        auto manifest = makeDeflateEntry("manifest.json", toBytes(std::string(200, 'a')));
+        const auto physicalSize = static_cast<std::uint32_t>(manifest.data.size());
+        manifest.localCompressedSize = manifest.centralCompressedSize =
+            physicalSize > 4 ? physicalSize - 4 : 1;
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(
+            !result.succeeded() &&
+                result.error == ZipContainerPreflightError::OverlappingOrUnaccountedByteRange,
+            "a local range shorter than its physical data overlaps the next header");
+    }
+}
+
+void testAttributes(Expectations& expectations) {
+    {
+        auto manifest = manifestEntry();
+        manifest.externalAttrs = (0040755U) << 16U; // Unix directory type + mode.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::NonRegularEntry,
+                            "a directory external-attribute bit is rejected");
+    }
+    {
+        auto manifest = manifestEntry();
+        manifest.externalAttrs = (0120644U) << 16U; // Unix symlink type.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::NonRegularEntry,
+                            "Unix symlink file-type bits are rejected");
+    }
+    {
+        auto manifest = manifestEntry();
+        manifest.externalAttrs = (0100755U) << 16U; // regular file, executable.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ExecutableEntry,
+                            "an executable mode bit is rejected");
+    }
+    {
+        // DOS host (versionMadeBy high byte 0) with the DOS directory bit set in the low
+        // attribute byte and no Unix mode bits present at all.
+        auto manifest = manifestEntry();
+        manifest.versionMadeBy = 0x0014U; // host 0 (DOS/FAT), version 20.
+        manifest.externalAttrs = 0x10U;   // DOS directory attribute bit.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::NonRegularEntry,
+                            "a DOS-host directory attribute bit is rejected");
+    }
+    {
+        // The DOS directory bit is checked unconditionally: a crafted entry that declares a Unix
+        // host with clean Unix mode type/execute bits must not be able to smuggle the DOS
+        // directory bit through in the low byte of the same external-attributes field.
+        auto manifest = manifestEntry();
+        manifest.versionMadeBy = 0x0314U; // host 3 (Unix), version 20.
+        manifest.externalAttrs =
+            (0100644U << 16U) | 0x10U; // regular Unix mode + DOS directory bit.
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::NonRegularEntry,
+                            "the DOS directory bit is rejected even under a declared Unix host "
+                            "with otherwise-clean mode bits");
+    }
+}
+
+void testStoredSizeMismatch(Expectations& expectations) {
+    auto manifest = manifestEntry("{\"m\":1}");
+    manifest.localUncompressedSize = manifest.centralUncompressedSize =
+        manifest.localCompressedSize + 1;
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+    const auto result = run(archive);
+    expectations.expect(!result.succeeded() &&
+                            result.error == ZipContainerPreflightError::StoredSizeMismatch,
+                        "a stored entry with compressed != uncompressed size is rejected");
+}
+
+void testLimitsExceeded(Expectations& expectations) {
+    {
+        ZipContainerPreflightLimits limits{};
+        limits.maxManifestBytes = 3;
+        const auto archive = buildConformingArchive(manifestEntry("{\"m\":1}"), documentEntry());
+        const auto result = run(archive, limits);
+        expectations.expect(!result.succeeded() &&
+                                result.error ==
+                                    ZipContainerPreflightError::ExpandedSizeLimitExceeded,
+                            "a per-entry manifest size above its limit is rejected");
+    }
+    {
+        ZipContainerPreflightLimits limits{};
+        limits.maxDocumentBytes = 3;
+        const auto archive = buildConformingArchive(manifestEntry(), documentEntry("{\"d\":1}"));
+        const auto result = run(archive, limits);
+        expectations.expect(!result.succeeded() &&
+                                result.error ==
+                                    ZipContainerPreflightError::ExpandedSizeLimitExceeded,
+                            "a per-entry document size above its limit is rejected");
+    }
+    {
+        ZipContainerPreflightLimits limits{};
+        limits.maxTotalExpandedBytes = 10;
+        const auto archive =
+            buildConformingArchive(manifestEntry("{\"m\":1}"), documentEntry("{\"d\":1}"));
+        const auto result = run(archive, limits);
+        expectations.expect(
+            !result.succeeded() &&
+                result.error == ZipContainerPreflightError::ExpandedSizeLimitExceeded,
+            "a total expanded size above its limit is rejected even when each entry alone fits");
+    }
+    {
+        // A tiny deflate payload whose declared (but not actually inflated -- preflight never
+        // decompresses) uncompressed size claims far more than maxExpansionRatio permits for its
+        // real compressed size.
+        auto manifest = makeDeflateEntry("manifest.json", toBytes(std::string(10, 'a')));
+        manifest.localUncompressedSize = manifest.centralUncompressedSize = 1'000'000;
+        const ZipContainerPreflightLimits limits{};
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result = run(archive, limits);
+        expectations.expect(!result.succeeded() &&
+                                result.error == ZipContainerPreflightError::ExpansionRatioExceeded,
+                            "an expansion ratio above its limit is rejected");
+    }
+}
+
+void testSizeOverflow(Expectations& expectations) {
+    ZipContainerPreflightLimits limits{};
+    limits.maxExpansionRatio = std::numeric_limits<std::uint64_t>::max();
+    auto manifest = manifestEntry("{\"m\":1}"); // compressed size 7, so ratio*7 overflows uint64.
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+    const auto result = run(archive, limits);
+    expectations.expect(
+        !result.succeeded() && result.error == ZipContainerPreflightError::SizeOverflow,
+        "an expansion-ratio multiply that overflows uint64 is reported as size overflow, "
+        "never a wrapped smaller number");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testConformingArchives(expectations);
+        testEmptyPayloadEntry(expectations);
+        testInvalidLimits(expectations);
+        testArchiveTooLarge(expectations);
+        testTruncation(expectations);
+        testEocdLocationAndComment(expectations);
+        testDiskNumbers(expectations);
+        testEntryCount(expectations);
+        testEntryNames(expectations);
+        testGeneralPurposeFlags(expectations);
+        testCompressionMethod(expectations);
+        testExtraField(expectations);
+        testEntryComment(expectations);
+        testZip64Sentinels(expectations);
+        testLocalCentralDisagreement(expectations);
+        testByteAccounting(expectations);
+        testAttributes(expectations);
+        testStoredSizeMismatch(expectations);
+        testLimitsExceeded(expectations);
+        testSizeOverflow(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "FAILED: test fixture exception: " << error.what() << '\n';
+        return 1;
+    }
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/project/tests/zip_container_test_support.hpp
+++ b/src/project/tests/zip_container_test_support.hpp
@@ -1,0 +1,215 @@
+#pragma once
+
+// A hand-rolled byte-level Constrained ZIP Profile archive builder shared by
+// zip_container_preflight_tests.cpp and zip_container_tests.cpp. It knows nothing about libzip:
+// every local file header, central directory header, and end-of-central-directory record is
+// assembled field-by-field so a test can construct either a fully conforming archive or a single
+// deliberate deviation from one. CRC and raw-deflate helpers use the qualified zlib the tests are
+// already linked against (test fixtures only; production code never uses zlib outside
+// zip_container.cpp).
+
+#include <zlib.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bloom::project::test {
+
+[[nodiscard]] inline std::uint32_t crc32Of(const std::span<const std::byte> payload) noexcept {
+    const auto value = crc32_z(0L, reinterpret_cast<const Bytef*>(payload.data()), payload.size());
+    return static_cast<std::uint32_t>(value);
+}
+
+// Raw deflate (no zlib/gzip wrapper) at level 6, matching what a ZIP method-8 entry stores.
+[[nodiscard]] inline std::vector<std::byte> deflateRaw(const std::span<const std::byte> payload) {
+    z_stream stream{};
+    constexpr int kLevel = 6;
+    constexpr int kWindowBits = -15; // negative: raw deflate, no zlib header/trailer.
+    constexpr int kMemLevel = 8;
+    if (deflateInit2(&stream, kLevel, Z_DEFLATED, kWindowBits, kMemLevel, Z_DEFAULT_STRATEGY) !=
+        Z_OK) {
+        throw std::runtime_error("deflateInit2 failed");
+    }
+    std::vector<std::byte> out(deflateBound(&stream, static_cast<uLong>(payload.size())));
+    stream.next_in = reinterpret_cast<Bytef*>(const_cast<std::byte*>(payload.data()));
+    stream.avail_in = static_cast<uInt>(payload.size());
+    stream.next_out = reinterpret_cast<Bytef*>(out.data());
+    stream.avail_out = static_cast<uInt>(out.size());
+    const auto result = deflate(&stream, Z_FINISH);
+    const auto producedBytes = out.size() - stream.avail_out;
+    deflateEnd(&stream);
+    if (result != Z_STREAM_END) {
+        throw std::runtime_error("deflate did not finish in one call");
+    }
+    out.resize(producedBytes);
+    return out;
+}
+
+[[nodiscard]] inline std::vector<std::byte> toBytes(const std::string_view text) {
+    return {reinterpret_cast<const std::byte*>(text.data()),
+            reinterpret_cast<const std::byte*>(text.data()) + text.size()};
+}
+
+// Every field a local or central header carries, defaulted to a conforming stored entry. Tests
+// mutate exactly the field(s) they mean to violate.
+struct EntrySpec final {
+    std::string localName = "manifest.json";
+    std::string centralName = "manifest.json";
+    std::uint16_t localFlags = 0x0800;
+    std::uint16_t centralFlags = 0x0800;
+    std::uint16_t localMethod = 0;
+    std::uint16_t centralMethod = 0;
+    std::vector<std::byte> data; // bytes physically written after the local header.
+    std::uint32_t localCompressedSize = 0;
+    std::uint32_t centralCompressedSize = 0;
+    std::uint32_t localUncompressedSize = 0;
+    std::uint32_t centralUncompressedSize = 0;
+    std::uint32_t localCrc = 0;
+    std::uint32_t centralCrc = 0;
+    std::vector<std::byte> localExtra;
+    std::vector<std::byte> centralExtra;
+    std::string centralComment;
+    // version made by: high byte 3 (Unix host), low byte 20 (spec version 2.0); external
+    // attributes: Unix mode 0644 (regular, non-executable) placed in the high 16 bits.
+    std::uint16_t versionMadeBy = 0x0314;
+    std::uint32_t externalAttrs = 0100644U << 16U;
+    std::uint16_t diskNumberStart = 0;
+};
+
+[[nodiscard]] inline EntrySpec makeStoredEntry(const std::string& name,
+                                               const std::span<const std::byte> payload) {
+    EntrySpec spec;
+    spec.localName = name;
+    spec.centralName = name;
+    spec.data.assign(payload.begin(), payload.end());
+    spec.localCompressedSize = spec.centralCompressedSize =
+        static_cast<std::uint32_t>(payload.size());
+    spec.localUncompressedSize = spec.centralUncompressedSize =
+        static_cast<std::uint32_t>(payload.size());
+    spec.localCrc = spec.centralCrc = crc32Of(payload);
+    return spec;
+}
+
+[[nodiscard]] inline EntrySpec makeDeflateEntry(const std::string& name,
+                                                const std::span<const std::byte> payload) {
+    EntrySpec spec = makeStoredEntry(name, payload);
+    spec.data = deflateRaw(payload);
+    spec.localCompressedSize = spec.centralCompressedSize =
+        static_cast<std::uint32_t>(spec.data.size());
+    spec.localMethod = spec.centralMethod = 8;
+    return spec;
+}
+
+// Appends fixed-width little-endian fields and raw byte ranges to build one archive from
+// individually-controlled local headers, central headers, and an EOCD record -- in whatever
+// order and with whatever field values a test supplies, valid or not.
+class ArchiveWriter final {
+  public:
+    // Returns the byte offset the local header was written at.
+    std::uint64_t appendLocal(const EntrySpec& entry) {
+        const auto offset = bytes_.size();
+        appendU32(0x04034b50U);
+        appendU16(20);
+        appendU16(entry.localFlags);
+        appendU16(entry.localMethod);
+        appendU16(0);
+        appendU16(0);
+        appendU32(entry.localCrc);
+        appendU32(entry.localCompressedSize);
+        appendU32(entry.localUncompressedSize);
+        appendU16(static_cast<std::uint16_t>(entry.localName.size()));
+        appendU16(static_cast<std::uint16_t>(entry.localExtra.size()));
+        appendText(entry.localName);
+        appendRaw(entry.localExtra);
+        appendRaw(entry.data);
+        return offset;
+    }
+
+    void appendCentral(const EntrySpec& entry, const std::uint32_t localHeaderOffset) {
+        appendU32(0x02014b50U);
+        appendU16(entry.versionMadeBy);
+        appendU16(20);
+        appendU16(entry.centralFlags);
+        appendU16(entry.centralMethod);
+        appendU16(0);
+        appendU16(0);
+        appendU32(entry.centralCrc);
+        appendU32(entry.centralCompressedSize);
+        appendU32(entry.centralUncompressedSize);
+        appendU16(static_cast<std::uint16_t>(entry.centralName.size()));
+        appendU16(static_cast<std::uint16_t>(entry.centralExtra.size()));
+        appendU16(static_cast<std::uint16_t>(entry.centralComment.size()));
+        appendU16(entry.diskNumberStart);
+        appendU16(0);
+        appendU32(entry.externalAttrs);
+        appendU32(localHeaderOffset);
+        appendText(entry.centralName);
+        appendRaw(entry.centralExtra);
+        appendText(entry.centralComment);
+    }
+
+    void appendEocd(const std::uint16_t diskNumber, const std::uint16_t diskWithCd,
+                    const std::uint16_t entriesThisDisk, const std::uint16_t entriesTotal,
+                    const std::uint32_t cdSize, const std::uint32_t cdOffset,
+                    const std::string& comment = {}) {
+        appendU32(0x06054b50U);
+        appendU16(diskNumber);
+        appendU16(diskWithCd);
+        appendU16(entriesThisDisk);
+        appendU16(entriesTotal);
+        appendU32(cdSize);
+        appendU32(cdOffset);
+        appendU16(static_cast<std::uint16_t>(comment.size()));
+        appendText(comment);
+    }
+
+    void appendRawBytes(const std::span<const std::byte> raw) { appendRaw(raw); }
+
+    [[nodiscard]] std::uint64_t size() const { return bytes_.size(); }
+    [[nodiscard]] const std::vector<std::byte>& bytes() const { return bytes_; }
+
+  private:
+    void appendU16(const std::uint16_t value) {
+        bytes_.push_back(static_cast<std::byte>(value & 0xFFU));
+        bytes_.push_back(static_cast<std::byte>((value >> 8U) & 0xFFU));
+    }
+    void appendU32(const std::uint32_t value) {
+        for (unsigned shift = 0; shift < 32U; shift += 8U) {
+            bytes_.push_back(static_cast<std::byte>((value >> shift) & 0xFFU));
+        }
+    }
+    void appendText(const std::string_view text) {
+        for (const char character : text) {
+            bytes_.push_back(static_cast<std::byte>(static_cast<unsigned char>(character)));
+        }
+    }
+    void appendRaw(const std::span<const std::byte> raw) {
+        bytes_.insert(bytes_.end(), raw.begin(), raw.end());
+    }
+
+    std::vector<std::byte> bytes_;
+};
+
+// Assembles a fully conforming two-entry archive: manifest local header at offset 0, its data
+// abutting, the document local header abutting, its data abutting, the central directory
+// abutting, and the EOCD abutting and ending the file.
+[[nodiscard]] inline std::vector<std::byte> buildConformingArchive(const EntrySpec& manifest,
+                                                                   const EntrySpec& document) {
+    ArchiveWriter writer;
+    const auto manifestOffset = writer.appendLocal(manifest);
+    const auto documentOffset = writer.appendLocal(document);
+    const auto centralStart = writer.size();
+    writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+    writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+    const auto centralSize = writer.size() - centralStart;
+    writer.appendEocd(0, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                      static_cast<std::uint32_t>(centralStart));
+    return writer.bytes();
+}
+
+} // namespace bloom::project::test

--- a/src/project/tests/zip_container_tests.cpp
+++ b/src/project/tests/zip_container_tests.cpp
@@ -1,0 +1,331 @@
+#include <bloom/project/zip_container.hpp>
+
+#include "zip_container_test_support.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <source_location>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::readZipContainer;
+using bloom::project::ZipContainerError;
+using bloom::project::ZipContainerLimits;
+using bloom::project::test::ArchiveWriter;
+using bloom::project::test::buildConformingArchive;
+using bloom::project::test::EntrySpec;
+using bloom::project::test::makeDeflateEntry;
+using bloom::project::test::makeStoredEntry;
+using bloom::project::test::toBytes;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U; // 32 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory
+makeOperation(const std::uint64_t limitBytes = kGenerousOperationBudget) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        throw std::runtime_error("failed to create test memory coordinator");
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        throw std::runtime_error("failed to create test operation memory");
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] EntrySpec manifestEntry(const std::string_view payload = "{}") {
+    return makeStoredEntry("manifest.json", toBytes(payload));
+}
+
+[[nodiscard]] EntrySpec documentEntry(const std::string_view payload = "{}") {
+    return makeStoredEntry("document.json", toBytes(payload));
+}
+
+[[nodiscard]] std::span<const std::byte> asSpan(const std::vector<std::byte>& bytes) noexcept {
+    return {bytes.data(), bytes.size()};
+}
+
+void testConformingStoredExtraction(Expectations& expectations) {
+    const std::string manifestPayload = "{\"manifest\":true}";
+    const std::string documentPayload = "{\"document\":true}";
+    const auto archive =
+        buildConformingArchive(manifestEntry(manifestPayload), documentEntry(documentPayload));
+
+    const auto operation = makeOperation();
+    auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, operation);
+    expectations.expect(static_cast<bool>(result), "a conforming stored archive is accepted");
+    if (!result) {
+        return;
+    }
+    const auto* document = result.document();
+    expectations.expect(document != nullptr, "a successful result exposes its document");
+    if (document == nullptr) {
+        return;
+    }
+    const std::string_view manifestOut(
+        reinterpret_cast<const char*>(document->manifestBytes().data()),
+        document->manifestBytes().size());
+    const std::string_view documentOut(
+        reinterpret_cast<const char*>(document->documentBytes().data()),
+        document->documentBytes().size());
+    expectations.expect(manifestOut == manifestPayload, "manifest bytes are extracted byte-exact");
+    expectations.expect(documentOut == documentPayload, "document bytes are extracted byte-exact");
+
+    auto second = readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(second) && second.document() != nullptr,
+                        "extracting the same archive twice succeeds both times");
+    if (second.document() != nullptr) {
+        const std::string_view secondManifest(
+            reinterpret_cast<const char*>(second.document()->manifestBytes().data()),
+            second.document()->manifestBytes().size());
+        expectations.expect(secondManifest == manifestPayload,
+                            "extraction is byte-for-byte deterministic across two runs");
+    }
+}
+
+void testConformingDeflateAndMixedExtraction(Expectations& expectations) {
+    {
+        const std::string manifestPayload(4000, 'm');
+        const std::string documentPayload(6000, 'd');
+        const auto archive =
+            buildConformingArchive(makeDeflateEntry("manifest.json", toBytes(manifestPayload)),
+                                   makeDeflateEntry("document.json", toBytes(documentPayload)));
+        auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+        expectations.expect(static_cast<bool>(result),
+                            "a conforming deflate-only archive is accepted");
+        if (result && result.document() != nullptr) {
+            const std::string_view manifestOut(
+                reinterpret_cast<const char*>(result.document()->manifestBytes().data()),
+                result.document()->manifestBytes().size());
+            expectations.expect(manifestOut == manifestPayload,
+                                "a deflated manifest entry inflates to its exact original bytes");
+        }
+    }
+    {
+        const std::string documentPayload(2500, 'x');
+        const auto archive = buildConformingArchive(
+            manifestEntry("{}"), makeDeflateEntry("document.json", toBytes(documentPayload)));
+        auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+        expectations.expect(static_cast<bool>(result),
+                            "a mixed stored/deflate archive is accepted");
+        if (result && result.document() != nullptr) {
+            const std::string_view documentOut(
+                reinterpret_cast<const char*>(result.document()->documentBytes().data()),
+                result.document()->documentBytes().size());
+            expectations.expect(documentOut == documentPayload,
+                                "the deflated entry in a mixed archive still inflates exactly");
+        }
+    }
+}
+
+void testEmptyPayloadExtraction(Expectations& expectations) {
+    const auto archive = buildConformingArchive(manifestEntry(""), documentEntry("{}"));
+    auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(result),
+                        "an archive with a zero-byte manifest is accepted");
+    if (result && result.document() != nullptr) {
+        expectations.expect(result.document()->manifestBytes().empty(),
+                            "the zero-byte manifest entry extracts to an empty buffer");
+    }
+}
+
+void testPreflightRejectionPropagates(Expectations& expectations) {
+    auto manifest = manifestEntry();
+    manifest.localName = manifest.centralName = "Manifest.json";
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+    const auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+    expectations.expect(
+        !result && result.error() == ZipContainerError::WrongEntryName,
+        "a preflight-stage rejection surfaces through the public API with its exact "
+        "translated error");
+}
+
+void testInvalidLimits(Expectations& expectations) {
+    ZipContainerLimits limits{};
+    limits.maxExpansionRatio = 0;
+    const auto archive = buildConformingArchive(manifestEntry(), documentEntry());
+    const auto result = readZipContainer(asSpan(archive), limits, makeOperation());
+    expectations.expect(!result && result.error() == ZipContainerError::InvalidLimits,
+                        "a zeroed public limit field is rejected before preflight runs");
+}
+
+void testExpandedSizeMismatchOnBomb(Expectations& expectations) {
+    const std::string realPayload(20000, 'a'); // deflates to a tiny stream.
+    auto manifest = makeDeflateEntry("manifest.json", toBytes(realPayload));
+    // Declare fewer bytes than the stream actually inflates to; the destination buffer is sized
+    // to this declared (smaller) value and can never be overrun, but the extra decompressed byte
+    // must still be caught.
+    const auto declared = static_cast<std::uint32_t>(realPayload.size() - 100);
+    manifest.localUncompressedSize = manifest.centralUncompressedSize = declared;
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+
+    ZipContainerLimits limits{};
+    const auto result = readZipContainer(asSpan(archive), limits, makeOperation());
+    expectations.expect(
+        !result && result.error() == ZipContainerError::ExpandedSizeMismatch,
+        "a stream that inflates past its declared size is rejected as an expanded-size "
+        "mismatch rather than overrunning the destination buffer");
+}
+
+void testUnderProductionMismatch(Expectations& expectations) {
+    // The mirror of the bomb case: a genuinely valid raw-deflate stream that inflates to FEWER
+    // bytes than declared. The preflight cannot see this (it never decompresses); the ratio check
+    // stays legal (200 declared / a handful of compressed bytes is far under the default 1000:1
+    // ceiling); local and central headers agree; CRC names the real 100 produced bytes.
+    // Empirically observed: libzip's zip_fread() for the main exact-size read returns the true
+    // available byte count (100) rather than the requested 200, which this code reports as a
+    // short read -- ExpandedSizeMismatch, deterministically, before any independent CRC check
+    // runs (there is no complete buffer to check yet).
+    const std::string realPayload(100, 'a');
+    auto manifest = makeDeflateEntry("manifest.json", toBytes(realPayload));
+    manifest.localUncompressedSize = manifest.centralUncompressedSize = 200;
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+
+    const auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+    expectations.expect(
+        !result && result.error() == ZipContainerError::ExpandedSizeMismatch,
+        "a valid deflate stream that inflates to fewer bytes than declared is rejected as an "
+        "expanded-size mismatch via the short main read");
+}
+
+void testQualifiedReaderDisagreementOnInvalidDeflateStream(Expectations& expectations) {
+    // A method-8 entry whose "compressed" bytes are not a valid raw-deflate stream at all. The
+    // preflight only inspects header fields (name/flags/method/sizes/CRC), never entry payload
+    // bytes, so a self-consistent local/central header pair with a legal declared ratio passes it
+    // cleanly; the corruption can only be discovered once the qualified reader actually attempts
+    // to decompress. Empirically observed: libzip's zip_fread() for the main exact-size read
+    // returns -1 (a genuine read error, not a short read) because the garbage bytes cannot be
+    // inflated at all -- this code reports that as QualifiedReaderDisagreement, deterministically,
+    // since it is libzip failing outright rather than the buffer-size accounting disagreeing.
+    EntrySpec manifest;
+    manifest.localName = "manifest.json";
+    manifest.centralName = "manifest.json";
+    manifest.localMethod = manifest.centralMethod = 8;
+    // Fixed, deterministic "garbage" payload: not a valid raw-deflate stream, but a legal byte
+    // sequence to write and account for structurally.
+    std::vector<std::byte> garbage(64);
+    for (std::size_t index = 0; index < garbage.size(); ++index) {
+        garbage[index] = static_cast<std::byte>((index * 97U + 13U) & 0xFFU);
+    }
+    manifest.data = garbage;
+    manifest.localCompressedSize = manifest.centralCompressedSize = 64;
+    // Declared uncompressed size passes the default 1000:1 ratio ceiling (100 / 64 is nowhere
+    // close) and both header limits comfortably.
+    manifest.localUncompressedSize = manifest.centralUncompressedSize = 100;
+    manifest.localCrc = manifest.centralCrc = 0xDEADBEEFU;
+    const auto archive = buildConformingArchive(manifest, documentEntry());
+
+    const auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+    expectations.expect(
+        !result && result.error() == ZipContainerError::QualifiedReaderDisagreement,
+        "a method-8 entry whose data is not a valid deflate stream is rejected as a qualified "
+        "reader disagreement once libzip's own decompression fails");
+}
+
+void testCrcMismatch(Expectations& expectations) {
+    {
+        auto manifest = manifestEntry("{\"m\":1}");
+        manifest.localCrc = manifest.centralCrc ^= 0xFFFFFFFFU;
+        const auto archive = buildConformingArchive(manifest, documentEntry());
+        const auto result =
+            readZipContainer(asSpan(archive), ZipContainerLimits{}, makeOperation());
+        expectations.expect(!result && result.error() == ZipContainerError::CrcMismatch,
+                            "a wrong declared CRC value is rejected");
+    }
+    {
+        auto manifest = manifestEntry("{\"m\":1}");
+        ArchiveWriter writer;
+        const auto manifestOffset = writer.appendLocal(manifest);
+        const auto document = documentEntry();
+        const auto documentOffset = writer.appendLocal(document);
+        const auto centralStart = writer.size();
+        writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+        writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+        const auto centralSize = writer.size() - centralStart;
+        writer.appendEocd(0, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                          static_cast<std::uint32_t>(centralStart));
+        auto bytes = writer.bytes();
+        // Corrupt one payload byte in place (stored: compressed bytes equal the payload bytes)
+        // while the declared CRC keeps naming the original, uncorrupted content. The data region
+        // starts right after the fixed 30-byte local header, the name, and the (empty) extra field.
+        const auto manifestDataOffset =
+            manifestOffset + 30 + manifest.localName.size() + manifest.localExtra.size();
+        bytes[manifestDataOffset] ^= std::byte{0x01};
+        const auto result = readZipContainer(asSpan(bytes), ZipContainerLimits{}, makeOperation());
+        expectations.expect(!result && result.error() == ZipContainerError::CrcMismatch,
+                            "corrupted payload bytes are rejected even when every header field is "
+                            "internally consistent");
+    }
+}
+
+void testBudgetExhaustion(Expectations& expectations) {
+    const auto archive =
+        buildConformingArchive(manifestEntry("{\"m\":1}"), documentEntry("{\"d\":1}"));
+    {
+        const auto operation = makeOperation(1024); // below even the working reservation.
+        auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, operation);
+        expectations.expect(!result && result.error() == ZipContainerError::ResourceExhausted,
+                            "a budget far below the required working reservation is rejected");
+        expectations.expect(operation.snapshot().currentBytes == 0,
+                            "a rejected operation leaves no leaked charge behind");
+    }
+    {
+        // Large enough for the working reservation to succeed, too small for the destination
+        // buffers: exercises the reservation being released again after a later allocation fails.
+        constexpr std::uint64_t kJustOverWorkingReservation = (4ULL << 20U) + 8;
+        const auto operation = makeOperation(kJustOverWorkingReservation);
+        auto result = readZipContainer(asSpan(archive), ZipContainerLimits{}, operation);
+        expectations.expect(!result && result.error() == ZipContainerError::ResourceExhausted,
+                            "a budget that only covers the working reservation still fails on the "
+                            "destination buffers");
+        expectations.expect(operation.snapshot().currentBytes == 0,
+                            "the working reservation is released even after it succeeded first");
+    }
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testConformingStoredExtraction(expectations);
+        testConformingDeflateAndMixedExtraction(expectations);
+        testEmptyPayloadExtraction(expectations);
+        testPreflightRejectionPropagates(expectations);
+        testInvalidLimits(expectations);
+        testExpandedSizeMismatchOnBomb(expectations);
+        testUnderProductionMismatch(expectations);
+        testQualifiedReaderDisagreementOnInvalidDeflateStream(expectations);
+        testCrcMismatch(expectations);
+        testBudgetExhaustion(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "FAILED: test fixture exception: " << error.what() << '\n';
+        return 1;
+    }
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/project/zip_container.cpp
+++ b/src/project/zip_container.cpp
@@ -1,0 +1,334 @@
+#include <bloom/project/zip_container.hpp>
+
+#include "zip_container_preflight.hpp"
+
+#include <zip.h>
+#include <zlib.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <memory_resource>
+#include <new>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace bloom::project {
+
+ZipContainerDocument::ZipContainerDocument(std::unique_ptr<ProjectIoMemoryResource> resource,
+                                           std::pmr::vector<std::byte> manifest,
+                                           std::pmr::vector<std::byte> document) noexcept
+    : resource_(std::move(resource)), manifest_(std::move(manifest)),
+      document_(std::move(document)) {}
+
+} // namespace bloom::project
+
+namespace bloom::project::detail {
+
+namespace {
+
+[[nodiscard]] ZipContainerError
+translatePreflightError(const ZipContainerPreflightError error) noexcept {
+    switch (error) {
+    case ZipContainerPreflightError::None:
+        return ZipContainerError::None;
+    case ZipContainerPreflightError::InvalidLimits:
+        return ZipContainerError::InvalidLimits;
+    case ZipContainerPreflightError::ArchiveTooLarge:
+        return ZipContainerError::ArchiveTooLarge;
+    case ZipContainerPreflightError::ArchiveTruncated:
+        return ZipContainerError::ArchiveTruncated;
+    case ZipContainerPreflightError::MissingOrMalformedEocd:
+        return ZipContainerError::MissingOrMalformedEocd;
+    case ZipContainerPreflightError::ArchiveCommentForbidden:
+        return ZipContainerError::ArchiveCommentForbidden;
+    case ZipContainerPreflightError::MultiDiskForbidden:
+        return ZipContainerError::MultiDiskForbidden;
+    case ZipContainerPreflightError::WrongEntryCount:
+        return ZipContainerError::WrongEntryCount;
+    case ZipContainerPreflightError::WrongEntryName:
+        return ZipContainerError::WrongEntryName;
+    case ZipContainerPreflightError::WrongEntryOrder:
+        return ZipContainerError::WrongEntryOrder;
+    case ZipContainerPreflightError::Utf8FlagMissing:
+        return ZipContainerError::Utf8FlagMissing;
+    case ZipContainerPreflightError::ForbiddenGeneralPurposeFlag:
+        return ZipContainerError::ForbiddenGeneralPurposeFlag;
+    case ZipContainerPreflightError::UnsupportedCompressionMethod:
+        return ZipContainerError::UnsupportedCompressionMethod;
+    case ZipContainerPreflightError::ExtraFieldForbidden:
+        return ZipContainerError::ExtraFieldForbidden;
+    case ZipContainerPreflightError::EntryCommentForbidden:
+        return ZipContainerError::EntryCommentForbidden;
+    case ZipContainerPreflightError::Zip64Forbidden:
+        return ZipContainerError::Zip64Forbidden;
+    case ZipContainerPreflightError::LocalCentralHeaderDisagreement:
+        return ZipContainerError::LocalCentralHeaderDisagreement;
+    case ZipContainerPreflightError::OverlappingOrUnaccountedByteRange:
+        return ZipContainerError::OverlappingOrUnaccountedByteRange;
+    case ZipContainerPreflightError::NonRegularEntry:
+        return ZipContainerError::NonRegularEntry;
+    case ZipContainerPreflightError::ExecutableEntry:
+        return ZipContainerError::ExecutableEntry;
+    case ZipContainerPreflightError::ExpandedSizeLimitExceeded:
+        return ZipContainerError::ExpandedSizeLimitExceeded;
+    case ZipContainerPreflightError::ExpansionRatioExceeded:
+        return ZipContainerError::ExpansionRatioExceeded;
+    case ZipContainerPreflightError::StoredSizeMismatch:
+        return ZipContainerError::StoredSizeMismatch;
+    case ZipContainerPreflightError::SizeOverflow:
+        return ZipContainerError::SizeOverflow;
+    }
+    return ZipContainerError::QualifiedReaderDisagreement;
+}
+
+// Conservative worst-case reservation for libzip/zlib's own working memory while opening the
+// source and extracting the two entries: zlib's raw-deflate inflate window is bounded at 32 KiB
+// (max windowBits 15), and libzip additionally keeps its zip_t/zip_source_t bookkeeping, a
+// zip_stat_t per entry, and a modest internal buffer per open zip_file_t -- all well under a few
+// hundred KiB for a strictly two-entry archive. 4 MiB stays generous across libzip point releases
+// without charging a meaningful fraction of the default 1 GiB per-operation budget.
+constexpr std::uint64_t kQualifiedReaderWorkingReservationBytes = 4ULL << 20U;
+
+[[nodiscard]] bool statMatches(const zip_stat_t& stat, const ZipContainerPreflightEntry& entry,
+                               const std::string_view expectedName) noexcept {
+    constexpr auto kRequiredFields =
+        ZIP_STAT_NAME | ZIP_STAT_SIZE | ZIP_STAT_COMP_SIZE | ZIP_STAT_CRC | ZIP_STAT_COMP_METHOD;
+    if ((stat.valid & kRequiredFields) != kRequiredFields) {
+        return false;
+    }
+    if (stat.name == nullptr || expectedName != std::string_view(stat.name)) {
+        return false;
+    }
+    return stat.size == entry.uncompressedSize && stat.comp_size == entry.compressedSize &&
+           stat.crc == entry.crc32Value &&
+           static_cast<std::uint16_t>(stat.comp_method) == entry.method;
+}
+
+} // namespace
+
+// The friend declared by bloom::project::zip_container.hpp names bloom::project::detail's own
+// ZipContainerBuilder, so this class must live directly in this namespace rather than the
+// anonymous namespace above (mirrors strict_json_dom.cpp's StrictJsonDomBuilder placement).
+class ZipContainerBuilder final {
+  public:
+    [[nodiscard]] static ZipContainerReadResult read(std::span<const std::byte> archive,
+                                                     const ZipContainerLimits& limits,
+                                                     ProjectIoOperationMemory operation) noexcept;
+
+  private:
+    [[nodiscard]] static ZipContainerReadResult makeFailure(ZipContainerError error,
+                                                            std::size_t byteOffset) noexcept;
+    [[nodiscard]] static ZipContainerReadResult makeSuccess(ZipContainerDocument document) noexcept;
+
+    // Not noexcept: sizing the destination buffer and reading into it are ordinary std::pmr::vector
+    // operations bound to ProjectIoMemoryResource's throwing memory_resource surface. A budget
+    // rejection here must propagate as std::bad_alloc to read()'s try/catch.
+    [[nodiscard]] static bool extractEntry(zip_t* archiveHandle, zip_uint64_t index,
+                                           const ZipContainerPreflightEntry& entry,
+                                           std::string_view expectedName,
+                                           std::pmr::vector<std::byte>& outBuffer,
+                                           ZipContainerError& error);
+};
+
+bool ZipContainerBuilder::extractEntry(zip_t* const archiveHandle, const zip_uint64_t index,
+                                       const ZipContainerPreflightEntry& entry,
+                                       const std::string_view expectedName,
+                                       std::pmr::vector<std::byte>& outBuffer,
+                                       ZipContainerError& error) {
+    outBuffer.resize(entry.uncompressedSize);
+
+    zip_stat_t stat{};
+    zip_stat_init(&stat);
+    if (zip_stat_index(archiveHandle, index, 0, &stat) != 0 ||
+        !statMatches(stat, entry, expectedName)) {
+        error = ZipContainerError::QualifiedReaderDisagreement;
+        return false;
+    }
+
+    zip_file_t* const file = zip_fopen_index(archiveHandle, index, 0);
+    if (file == nullptr) {
+        error = ZipContainerError::QualifiedReaderDisagreement;
+        return false;
+    }
+    struct FileGuard final {
+        zip_file_t* handle;
+        ~FileGuard() { zip_fclose(handle); }
+    } fileGuard{file};
+
+    if (!outBuffer.empty()) {
+        const auto readBytes = zip_fread(file, outBuffer.data(), outBuffer.size());
+        if (readBytes < 0) {
+            error = ZipContainerError::QualifiedReaderDisagreement;
+            return false;
+        }
+        if (static_cast<std::uint64_t>(readBytes) != outBuffer.size()) {
+            error = ZipContainerError::ExpandedSizeMismatch;
+            return false;
+        }
+    }
+
+    // A trailing probe read: the destination buffer is exactly the declared uncompressed size, so
+    // it can never be written past regardless of how much decompressed data the stream actually
+    // holds. A stream that keeps producing bytes past its declared size is caught here, not by an
+    // out-of-bounds write. libzip verifies its own internal running CRC exactly when it detects
+    // EOF, so a mismatched CRC surfaces as a failed *read* here (ZIP_ER_CRC) rather than as a
+    // clean zero-byte EOF. That failure alone is never trusted as the verification (per contract,
+    // libzip's internal check is welcome redundancy, not authoritative): it is treated as
+    // equivalent to reaching EOF and deferred to the independent CRC-32 comparison below, which
+    // is computed with the qualified zlib crc32_z() over the buffer this code fully controls and
+    // is the actual source of any reported CrcMismatch. Any other negative probe read is a
+    // genuine, unrelated qualified-reader disagreement.
+    std::array<std::byte, 1> probe{};
+    const auto probeRead = zip_fread(file, probe.data(), probe.size());
+    if (probeRead < 0) {
+        const auto* const fileError = zip_file_get_error(file);
+        if (fileError == nullptr || zip_error_code_zip(fileError) != ZIP_ER_CRC) {
+            error = ZipContainerError::QualifiedReaderDisagreement;
+            return false;
+        }
+    } else if (probeRead != 0) {
+        error = ZipContainerError::ExpandedSizeMismatch;
+        return false;
+    }
+
+    const auto computedCrc =
+        crc32_z(0L, reinterpret_cast<const Bytef*>(outBuffer.data()), outBuffer.size());
+    if (static_cast<std::uint32_t>(computedCrc) != entry.crc32Value) {
+        error = ZipContainerError::CrcMismatch;
+        return false;
+    }
+    return true;
+}
+
+ZipContainerReadResult ZipContainerBuilder::read(const std::span<const std::byte> archive,
+                                                 const ZipContainerLimits& limits,
+                                                 ProjectIoOperationMemory operation) noexcept {
+    if (limits.maxArchiveBytes == 0 || limits.maxManifestBytes == 0 ||
+        limits.maxDocumentBytes == 0 || limits.maxTotalExpandedBytes == 0 ||
+        limits.maxExpansionRatio == 0) {
+        return makeFailure(ZipContainerError::InvalidLimits, 0);
+    }
+
+    const ZipContainerPreflightLimits preflightLimits{
+        .maxArchiveBytes = limits.maxArchiveBytes,
+        .maxManifestBytes = limits.maxManifestBytes,
+        .maxDocumentBytes = limits.maxDocumentBytes,
+        .maxTotalExpandedBytes = limits.maxTotalExpandedBytes,
+        .maxExpansionRatio = limits.maxExpansionRatio,
+    };
+    const auto preflight = preflightZipContainer(archive, preflightLimits);
+    if (!preflight.succeeded()) {
+        return makeFailure(translatePreflightError(preflight.error), preflight.byteOffset);
+    }
+
+    try {
+        // Reserve libzip/zlib's worst-case working memory before any dependency call, per the
+        // contract that unmetered dependency allocation is not permitted; held for the duration
+        // of every libzip call below and released by RAII on every return path.
+        auto workingReservationResult = operation.reserve(kQualifiedReaderWorkingReservationBytes);
+        if (!workingReservationResult) {
+            return makeFailure(ZipContainerError::ResourceExhausted, 0);
+        }
+        auto workingReservation = std::move(workingReservationResult).takeReservation();
+
+        std::unique_ptr<ProjectIoMemoryResource> resource;
+        try {
+            resource = std::make_unique<ProjectIoMemoryResource>(std::move(operation));
+        } catch (const std::bad_alloc&) {
+            return makeFailure(ZipContainerError::ResourceExhausted, 0);
+        }
+
+        std::pmr::vector<std::byte> manifestBuffer(resource.get());
+        std::pmr::vector<std::byte> documentBuffer(resource.get());
+
+        zip_error_t zipError{};
+        zip_error_init(&zipError);
+        zip_source_t* const source =
+            zip_source_buffer_create(archive.data(), archive.size(), 0, &zipError);
+        if (source == nullptr) {
+            zip_error_fini(&zipError);
+            return makeFailure(ZipContainerError::QualifiedReaderDisagreement, 0);
+        }
+        zip_t* const archiveHandle =
+            zip_open_from_source(source, ZIP_RDONLY | ZIP_CHECKCONS, &zipError);
+        zip_error_fini(&zipError);
+        if (archiveHandle == nullptr) {
+            // zip_open_from_source() did not take ownership on failure; the source must be freed
+            // here or it leaks.
+            zip_source_free(source);
+            return makeFailure(ZipContainerError::QualifiedReaderDisagreement, 0);
+        }
+        // On success, libzip keeps its own reference to `source` and frees it when the archive is
+        // closed or discarded; freeing it here as well would be a use of a resource libzip still
+        // owns.
+
+        struct ArchiveGuard final {
+            zip_t* handle;
+            ~ArchiveGuard() {
+                if (handle != nullptr) {
+                    zip_discard(handle);
+                }
+            }
+        } archiveGuard{archiveHandle};
+
+        if (zip_get_num_entries(archiveHandle, 0) != 2) {
+            return makeFailure(ZipContainerError::QualifiedReaderDisagreement, 0);
+        }
+
+        ZipContainerError extractionError = ZipContainerError::None;
+        if (!extractEntry(archiveHandle, 0, preflight.manifest, "manifest.json", manifestBuffer,
+                          extractionError) ||
+            !extractEntry(archiveHandle, 1, preflight.document, "document.json", documentBuffer,
+                          extractionError)) {
+            return makeFailure(extractionError, 0);
+        }
+
+        if (zip_close(archiveHandle) != 0) {
+            // Every read already succeeded on a read-only archive; a close failure here is the
+            // qualified reader disagreeing with its own established state. archiveGuard still owns
+            // `handle` and discards it below.
+            return makeFailure(ZipContainerError::QualifiedReaderDisagreement, 0);
+        }
+        // zip_close() already freed the handle on success; the guard must not discard it again.
+        archiveGuard.handle = nullptr;
+
+        ZipContainerDocument document(std::move(resource), std::move(manifestBuffer),
+                                      std::move(documentBuffer));
+        return makeSuccess(std::move(document));
+    } catch (const std::bad_alloc&) {
+        return makeFailure(ZipContainerError::ResourceExhausted, 0);
+    } catch (...) {
+        return makeFailure(ZipContainerError::QualifiedReaderDisagreement, 0);
+    }
+}
+
+ZipContainerReadResult ZipContainerBuilder::makeFailure(const ZipContainerError error,
+                                                        const std::size_t byteOffset) noexcept {
+    ZipContainerReadResult result;
+    result.error_ = error;
+    result.byteOffset_ = byteOffset;
+    return result;
+}
+
+ZipContainerReadResult ZipContainerBuilder::makeSuccess(ZipContainerDocument document) noexcept {
+    ZipContainerReadResult result;
+    result.error_ = ZipContainerError::None;
+    result.document_.emplace(std::move(document));
+    return result;
+}
+
+} // namespace bloom::project::detail
+
+namespace bloom::project {
+
+ZipContainerReadResult readZipContainer(const std::span<const std::byte> archive,
+                                        const ZipContainerLimits& limits,
+                                        ProjectIoOperationMemory operation) noexcept {
+    return detail::ZipContainerBuilder::read(archive, limits, std::move(operation));
+}
+
+} // namespace bloom::project

--- a/src/project/zip_container_preflight.cpp
+++ b/src/project/zip_container_preflight.cpp
@@ -1,0 +1,617 @@
+#include "zip_container_preflight.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string_view>
+
+namespace {
+
+using bloom::project::detail::ZipContainerPreflightEntry;
+using bloom::project::detail::ZipContainerPreflightError;
+using bloom::project::detail::ZipContainerPreflightLimits;
+using bloom::project::detail::ZipContainerPreflightResult;
+
+constexpr std::uint32_t kLocalFileHeaderSignature = 0x04034b50U;
+constexpr std::uint32_t kCentralDirectorySignature = 0x02014b50U;
+constexpr std::uint32_t kEndOfCentralDirectorySignature = 0x06054b50U;
+constexpr std::uint64_t kLocalHeaderFixedBytes = 30;
+constexpr std::uint64_t kCentralHeaderFixedBytes = 46;
+constexpr std::uint64_t kEocdFixedBytes = 22;
+constexpr std::uint64_t kEocdMaximumCommentLength = 0xFFFFU;
+constexpr std::uint16_t kZip64Sentinel16 = 0xFFFFU;
+constexpr std::uint32_t kZip64Sentinel32 = 0xFFFFFFFFU;
+constexpr std::uint16_t kUtf8FlagBit = 0x0800U;
+constexpr std::uint16_t kMethodStored = 0;
+constexpr std::uint16_t kMethodDeflate = 8;
+constexpr std::string_view kManifestName = "manifest.json";
+constexpr std::string_view kDocumentName = "document.json";
+
+[[nodiscard]] constexpr bool checkedAdd(const std::uint64_t left, const std::uint64_t right,
+                                        std::uint64_t& result) noexcept {
+    if (right > std::numeric_limits<std::uint64_t>::max() - left) {
+        return false;
+    }
+    result = left + right;
+    return true;
+}
+
+[[nodiscard]] constexpr bool checkedMul(const std::uint64_t left, const std::uint64_t right,
+                                        std::uint64_t& result) noexcept {
+    if (left != 0 && right > std::numeric_limits<std::uint64_t>::max() / left) {
+        return false;
+    }
+    result = left * right;
+    return true;
+}
+
+[[nodiscard]] std::uint8_t byteValue(const std::byte value) noexcept {
+    return std::to_integer<std::uint8_t>(value);
+}
+
+// One fully decoded local file header: every field this profile inspects, plus the resolved data
+// byte range (checked, in-bounds by construction of advance()).
+struct LocalHeader final {
+    std::uint64_t offset = 0;
+    std::uint16_t flags = 0;
+    std::uint16_t method = 0;
+    std::uint32_t crc32Value = 0;
+    std::uint32_t compressedSize = 0;
+    std::uint32_t uncompressedSize = 0;
+    std::string_view name;
+    std::uint64_t dataOffset = 0;
+    std::uint64_t dataEnd = 0;
+};
+
+// One fully decoded central directory file header.
+struct CentralEntry final {
+    std::uint64_t offset = 0;
+    std::uint16_t versionMadeBy = 0;
+    std::uint16_t flags = 0;
+    std::uint16_t method = 0;
+    std::uint32_t crc32Value = 0;
+    std::uint32_t compressedSize = 0;
+    std::uint32_t uncompressedSize = 0;
+    std::string_view name;
+    std::uint16_t diskNumberStart = 0;
+    std::uint32_t externalAttrs = 0;
+    std::uint32_t localHeaderOffset = 0;
+    std::uint64_t entryEnd = 0;
+};
+
+struct EocdInfo final {
+    std::uint64_t offset = 0;
+    std::uint16_t diskNumber = 0;
+    std::uint16_t diskWithCd = 0;
+    std::uint16_t entriesThisDisk = 0;
+    std::uint16_t entriesTotal = 0;
+    std::uint32_t cdSize = 0;
+    std::uint32_t cdOffset = 0;
+};
+
+class Scanner final {
+  public:
+    Scanner(const std::span<const std::byte> archive,
+            const ZipContainerPreflightLimits limits) noexcept
+        : archive_(archive), limits_(limits) {}
+
+    [[nodiscard]] ZipContainerPreflightResult run() noexcept;
+
+  private:
+    [[nodiscard]] bool limitsAreValid() const noexcept {
+        return limits_.maxArchiveBytes != 0 && limits_.maxManifestBytes != 0 &&
+               limits_.maxDocumentBytes != 0 && limits_.maxTotalExpandedBytes != 0 &&
+               limits_.maxExpansionRatio != 0;
+    }
+
+    [[nodiscard]] std::uint16_t readU16(const std::uint64_t offset) const noexcept {
+        return static_cast<std::uint16_t>(
+            static_cast<std::uint16_t>(byteValue(archive_[offset])) |
+            (static_cast<std::uint16_t>(byteValue(archive_[offset + 1])) << 8U));
+    }
+
+    [[nodiscard]] std::uint32_t readU32(const std::uint64_t offset) const noexcept {
+        return static_cast<std::uint32_t>(byteValue(archive_[offset])) |
+               (static_cast<std::uint32_t>(byteValue(archive_[offset + 1])) << 8U) |
+               (static_cast<std::uint32_t>(byteValue(archive_[offset + 2])) << 16U) |
+               (static_cast<std::uint32_t>(byteValue(archive_[offset + 3])) << 24U);
+    }
+
+    [[nodiscard]] std::string_view viewBytes(const std::uint64_t offset,
+                                             const std::uint64_t length) const noexcept {
+        // Archive bytes are proven in-bounds by every caller via advance() before this is
+        // invoked; std::byte and char share the same object representation, so this reinterpret
+        // is the standard way to hand a contiguous byte range to string_view for exact
+        // byte-for-byte name comparison.
+        return {reinterpret_cast<const char*>(archive_.data()) + offset, length};
+    }
+
+    // Advances `cursor` by `amount`, checked against arithmetic overflow and the archive's true
+    // size. Every structural offset in this scanner is derived exclusively through this helper so
+    // no field is ever read out of bounds.
+    [[nodiscard]] bool advance(std::uint64_t& cursor, const std::uint64_t amount) noexcept {
+        std::uint64_t next = 0;
+        if (!checkedAdd(cursor, amount, next)) {
+            setError(ZipContainerPreflightError::SizeOverflow, cursor);
+            return false;
+        }
+        if (next > archive_.size()) {
+            setError(ZipContainerPreflightError::ArchiveTruncated, archive_.size());
+            return false;
+        }
+        cursor = next;
+        return true;
+    }
+
+    void setError(const ZipContainerPreflightError error, const std::uint64_t offset) noexcept {
+        error_ = error;
+        byteOffset_ = offset;
+    }
+
+    [[nodiscard]] ZipContainerPreflightResult currentFailure() const noexcept {
+        return {.error = error_, .byteOffset = static_cast<std::size_t>(byteOffset_)};
+    }
+
+    [[nodiscard]] bool locateEocd(EocdInfo& out) noexcept;
+    [[nodiscard]] bool validateEocdFields(const EocdInfo& eocd) noexcept;
+    [[nodiscard]] bool parseLocalHeader(std::uint64_t offset, LocalHeader& out) noexcept;
+    [[nodiscard]] bool parseCentralEntry(std::uint64_t offset, CentralEntry& out) noexcept;
+    [[nodiscard]] bool checkGeneralPurposeFlag(std::uint16_t flags, std::uint64_t offset) noexcept;
+    [[nodiscard]] bool checkMethod(std::uint16_t method, std::uint64_t offset) noexcept;
+    [[nodiscard]] bool checkStoredConsistency(std::uint16_t method, std::uint32_t compressedSize,
+                                              std::uint32_t uncompressedSize,
+                                              std::uint64_t offset) noexcept;
+    [[nodiscard]] bool resolveNames(std::string_view firstName, std::string_view secondName,
+                                    std::uint64_t firstOffset, std::uint64_t secondOffset) noexcept;
+    [[nodiscard]] bool checkAgreement(const LocalHeader& local, const CentralEntry& central,
+                                      std::uint64_t expectedLocalOffset) noexcept;
+    [[nodiscard]] bool checkAttributes(const CentralEntry& central) noexcept;
+    [[nodiscard]] bool checkRatio(const ZipContainerPreflightEntry& entry) noexcept;
+    [[nodiscard]] bool checkLimits(const ZipContainerPreflightEntry& manifest,
+                                   const ZipContainerPreflightEntry& document) noexcept;
+
+    std::span<const std::byte> archive_;
+    ZipContainerPreflightLimits limits_;
+    ZipContainerPreflightError error_ = ZipContainerPreflightError::None;
+    std::uint64_t byteOffset_ = 0;
+};
+
+bool Scanner::locateEocd(EocdInfo& out) noexcept {
+    const auto size = static_cast<std::uint64_t>(archive_.size());
+    const auto maxBack = kEocdFixedBytes + kEocdMaximumCommentLength;
+    const auto scanFloor = size > maxBack ? size - maxBack : 0;
+    auto candidate = size - kEocdFixedBytes;
+    while (true) {
+        if (readU32(candidate) == kEndOfCentralDirectorySignature) {
+            const auto commentLength = readU16(candidate + 20);
+            if (candidate + kEocdFixedBytes + commentLength == size) {
+                if (commentLength != 0) {
+                    setError(ZipContainerPreflightError::ArchiveCommentForbidden, candidate);
+                    return false;
+                }
+                out.offset = candidate;
+                out.diskNumber = readU16(candidate + 4);
+                out.diskWithCd = readU16(candidate + 6);
+                out.entriesThisDisk = readU16(candidate + 8);
+                out.entriesTotal = readU16(candidate + 10);
+                out.cdSize = readU32(candidate + 12);
+                out.cdOffset = readU32(candidate + 16);
+                return true;
+            }
+        }
+        if (candidate == scanFloor) {
+            break;
+        }
+        --candidate;
+    }
+    setError(ZipContainerPreflightError::MissingOrMalformedEocd, size - kEocdFixedBytes);
+    return false;
+}
+
+bool Scanner::validateEocdFields(const EocdInfo& eocd) noexcept {
+    if (eocd.diskNumber != 0 || eocd.diskWithCd != 0) {
+        setError(ZipContainerPreflightError::MultiDiskForbidden, eocd.offset + 4);
+        return false;
+    }
+    if (eocd.entriesThisDisk == kZip64Sentinel16 || eocd.entriesTotal == kZip64Sentinel16 ||
+        eocd.cdSize == kZip64Sentinel32 || eocd.cdOffset == kZip64Sentinel32) {
+        setError(ZipContainerPreflightError::Zip64Forbidden, eocd.offset);
+        return false;
+    }
+    if (eocd.entriesThisDisk != 2 || eocd.entriesTotal != 2) {
+        setError(ZipContainerPreflightError::WrongEntryCount, eocd.offset + 8);
+        return false;
+    }
+    return true;
+}
+
+bool Scanner::checkGeneralPurposeFlag(const std::uint16_t flags,
+                                      const std::uint64_t offset) noexcept {
+    if (flags == kUtf8FlagBit) {
+        return true;
+    }
+    if (flags == 0) {
+        setError(ZipContainerPreflightError::Utf8FlagMissing, offset);
+        return false;
+    }
+    setError(ZipContainerPreflightError::ForbiddenGeneralPurposeFlag, offset);
+    return false;
+}
+
+bool Scanner::checkMethod(const std::uint16_t method, const std::uint64_t offset) noexcept {
+    if (method == kMethodStored || method == kMethodDeflate) {
+        return true;
+    }
+    setError(ZipContainerPreflightError::UnsupportedCompressionMethod, offset);
+    return false;
+}
+
+bool Scanner::checkStoredConsistency(const std::uint16_t method, const std::uint32_t compressedSize,
+                                     const std::uint32_t uncompressedSize,
+                                     const std::uint64_t offset) noexcept {
+    if (method == kMethodStored && compressedSize != uncompressedSize) {
+        setError(ZipContainerPreflightError::StoredSizeMismatch, offset);
+        return false;
+    }
+    return true;
+}
+
+bool Scanner::parseLocalHeader(const std::uint64_t offset, LocalHeader& out) noexcept {
+    std::uint64_t cursor = offset;
+    if (!advance(cursor, kLocalHeaderFixedBytes)) {
+        return false;
+    }
+    if (readU32(offset) != kLocalFileHeaderSignature) {
+        setError(ZipContainerPreflightError::OverlappingOrUnaccountedByteRange, offset);
+        return false;
+    }
+    const auto flags = readU16(offset + 6);
+    const auto method = readU16(offset + 8);
+    const auto crc32Value = readU32(offset + 14);
+    const auto compressedSize = readU32(offset + 18);
+    const auto uncompressedSize = readU32(offset + 22);
+    const auto nameLength = readU16(offset + 26);
+    const auto extraLength = readU16(offset + 28);
+
+    const auto nameStart = cursor;
+    if (!advance(cursor, nameLength)) {
+        return false;
+    }
+    const auto name = viewBytes(nameStart, nameLength);
+    if (!advance(cursor, extraLength)) {
+        return false;
+    }
+    const auto dataStart = cursor;
+    if (!advance(cursor, compressedSize)) {
+        return false;
+    }
+
+    if (!checkGeneralPurposeFlag(flags, offset)) {
+        return false;
+    }
+    if (!checkMethod(method, offset)) {
+        return false;
+    }
+    if (compressedSize == kZip64Sentinel32 || uncompressedSize == kZip64Sentinel32) {
+        setError(ZipContainerPreflightError::Zip64Forbidden, offset);
+        return false;
+    }
+    if (!checkStoredConsistency(method, compressedSize, uncompressedSize, offset)) {
+        return false;
+    }
+    if (extraLength != 0) {
+        setError(ZipContainerPreflightError::ExtraFieldForbidden, offset);
+        return false;
+    }
+
+    out = LocalHeader{
+        .offset = offset,
+        .flags = flags,
+        .method = method,
+        .crc32Value = crc32Value,
+        .compressedSize = compressedSize,
+        .uncompressedSize = uncompressedSize,
+        .name = name,
+        .dataOffset = dataStart,
+        .dataEnd = cursor,
+    };
+    return true;
+}
+
+bool Scanner::parseCentralEntry(const std::uint64_t offset, CentralEntry& out) noexcept {
+    std::uint64_t cursor = offset;
+    if (!advance(cursor, kCentralHeaderFixedBytes)) {
+        return false;
+    }
+    if (readU32(offset) != kCentralDirectorySignature) {
+        setError(ZipContainerPreflightError::OverlappingOrUnaccountedByteRange, offset);
+        return false;
+    }
+    const auto versionMadeBy = readU16(offset + 4);
+    const auto flags = readU16(offset + 8);
+    const auto method = readU16(offset + 10);
+    const auto crc32Value = readU32(offset + 16);
+    const auto compressedSize = readU32(offset + 20);
+    const auto uncompressedSize = readU32(offset + 24);
+    const auto nameLength = readU16(offset + 28);
+    const auto extraLength = readU16(offset + 30);
+    const auto commentLength = readU16(offset + 32);
+    const auto diskNumberStart = readU16(offset + 34);
+    const auto externalAttrs = readU32(offset + 38);
+    const auto localHeaderOffset = readU32(offset + 42);
+
+    const auto nameStart = cursor;
+    if (!advance(cursor, nameLength)) {
+        return false;
+    }
+    const auto name = viewBytes(nameStart, nameLength);
+    if (!advance(cursor, extraLength)) {
+        return false;
+    }
+    if (!advance(cursor, commentLength)) {
+        return false;
+    }
+
+    if (!checkGeneralPurposeFlag(flags, offset)) {
+        return false;
+    }
+    if (!checkMethod(method, offset)) {
+        return false;
+    }
+    if (compressedSize == kZip64Sentinel32 || uncompressedSize == kZip64Sentinel32 ||
+        localHeaderOffset == kZip64Sentinel32) {
+        setError(ZipContainerPreflightError::Zip64Forbidden, offset);
+        return false;
+    }
+    if (!checkStoredConsistency(method, compressedSize, uncompressedSize, offset)) {
+        return false;
+    }
+    if (extraLength != 0) {
+        setError(ZipContainerPreflightError::ExtraFieldForbidden, offset);
+        return false;
+    }
+    if (commentLength != 0) {
+        setError(ZipContainerPreflightError::EntryCommentForbidden, offset);
+        return false;
+    }
+
+    out = CentralEntry{
+        .offset = offset,
+        .versionMadeBy = versionMadeBy,
+        .flags = flags,
+        .method = method,
+        .crc32Value = crc32Value,
+        .compressedSize = compressedSize,
+        .uncompressedSize = uncompressedSize,
+        .name = name,
+        .diskNumberStart = diskNumberStart,
+        .externalAttrs = externalAttrs,
+        .localHeaderOffset = localHeaderOffset,
+        .entryEnd = cursor,
+    };
+    return true;
+}
+
+bool Scanner::resolveNames(const std::string_view firstName, const std::string_view secondName,
+                           const std::uint64_t firstOffset,
+                           const std::uint64_t secondOffset) noexcept {
+    if (firstName == kManifestName && secondName == kDocumentName) {
+        return true;
+    }
+    if (firstName == kDocumentName && secondName == kManifestName) {
+        setError(ZipContainerPreflightError::WrongEntryOrder, secondOffset);
+        return false;
+    }
+    setError(ZipContainerPreflightError::WrongEntryName, firstOffset);
+    return false;
+}
+
+bool Scanner::checkAgreement(const LocalHeader& local, const CentralEntry& central,
+                             const std::uint64_t expectedLocalOffset) noexcept {
+    if (local.name != central.name || local.flags != central.flags ||
+        local.method != central.method || local.crc32Value != central.crc32Value ||
+        local.compressedSize != central.compressedSize ||
+        local.uncompressedSize != central.uncompressedSize ||
+        central.localHeaderOffset != expectedLocalOffset) {
+        setError(ZipContainerPreflightError::LocalCentralHeaderDisagreement, central.offset);
+        return false;
+    }
+    return true;
+}
+
+bool Scanner::checkAttributes(const CentralEntry& central) noexcept {
+    constexpr std::uint8_t kHostUnix = 3;
+    constexpr std::uint32_t kUnixFileTypeRegular = 0x8U;
+    constexpr std::uint32_t kUnixExecuteBits = 0111U;
+    constexpr std::uint32_t kDosDirectoryBit = 0x10U;
+
+    // The DOS-compatible low attribute byte is checked unconditionally, on every host: many zip
+    // tools populate it regardless of the primary host they declare, so a crafted entry cannot
+    // claim Unix host with clean Unix mode type/execute bits while still smuggling the DOS
+    // directory bit through in the same external-attributes field.
+    if ((central.externalAttrs & kDosDirectoryBit) != 0) {
+        setError(ZipContainerPreflightError::NonRegularEntry, central.offset);
+        return false;
+    }
+
+    const auto host = static_cast<std::uint8_t>(central.versionMadeBy >> 8U);
+    if (host == kHostUnix) {
+        const auto mode = central.externalAttrs >> 16U;
+        const auto fileType = (mode >> 12U) & 0xFU;
+        if (fileType != 0 && fileType != kUnixFileTypeRegular) {
+            setError(ZipContainerPreflightError::NonRegularEntry, central.offset);
+            return false;
+        }
+        if ((mode & kUnixExecuteBits) != 0) {
+            setError(ZipContainerPreflightError::ExecutableEntry, central.offset);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool Scanner::checkRatio(const ZipContainerPreflightEntry& entry) noexcept {
+    const auto denominator = std::max<std::uint64_t>(1, entry.compressedSize);
+    std::uint64_t allowedMaximum = 0;
+    if (!checkedMul(limits_.maxExpansionRatio, denominator, allowedMaximum)) {
+        setError(ZipContainerPreflightError::SizeOverflow, entry.localHeaderOffset);
+        return false;
+    }
+    if (entry.uncompressedSize > allowedMaximum) {
+        setError(ZipContainerPreflightError::ExpansionRatioExceeded, entry.localHeaderOffset);
+        return false;
+    }
+    return true;
+}
+
+bool Scanner::checkLimits(const ZipContainerPreflightEntry& manifest,
+                          const ZipContainerPreflightEntry& document) noexcept {
+    if (manifest.uncompressedSize > limits_.maxManifestBytes) {
+        setError(ZipContainerPreflightError::ExpandedSizeLimitExceeded, manifest.localHeaderOffset);
+        return false;
+    }
+    if (document.uncompressedSize > limits_.maxDocumentBytes) {
+        setError(ZipContainerPreflightError::ExpandedSizeLimitExceeded, document.localHeaderOffset);
+        return false;
+    }
+    std::uint64_t total = 0;
+    if (!checkedAdd(manifest.uncompressedSize, document.uncompressedSize, total)) {
+        setError(ZipContainerPreflightError::SizeOverflow, 0);
+        return false;
+    }
+    if (total > limits_.maxTotalExpandedBytes) {
+        setError(ZipContainerPreflightError::ExpandedSizeLimitExceeded, 0);
+        return false;
+    }
+    if (!checkRatio(manifest)) {
+        return false;
+    }
+    if (!checkRatio(document)) {
+        return false;
+    }
+    return true;
+}
+
+ZipContainerPreflightResult Scanner::run() noexcept {
+    if (!limitsAreValid()) {
+        setError(ZipContainerPreflightError::InvalidLimits, 0);
+        return currentFailure();
+    }
+    const auto size = static_cast<std::uint64_t>(archive_.size());
+    if (size > limits_.maxArchiveBytes) {
+        setError(ZipContainerPreflightError::ArchiveTooLarge, limits_.maxArchiveBytes);
+        return currentFailure();
+    }
+    if (size < kEocdFixedBytes) {
+        setError(ZipContainerPreflightError::ArchiveTruncated, size);
+        return currentFailure();
+    }
+
+    EocdInfo eocd{};
+    if (!locateEocd(eocd)) {
+        return currentFailure();
+    }
+    if (!validateEocdFields(eocd)) {
+        return currentFailure();
+    }
+
+    LocalHeader localA{};
+    if (!parseLocalHeader(0, localA)) {
+        return currentFailure();
+    }
+    LocalHeader localB{};
+    if (!parseLocalHeader(localA.dataEnd, localB)) {
+        return currentFailure();
+    }
+    if (!resolveNames(localA.name, localB.name, localA.offset, localB.offset)) {
+        return currentFailure();
+    }
+
+    CentralEntry centralA{};
+    if (!parseCentralEntry(localB.dataEnd, centralA)) {
+        return currentFailure();
+    }
+    CentralEntry centralB{};
+    if (!parseCentralEntry(centralA.entryEnd, centralB)) {
+        return currentFailure();
+    }
+    if (!resolveNames(centralA.name, centralB.name, centralA.offset, centralB.offset)) {
+        return currentFailure();
+    }
+
+    const auto centralDirectoryStart = localB.dataEnd;
+    const auto centralDirectoryEnd = centralB.entryEnd;
+    if (eocd.cdOffset != centralDirectoryStart ||
+        eocd.cdSize != centralDirectoryEnd - centralDirectoryStart) {
+        setError(ZipContainerPreflightError::OverlappingOrUnaccountedByteRange,
+                 centralDirectoryStart);
+        return currentFailure();
+    }
+    if (centralDirectoryEnd != eocd.offset) {
+        setError(ZipContainerPreflightError::OverlappingOrUnaccountedByteRange,
+                 centralDirectoryEnd);
+        return currentFailure();
+    }
+
+    if (!checkAgreement(localA, centralA, 0)) {
+        return currentFailure();
+    }
+    if (!checkAgreement(localB, centralB, localA.dataEnd)) {
+        return currentFailure();
+    }
+    if (!checkAttributes(centralA)) {
+        return currentFailure();
+    }
+    if (!checkAttributes(centralB)) {
+        return currentFailure();
+    }
+    if (centralA.diskNumberStart != 0) {
+        setError(ZipContainerPreflightError::MultiDiskForbidden, centralA.offset + 34);
+        return currentFailure();
+    }
+    if (centralB.diskNumberStart != 0) {
+        setError(ZipContainerPreflightError::MultiDiskForbidden, centralB.offset + 34);
+        return currentFailure();
+    }
+
+    ZipContainerPreflightEntry manifest{
+        .localHeaderOffset = 0,
+        .dataOffset = localA.dataOffset,
+        .compressedSize = localA.compressedSize,
+        .uncompressedSize = localA.uncompressedSize,
+        .crc32Value = localA.crc32Value,
+        .method = localA.method,
+    };
+    ZipContainerPreflightEntry document{
+        .localHeaderOffset = localA.dataEnd,
+        .dataOffset = localB.dataOffset,
+        .compressedSize = localB.compressedSize,
+        .uncompressedSize = localB.uncompressedSize,
+        .crc32Value = localB.crc32Value,
+        .method = localB.method,
+    };
+    if (!checkLimits(manifest, document)) {
+        return currentFailure();
+    }
+
+    return {
+        .error = ZipContainerPreflightError::None,
+        .byteOffset = archive_.size(),
+        .manifest = manifest,
+        .document = document,
+    };
+}
+
+} // namespace
+
+namespace bloom::project::detail {
+
+ZipContainerPreflightResult
+preflightZipContainer(const std::span<const std::byte> archive,
+                      const ZipContainerPreflightLimits& limits) noexcept {
+    return Scanner(archive, limits).run();
+}
+
+} // namespace bloom::project::detail

--- a/src/project/zip_container_preflight.hpp
+++ b/src/project/zip_container_preflight.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace bloom::project::detail {
+
+// Mirrors bloom::project::ZipContainerLimits exactly; kept as an independent type (rather than
+// reusing the public struct) so this raw scanner has no dependency on the public header, matching
+// strict_json_preflight.hpp's separation from strict_json_dom.hpp.
+struct ZipContainerPreflightLimits final {
+    std::uint64_t maxArchiveBytes = 272629760;
+    std::uint64_t maxManifestBytes = 1048576;
+    std::uint64_t maxDocumentBytes = 268435456;
+    std::uint64_t maxTotalExpandedBytes = 269484032;
+    std::uint64_t maxExpansionRatio = 1000;
+};
+
+// A strict subset of bloom::project::ZipContainerError: every value here has a exact translation
+// in the public enum; the public enum additionally has extraction-stage-only values
+// (ExpandedSizeMismatch, CrcMismatch, ResourceExhausted, QualifiedReaderDisagreement) that this
+// allocation-free, libzip-free scanner can never produce.
+enum class ZipContainerPreflightError : std::uint8_t {
+    None,
+    InvalidLimits,
+    ArchiveTooLarge,
+    ArchiveTruncated,
+    MissingOrMalformedEocd,
+    ArchiveCommentForbidden,
+    MultiDiskForbidden,
+    WrongEntryCount,
+    WrongEntryName,
+    WrongEntryOrder,
+    Utf8FlagMissing,
+    ForbiddenGeneralPurposeFlag,
+    UnsupportedCompressionMethod,
+    ExtraFieldForbidden,
+    EntryCommentForbidden,
+    Zip64Forbidden,
+    LocalCentralHeaderDisagreement,
+    OverlappingOrUnaccountedByteRange,
+    NonRegularEntry,
+    ExecutableEntry,
+    ExpandedSizeLimitExceeded,
+    ExpansionRatioExceeded,
+    StoredSizeMismatch,
+    SizeOverflow,
+};
+
+// The exact byte range and declared metadata the preflight established for one entry, handed to
+// the extraction stage so it can charge the destination buffer and cross-check every fact libzip
+// reports rather than trusting it blindly.
+struct ZipContainerPreflightEntry final {
+    std::uint64_t localHeaderOffset = 0;
+    std::uint64_t dataOffset = 0;
+    std::uint32_t compressedSize = 0;
+    std::uint32_t uncompressedSize = 0;
+    std::uint32_t crc32Value = 0;
+    std::uint16_t method = 0;
+};
+
+struct ZipContainerPreflightResult final {
+    ZipContainerPreflightError error = ZipContainerPreflightError::InvalidLimits;
+    std::size_t byteOffset = 0;
+    ZipContainerPreflightEntry manifest{};
+    ZipContainerPreflightEntry document{};
+
+    [[nodiscard]] constexpr bool succeeded() const noexcept {
+        return error == ZipContainerPreflightError::None;
+    }
+    [[nodiscard]] explicit constexpr operator bool() const noexcept { return succeeded(); }
+};
+
+// Performs only strict, allocation-free structural validation of the Constrained ZIP Profile
+// (docs/architecture/project-format.md, "Constrained ZIP Profile" + "Resource Limits") against
+// raw archive bytes: no libzip call, no decompression, and no entry payload byte is inspected
+// (only header fields). Success proves an exact, non-overlapping, fully-accounted byte layout for
+// exactly two regular-file entries named "manifest.json" then "document.json" and returns their
+// declared metadata; it is not itself a trusted extraction. The scanner allocates nothing and
+// retains no reference to `archive` past the call.
+[[nodiscard]] ZipContainerPreflightResult
+preflightZipContainer(std::span<const std::byte> archive,
+                      const ZipContainerPreflightLimits& limits) noexcept;
+
+} // namespace bloom::project::detail


### PR DESCRIPTION
Closes #42.

The Constrained ZIP Profile container reader (`readZipContainer`): archive bytes in, the two expanded entry byte buffers out, or a typed rejection naming the exact profile violation.

**Preflight before trust**: a raw, allocation-free scanner proves the archive is a conforming two-entry container before any qualified-library call — EOCD at the exact end with zero comment, exact byte accounting (no prepended, trailing, gap, or overlapping bytes can be accepted), the `manifest.json`/`document.json` allowlist in order at local and central level, UTF-8-only flags, stored/deflate only, no descriptors/extra fields/comments/encryption/multi-disk/ZIP64, full local/central agreement, regular non-executable entries, and all v1 resource limits checked with overflow-safe arithmetic before allocation.

**Bounded qualified extraction**: libzip confined to one translation unit, a documented worst-case working-memory reservation charged before any dependency call, destination buffers bounded by the Project I/O operation budget and never given more capacity than declared (bombs surface as typed mismatches, not overruns), every libzip-reported fact cross-checked against the preflight, and each entry's CRC-32 verified independently with the qualified zlib over the fully expanded bytes.

**Qualified resolution hardening**: libzip's package config resolves ZLIB in module mode, which the existing per-package restriction did not cover; qualified mode now pins that transitive lookup to the validated prefix and fails the configure if resolution escapes it.

Testing: 30 test functions across two suites over a hand-rolled byte-level archive builder; every typed error pinned by at least one adversarial fixture; budget exhaustion leaves zero leaked charges; extraction byte-exact and deterministic. Full ci-linux-native suite 59/59 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (one review round).