### PR TITLE
docs: make member-order significance explicit

### DIFF
--- a/docs/architecture/project-format.md
+++ b/docs/architecture/project-format.md
@@ -243,7 +243,11 @@ array.
 
 ## Canonical JSON Primitives
 
-The reader accepts insignificant RFC 8259 whitespace and any object-member order. The writer emits
+The reader accepts insignificant RFC 8259 whitespace; typed decode requires known members in
+their exact canonical order, consistent with the exact-order shape sections and with the
+rejection of non-canonical spellings elsewhere in this contract — a reordered known member is a
+typed decode error, not input to silent normalization, and the retained-unknown-member rules
+depend on this order significance. The writer emits
 every non-empty object and array over multiple lines, with one member or array element block per
 level, two-space indentation, a single space after `:`, and commas only after non-final members or
 elements. Empty containers are `{}` and `[]`. Output uses LF line endings, one final LF, and no


### PR DESCRIPTION
Closes #48.

Scopes the Canonical JSON Primitives reader-tolerance sentence to insignificant RFC 8259 whitespace and states canonical member order as a typed-decode requirement. The removed "any object-member order" clause contradicted the normative exact-order shape sections, the merged decoder's typed `MemberOutOfOrder` rule, and the retained-unknown-member capture model, whose trailing-unknown rule depends on order significance. The amendment aligns the documented reader contract with the contract's own reject-don't-normalize philosophy (non-canonical integer/rational spellings are already rejected, and float-spelling leniency is an explicitly narrow exception) and with behavior enforced since typed decode merged.