### PR TITLE
feat: write constrained zip containers

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(
         zip_container.cpp
         zip_container_preflight.cpp
         zip_container_preflight.hpp
+        zip_container_writer.cpp
     PUBLIC
         FILE_SET HEADERS
         BASE_DIRS include
@@ -47,6 +48,7 @@ target_sources(
             include/bloom/project/strict_json_dom.hpp
             include/bloom/project/unknown_json_number.hpp
             include/bloom/project/zip_container.hpp
+            include/bloom/project/zip_container_writer.hpp
 )
 
 target_compile_features(bloom_project PUBLIC cxx_std_20)
@@ -240,6 +242,22 @@ if(BUILD_TESTING)
     bloom_add_test(
         NAME bloom.project.zip_container
         COMMAND bloom_project_zip_container_test
+        LABELS unit project persistence security
+    )
+
+    add_executable(bloom_project_zip_container_writer_test tests/zip_container_writer_tests.cpp)
+    target_include_directories(
+        bloom_project_zip_container_writer_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_project_zip_container_writer_test
+        PRIVATE bloom_project ZLIB::ZLIB
+    )
+    bloom_enable_warnings(bloom_project_zip_container_writer_test)
+    bloom_add_test(
+        NAME bloom.project.zip_container_writer
+        COMMAND bloom_project_zip_container_writer_test
         LABELS unit project persistence security
     )
 endif()

--- a/src/project/include/bloom/project/zip_container_writer.hpp
+++ b/src/project/include/bloom/project/zip_container_writer.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/project_io_memory_resource.hpp>
+#include <bloom/project/zip_container.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <memory_resource>
+#include <optional>
+#include <span>
+#include <vector>
+
+// The Constrained ZIP Profile container writer, per docs/architecture/project-format.md
+// ("Constrained ZIP Profile" + "Resource Limits"). `writeZipContainer()` hand-assembles the fixed
+// two-entry ("manifest.json" then "document.json") archive layout byte-by-byte and uses the
+// qualified zlib (`deflateInit2` with negative windowBits for a raw stream, level 6) confined to
+// zip_container_writer.cpp for compression and `crc32_z` for entry CRCs. It never calls libzip: the
+// profile makes the writer's exact field bytes (flags 0x0800, zero extra fields, DOS epoch, mode
+// 0644) contractual against the strict reader, and libzip's emission details are not controllable
+// to that precision. Every written archive is accepted by `readZipContainer()` with default limits
+// by construction (the refusal rules below make a rejected-by-the-reader output unreachable); the
+// writer itself never runs the reader in production.
+
+namespace bloom::project {
+
+namespace detail {
+class ZipContainerWriteBuilder;
+} // namespace detail
+
+enum class ZipContainerWriteError : std::uint8_t {
+    None,
+    InvalidLimits,
+    // manifest or document payload exceeds its per-entry expanded-size limit; see entryInError().
+    EntrySizeLimitExceeded,
+    TotalExpandedLimitExceeded,
+    ArchiveSizeLimitExceeded,
+    SizeOverflow,
+    ResourceExhausted,
+    // The qualified zlib compressor reported a failure this writer cannot interpret. Fail closed:
+    // never emit a suspect archive.
+    QualifiedCompressorFailure,
+};
+
+// Names which entry an EntrySizeLimitExceeded failure names; None for every other error.
+enum class ZipContainerWriteEntry : std::uint8_t {
+    None,
+    Manifest,
+    Document,
+};
+
+// The successfully written archive's bytes, owning its PMR resource behind a stable heap address
+// (mirrors ZipContainerDocument) so moving the result never invalidates the byte buffer's
+// allocator state.
+class ZipContainerArchive final {
+  public:
+    ZipContainerArchive(const ZipContainerArchive&) = delete;
+    ZipContainerArchive& operator=(const ZipContainerArchive&) = delete;
+    ZipContainerArchive(ZipContainerArchive&&) noexcept = default;
+    ZipContainerArchive& operator=(ZipContainerArchive&&) noexcept = default;
+    ~ZipContainerArchive() = default;
+
+    [[nodiscard]] std::span<const std::byte> bytes() const noexcept {
+        return {bytes_.data(), bytes_.size()};
+    }
+
+  private:
+    friend class detail::ZipContainerWriteBuilder;
+
+    ZipContainerArchive(std::unique_ptr<ProjectIoMemoryResource> resource,
+                        std::pmr::vector<std::byte> bytes) noexcept;
+
+    std::unique_ptr<ProjectIoMemoryResource> resource_;
+    std::pmr::vector<std::byte> bytes_;
+};
+
+// [[nodiscard]] failure-aware result. On success, archive() names the assembled bytes; on failure,
+// error() names the typed cause and entryInError() additionally names the offending entry for
+// EntrySizeLimitExceeded (None otherwise).
+class [[nodiscard]] ZipContainerWriteResult final {
+  public:
+    ZipContainerWriteResult(const ZipContainerWriteResult&) = delete;
+    ZipContainerWriteResult& operator=(const ZipContainerWriteResult&) = delete;
+    ZipContainerWriteResult(ZipContainerWriteResult&&) noexcept = default;
+    ZipContainerWriteResult& operator=(ZipContainerWriteResult&&) noexcept = default;
+    ~ZipContainerWriteResult() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error_ == ZipContainerWriteError::None;
+    }
+    [[nodiscard]] ZipContainerWriteError error() const noexcept { return error_; }
+    [[nodiscard]] ZipContainerWriteEntry entryInError() const noexcept { return entry_; }
+    [[nodiscard]] const ZipContainerArchive* archive() const& noexcept {
+        return archive_.has_value() ? &*archive_ : nullptr;
+    }
+    [[nodiscard]] const ZipContainerArchive* archive() const&& = delete;
+
+  private:
+    friend class detail::ZipContainerWriteBuilder;
+
+    ZipContainerWriteResult() noexcept = default;
+
+    std::optional<ZipContainerArchive> archive_;
+    ZipContainerWriteError error_ = ZipContainerWriteError::InvalidLimits;
+    ZipContainerWriteEntry entry_ = ZipContainerWriteEntry::None;
+};
+
+// Builds a Constrained ZIP Profile archive from `manifest` and `document` bytes, refusing to build
+// one outside `limits` (checked arithmetic throughout; overflow is SizeOverflow, never a wrapped
+// smaller value) so every returned archive is accepted by readZipContainer() with default limits.
+// Per entry, deflate (level 6) is attempted first; the entry falls back to stored (method 0) when
+// deflate would not reduce it or would exceed the permitted expansion ratio. Charges the output
+// archive buffer, any intermediate deflate buffer, and a documented worst-case reservation for
+// zlib's internal deflate working memory through `operation`. Budget rejection is reported as
+// ResourceExhausted rather than throwing or falling back to unmetered heap allocation. Never
+// throws.
+[[nodiscard]] ZipContainerWriteResult
+writeZipContainer(std::span<const std::byte> manifest, std::span<const std::byte> document,
+                  const ZipContainerLimits& limits, ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::project

--- a/src/project/tests/zip_container_writer_tests.cpp
+++ b/src/project/tests/zip_container_writer_tests.cpp
@@ -1,0 +1,505 @@
+#include <bloom/project/zip_container.hpp>
+#include <bloom/project/zip_container_writer.hpp>
+
+#include "zip_container_preflight.hpp"
+#include "zip_container_test_support.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <source_location>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::readZipContainer;
+using bloom::project::writeZipContainer;
+using bloom::project::ZipContainerLimits;
+using bloom::project::ZipContainerWriteEntry;
+using bloom::project::ZipContainerWriteError;
+using bloom::project::detail::preflightZipContainer;
+using bloom::project::detail::ZipContainerPreflightLimits;
+using bloom::project::test::crc32Of;
+using bloom::project::test::toBytes;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 16ULL << 20U; // 16 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory
+makeOperation(const std::uint64_t limitBytes = kGenerousOperationBudget) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        throw std::runtime_error("failed to create test memory coordinator");
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        throw std::runtime_error("failed to create test operation memory");
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::span<const std::byte> asSpan(const std::vector<std::byte>& bytes) noexcept {
+    return {bytes.data(), bytes.size()};
+}
+
+// A deterministic, high-avalanche byte stream (splitmix64) standing in for "incompressible data"
+// -- no std::random_device or time-based seed, so the fixture is exactly reproducible.
+[[nodiscard]] std::uint64_t splitmix64Next(std::uint64_t& state) noexcept {
+    state += 0x9E3779B97F4A7C15ULL;
+    std::uint64_t mixed = state;
+    mixed = (mixed ^ (mixed >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    mixed = (mixed ^ (mixed >> 27U)) * 0x94D049BB133111EBULL;
+    return mixed ^ (mixed >> 31U);
+}
+
+[[nodiscard]] std::vector<std::byte> pseudoRandomBytes(const std::size_t count,
+                                                       const std::uint64_t seed) {
+    std::vector<std::byte> out;
+    out.reserve(count);
+    std::uint64_t state = seed;
+    while (out.size() < count) {
+        const auto value = splitmix64Next(state);
+        for (unsigned shift = 0; shift < 64U && out.size() < count; shift += 8U) {
+            out.push_back(static_cast<std::byte>((value >> shift) & 0xFFU));
+        }
+    }
+    return out;
+}
+
+// Hand-derives the exact expected bytes of a two-entry, both-stored Constrained ZIP Profile
+// archive directly from the layout rules in docs/architecture/project-format.md, independent of
+// the production writer, so the golden-bytes test proves the writer's actual field values rather
+// than its own logic against itself.
+//
+// Field map (identical for both entries' local and central headers):
+//   local header (30 bytes fixed + name):
+//     signature(4)=0x04034b50 | versionNeeded(2)=20 | flags(2)=0x0800 (UTF-8, exact)
+//     method(2)=0 (stored) | modTime(2)=0x0000 | modDate(2)=0x0021 (DOS epoch 1980-01-01)
+//     crc32(4) | compressedSize(4)=payload size | uncompressedSize(4)=payload size
+//     nameLength(2) | extraLength(2)=0 | name | payload bytes
+//   central header (46 bytes fixed + name):
+//     signature(4)=0x02014b50 | versionMadeBy(2)=0x0314 (Unix host 3, version 20)
+//     versionNeeded(2)=20 | flags(2)=0x0800 | method(2)=0 | modTime/modDate as above
+//     crc32(4) | compressedSize(4) | uncompressedSize(4) | nameLength(2)
+//     extraLength(2)=0 | commentLength(2)=0 | diskNumberStart(2)=0 | internalAttrs(2)=0
+//     externalAttrs(4)=0100644<<16 (regular, non-executable) | localHeaderOffset(4) | name
+//   EOCD (22 bytes fixed): signature(4)=0x06054b50 | diskNumber/diskWithCd(2+2)=0
+//     entriesThisDisk/entriesTotal(2+2)=2/2 | cdSize(4) | cdOffset(4) | commentLength(2)=0
+[[nodiscard]] std::vector<std::byte>
+buildExpectedStoredArchive(const std::string_view manifestPayload,
+                           const std::string_view documentPayload) {
+    constexpr std::string_view kManifestName = "manifest.json";
+    constexpr std::string_view kDocumentName = "document.json";
+    constexpr std::uint16_t kVersionNeeded = 20;
+    constexpr std::uint16_t kFlags = 0x0800;
+    constexpr std::uint16_t kMethodStored = 0;
+    constexpr std::uint16_t kModTime = 0x0000;
+    constexpr std::uint16_t kModDate = 0x0021;
+    constexpr std::uint16_t kVersionMadeBy = 0x0314;
+    constexpr std::uint32_t kExternalAttrs = 0100644U << 16U;
+
+    std::vector<std::byte> out;
+    const auto putU16 = [&out](const std::uint16_t value) {
+        out.push_back(static_cast<std::byte>(value & 0xFFU));
+        out.push_back(static_cast<std::byte>((value >> 8U) & 0xFFU));
+    };
+    const auto putU32 = [&out](const std::uint32_t value) {
+        for (unsigned shift = 0; shift < 32U; shift += 8U) {
+            out.push_back(static_cast<std::byte>((value >> shift) & 0xFFU));
+        }
+    };
+    const auto putText = [&out](const std::string_view text) {
+        for (const char character : text) {
+            out.push_back(static_cast<std::byte>(static_cast<unsigned char>(character)));
+        }
+    };
+    const auto putLocalHeader = [&](const std::string_view name, const std::string_view payload,
+                                    const std::uint32_t crc) {
+        putU32(0x04034b50U);
+        putU16(kVersionNeeded);
+        putU16(kFlags);
+        putU16(kMethodStored);
+        putU16(kModTime);
+        putU16(kModDate);
+        putU32(crc);
+        putU32(static_cast<std::uint32_t>(payload.size()));
+        putU32(static_cast<std::uint32_t>(payload.size()));
+        putU16(static_cast<std::uint16_t>(name.size()));
+        putU16(0);
+        putText(name);
+        putText(payload);
+    };
+    const auto putCentralHeader = [&](const std::string_view name, const std::string_view payload,
+                                      const std::uint32_t crc,
+                                      const std::uint32_t localHeaderOffset) {
+        putU32(0x02014b50U);
+        putU16(kVersionMadeBy);
+        putU16(kVersionNeeded);
+        putU16(kFlags);
+        putU16(kMethodStored);
+        putU16(kModTime);
+        putU16(kModDate);
+        putU32(crc);
+        putU32(static_cast<std::uint32_t>(payload.size()));
+        putU32(static_cast<std::uint32_t>(payload.size()));
+        putU16(static_cast<std::uint16_t>(name.size()));
+        putU16(0);
+        putU16(0);
+        putU16(0);
+        putU16(0);
+        putU32(kExternalAttrs);
+        putU32(localHeaderOffset);
+        putText(name);
+    };
+
+    const auto manifestCrc = crc32Of(toBytes(manifestPayload));
+    const auto documentCrc = crc32Of(toBytes(documentPayload));
+
+    const auto manifestLocalOffset = static_cast<std::uint32_t>(out.size());
+    putLocalHeader(kManifestName, manifestPayload, manifestCrc);
+    const auto documentLocalOffset = static_cast<std::uint32_t>(out.size());
+    putLocalHeader(kDocumentName, documentPayload, documentCrc);
+
+    const auto centralStart = static_cast<std::uint32_t>(out.size());
+    putCentralHeader(kManifestName, manifestPayload, manifestCrc, manifestLocalOffset);
+    putCentralHeader(kDocumentName, documentPayload, documentCrc, documentLocalOffset);
+    const auto centralEnd = static_cast<std::uint32_t>(out.size());
+
+    putU32(0x06054b50U);
+    putU16(0);
+    putU16(0);
+    putU16(2);
+    putU16(2);
+    putU32(centralEnd - centralStart);
+    putU32(centralStart);
+    putU16(0);
+
+    return out;
+}
+
+void testGoldenBytesAndDeterminism(Expectations& expectations) {
+    // "{}" deflates to more bytes than it is (raw-deflate overhead exceeds two source bytes), so
+    // the stored-fallback rule naturally picks method 0 for both entries -- a genuine exercise of
+    // the fallback logic, not a hand-picked stored-only shortcut.
+    const std::string manifestPayload = "{}";
+    const std::string documentPayload = "{}";
+    const auto expected = buildExpectedStoredArchive(manifestPayload, documentPayload);
+
+    auto first = writeZipContainer(toBytes(manifestPayload), toBytes(documentPayload),
+                                   ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(first), "a minimal two-entry archive is written");
+    if (first && first.archive() != nullptr) {
+        const auto bytes = first.archive()->bytes();
+        expectations.expect(
+            std::equal(bytes.begin(), bytes.end(), expected.begin(), expected.end()),
+            "the minimal archive matches the hand-derived golden bytes exactly");
+    }
+
+    auto second = writeZipContainer(toBytes(manifestPayload), toBytes(documentPayload),
+                                    ZipContainerLimits{}, makeOperation());
+    if (first.archive() != nullptr && second.archive() != nullptr) {
+        const auto bytes1 = first.archive()->bytes();
+        const auto bytes2 = second.archive()->bytes();
+        expectations.expect(std::equal(bytes1.begin(), bytes1.end(), bytes2.begin(), bytes2.end()),
+                            "two stored-entry writes of the same input produce byte-identical "
+                            "archives");
+    }
+
+    // Determinism also holds for deflate output: same qualified zlib, same level, same input.
+    const std::string compressible(4000, 'z');
+    auto deflateFirst = writeZipContainer(toBytes(compressible), toBytes(compressible),
+                                          ZipContainerLimits{}, makeOperation());
+    auto deflateSecond = writeZipContainer(toBytes(compressible), toBytes(compressible),
+                                           ZipContainerLimits{}, makeOperation());
+    if (deflateFirst && deflateSecond && deflateFirst.archive() != nullptr &&
+        deflateSecond.archive() != nullptr) {
+        const auto bytes1 = deflateFirst.archive()->bytes();
+        const auto bytes2 = deflateSecond.archive()->bytes();
+        expectations.expect(std::equal(bytes1.begin(), bytes1.end(), bytes2.begin(), bytes2.end()),
+                            "two deflate-entry writes of the same input produce byte-identical "
+                            "archives");
+    }
+}
+
+void expectRoundTrip(Expectations& expectations, const std::span<const std::byte> manifest,
+                     const std::span<const std::byte> document, const std::string_view writeMessage,
+                     const std::string_view readMessage, const std::string_view manifestMessage,
+                     const std::string_view documentMessage) {
+    auto writeResult = writeZipContainer(manifest, document, ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(writeResult), writeMessage);
+    if (!writeResult || writeResult.archive() == nullptr) {
+        return;
+    }
+    const auto archiveBytes = writeResult.archive()->bytes();
+    auto readResult = readZipContainer(archiveBytes, ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(readResult), readMessage);
+    if (!readResult || readResult.document() == nullptr) {
+        return;
+    }
+    const auto readManifest = readResult.document()->manifestBytes();
+    const auto readDocument = readResult.document()->documentBytes();
+    expectations.expect(
+        std::equal(readManifest.begin(), readManifest.end(), manifest.begin(), manifest.end()),
+        manifestMessage);
+    expectations.expect(
+        std::equal(readDocument.begin(), readDocument.end(), document.begin(), document.end()),
+        documentMessage);
+}
+
+void testRoundTripStored(Expectations& expectations) {
+    const std::string manifestPayload = "{\"manifest\":true}";
+    const std::string documentPayload = "{\"document\":true}";
+    expectRoundTrip(expectations, toBytes(manifestPayload), toBytes(documentPayload),
+                    "a small stored-eligible archive is written",
+                    "the stored archive is accepted by the reader",
+                    "the stored manifest round-trips byte-exact",
+                    "the stored document round-trips byte-exact");
+}
+
+void testRoundTripDeflate(Expectations& expectations) {
+    // Moderately compressible JSON-shaped text: deflate shrinks it well under the 1000:1 ceiling,
+    // so this exercises the ordinary (non-fallback) deflate path.
+    std::string payload;
+    payload.reserve(6000);
+    for (int index = 0; index < 200; ++index) {
+        payload += "{\"key\":\"value\",\"index\":" + std::to_string(index % 37) + "},";
+    }
+    expectRoundTrip(expectations, toBytes(payload), toBytes(payload),
+                    "a compressible deflate-eligible archive is written",
+                    "the deflate archive is accepted by the reader",
+                    "the deflated manifest round-trips byte-exact",
+                    "the deflated document round-trips byte-exact");
+}
+
+void testRoundTripMixed(Expectations& expectations) {
+    const std::string manifestPayload = "{}"; // stores naturally.
+    std::string documentPayload;
+    documentPayload.reserve(5000);
+    for (int index = 0; index < 150; ++index) {
+        documentPayload += "{\"layer\":\"solid\",\"n\":" + std::to_string(index % 11) + "},";
+    }
+    expectRoundTrip(expectations, toBytes(manifestPayload), toBytes(documentPayload),
+                    "a mixed stored/deflate archive is written",
+                    "the mixed archive is accepted by the reader",
+                    "the stored manifest in a mixed archive round-trips byte-exact",
+                    "the deflated document in a mixed archive round-trips byte-exact");
+}
+
+void testRoundTripEmptyPayload(Expectations& expectations) {
+    expectRoundTrip(expectations, toBytes(""), toBytes("{}"),
+                    "an archive with a zero-byte manifest is written",
+                    "the empty-manifest archive is accepted by the reader",
+                    "the zero-byte manifest round-trips to an empty buffer",
+                    "the document alongside an empty manifest round-trips byte-exact");
+    expectRoundTrip(expectations, toBytes("{}"), toBytes(""),
+                    "an archive with a zero-byte document is written",
+                    "the empty-document archive is accepted by the reader",
+                    "the manifest alongside an empty document round-trips byte-exact",
+                    "the zero-byte document round-trips to an empty buffer");
+}
+
+void expectStoredFallback(Expectations& expectations, const std::span<const std::byte> manifest,
+                          const std::span<const std::byte> document,
+                          const bool expectManifestStored, const bool expectDocumentStored,
+                          const std::string_view writeMessage, const std::string_view methodMessage,
+                          const std::string_view readMessage) {
+    auto writeResult = writeZipContainer(manifest, document, ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(writeResult), writeMessage);
+    if (!writeResult || writeResult.archive() == nullptr) {
+        return;
+    }
+    const auto archiveBytes = writeResult.archive()->bytes();
+
+    const auto preflight = preflightZipContainer(archiveBytes, ZipContainerPreflightLimits{});
+    expectations.expect(preflight.succeeded(), "the fallback archive's own header layout is well "
+                                               "formed");
+    if (preflight.succeeded()) {
+        if (expectManifestStored) {
+            expectations.expect(preflight.manifest.method == 0, methodMessage);
+        }
+        if (expectDocumentStored) {
+            expectations.expect(preflight.document.method == 0, methodMessage);
+        }
+    }
+
+    auto readResult = readZipContainer(archiveBytes, ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(readResult), readMessage);
+}
+
+void testStoredFallbackIncompressiblePayload(Expectations& expectations) {
+    // Trigger (a): deflate does not reduce a genuinely incompressible payload, so the manifest
+    // entry stores instead (well under the default 1 MiB manifest cap).
+    const auto manifest = pseudoRandomBytes(65536, 0x1234'5678'9ABC'DEF0ULL);
+    const std::string document = "{}";
+    expectStoredFallback(
+        expectations, asSpan(manifest), toBytes(document), /*expectManifestStored=*/true,
+        /*expectDocumentStored=*/false,
+        "an archive with an incompressible manifest payload is written",
+        "the incompressible manifest chose stored (method 0) because deflate did not reduce it",
+        "the incompressible-manifest archive is accepted by the reader");
+}
+
+void testStoredFallbackHyperCompressiblePayload(Expectations& expectations) {
+    // Trigger (b): 2 MiB of one repeated byte deflates far below the 1000:1 ceiling, so the
+    // document entry stores instead even though deflate would shrink it. Placed in the document
+    // entry because the default manifest cap (1 MiB) is smaller than this payload.
+    const std::string manifest = "{}";
+    const std::vector<std::byte> document(2ULL * 1024 * 1024, std::byte{'A'});
+    expectStoredFallback(
+        expectations, toBytes(manifest), asSpan(document), /*expectManifestStored=*/false,
+        /*expectDocumentStored=*/true,
+        "an archive with a hyper-compressible document payload is written",
+        "the hyper-compressible document chose stored (method 0) because deflate would exceed "
+        "the expansion-ratio ceiling",
+        "the hyper-compressible-document archive is accepted by the reader");
+}
+
+void testRefusalInvalidLimits(Expectations& expectations) {
+    ZipContainerLimits limits{};
+    limits.maxExpansionRatio = 0;
+    auto result = writeZipContainer(toBytes("{}"), toBytes("{}"), limits, makeOperation());
+    expectations.expect(!result && result.error() == ZipContainerWriteError::InvalidLimits,
+                        "a zeroed limit field is rejected before any work begins");
+}
+
+void testRefusalEntrySizeLimitExceeded(Expectations& expectations) {
+    {
+        ZipContainerLimits limits{};
+        limits.maxManifestBytes = 4;
+        const std::string manifestPayload = "12345";
+        auto result =
+            writeZipContainer(toBytes(manifestPayload), toBytes("{}"), limits, makeOperation());
+        expectations.expect(
+            !result && result.error() == ZipContainerWriteError::EntrySizeLimitExceeded &&
+                result.entryInError() == ZipContainerWriteEntry::Manifest,
+            "a manifest payload over its per-entry cap is refused and names the manifest entry");
+    }
+    {
+        ZipContainerLimits limits{};
+        limits.maxDocumentBytes = 4;
+        const std::string documentPayload = "12345";
+        auto result =
+            writeZipContainer(toBytes("{}"), toBytes(documentPayload), limits, makeOperation());
+        expectations.expect(
+            !result && result.error() == ZipContainerWriteError::EntrySizeLimitExceeded &&
+                result.entryInError() == ZipContainerWriteEntry::Document,
+            "a document payload over its per-entry cap is refused and names the document entry");
+    }
+}
+
+void testRefusalTotalExpandedLimitExceeded(Expectations& expectations) {
+    ZipContainerLimits limits{};
+    limits.maxManifestBytes = 10;
+    limits.maxDocumentBytes = 10;
+    limits.maxTotalExpandedBytes = 15; // below 10 + 10, above either individual cap.
+    const std::string manifestPayload(10, 'm');
+    const std::string documentPayload(10, 'd');
+    auto result = writeZipContainer(toBytes(manifestPayload), toBytes(documentPayload), limits,
+                                    makeOperation());
+    expectations.expect(
+        !result && result.error() == ZipContainerWriteError::TotalExpandedLimitExceeded,
+        "a sum over the total-expanded cap is refused even though each entry fits its own cap");
+}
+
+void testRefusalArchiveSizeLimitExceeded(Expectations& expectations) {
+    ZipContainerLimits limits{};
+    limits.maxArchiveBytes = 50; // well under the ~230-byte minimum two-entry archive overhead.
+    auto result = writeZipContainer(toBytes("{}"), toBytes("{}"), limits, makeOperation());
+    expectations.expect(!result &&
+                            result.error() == ZipContainerWriteError::ArchiveSizeLimitExceeded,
+                        "an assembled archive over the archive-size cap is refused");
+}
+
+void testRefusalSizeOverflow(Expectations& expectations) {
+    ZipContainerLimits limits{};
+    limits.maxManifestBytes = std::numeric_limits<std::uint64_t>::max();
+    // A span reporting a size past the 32-bit ZIP field ceiling, backed by a tiny real buffer.
+    // The writer's 32-bit-fit check is the very first thing it does with this size and never
+    // dereferences payload bytes before returning, so this never reads past the real allocation.
+    constexpr std::array<std::byte, 4> tinyBacking{};
+    const std::span<const std::byte> oversizedManifest(
+        tinyBacking.data(), std::uint64_t{std::numeric_limits<std::uint32_t>::max()} + 1);
+    auto result = writeZipContainer(oversizedManifest, toBytes("{}"), limits, makeOperation());
+    expectations.expect(
+        !result && result.error() == ZipContainerWriteError::SizeOverflow,
+        "a declared payload size that cannot fit the 32-bit ZIP size fields is refused as "
+        "overflow rather than silently truncated");
+}
+
+void testBudgetExhaustion(Expectations& expectations) {
+    const std::string manifestPayload = "{\"m\":1}";
+    const std::string documentPayload = "{\"d\":1}";
+    {
+        const auto operation = makeOperation(1024); // below even the working reservation.
+        auto result = writeZipContainer(toBytes(manifestPayload), toBytes(documentPayload),
+                                        ZipContainerLimits{}, operation);
+        expectations.expect(!result && result.error() == ZipContainerWriteError::ResourceExhausted,
+                            "a budget far below the required working reservation is rejected");
+        expectations.expect(operation.snapshot().currentBytes == 0,
+                            "a rejected operation leaves no leaked charge behind");
+    }
+    {
+        // Large enough for the working reservation to succeed, too small for the destination
+        // buffers: exercises the reservation being released again after a later allocation
+        // fails.
+        constexpr std::uint64_t kJustOverWorkingReservation = (4ULL << 20U) + 8;
+        const auto operation = makeOperation(kJustOverWorkingReservation);
+        auto result = writeZipContainer(toBytes(manifestPayload), toBytes(documentPayload),
+                                        ZipContainerLimits{}, operation);
+        expectations.expect(!result && result.error() == ZipContainerWriteError::ResourceExhausted,
+                            "a budget that only covers the working reservation still fails on the "
+                            "destination buffers");
+        expectations.expect(operation.snapshot().currentBytes == 0,
+                            "the working reservation is released even after it succeeded first");
+    }
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testGoldenBytesAndDeterminism(expectations);
+        testRoundTripStored(expectations);
+        testRoundTripDeflate(expectations);
+        testRoundTripMixed(expectations);
+        testRoundTripEmptyPayload(expectations);
+        testStoredFallbackIncompressiblePayload(expectations);
+        testStoredFallbackHyperCompressiblePayload(expectations);
+        testRefusalInvalidLimits(expectations);
+        testRefusalEntrySizeLimitExceeded(expectations);
+        testRefusalTotalExpandedLimitExceeded(expectations);
+        testRefusalArchiveSizeLimitExceeded(expectations);
+        testRefusalSizeOverflow(expectations);
+        testBudgetExhaustion(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "FAILED: test fixture exception: " << error.what() << '\n';
+        return 1;
+    }
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/project/zip_container_writer.cpp
+++ b/src/project/zip_container_writer.cpp
@@ -1,0 +1,468 @@
+#include <bloom/project/zip_container_writer.hpp>
+
+#include <zlib.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <memory_resource>
+#include <new>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace bloom::project {
+
+ZipContainerArchive::ZipContainerArchive(std::unique_ptr<ProjectIoMemoryResource> resource,
+                                         std::pmr::vector<std::byte> bytes) noexcept
+    : resource_(std::move(resource)), bytes_(std::move(bytes)) {}
+
+} // namespace bloom::project
+
+namespace bloom::project::detail {
+
+namespace {
+
+constexpr std::uint32_t kLocalFileHeaderSignature = 0x04034b50U;
+constexpr std::uint32_t kCentralDirectorySignature = 0x02014b50U;
+constexpr std::uint32_t kEocdSignature = 0x06054b50U;
+constexpr std::uint64_t kLocalHeaderFixedBytes = 30;
+constexpr std::uint64_t kCentralHeaderFixedBytes = 46;
+constexpr std::uint64_t kEocdFixedBytes = 22;
+constexpr std::uint16_t kVersionNeeded = 20;
+// Exactly bit 11 (UTF-8 names), the only general-purpose flag the reader's preflight accepts, set
+// identically in every local and central header.
+constexpr std::uint16_t kGeneralPurposeFlags = 0x0800U;
+constexpr std::uint16_t kMethodStored = 0;
+constexpr std::uint16_t kMethodDeflate = 8;
+constexpr std::string_view kManifestName = "manifest.json";
+constexpr std::string_view kDocumentName = "document.json";
+// The largest value the 32-bit local/central-header size and offset fields can hold without a
+// ZIP64 extension, which this profile never emits.
+constexpr std::uint64_t kMaxZipFieldValue = std::numeric_limits<std::uint32_t>::max();
+
+// version made by: high byte 3 (Unix host, matching the reader's unconditional Unix-mode
+// attribute check), low byte the same version-needed spelling used everywhere else in this
+// profile.
+constexpr std::uint8_t kVersionMadeByHostUnix = 3;
+constexpr std::uint16_t kVersionMadeBy = static_cast<std::uint16_t>(
+    (static_cast<std::uint16_t>(kVersionMadeByHostUnix) << 8U) | kVersionNeeded);
+static_assert(kVersionMadeBy == 0x0314U);
+
+// External attributes: Unix mode 0644 (regular file, rw-r--r--, no executable bit) placed in the
+// high 16 bits, with the low DOS-compatible byte left zero so the reader's unconditional
+// DOS-directory-bit check never fires.
+constexpr std::uint32_t kRegularFileMode0644 = 0100644U;
+constexpr std::uint32_t kExternalAttributesRegularFile = kRegularFileMode0644 << 16U;
+static_assert(kExternalAttributesRegularFile == 0x81A40000U);
+
+// DOS epoch 1980-01-01 00:00:00 (docs/architecture/project-format.md, "Constrained ZIP Profile").
+// DOS time packs hour(5 bits) | minute(6 bits) | second/2(5 bits); midnight is all zero bits.
+constexpr std::uint16_t kDosModTime = 0x0000U;
+// DOS date packs (year-1980)(7 bits) | month(4 bits) | day(5 bits), 1-indexed month/day.
+constexpr std::uint16_t kDosEpochYearOffset = 0;
+constexpr std::uint16_t kDosEpochMonth = 1;
+constexpr std::uint16_t kDosEpochDay = 1;
+constexpr std::uint16_t kDosModDate =
+    static_cast<std::uint16_t>((kDosEpochYearOffset << 9U) | (kDosEpochMonth << 5U) | kDosEpochDay);
+static_assert(kDosModDate == 0x0021U);
+
+// Conservative worst-case reservation for zlib's own internal deflateInit2 working memory (raw
+// deflate, windowBits magnitude 15, memLevel 8): the documented zlib formula
+// (1 << (windowBits+2)) + (1 << (memLevel+9)) is ~256 KiB for these parameters; this stays
+// generous across zlib point releases and platform allocator overhead without charging a
+// meaningful fraction of the default 1 GiB per-operation budget. Held for the duration of every
+// deflateInit2/deflate/deflateEnd call below (both entries compress sequentially, one stream
+// live at a time, so a single reservation covers the whole operation).
+constexpr std::uint64_t kQualifiedWriterWorkingReservationBytes = 4ULL << 20U;
+
+[[nodiscard]] constexpr bool checkedAdd(const std::uint64_t left, const std::uint64_t right,
+                                        std::uint64_t& result) noexcept {
+    if (right > std::numeric_limits<std::uint64_t>::max() - left) {
+        return false;
+    }
+    result = left + right;
+    return true;
+}
+
+[[nodiscard]] constexpr bool checkedMul(const std::uint64_t left, const std::uint64_t right,
+                                        std::uint64_t& result) noexcept {
+    if (left != 0 && right > std::numeric_limits<std::uint64_t>::max() / left) {
+        return false;
+    }
+    result = left * right;
+    return true;
+}
+
+[[nodiscard]] std::span<const std::byte> nameBytes(const std::string_view name) noexcept {
+    return {reinterpret_cast<const std::byte*>(name.data()), name.size()};
+}
+
+// One entry's fully resolved on-disk representation: the method the stored-fallback rule chose,
+// the payload's CRC-32 and true uncompressed size, and the exact bytes to write after the local
+// header (the compressed stream, or the stored payload copy). `data` is also this function's
+// intermediate deflate-attempt buffer: encodeEntry() first sizes it as the deflate destination,
+// then either trims it in place (deflate kept) or replaces it with a stored copy (deflate
+// discarded), so every byte it ever holds is charged through the caller's resource.
+struct EncodedEntry final {
+    explicit EncodedEntry(std::pmr::memory_resource* const resource) : data(resource) {}
+
+    std::uint16_t method = kMethodStored;
+    std::uint32_t crc32Value = 0;
+    std::uint32_t uncompressedSize = 0;
+    std::pmr::vector<std::byte> data;
+};
+
+// Appends fixed-width little-endian fields and raw byte ranges to a pre-sized destination buffer,
+// checked against arithmetic overflow and the buffer's true size on every write (mirrors
+// zip_container_preflight.cpp's Scanner::advance()). A `false` return means the precomputed
+// layout and this writer's actual output disagree -- an internal invariant break, never a
+// legitimate runtime condition -- and every caller treats it as a fail-closed SizeOverflow rather
+// than writing past the buffer.
+class ArchiveWriter final {
+  public:
+    explicit ArchiveWriter(std::pmr::vector<std::byte>& destination) noexcept
+        : destination_(destination) {}
+
+    [[nodiscard]] std::uint64_t cursor() const noexcept { return cursor_; }
+
+    [[nodiscard]] bool putU16(const std::uint16_t value) noexcept {
+        const std::array<std::byte, 2> bytes{static_cast<std::byte>(value & 0xFFU),
+                                             static_cast<std::byte>((value >> 8U) & 0xFFU)};
+        return putBytes(bytes);
+    }
+
+    [[nodiscard]] bool putU32(const std::uint32_t value) noexcept {
+        const std::array<std::byte, 4> bytes{static_cast<std::byte>(value & 0xFFU),
+                                             static_cast<std::byte>((value >> 8U) & 0xFFU),
+                                             static_cast<std::byte>((value >> 16U) & 0xFFU),
+                                             static_cast<std::byte>((value >> 24U) & 0xFFU)};
+        return putBytes(bytes);
+    }
+
+    [[nodiscard]] bool putBytes(const std::span<const std::byte> bytes) noexcept {
+        std::uint64_t next = 0;
+        if (!checkedAdd(cursor_, bytes.size(), next) || next > destination_.size()) {
+            return false;
+        }
+        std::copy(bytes.begin(), bytes.end(),
+                  destination_.begin() + static_cast<std::ptrdiff_t>(cursor_));
+        cursor_ = next;
+        return true;
+    }
+
+  private:
+    std::pmr::vector<std::byte>& destination_;
+    std::uint64_t cursor_ = 0;
+};
+
+[[nodiscard]] bool writeLocalHeader(ArchiveWriter& writer, const std::string_view name,
+                                    const EncodedEntry& entry) noexcept {
+    return writer.putU32(kLocalFileHeaderSignature) && writer.putU16(kVersionNeeded) &&
+           writer.putU16(kGeneralPurposeFlags) && writer.putU16(entry.method) &&
+           writer.putU16(kDosModTime) && writer.putU16(kDosModDate) &&
+           writer.putU32(entry.crc32Value) &&
+           writer.putU32(static_cast<std::uint32_t>(entry.data.size())) &&
+           writer.putU32(entry.uncompressedSize) &&
+           writer.putU16(static_cast<std::uint16_t>(name.size())) && writer.putU16(0) &&
+           writer.putBytes(nameBytes(name));
+}
+
+[[nodiscard]] bool writeCentralHeader(ArchiveWriter& writer, const std::string_view name,
+                                      const EncodedEntry& entry,
+                                      const std::uint32_t localHeaderOffset) noexcept {
+    return writer.putU32(kCentralDirectorySignature) && writer.putU16(kVersionMadeBy) &&
+           writer.putU16(kVersionNeeded) && writer.putU16(kGeneralPurposeFlags) &&
+           writer.putU16(entry.method) && writer.putU16(kDosModTime) &&
+           writer.putU16(kDosModDate) && writer.putU32(entry.crc32Value) &&
+           writer.putU32(static_cast<std::uint32_t>(entry.data.size())) &&
+           writer.putU32(entry.uncompressedSize) &&
+           writer.putU16(static_cast<std::uint16_t>(name.size())) &&
+           writer.putU16(0) /* extra length */ && writer.putU16(0) /* comment length */ &&
+           writer.putU16(0) /* disk number start */ && writer.putU16(0) /* internal attrs */ &&
+           writer.putU32(kExternalAttributesRegularFile) && writer.putU32(localHeaderOffset) &&
+           writer.putBytes(nameBytes(name));
+}
+
+// Fixed archive overhead: two 30-byte local headers plus their exact names, two 46-byte central
+// headers plus the same names (no extra field or comment anywhere), and one 22-byte EOCD with a
+// zero-length comment.
+[[nodiscard]] bool computeArchiveSize(const std::uint64_t manifestDataSize,
+                                      const std::uint64_t documentDataSize,
+                                      std::uint64_t& out) noexcept {
+    std::uint64_t total = kEocdFixedBytes;
+    std::uint64_t entryBytes = 0;
+    if (!checkedAdd(kLocalHeaderFixedBytes, kManifestName.size(), entryBytes) ||
+        !checkedAdd(total, entryBytes, total) || !checkedAdd(total, manifestDataSize, total)) {
+        return false;
+    }
+    if (!checkedAdd(kLocalHeaderFixedBytes, kDocumentName.size(), entryBytes) ||
+        !checkedAdd(total, entryBytes, total) || !checkedAdd(total, documentDataSize, total)) {
+        return false;
+    }
+    if (!checkedAdd(kCentralHeaderFixedBytes, kManifestName.size(), entryBytes) ||
+        !checkedAdd(total, entryBytes, total)) {
+        return false;
+    }
+    if (!checkedAdd(kCentralHeaderFixedBytes, kDocumentName.size(), entryBytes) ||
+        !checkedAdd(total, entryBytes, total)) {
+        return false;
+    }
+    out = total;
+    return true;
+}
+
+// Writes the complete archive -- manifest local header+data, document local header+data, central
+// directory (manifest then document), EOCD with counts 2/2 -- into a buffer already sized to
+// exactly computeArchiveSize()'s result. `false` means the precomputed size and the actual
+// written byte count disagree (see ArchiveWriter's contract above).
+[[nodiscard]] bool assembleArchive(const EncodedEntry& manifestEntry,
+                                   const EncodedEntry& documentEntry,
+                                   std::pmr::vector<std::byte>& archiveBytes) noexcept {
+    ArchiveWriter writer(archiveBytes);
+    const auto manifestLocalOffset = writer.cursor();
+    if (!writeLocalHeader(writer, kManifestName, manifestEntry) ||
+        !writer.putBytes(manifestEntry.data)) {
+        return false;
+    }
+    const auto documentLocalOffset = writer.cursor();
+    if (!writeLocalHeader(writer, kDocumentName, documentEntry) ||
+        !writer.putBytes(documentEntry.data)) {
+        return false;
+    }
+    if (manifestLocalOffset > kMaxZipFieldValue || documentLocalOffset > kMaxZipFieldValue) {
+        return false; // unreachable: the caller already rejected archives above maxArchiveBytes.
+    }
+
+    const auto centralDirectoryOffset = writer.cursor();
+    if (!writeCentralHeader(writer, kManifestName, manifestEntry,
+                            static_cast<std::uint32_t>(manifestLocalOffset)) ||
+        !writeCentralHeader(writer, kDocumentName, documentEntry,
+                            static_cast<std::uint32_t>(documentLocalOffset))) {
+        return false;
+    }
+    const auto centralDirectorySize = writer.cursor() - centralDirectoryOffset;
+    if (centralDirectoryOffset > kMaxZipFieldValue || centralDirectorySize > kMaxZipFieldValue) {
+        return false; // unreachable: same archive-size ceiling as above.
+    }
+
+    if (!writer.putU32(kEocdSignature) || !writer.putU16(0) /* disk number */ ||
+        !writer.putU16(0) /* disk with central directory */ ||
+        !writer.putU16(2) /* entries on this disk */ || !writer.putU16(2) /* entries total */ ||
+        !writer.putU32(static_cast<std::uint32_t>(centralDirectorySize)) ||
+        !writer.putU32(static_cast<std::uint32_t>(centralDirectoryOffset)) ||
+        !writer.putU16(0) /* comment length */) {
+        return false;
+    }
+    return writer.cursor() == archiveBytes.size();
+}
+
+} // namespace
+
+// The friend declared by bloom::project::zip_container_writer.hpp names bloom::project::detail's
+// own ZipContainerWriteBuilder, so this class must live directly in this namespace rather than the
+// anonymous namespace above (mirrors zip_container.cpp's ZipContainerBuilder placement).
+class ZipContainerWriteBuilder final {
+  public:
+    [[nodiscard]] static ZipContainerWriteResult write(std::span<const std::byte> manifest,
+                                                       std::span<const std::byte> document,
+                                                       const ZipContainerLimits& limits,
+                                                       ProjectIoOperationMemory operation) noexcept;
+
+  private:
+    [[nodiscard]] static ZipContainerWriteResult
+    makeFailure(ZipContainerWriteError error,
+                ZipContainerWriteEntry entry = ZipContainerWriteEntry::None) noexcept;
+    [[nodiscard]] static ZipContainerWriteResult makeSuccess(ZipContainerArchive archive) noexcept;
+
+    // Not noexcept: resizing/assigning the PMR-backed intermediate and final buffers is ordinary
+    // std::pmr::vector work bound to ProjectIoMemoryResource's throwing memory_resource surface.
+    // A budget rejection here must propagate as std::bad_alloc to write()'s try/catch.
+    [[nodiscard]] static bool encodeEntry(std::span<const std::byte> payload,
+                                          std::uint64_t maxExpansionRatio, EncodedEntry& out,
+                                          ZipContainerWriteError& error);
+};
+
+bool ZipContainerWriteBuilder::encodeEntry(const std::span<const std::byte> payload,
+                                           const std::uint64_t maxExpansionRatio, EncodedEntry& out,
+                                           ZipContainerWriteError& error) {
+    out.uncompressedSize = static_cast<std::uint32_t>(payload.size());
+    out.crc32Value = static_cast<std::uint32_t>(
+        crc32_z(0L, reinterpret_cast<const Bytef*>(payload.data()), payload.size()));
+
+    z_stream stream{};
+    constexpr int kLevel = 6;
+    constexpr int kWindowBits = -15; // negative: raw deflate, no zlib/gzip header or trailer.
+    constexpr int kMemLevel = 8;
+    if (deflateInit2(&stream, kLevel, Z_DEFLATED, kWindowBits, kMemLevel, Z_DEFAULT_STRATEGY) !=
+        Z_OK) {
+        error = ZipContainerWriteError::QualifiedCompressorFailure;
+        return false;
+    }
+    struct StreamGuard final {
+        z_stream* handle;
+        ~StreamGuard() { deflateEnd(handle); }
+    } streamGuard{&stream};
+
+    out.data.resize(deflateBound(&stream, static_cast<uLong>(payload.size())));
+    stream.next_in = reinterpret_cast<Bytef*>(const_cast<std::byte*>(payload.data()));
+    stream.avail_in = static_cast<uInt>(payload.size());
+    stream.next_out = reinterpret_cast<Bytef*>(out.data.data());
+    stream.avail_out = static_cast<uInt>(out.data.size());
+    if (deflate(&stream, Z_FINISH) != Z_STREAM_END) {
+        error = ZipContainerWriteError::QualifiedCompressorFailure;
+        return false;
+    }
+    const auto producedBytes = static_cast<std::uint64_t>(out.data.size() - stream.avail_out);
+
+    // Stored fallback rule (docs/architecture/project-format.md, "Constrained ZIP Profile"):
+    // store this entry instead of the deflate stream just produced when either
+    //   (a) deflate did not reduce it (produced byte count >= payload byte count), or
+    //   (b) the deflated form would exceed the reader's permitted expansion ratio
+    //       (payloadSize > maxExpansionRatio * max(1, deflateSize)) -- the default reader would
+    //       reject that entry outright (e.g. megabytes of a single repeated byte).
+    // A stored entry always satisfies the reader: its ratio is exactly 1.
+    bool useStore = producedBytes >= payload.size();
+    if (!useStore) {
+        const auto denominator = std::max<std::uint64_t>(1, producedBytes);
+        std::uint64_t allowedMaximum = 0;
+        if (checkedMul(maxExpansionRatio, denominator, allowedMaximum) &&
+            payload.size() > allowedMaximum) {
+            useStore = true;
+        }
+        // A checkedMul overflow leaves allowedMaximum conceptually unbounded for any payload this
+        // writer can ever hold under the Resource Limits table, so deflate stays legal.
+    }
+
+    if (useStore) {
+        out.method = kMethodStored;
+        out.data.assign(payload.begin(), payload.end());
+    } else {
+        out.method = kMethodDeflate;
+        out.data.resize(producedBytes);
+    }
+    return true;
+}
+
+ZipContainerWriteResult ZipContainerWriteBuilder::write(
+    const std::span<const std::byte> manifest, const std::span<const std::byte> document,
+    const ZipContainerLimits& limits, ProjectIoOperationMemory operation) noexcept {
+    if (limits.maxArchiveBytes == 0 || limits.maxManifestBytes == 0 ||
+        limits.maxDocumentBytes == 0 || limits.maxTotalExpandedBytes == 0 ||
+        limits.maxExpansionRatio == 0) {
+        return makeFailure(ZipContainerWriteError::InvalidLimits);
+    }
+
+    // Entry payload sizes must fit the 32-bit local/central header size fields; anything needing
+    // a ZIP64 representation is refused. The Resource Limits table keeps this unreachable at the
+    // default limits, but a caller-supplied limits value could raise the per-entry ceilings above
+    // 4 GiB, so this check runs unconditionally, ahead of and independent from the policy limit
+    // comparisons below.
+    if (manifest.size() > kMaxZipFieldValue || document.size() > kMaxZipFieldValue) {
+        return makeFailure(ZipContainerWriteError::SizeOverflow);
+    }
+
+    if (manifest.size() > limits.maxManifestBytes) {
+        return makeFailure(ZipContainerWriteError::EntrySizeLimitExceeded,
+                           ZipContainerWriteEntry::Manifest);
+    }
+    if (document.size() > limits.maxDocumentBytes) {
+        return makeFailure(ZipContainerWriteError::EntrySizeLimitExceeded,
+                           ZipContainerWriteEntry::Document);
+    }
+
+    std::uint64_t totalExpanded = 0;
+    if (!checkedAdd(manifest.size(), document.size(), totalExpanded)) {
+        return makeFailure(ZipContainerWriteError::SizeOverflow);
+    }
+    if (totalExpanded > limits.maxTotalExpandedBytes) {
+        return makeFailure(ZipContainerWriteError::TotalExpandedLimitExceeded);
+    }
+
+    try {
+        // Reserve zlib's worst-case working memory before any dependency call, per the contract
+        // that unmetered dependency allocation is not permitted; held for the duration of every
+        // deflate call below and released by RAII on every return path.
+        auto workingReservationResult = operation.reserve(kQualifiedWriterWorkingReservationBytes);
+        if (!workingReservationResult) {
+            return makeFailure(ZipContainerWriteError::ResourceExhausted);
+        }
+        auto workingReservation = std::move(workingReservationResult).takeReservation();
+
+        std::unique_ptr<ProjectIoMemoryResource> resource;
+        try {
+            resource = std::make_unique<ProjectIoMemoryResource>(std::move(operation));
+        } catch (const std::bad_alloc&) {
+            return makeFailure(ZipContainerWriteError::ResourceExhausted);
+        }
+
+        ZipContainerWriteError entryError = ZipContainerWriteError::None;
+        EncodedEntry manifestEntry(resource.get());
+        if (!encodeEntry(manifest, limits.maxExpansionRatio, manifestEntry, entryError)) {
+            return makeFailure(entryError);
+        }
+        EncodedEntry documentEntry(resource.get());
+        if (!encodeEntry(document, limits.maxExpansionRatio, documentEntry, entryError)) {
+            return makeFailure(entryError);
+        }
+
+        std::uint64_t archiveSize = 0;
+        if (!computeArchiveSize(manifestEntry.data.size(), documentEntry.data.size(),
+                                archiveSize)) {
+            return makeFailure(ZipContainerWriteError::SizeOverflow);
+        }
+        if (archiveSize > limits.maxArchiveBytes) {
+            return makeFailure(ZipContainerWriteError::ArchiveSizeLimitExceeded);
+        }
+
+        std::pmr::vector<std::byte> archiveBytes(static_cast<std::size_t>(archiveSize),
+                                                 resource.get());
+        if (!assembleArchive(manifestEntry, documentEntry, archiveBytes)) {
+            return makeFailure(ZipContainerWriteError::SizeOverflow);
+        }
+
+        ZipContainerArchive archive(std::move(resource), std::move(archiveBytes));
+        return makeSuccess(std::move(archive));
+    } catch (const std::bad_alloc&) {
+        return makeFailure(ZipContainerWriteError::ResourceExhausted);
+    } catch (...) {
+        // No other exception source is expected: zlib failures are reported as ordinary return
+        // codes above, never thrown. Fail closed rather than propagate an unidentified exception.
+        return makeFailure(ZipContainerWriteError::QualifiedCompressorFailure);
+    }
+}
+
+ZipContainerWriteResult
+ZipContainerWriteBuilder::makeFailure(const ZipContainerWriteError error,
+                                      const ZipContainerWriteEntry entry) noexcept {
+    ZipContainerWriteResult result;
+    result.error_ = error;
+    result.entry_ = entry;
+    return result;
+}
+
+ZipContainerWriteResult
+ZipContainerWriteBuilder::makeSuccess(ZipContainerArchive archive) noexcept {
+    ZipContainerWriteResult result;
+    result.error_ = ZipContainerWriteError::None;
+    result.archive_.emplace(std::move(archive));
+    return result;
+}
+
+} // namespace bloom::project::detail
+
+namespace bloom::project {
+
+ZipContainerWriteResult writeZipContainer(const std::span<const std::byte> manifest,
+                                          const std::span<const std::byte> document,
+                                          const ZipContainerLimits& limits,
+                                          ProjectIoOperationMemory operation) noexcept {
+    return detail::ZipContainerWriteBuilder::write(manifest, document, limits,
+                                                   std::move(operation));
+}
+
+} // namespace bloom::project


### PR DESCRIPTION
Closes #44.

The Constrained ZIP Profile container writer (`writeZipContainer`), completing the container story alongside #43's reader: manifest and document bytes in, a conforming archive out, or a typed refusal.

**Raw contractual emission**: the profile makes the writer's exact field bytes contractual against the strict reader — general-purpose flags exactly UTF-8, zero extra fields and comments, DOS epoch `1980-01-01 00:00:00`, regular mode `0644`, exact contiguous layout ending in an EOCD with counts 2/2 and zero comment — so every field is hand-assembled over the qualified zlib (deflate level 6, raw stream) and `static_assert`ed, rather than delegated to a library whose emission details can't be controlled to that precision.

**Stored fallback, both triggers**: an entry stores instead of deflating when deflate would not reduce it, or when the deflated form's expansion ratio would exceed the reader's permitted `1000:1` (a stored entry always satisfies the reader at ratio 1).

**Refusals over surprises**: per-entry, total-expanded, and physical-archive limits enforced with checked arithmetic; a payload needing ZIP64 representation is refused as overflow even under caller-raised limits. Every written archive is accepted by the default reader by construction — and the tests prove that claim with the real reader, not by assertion.

**Bounded memory**: intermediate deflate buffers and the archive output are PMR-charged through the operation budget with a documented worst-case reservation for zlib's internal working memory; exhaustion is typed with zero leaked charges.

Testing: 13 test functions including a byte-for-byte golden archive derived independently from the format doc's layout rules, stored/deflate determinism, round-trips through the real reader (stored, deflate, mixed, both empty-payload orientations), both fallback triggers verified from the archive's own headers, and every typed refusal pinned. Full ci-linux-native suite 60/60 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).