### PR TITLE
feat: decode manifests into typed truth

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(
         document_decode_composition.cpp
         document_decode_internal.hpp
         document_reconstruct.cpp
+        manifest_decode.cpp
         manifest_requirements.cpp
         project_io_memory.cpp
         project_io_memory_resource.cpp
@@ -41,6 +42,7 @@ target_sources(
             include/bloom/project/canonical_manifest.hpp
             include/bloom/project/document_decode.hpp
             include/bloom/project/document_reconstruct.hpp
+            include/bloom/project/manifest_decode.hpp
             include/bloom/project/manifest_requirements.hpp
             include/bloom/project/project_io_memory.hpp
             include/bloom/project/project_io_memory_resource.hpp
@@ -161,6 +163,15 @@ if(BUILD_TESTING)
         NAME bloom.project.manifest_requirements
         COMMAND bloom_project_manifest_requirements_test
         LABELS unit project persistence document
+    )
+
+    add_executable(bloom_project_manifest_decode_test tests/manifest_decode_tests.cpp)
+    target_link_libraries(bloom_project_manifest_decode_test PRIVATE bloom_project)
+    bloom_enable_warnings(bloom_project_manifest_decode_test)
+    bloom_add_test(
+        NAME bloom.project.manifest_decode
+        COMMAND bloom_project_manifest_decode_test
+        LABELS unit project persistence manifest
     )
 
     add_executable(bloom_project_canonical_base64_test tests/canonical_base64_tests.cpp)

--- a/src/project/include/bloom/project/manifest_decode.hpp
+++ b/src/project/include/bloom/project/manifest_decode.hpp
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Typed decode of the manifest.json envelope from a parsed strict JSON DOM (see
+// docs/architecture/project-format.md, "Manifest Shape", "Version 1 Constants", "Canonical JSON
+// Primitives" -- "Decimal Strings And JSON Integers" -- and "Resource Limits" for the namespaced-ID
+// lexical domain). This mirrors decodeDocumentEnvelope's idiom (document_decode.hpp) at manifest
+// scale: exact member order over a closed shape, checked value surfaces, member-path diagnostics on
+// failure, and a three-way outcome distinguishing a hard decode error from a same-major newer-minor
+// containerVersion that cannot yet be handled losslessly.
+//
+// Scope: the manifest root (format/containerVersion/document/requirements) and every requirement
+// record, decoded into a shape bloom::project::validateManifestRequirements() (see
+// manifest_requirements.hpp) can consume directly -- ManifestRequirement is reused verbatim,
+// exactly as document_decode.hpp reuses bloom::document::ParameterRecord/NodeRecord/... rather than
+// reinventing a parallel decode-only shape. Only the lexical/structural requirement invariants that
+// do not need decoded project truth are checked here (canonical member order, exact `format`/
+// `document.path`, requirement sort order, duplicate provider/capability pairs, provided-node-type
+// sort order and uniqueness, and namespaced-ID lexical domains); coverage against a decoded project
+// (exact non-foundation node-type coverage, extension-owner coverage) stays in
+// validateManifestRequirements() and is deliberately not duplicated here.
+//
+// Identity before version: `format` is checked (exact kind and value) immediately after the
+// tolerant first pass over the root, before containerVersion is even peeked at. A manifest that
+// does not declare itself as this format is a typed WrongValueKind/InvalidFormat decode error
+// outright -- it never reaches containerVersion classification below, so a file that explicitly
+// declares itself NOT a Bloom manifest (wrong or non-string `format`) can never be misclassified as
+// a newer *Bloom* manifest just because its containerVersion happens to parse as {1, minor > 0}.
+//
+// Version gates: containerVersion.major or document.schemaVersion.major != 1 is a typed
+// UnsupportedMajorVersion decode error (migration is out of scope of this module). An exact
+// containerVersion {1,0} decodes strictly: an unrecognized member anywhere in the manifest (root,
+// either version object, the document object, or a requirement) is a typed UnknownMember/
+// MemberOutOfOrder decode error. A same-major newer-minor containerVersion ({1, minor > 0}) is
+// classified as PreservationRequired instead -- a distinct outcome from both Decoded and Failed --
+// unconditionally, whether or not the manifest actually contains an unrecognized member: manifest
+// round-trip capture (this module's analogue of document_decode.hpp's RT1 unknown-member capture
+// into RoundTripState) is a later slice, exactly as the document decoder staged its own R1/R2 (full
+// decode, no capture) before RT1 added capture for a same-major newer-minor document. Until that
+// slice lands, this module cannot tell "safely re-encodable extra content" apart from "content that
+// would be silently dropped," so it refuses to guess either way and reports PreservationRequired
+// without inspecting the rest of the manifest beyond the `format` identity check already performed
+// above. A newer-minor *document* `schemaVersion` value embedded in an otherwise-{1,0} manifest is
+// NOT a manifest-level refusal: it is decoded and exposed like any other value. Manifest/document
+// schema agreement and the document side's own newer-minor handling belong to a later chain-layer
+// slice, not this module.
+//
+// Decoding reuses canonical_decimal.hpp's parseCanonicalJsonUInt32 for every `major`/`minor` field
+// and bloom::document::isValidNamespacedIdentifier (persisted_text.hpp) for every providerId/
+// capabilityId/providedNodeTypeIds lexical check -- the same checked surfaces
+// canonical_manifest.cpp's writer-side validator uses -- rather than hand-rolling a duplicate
+// regex-shaped check. This module does not include document_decode_internal.hpp: that header is a
+// private two-translation-unit seam typed to DocumentDecodeError/RoundTripState (see its own file
+// comment) and reusing it here would be a layering violation, so the shared *shape* of its
+// matchOrderedMembers/decodeStringMember/decodeUInt32Member helpers is mirrored locally in
+// manifest_decode.cpp instead, typed to ManifestDecodeError.
+//
+// decodeManifestEnvelope() is not noexcept, for the same reason as decodeDocumentEnvelope(): its
+// intermediate std::string/std::vector-backed results can throw std::bad_alloc on allocation
+// failure, so marking it noexcept while it allocates through a throwing surface would be an
+// untruthful noexcept claim. Callers that need a termination-free boundary wrap the call
+// themselves.
+
+namespace bloom::project {
+
+// The decoded manifest.json envelope's durable values: the container version, the declared document
+// path and schema version, and the requirement set in the exact shape
+// validateManifestRequirements() consumes.
+struct DecodedManifest final {
+    document::SchemaVersion containerVersion;
+    std::string documentPath;
+    document::SchemaVersion documentSchemaVersion;
+    std::vector<ManifestRequirement> requirements;
+
+    friend bool operator==(const DecodedManifest&, const DecodedManifest&) = default;
+};
+
+enum class ManifestDecodeError : std::uint8_t {
+    None,
+    // A member's JSON value kind did not match the schema (e.g. a number where a string was
+    // required, or an array where an object was required).
+    WrongValueKind,
+    // A required member was absent from an otherwise well-formed object.
+    MissingMember,
+    // An object member's key is not a member this schema/position recognizes.
+    UnknownMember,
+    // An object member's key is known to this schema but appeared in the wrong position; exact
+    // member order is part of canonical acceptance.
+    MemberOutOfOrder,
+    // A version object's `major`/`minor` JSON-number token is not a canonical non-negative integer
+    // spelling (fraction, exponent, leading zero, or a `+`/`-` sign) or does not fit uint32.
+    InvalidJsonUInt32,
+    // containerVersion.major or document.schemaVersion.major is not 1 (decode refuses; migration is
+    // out of scope of this module).
+    UnsupportedMajorVersion,
+    // `format` is not exactly "org.kinetik.bloom.project".
+    InvalidFormat,
+    // `document.path` is not exactly "document.json".
+    InvalidDocumentPath,
+    // A requirement's `providerId` does not match the namespaced-ID lexical domain
+    // `[a-z0-9][a-z0-9._-]{0,127}`.
+    InvalidProviderId,
+    // A requirement's `capabilityId` does not match the namespaced-ID lexical domain.
+    InvalidCapabilityId,
+    // Requirements are not sorted by providerId, then capabilityId, then schema major/minor.
+    InvalidRequirementOrder,
+    // Two requirements declare the same (providerId, capabilityId) pair.
+    DuplicateRequirementIdentity,
+    // A `providedNodeTypeIds` entry does not match the namespaced-ID lexical domain.
+    InvalidProvidedNodeTypeId,
+    // `providedNodeTypeIds` is not sorted by UTF-8 bytes.
+    InvalidProvidedNodeTypeOrder,
+    // Two entries in the same requirement's `providedNodeTypeIds` are identical.
+    DuplicateProvidedNodeTypeId,
+};
+
+enum class ManifestDecodeOutcome : std::uint8_t {
+    // decodeManifestEnvelope() found a typed decode error; error()/path() are valid.
+    Failed,
+    // A DecodedManifest was constructed; value() is non-null. Only possible for an exact
+    // containerVersion {1,0}.
+    Decoded,
+    // containerVersion is same-major newer-minor ({1, minor > 0}); no DecodedManifest is
+    // constructed (value() is null) and no typed error is reported (error() is None). path() names
+    // "/containerVersion/minor". See the file comment above for why this is unconditional rather
+    // than contingent on whether an unrecognized member is actually present.
+    PreservationRequired,
+};
+
+// A bounded diagnostic path to one JSON member, formatted as `/key/0/key`, mirroring
+// DocumentDecodePathText's shape and truncation contract.
+class ManifestDecodePathText final {
+  public:
+    constexpr ManifestDecodePathText() noexcept = default;
+
+    [[nodiscard]] static ManifestDecodePathText from(std::string_view text) noexcept;
+
+    [[nodiscard]] std::string_view view() const& noexcept { return {chars_.data(), size_}; }
+    [[nodiscard]] std::string_view view() const&& = delete;
+    [[nodiscard]] bool truncated() const noexcept { return truncated_; }
+
+  private:
+    std::array<char, 512> chars_{};
+    std::uint16_t size_ = 0;
+    bool truncated_ = false;
+};
+
+// [[nodiscard]] failure-aware result. outcome() names which of the three shapes is populated:
+//   - Failed: error()/path() are valid.
+//   - Decoded: value() is non-null.
+//   - PreservationRequired: value() is null; error() is None; path() is valid.
+// operator bool() is true only for Decoded, so every `if (!decoded)` / `if (decoded)` caller treats
+// PreservationRequired like Failed (neither produces value()) without needing to know the outcome
+// enum exists.
+class [[nodiscard]] ManifestDecodeResult final {
+  public:
+    [[nodiscard]] static ManifestDecodeResult success(DecodedManifest manifest);
+    [[nodiscard]] static ManifestDecodeResult failure(ManifestDecodeError error,
+                                                      std::string_view path);
+    [[nodiscard]] static ManifestDecodeResult preservationRequired(std::string_view path);
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return outcome_ == ManifestDecodeOutcome::Decoded;
+    }
+    [[nodiscard]] ManifestDecodeOutcome outcome() const noexcept { return outcome_; }
+    [[nodiscard]] ManifestDecodeError error() const noexcept { return error_; }
+    [[nodiscard]] std::string_view path() const noexcept { return path_.view(); }
+    [[nodiscard]] bool pathTruncated() const noexcept { return path_.truncated(); }
+    [[nodiscard]] const DecodedManifest* value() const& noexcept {
+        return manifest_.has_value() ? &*manifest_ : nullptr;
+    }
+    [[nodiscard]] const DecodedManifest* value() const&& = delete;
+
+  private:
+    ManifestDecodeResult() = default;
+
+    std::optional<DecodedManifest> manifest_;
+    ManifestDecodeOutcome outcome_ = ManifestDecodeOutcome::Failed;
+    ManifestDecodeError error_ = ManifestDecodeError::None;
+    ManifestDecodePathText path_;
+};
+
+// Decodes `root` (the manifest.json root value from a parsed StrictJsonDomDocument) into a
+// DecodedManifest. `root` must outlive the call; nothing is retained past return. See the
+// file-level comment above for exact scope. May throw std::bad_alloc; never throws otherwise.
+[[nodiscard]] ManifestDecodeResult decodeManifestEnvelope(const JsonValue& root);
+
+} // namespace bloom::project

--- a/src/project/manifest_decode.cpp
+++ b/src/project/manifest_decode.cpp
@@ -1,0 +1,476 @@
+#include <bloom/project/manifest_decode.hpp>
+
+#include <bloom/core/utf8.hpp>
+#include <bloom/document/persisted_text.hpp>
+#include <bloom/project/canonical_decimal.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+
+#include <algorithm>
+#include <array>
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace bloom::project {
+
+namespace {
+
+// ------------------------------------------------------------------------------------------
+// Decode plumbing. Deliberately mirrors document_decode_internal.hpp's shape (matchOrderedMembers/
+// decodeStringMember/decodeUInt32Member/joinPath) rather than including that header: it is a
+// private seam typed to DocumentDecodeError/RoundTripState shared only between document_decode.cpp
+// and document_decode_composition.cpp (see its own file comment), and this module has no RT1-style
+// capture state to thread through it. Unlike that header's matchOrderedMembers, the overload here
+// never captures a trailing member: manifest round-trip capture is out of scope (see
+// manifest_decode.hpp's file comment), so a rejected trailing member is always either a hard error
+// (containerVersion {1,0}) or moot (containerVersion {1, minor > 0} short-circuits to
+// PreservationRequired before any object's trailing members are ever inspected).
+// ------------------------------------------------------------------------------------------
+
+struct DecodeState final {
+    ManifestDecodeError error = ManifestDecodeError::None;
+    std::string path;
+
+    void fail(const ManifestDecodeError newError, std::string newPath) noexcept {
+        if (error == ManifestDecodeError::None) {
+            error = newError;
+            path = std::move(newPath);
+        }
+    }
+};
+
+[[nodiscard]] std::string joinPath(const std::string& base, const std::string_view segment) {
+    std::string result;
+    result.reserve(base.size() + 1 + segment.size());
+    result.append(base);
+    result.push_back('/');
+    result.append(segment);
+    return result;
+}
+
+[[nodiscard]] std::string joinPathIndex(const std::string& base, const std::size_t index) {
+    return joinPath(base, std::to_string(index));
+}
+
+// Checks that `object` is a JSON object whose leading members exactly match `expectedKeys` in
+// order, filling `outValues` with pointers to each matched member's value. When
+// `rejectExtraMembers` is false, trailing members beyond the matched prefix are accepted without
+// inspection -- used only to peek at containerVersion's major/minor before this module knows
+// whether trailing members (here or anywhere else in the manifest) should be tolerated at all (see
+// decodeManifestEnvelope's own two-pass bootstrap, mirroring decodeDocumentEnvelope's).
+[[nodiscard]] bool matchOrderedMembers(const JsonValue& object,
+                                       const std::span<const std::string_view> expectedKeys,
+                                       const bool rejectExtraMembers, DecodeState& state,
+                                       const std::string& basePath,
+                                       std::vector<const JsonValue*>& outValues) {
+    if (object.kind() != JsonValueKind::Object) {
+        state.fail(ManifestDecodeError::WrongValueKind, basePath);
+        return false;
+    }
+
+    const auto members = object.objectMembers();
+    outValues.clear();
+    outValues.reserve(expectedKeys.size());
+    for (std::size_t index = 0; index < expectedKeys.size(); ++index) {
+        if (members.size() <= index) {
+            state.fail(ManifestDecodeError::MissingMember, joinPath(basePath, expectedKeys[index]));
+            return false;
+        }
+        if (members[index].key() != expectedKeys[index]) {
+            const bool knownElsewhere = std::find(expectedKeys.begin(), expectedKeys.end(),
+                                                  members[index].key()) != expectedKeys.end();
+            state.fail(knownElsewhere ? ManifestDecodeError::MemberOutOfOrder
+                                      : ManifestDecodeError::UnknownMember,
+                       joinPath(basePath, members[index].key()));
+            return false;
+        }
+        outValues.push_back(&members[index].value());
+    }
+
+    if (rejectExtraMembers && members.size() > expectedKeys.size()) {
+        state.fail(ManifestDecodeError::UnknownMember,
+                   joinPath(basePath, members[expectedKeys.size()].key()));
+        return false;
+    }
+    return true;
+}
+
+// Not noexcept: DecodeState::fail() takes its path argument by value, so a failing call here copies
+// `path` into that by-value parameter -- an allocation that can throw std::bad_alloc. Marking this
+// noexcept while it allocates on the failure path would be an untruthful noexcept claim.
+[[nodiscard]] bool decodeStringMember(const JsonValue& value, DecodeState& state,
+                                      const std::string& path, std::string_view& out) {
+    if (value.kind() != JsonValueKind::String) {
+        state.fail(ManifestDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto text = value.asString();
+    if (!text.has_value()) {
+        state.fail(ManifestDecodeError::WrongValueKind, path);
+        return false;
+    }
+    out = *text;
+    return true;
+}
+
+// asNumberToken() is documented to return a value whenever kind() already matches, but that
+// invariant is not visible to static analysis; re-check has_value() immediately before
+// dereferencing rather than trusting the prior kind() check alone (mirrors document_decode.cpp's
+// own decodeUInt32Member).
+[[nodiscard]] bool decodeUInt32Member(const JsonValue& value, DecodeState& state,
+                                      const std::string& path, std::uint32_t& out) {
+    if (value.kind() != JsonValueKind::Number) {
+        state.fail(ManifestDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto token = value.asNumberToken();
+    if (!token.has_value()) {
+        state.fail(ManifestDecodeError::WrongValueKind, path);
+        return false;
+    }
+    // Every version-object component is an unbounded uint32 (see "Decimal Strings And JSON
+    // Integers": "must fit their declared uint32 or smaller range" -- major/minor declare no
+    // smaller range). Both CanonicalDecimalError variants parseCanonicalJsonUInt32 can report here
+    // (non-canonical spelling, or a value that fits uint64 but exceeds uint32) collapse to the same
+    // InvalidJsonUInt32: unlike document_decode.cpp's DomainViolation catch-all (which also covers
+    // unrelated semantic domains such as OCIO/pixel-format rules), this module has no broader
+    // "value parsed fine but violates a domain rule" concept for a bare version component to share
+    // with, so a second error value would only exist to distinguish two flavors of "not a valid
+    // uint32" that the adversarial test corpus does not ask decode() callers to tell apart.
+    const auto parsed = parseCanonicalJsonUInt32(*token, std::numeric_limits<std::uint32_t>::max());
+    if (!parsed) {
+        state.fail(ManifestDecodeError::InvalidJsonUInt32, path);
+        return false;
+    }
+    out = *parsed.value();
+    return true;
+}
+
+[[nodiscard]] bool decodeVersionField(const JsonValue& node, DecodeState& state,
+                                      const std::string& path, const bool rejectExtraMembers,
+                                      document::SchemaVersion& out) {
+    static constexpr std::array<std::string_view, 2> kKeys{"major", "minor"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, rejectExtraMembers, state, path, members)) {
+        return false;
+    }
+    std::uint32_t major = 0;
+    if (!decodeUInt32Member(*members[0], state, joinPath(path, "major"), major)) {
+        return false;
+    }
+    std::uint32_t minor = 0;
+    if (!decodeUInt32Member(*members[1], state, joinPath(path, "minor"), minor)) {
+        return false;
+    }
+    out.major = major;
+    out.minor = minor;
+    return true;
+}
+
+// ------------------------------------------------------------------------------------------
+// `document` member (docs/architecture/project-format.md, "Manifest Shape"): exactly `path` then
+// `schemaVersion`, closed.
+// ------------------------------------------------------------------------------------------
+
+[[nodiscard]] bool decodeDocumentSection(const JsonValue& node, DecodeState& state,
+                                         const std::string& path, DecodedManifest& out) {
+    static constexpr std::array<std::string_view, 2> kKeys{"path", "schemaVersion"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    const auto pathMemberPath = joinPath(path, "path");
+    std::string_view pathText;
+    if (!decodeStringMember(*members[0], state, pathMemberPath, pathText)) {
+        return false;
+    }
+    if (pathText != kCanonicalManifestDocumentPath) {
+        state.fail(ManifestDecodeError::InvalidDocumentPath, pathMemberPath);
+        return false;
+    }
+    out.documentPath = std::string(pathText);
+
+    const auto schemaVersionPath = joinPath(path, "schemaVersion");
+    document::SchemaVersion schemaVersion;
+    if (!decodeVersionField(*members[1], state, schemaVersionPath, true, schemaVersion)) {
+        return false;
+    }
+    // Document `schemaVersion`'s major gates the same way containerVersion's does (decode refuses
+    // an unsupported major; migration is out of scope). Its minor does NOT: a newer document minor
+    // embedded in an otherwise-{1,0} manifest is exposed as a plain decoded value rather than
+    // refused here -- manifest/document agreement and the document side's own newer-minor handling
+    // belong to a later chain-layer slice (see manifest_decode.hpp's file comment).
+    if (schemaVersion.major != kCanonicalManifestDocumentSchemaVersionV1.major) {
+        state.fail(ManifestDecodeError::UnsupportedMajorVersion,
+                   joinPath(schemaVersionPath, "major"));
+        return false;
+    }
+    out.documentSchemaVersion = schemaVersion;
+    return true;
+}
+
+// ------------------------------------------------------------------------------------------
+// `requirements` array (docs/architecture/project-format.md, "Manifest Shape"): each record is
+// exactly providerId/capabilityId/schemaVersion/providedNodeTypeIds, closed; sorted by providerId,
+// then capabilityId, then schema major/minor; duplicate provider/capability pairs invalid.
+// ------------------------------------------------------------------------------------------
+
+// Mirrors canonical_manifest.cpp's and manifest_requirements.cpp's own file-local requirementLess:
+// this exact three-key comparator (UTF-8 providerId, then UTF-8 capabilityId, then schema
+// major/minor) is already duplicated identically between those two translation units (the writer's
+// pre-encode validator and the semantic coverage validator), so mirroring it a third time here for
+// the read side matches the codebase's existing precedent rather than introducing a new shared
+// header only decode would use.
+[[nodiscard]] bool requirementLess(const ManifestRequirement& left,
+                                   const ManifestRequirement& right) noexcept {
+    const auto providerOrder = core::compareUtf8Bytes(left.providerId, right.providerId);
+    if (providerOrder != std::strong_ordering::equal) {
+        return providerOrder == std::strong_ordering::less;
+    }
+    const auto capabilityOrder = core::compareUtf8Bytes(left.capabilityId, right.capabilityId);
+    if (capabilityOrder != std::strong_ordering::equal) {
+        return capabilityOrder == std::strong_ordering::less;
+    }
+    return left.schemaVersion < right.schemaVersion;
+}
+
+[[nodiscard]] bool decodeProvidedNodeTypeIds(const JsonValue& node, DecodeState& state,
+                                             const std::string& path,
+                                             std::vector<std::string>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(ManifestDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+
+    std::string_view previous;
+    bool hasPrevious = false;
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        const auto elementPath = joinPathIndex(path, index);
+        std::string_view text;
+        if (!decodeStringMember(elements[index], state, elementPath, text)) {
+            return false;
+        }
+        if (!document::isValidNamespacedIdentifier(text)) {
+            state.fail(ManifestDecodeError::InvalidProvidedNodeTypeId, elementPath);
+            return false;
+        }
+        if (hasPrevious) {
+            const auto order = core::compareUtf8Bytes(previous, text);
+            if (order == std::strong_ordering::equal) {
+                state.fail(ManifestDecodeError::DuplicateProvidedNodeTypeId, elementPath);
+                return false;
+            }
+            if (order != std::strong_ordering::less) {
+                state.fail(ManifestDecodeError::InvalidProvidedNodeTypeOrder, elementPath);
+                return false;
+            }
+        }
+        // `text` is a view into the DOM node's own decoded string storage (JsonValue::asString()),
+        // which the caller contract (see manifest_decode.hpp) guarantees outlives this whole call;
+        // safe to keep comparing against across iterations without re-reading `out`.
+        previous = text;
+        hasPrevious = true;
+        out.emplace_back(text);
+    }
+    return true;
+}
+
+[[nodiscard]] bool decodeRequirement(const JsonValue& node, DecodeState& state,
+                                     const std::string& path, ManifestRequirement& out) {
+    static constexpr std::array<std::string_view, 4> kKeys{"providerId", "capabilityId",
+                                                           "schemaVersion", "providedNodeTypeIds"};
+    std::vector<const JsonValue*> members;
+    if (!matchOrderedMembers(node, kKeys, true, state, path, members)) {
+        return false;
+    }
+
+    const auto providerIdPath = joinPath(path, "providerId");
+    std::string_view providerIdText;
+    if (!decodeStringMember(*members[0], state, providerIdPath, providerIdText)) {
+        return false;
+    }
+    if (!document::isValidNamespacedIdentifier(providerIdText)) {
+        state.fail(ManifestDecodeError::InvalidProviderId, providerIdPath);
+        return false;
+    }
+    out.providerId = std::string(providerIdText);
+
+    const auto capabilityIdPath = joinPath(path, "capabilityId");
+    std::string_view capabilityIdText;
+    if (!decodeStringMember(*members[1], state, capabilityIdPath, capabilityIdText)) {
+        return false;
+    }
+    if (!document::isValidNamespacedIdentifier(capabilityIdText)) {
+        state.fail(ManifestDecodeError::InvalidCapabilityId, capabilityIdPath);
+        return false;
+    }
+    out.capabilityId = std::string(capabilityIdText);
+
+    if (!decodeVersionField(*members[2], state, joinPath(path, "schemaVersion"), true,
+                            out.schemaVersion)) {
+        return false;
+    }
+
+    return decodeProvidedNodeTypeIds(*members[3], state, joinPath(path, "providedNodeTypeIds"),
+                                     out.providedNodeTypeIds);
+}
+
+[[nodiscard]] bool decodeRequirements(const JsonValue& node, DecodeState& state,
+                                      const std::string& path,
+                                      std::vector<ManifestRequirement>& out) {
+    if (node.kind() != JsonValueKind::Array) {
+        state.fail(ManifestDecodeError::WrongValueKind, path);
+        return false;
+    }
+    const auto elements = node.arrayElements();
+    out.clear();
+    out.reserve(elements.size());
+
+    for (std::size_t index = 0; index < elements.size(); ++index) {
+        const auto elementPath = joinPathIndex(path, index);
+        ManifestRequirement requirement;
+        if (!decodeRequirement(elements[index], state, elementPath, requirement)) {
+            return false;
+        }
+        if (!out.empty()) {
+            const auto& previous = out.back();
+            if (previous.providerId == requirement.providerId &&
+                previous.capabilityId == requirement.capabilityId) {
+                state.fail(ManifestDecodeError::DuplicateRequirementIdentity, elementPath);
+                return false;
+            }
+            if (!requirementLess(previous, requirement)) {
+                state.fail(ManifestDecodeError::InvalidRequirementOrder, elementPath);
+                return false;
+            }
+        }
+        // `out` is reserved to elements.size() up front and grows by exactly one push per
+        // iteration, so `out.back()` above never dangles across the next iteration's reserve.
+        out.push_back(std::move(requirement));
+    }
+    return true;
+}
+
+} // namespace
+
+ManifestDecodePathText ManifestDecodePathText::from(const std::string_view text) noexcept {
+    ManifestDecodePathText result;
+    const auto copySize = std::min(text.size(), result.chars_.size());
+    for (std::size_t index = 0; index < copySize; ++index) {
+        result.chars_[index] = text[index];
+    }
+    result.size_ = static_cast<std::uint16_t>(copySize);
+    result.truncated_ = text.size() > copySize;
+    return result;
+}
+
+ManifestDecodeResult ManifestDecodeResult::success(DecodedManifest manifest) {
+    ManifestDecodeResult result;
+    result.manifest_ = std::move(manifest);
+    result.outcome_ = ManifestDecodeOutcome::Decoded;
+    return result;
+}
+
+ManifestDecodeResult ManifestDecodeResult::failure(const ManifestDecodeError error,
+                                                   const std::string_view path) {
+    ManifestDecodeResult result;
+    result.outcome_ = ManifestDecodeOutcome::Failed;
+    result.error_ = error;
+    result.path_ = ManifestDecodePathText::from(path);
+    return result;
+}
+
+ManifestDecodeResult ManifestDecodeResult::preservationRequired(const std::string_view path) {
+    ManifestDecodeResult result;
+    result.outcome_ = ManifestDecodeOutcome::PreservationRequired;
+    result.path_ = ManifestDecodePathText::from(path);
+    return result;
+}
+
+ManifestDecodeResult decodeManifestEnvelope(const JsonValue& root) {
+    static constexpr std::array<std::string_view, 4> kRootKeys{"format", "containerVersion",
+                                                               "document", "requirements"};
+    DecodeState state;
+    std::vector<const JsonValue*> members;
+    // First pass: match only the exact-order prefix, not yet rejecting a trailing member. Whether
+    // the root object's (or containerVersion's own) trailing members should ever be tolerated
+    // depends on containerVersion.minor, which this same pass's own result (members[1]) is what
+    // determines -- an unavoidable bootstrap order, mirroring decodeDocumentEnvelope's identical
+    // two-pass root read in document_decode.cpp.
+    if (!matchOrderedMembers(root, kRootKeys, false, state, std::string{}, members)) {
+        return ManifestDecodeResult::failure(state.error, state.path);
+    }
+
+    // Identity before version: `format` is this file's identity declaration -- pass 1 above has
+    // already proven members[0] occupies format's canonical position, so checking its kind and
+    // exact value costs nothing extra here, before containerVersion is even peeked at. A manifest
+    // that does not declare itself as this format must fail outright (WrongValueKind/InvalidFormat)
+    // rather than falling into the newer-minor containerVersion short-circuit below and being
+    // misclassified as a newer *Bloom* manifest -- containerVersion classification only makes sense
+    // once the file has already claimed to be this format at all.
+    const auto formatPath = std::string("/format");
+    std::string_view formatText;
+    if (!decodeStringMember(*members[0], state, formatPath, formatText)) {
+        return ManifestDecodeResult::failure(state.error, state.path);
+    }
+    if (formatText != kCanonicalManifestFormat) {
+        return ManifestDecodeResult::failure(ManifestDecodeError::InvalidFormat, formatPath);
+    }
+
+    document::SchemaVersion containerVersion;
+    if (!decodeVersionField(*members[1], state, "/containerVersion", false, containerVersion)) {
+        return ManifestDecodeResult::failure(state.error, state.path);
+    }
+    if (containerVersion.major != kCanonicalManifestContainerVersionV1.major) {
+        return ManifestDecodeResult::failure(ManifestDecodeError::UnsupportedMajorVersion,
+                                             "/containerVersion/major");
+    }
+    if (containerVersion.minor != kCanonicalManifestContainerVersionV1.minor) {
+        // Same-major newer-minor containerVersion: classify and stop without inspecting anything
+        // else in the manifest beyond the `format` identity check already done above (root's own
+        // trailing members, containerVersion's own trailing members, `document`, or `requirements`)
+        // -- see manifest_decode.hpp's file comment for why this is unconditional rather than
+        // contingent on whether an unrecognized member is actually present anywhere.
+        return ManifestDecodeResult::preservationRequired("/containerVersion/minor");
+    }
+
+    // Exact {1,0}: strict decode from here on. Second pass over the root re-checks its own shape
+    // now that containerVersion.minor is known to be 0, so a trailing unknown root member is a hard
+    // error (mirrors decodeDocumentEnvelope's second pass, minus RT1 capture -- this module never
+    // captures).
+    if (!matchOrderedMembers(root, kRootKeys, true, state, std::string{}, members)) {
+        return ManifestDecodeResult::failure(state.error, state.path);
+    }
+    // containerVersion's own shape gets the same strict re-check: a trailing member there is only
+    // tolerated (by short-circuiting above, before this point is ever reached) when minor > 0.
+    document::SchemaVersion strictContainerVersion;
+    if (!decodeVersionField(*members[1], state, "/containerVersion", true,
+                            strictContainerVersion)) {
+        return ManifestDecodeResult::failure(state.error, state.path);
+    }
+
+    DecodedManifest manifest;
+    manifest.containerVersion = strictContainerVersion;
+
+    if (!decodeDocumentSection(*members[2], state, "/document", manifest)) {
+        return ManifestDecodeResult::failure(state.error, state.path);
+    }
+
+    if (!decodeRequirements(*members[3], state, "/requirements", manifest.requirements)) {
+        return ManifestDecodeResult::failure(state.error, state.path);
+    }
+
+    return ManifestDecodeResult::success(std::move(manifest));
+}
+
+} // namespace bloom::project

--- a/src/project/tests/manifest_decode_tests.cpp
+++ b/src/project/tests/manifest_decode_tests.cpp
@@ -1,0 +1,788 @@
+#include <bloom/project/manifest_decode.hpp>
+
+#include <bloom/document/persisted_text.hpp>
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using bloom::document::SchemaVersion;
+using bloom::project::DecodedManifest;
+using bloom::project::JsonValue;
+using bloom::project::ManifestDecodeError;
+using bloom::project::ManifestDecodeOutcome;
+using bloom::project::ManifestDecodeResult;
+using bloom::project::ManifestRequirement;
+using bloom::project::ProjectIoOperationMemory;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 8ULL << 20U; // 8 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = bloom::project::ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+// ---------------------------------------------------------------------------------------------
+// Minimal hand-assembled manifest.json fixtures. parseStrictJsonDom accepts any insignificant
+// whitespace and member order (canonical layout is only a writer requirement), so these compact,
+// non-canonically-ordered literals are valid input; manifest_decode.cpp's own order checks are
+// exercised deliberately by the "wrong member order" fixtures below.
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] std::string versionJson(const std::string_view majorToken,
+                                      const std::string_view minorToken) {
+    std::string result = "{\"major\":";
+    result += majorToken;
+    result += ",\"minor\":";
+    result += minorToken;
+    result += "}";
+    return result;
+}
+
+[[nodiscard]] std::string documentSectionJson(const std::string_view pathJson,
+                                              const std::string_view schemaVersionJson) {
+    std::string result = "{\"path\":";
+    result += pathJson;
+    result += ",\"schemaVersion\":";
+    result += schemaVersionJson;
+    result += "}";
+    return result;
+}
+
+[[nodiscard]] std::string requirementJson(const std::string_view providerIdJson,
+                                          const std::string_view capabilityIdJson,
+                                          const std::string_view schemaVersionJson,
+                                          const std::string_view nodeTypesJson) {
+    std::string result = "{\"providerId\":";
+    result += providerIdJson;
+    result += ",\"capabilityId\":";
+    result += capabilityIdJson;
+    result += ",\"schemaVersion\":";
+    result += schemaVersionJson;
+    result += ",\"providedNodeTypeIds\":";
+    result += nodeTypesJson;
+    result += "}";
+    return result;
+}
+
+[[nodiscard]] std::string manifestJson(const std::string_view formatJson,
+                                       const std::string_view containerVersionJson,
+                                       const std::string_view documentJson,
+                                       const std::string_view requirementsJson) {
+    std::string result = "{\"format\":";
+    result += formatJson;
+    result += ",\"containerVersion\":";
+    result += containerVersionJson;
+    result += ",\"document\":";
+    result += documentJson;
+    result += ",\"requirements\":";
+    result += requirementsJson;
+    result += "}";
+    return result;
+}
+
+constexpr std::string_view kValidFormatJson = R"("org.kinetik.bloom.project")";
+
+[[nodiscard]] std::string validVersion10Json() { return versionJson("1", "0"); }
+
+[[nodiscard]] std::string validDocumentJson() {
+    return documentSectionJson(R"("document.json")", validVersion10Json());
+}
+
+[[nodiscard]] std::string defaultRequirementJson() {
+    return requirementJson(R"("provider.a")", R"("provider.a.cap")", validVersion10Json(), "[]");
+}
+
+[[nodiscard]] std::string baselineManifestJson() {
+    return manifestJson(kValidFormatJson, validVersion10Json(), validDocumentJson(), "[]");
+}
+
+[[nodiscard]] std::string manifestWithFormat(const std::string_view formatJson) {
+    return manifestJson(formatJson, validVersion10Json(), validDocumentJson(), "[]");
+}
+
+[[nodiscard]] std::string
+manifestWithFormatAndContainerVersion(const std::string_view formatJson,
+                                      const std::string_view containerVersionJson) {
+    return manifestJson(formatJson, containerVersionJson, validDocumentJson(), "[]");
+}
+
+[[nodiscard]] std::string
+manifestWithContainerVersion(const std::string_view containerVersionJson) {
+    return manifestJson(kValidFormatJson, containerVersionJson, validDocumentJson(), "[]");
+}
+
+[[nodiscard]] std::string manifestWithDocument(const std::string_view documentJson) {
+    return manifestJson(kValidFormatJson, validVersion10Json(), documentJson, "[]");
+}
+
+[[nodiscard]] std::string manifestWithRequirements(const std::string_view requirementsJson) {
+    return manifestJson(kValidFormatJson, validVersion10Json(), validDocumentJson(),
+                        requirementsJson);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Decode helpers
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] ManifestDecodeResult decodeText(const std::string& text) {
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(text), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    if (!parsed) {
+        // Every fixture below is constructed to be syntactically valid strict JSON; a parse
+        // failure means the fixture itself is broken, not the decoder under test. Fail loudly
+        // rather than reporting a misleading decode mismatch.
+        std::cerr << "fixture failed to parse as strict JSON (error="
+                  << static_cast<int>(parsed.error()) << ")\n";
+        std::abort();
+    }
+    return bloom::project::decodeManifestEnvelope(parsed.document()->root());
+}
+
+void expectDecodeFailure(Expectations& expectations, const std::string& text,
+                         const ManifestDecodeError expectedError,
+                         const std::string_view expectedPath, const std::string_view message) {
+    const auto decoded = decodeText(text);
+    expectations.expect(!decoded && decoded.outcome() == ManifestDecodeOutcome::Failed &&
+                            decoded.error() == expectedError && decoded.path() == expectedPath,
+                        message);
+}
+
+void expectPreservationRequired(Expectations& expectations, const std::string& text,
+                                const std::string_view expectedPath,
+                                const std::string_view message) {
+    const auto decoded = decodeText(text);
+    expectations.expect(!decoded &&
+                            decoded.outcome() == ManifestDecodeOutcome::PreservationRequired &&
+                            decoded.error() == ManifestDecodeError::None &&
+                            decoded.path() == expectedPath && decoded.value() == nullptr,
+                        message);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Round trip: bytes produced by encodeCanonicalManifest (canonical_manifest.hpp's writer, the
+// module this decoder round-trips against per the task) parse and decode back to exactly the
+// input values.
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] ManifestRequirement makeRequirement(std::string providerId, std::string capabilityId,
+                                                  std::vector<std::string> nodeTypeIds = {},
+                                                  const SchemaVersion version = {1, 0}) {
+    return {.providerId = std::move(providerId),
+            .capabilityId = std::move(capabilityId),
+            .schemaVersion = version,
+            .providedNodeTypeIds = std::move(nodeTypeIds)};
+}
+
+void expectRoundTrip(Expectations& expectations,
+                     const std::vector<ManifestRequirement>& requirements,
+                     const std::string_view message) {
+    const bloom::project::CanonicalManifestV1 manifest{.requirements = requirements};
+    const auto size = bloom::project::canonicalManifestSize(manifest);
+    if (!size) {
+        expectations.expect(false, "fixture manifest sizes successfully");
+        return;
+    }
+    std::vector<char> output(*size.value());
+    const auto written = bloom::project::encodeCanonicalManifest(manifest, output);
+    if (!written) {
+        expectations.expect(false, "fixture manifest encodes successfully");
+        return;
+    }
+
+    const std::string_view encodedText(output.data(), output.size());
+    auto parsed = bloom::project::parseStrictJsonDom(asBytes(encodedText), {},
+                                                     makeOperation(kGenerousOperationBudget));
+    if (!parsed) {
+        expectations.expect(false, "the canonical writer's own bytes parse as strict JSON");
+        return;
+    }
+
+    const auto decoded = bloom::project::decodeManifestEnvelope(parsed.document()->root());
+    const bool decodedOk = static_cast<bool>(decoded) && decoded.value() != nullptr;
+    expectations.expect(decodedOk, message);
+    if (!decodedOk) {
+        return;
+    }
+
+    const auto& envelope = *decoded.value();
+    expectations.expect(envelope.containerVersion ==
+                            bloom::project::kCanonicalManifestContainerVersionV1,
+                        "round trip: decoded containerVersion equals the canonical v1 constant");
+    expectations.expect(envelope.documentPath == bloom::project::kCanonicalManifestDocumentPath,
+                        "round trip: decoded document path equals the canonical constant");
+    expectations.expect(envelope.documentSchemaVersion ==
+                            bloom::project::kCanonicalManifestDocumentSchemaVersionV1,
+                        "round trip: decoded document schemaVersion equals the canonical constant");
+    expectations.expect(envelope.requirements == requirements,
+                        "round trip: decoded requirements equal the source requirements exactly");
+}
+
+void testRoundTripEmptyRequirements(Expectations& expectations) {
+    expectRoundTrip(expectations, {}, "an empty-requirements manifest round-trips through decode");
+}
+
+void testRoundTripPopulatedRequirements(Expectations& expectations) {
+    const std::vector<ManifestRequirement> requirements{
+        makeRequirement("provider.a", "provider.a.data"),
+        makeRequirement("provider.b", "provider.b.nodes", {"provider.b.blur", "provider.b.text"},
+                        {2, 3}),
+        makeRequirement("provider.c", "provider.c.data", {"provider.c.only"}),
+    };
+    expectRoundTrip(expectations, requirements,
+                    "a populated multi-requirement, multi-node-type manifest round-trips exactly");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Success path sanity
+// ---------------------------------------------------------------------------------------------
+
+void testBaselineDecodesSuccessfully(Expectations& expectations) {
+    const auto decoded = decodeText(baselineManifestJson());
+    expectations.expect(static_cast<bool>(decoded) && decoded.value() != nullptr,
+                        "the hand-assembled baseline fixture decodes without error");
+    if (decoded.value() == nullptr) {
+        return;
+    }
+    const auto& manifest = *decoded.value();
+    expectations.expect(manifest.containerVersion == SchemaVersion{1, 0},
+                        "the baseline containerVersion decodes to exactly {1,0}");
+    expectations.expect(manifest.documentPath == "document.json",
+                        "the baseline document path decodes exactly");
+    expectations.expect(manifest.documentSchemaVersion == SchemaVersion{1, 0},
+                        "the baseline document schemaVersion decodes to exactly {1,0}");
+    expectations.expect(manifest.requirements.empty(),
+                        "the baseline fixture decodes zero requirements");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Exact values: format, document.path
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsWrongFormat(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithFormat(R"("org.kinetik.bloom.other")"),
+                        ManifestDecodeError::InvalidFormat, "/format",
+                        "a wrong format string is a typed InvalidFormat error");
+}
+
+void testRejectsWrongDocumentPath(Expectations& expectations) {
+    expectDecodeFailure(
+        expectations,
+        manifestWithDocument(documentSectionJson(R"("other.json")", validVersion10Json())),
+        ManifestDecodeError::InvalidDocumentPath, "/document/path",
+        "a wrong document.path string is a typed InvalidDocumentPath error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Missing member (one per object; the trailing expected key omitted so the mismatch is a genuine
+// absence rather than a reordering)
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsRootMissingRequirements(Expectations& expectations) {
+    std::string root = "{\"format\":";
+    root += kValidFormatJson;
+    root += ",\"containerVersion\":";
+    root += validVersion10Json();
+    root += ",\"document\":";
+    root += validDocumentJson();
+    root += "}";
+    expectDecodeFailure(expectations, root, ManifestDecodeError::MissingMember, "/requirements",
+                        "a root missing requirements is a typed MissingMember error");
+}
+
+void testRejectsContainerVersionMissingMinor(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(R"({"major":1})"),
+                        ManifestDecodeError::MissingMember, "/containerVersion/minor",
+                        "a containerVersion missing minor is a typed MissingMember error");
+}
+
+void testRejectsDocumentMissingSchemaVersion(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithDocument(R"({"path":"document.json"})"),
+                        ManifestDecodeError::MissingMember, "/document/schemaVersion",
+                        "a document missing schemaVersion is a typed MissingMember error");
+}
+
+void testRejectsRequirementMissingProvidedNodeTypeIds(Expectations& expectations) {
+    std::string truncated = "{\"providerId\":\"provider.a\",\"capabilityId\":\"provider.a.cap\","
+                            "\"schemaVersion\":";
+    truncated += validVersion10Json();
+    truncated += "}";
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + truncated + "]"),
+                        ManifestDecodeError::MissingMember, "/requirements/0/providedNodeTypeIds",
+                        "a requirement missing providedNodeTypeIds is a typed MissingMember error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Extra unknown member at {1,0} (root, version object, document object, requirement)
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsRootUnknownMember(Expectations& expectations) {
+    std::string root = baselineManifestJson();
+    root.pop_back(); // drop closing '}'
+    root += R"(,"extra":true})";
+    expectDecodeFailure(expectations, root, ManifestDecodeError::UnknownMember, "/extra",
+                        "an extra root member at {1,0} is a typed UnknownMember error");
+}
+
+void testRejectsContainerVersionUnknownMember(Expectations& expectations) {
+    expectDecodeFailure(expectations,
+                        manifestWithContainerVersion(R"({"major":1,"minor":0,"extra":true})"),
+                        ManifestDecodeError::UnknownMember, "/containerVersion/extra",
+                        "an extra containerVersion member at {1,0} is a typed UnknownMember error");
+}
+
+void testRejectsDocumentUnknownMember(Expectations& expectations) {
+    std::string document = validDocumentJson();
+    document.pop_back();
+    document += R"(,"extra":true})";
+    expectDecodeFailure(expectations, manifestWithDocument(document),
+                        ManifestDecodeError::UnknownMember, "/document/extra",
+                        "an extra document member at {1,0} is a typed UnknownMember error");
+}
+
+void testRejectsRequirementUnknownMember(Expectations& expectations) {
+    std::string requirement = defaultRequirementJson();
+    requirement.pop_back();
+    requirement += R"(,"extra":true})";
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + requirement + "]"),
+                        ManifestDecodeError::UnknownMember, "/requirements/0/extra",
+                        "an extra requirement member at {1,0} is a typed UnknownMember error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Members out of order (each object)
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsRootMemberOrder(Expectations& expectations) {
+    std::string root = "{\"containerVersion\":";
+    root += validVersion10Json();
+    root += ",\"format\":";
+    root += kValidFormatJson;
+    root += ",\"document\":";
+    root += validDocumentJson();
+    root += ",\"requirements\":[]}";
+    expectDecodeFailure(expectations, root, ManifestDecodeError::MemberOutOfOrder,
+                        "/containerVersion",
+                        "a reordered root member is a typed MemberOutOfOrder error");
+}
+
+void testRejectsContainerVersionMemberOrder(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(R"({"minor":0,"major":1})"),
+                        ManifestDecodeError::MemberOutOfOrder, "/containerVersion/minor",
+                        "a reordered containerVersion member is a typed MemberOutOfOrder error");
+}
+
+void testRejectsDocumentMemberOrder(Expectations& expectations) {
+    std::string document = "{\"schemaVersion\":";
+    document += validVersion10Json();
+    document += R"(,"path":"document.json"})";
+    expectDecodeFailure(expectations, manifestWithDocument(document),
+                        ManifestDecodeError::MemberOutOfOrder, "/document/schemaVersion",
+                        "a reordered document member is a typed MemberOutOfOrder error");
+}
+
+void testRejectsRequirementMemberOrder(Expectations& expectations) {
+    // A requirement's key ORDER is swapped here (capabilityId before providerId), unlike
+    // requirementJson()'s argument order which only controls key VALUES.
+    std::string reordered = "{\"capabilityId\":\"provider.a.cap\",\"providerId\":\"provider.a\","
+                            "\"schemaVersion\":";
+    reordered += validVersion10Json();
+    reordered += R"(,"providedNodeTypeIds":[]})";
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + reordered + "]"),
+                        ManifestDecodeError::MemberOutOfOrder, "/requirements/0/capabilityId",
+                        "a reordered requirement member is a typed MemberOutOfOrder error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Non-canonical version numbers (negative, fractional, exponent, string-typed, > uint32)
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsNegativeVersionNumber(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(versionJson("-1", "0")),
+                        ManifestDecodeError::InvalidJsonUInt32, "/containerVersion/major",
+                        "a negative version number is a typed InvalidJsonUInt32 error");
+}
+
+void testRejectsFractionalVersionNumber(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(versionJson("1.0", "0")),
+                        ManifestDecodeError::InvalidJsonUInt32, "/containerVersion/major",
+                        "a fractional version number is a typed InvalidJsonUInt32 error");
+}
+
+void testRejectsExponentVersionNumber(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(versionJson("1e0", "0")),
+                        ManifestDecodeError::InvalidJsonUInt32, "/containerVersion/major",
+                        "an exponent version number is a typed InvalidJsonUInt32 error");
+}
+
+void testRejectsStringTypedVersionNumber(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(versionJson(R"("1")", "0")),
+                        ManifestDecodeError::WrongValueKind, "/containerVersion/major",
+                        "a string-typed version number is a typed WrongValueKind error");
+}
+
+void testRejectsOverflowVersionNumber(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(versionJson("4294967296", "0")),
+                        ManifestDecodeError::InvalidJsonUInt32, "/containerVersion/major",
+                        "a > uint32 version number is a typed InvalidJsonUInt32 error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Unsupported majors (0, 2), on both containerVersion.major and document.schemaVersion.major
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsContainerVersionMajorZero(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(versionJson("0", "0")),
+                        ManifestDecodeError::UnsupportedMajorVersion, "/containerVersion/major",
+                        "containerVersion major 0 is a typed UnsupportedMajorVersion error");
+}
+
+void testRejectsContainerVersionMajorTwo(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithContainerVersion(versionJson("2", "0")),
+                        ManifestDecodeError::UnsupportedMajorVersion, "/containerVersion/major",
+                        "containerVersion major 2 is a typed UnsupportedMajorVersion error");
+}
+
+void testRejectsDocumentSchemaVersionMajorZero(Expectations& expectations) {
+    expectDecodeFailure(
+        expectations,
+        manifestWithDocument(documentSectionJson(R"("document.json")", versionJson("0", "0"))),
+        ManifestDecodeError::UnsupportedMajorVersion, "/document/schemaVersion/major",
+        "document schemaVersion major 0 is a typed UnsupportedMajorVersion error");
+}
+
+void testRejectsDocumentSchemaVersionMajorTwo(Expectations& expectations) {
+    expectDecodeFailure(
+        expectations,
+        manifestWithDocument(documentSectionJson(R"("document.json")", versionJson("2", "0"))),
+        ManifestDecodeError::UnsupportedMajorVersion, "/document/schemaVersion/major",
+        "document schemaVersion major 2 is a typed UnsupportedMajorVersion error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Unsorted requirements (each independently reachable sort key -- see the report: providerId and
+// capabilityId are independently testable, but a schemaVersion-only ordering violation cannot
+// occur without also being a DuplicateRequirementIdentity, since identity is (providerId,
+// capabilityId) alone; the writer's own tests carry the same limitation)
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnsortedRequirementsByProviderId(Expectations& expectations) {
+    const std::string requirements =
+        "[" +
+        requirementJson(R"("provider.b")", R"("provider.b.cap")", validVersion10Json(), "[]") +
+        "," +
+        requirementJson(R"("provider.a")", R"("provider.a.cap")", validVersion10Json(), "[]") + "]";
+    expectDecodeFailure(
+        expectations, manifestWithRequirements(requirements),
+        ManifestDecodeError::InvalidRequirementOrder, "/requirements/1",
+        "requirements out of order by providerId are a typed InvalidRequirementOrder error");
+}
+
+void testRejectsUnsortedRequirementsByCapabilityId(Expectations& expectations) {
+    const std::string requirements =
+        "[" + requirementJson(R"("provider.a")", R"("provider.a.z")", validVersion10Json(), "[]") +
+        "," + requirementJson(R"("provider.a")", R"("provider.a.a")", validVersion10Json(), "[]") +
+        "]";
+    expectDecodeFailure(expectations, manifestWithRequirements(requirements),
+                        ManifestDecodeError::InvalidRequirementOrder, "/requirements/1",
+                        "requirements out of order by capabilityId (same providerId) are a typed "
+                        "InvalidRequirementOrder error");
+}
+
+void testRejectsDuplicateRequirementIdentity(Expectations& expectations) {
+    const std::string requirements =
+        "[" +
+        requirementJson(R"("provider.a")", R"("provider.a.cap")", versionJson("1", "0"), "[]") +
+        "," +
+        requirementJson(R"("provider.a")", R"("provider.a.cap")", versionJson("2", "0"), "[]") +
+        "]";
+    expectDecodeFailure(
+        expectations, manifestWithRequirements(requirements),
+        ManifestDecodeError::DuplicateRequirementIdentity, "/requirements/1",
+        "duplicate provider/capability pairs are a typed DuplicateRequirementIdentity error "
+        "regardless of schemaVersion");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Unsorted / duplicate providedNodeTypeIds
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsUnsortedProvidedNodeTypeIds(Expectations& expectations) {
+    const std::string requirement =
+        requirementJson(R"("provider.a")", R"("provider.a.cap")", validVersion10Json(),
+                        R"(["provider.a.z","provider.a.a"])");
+    expectDecodeFailure(
+        expectations, manifestWithRequirements("[" + requirement + "]"),
+        ManifestDecodeError::InvalidProvidedNodeTypeOrder, "/requirements/0/providedNodeTypeIds/1",
+        "unsorted providedNodeTypeIds are a typed InvalidProvidedNodeTypeOrder error");
+}
+
+void testRejectsDuplicateProvidedNodeTypeIds(Expectations& expectations) {
+    const std::string requirement =
+        requirementJson(R"("provider.a")", R"("provider.a.cap")", validVersion10Json(),
+                        R"(["provider.a.x","provider.a.x"])");
+    expectDecodeFailure(
+        expectations, manifestWithRequirements("[" + requirement + "]"),
+        ManifestDecodeError::DuplicateProvidedNodeTypeId, "/requirements/0/providedNodeTypeIds/1",
+        "duplicate providedNodeTypeIds are a typed DuplicateProvidedNodeTypeId error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Invalid ID lexical domains (uppercase, leading dot, over-length, empty)
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsProviderIdUppercase(Expectations& expectations) {
+    const std::string requirement =
+        requirementJson(R"("Provider")", R"("provider.cap")", validVersion10Json(), "[]");
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + requirement + "]"),
+                        ManifestDecodeError::InvalidProviderId, "/requirements/0/providerId",
+                        "an uppercase providerId is a typed InvalidProviderId error");
+}
+
+void testRejectsProviderIdLeadingDot(Expectations& expectations) {
+    const std::string requirement =
+        requirementJson(R"(".provider")", R"("provider.cap")", validVersion10Json(), "[]");
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + requirement + "]"),
+                        ManifestDecodeError::InvalidProviderId, "/requirements/0/providerId",
+                        "a leading-dot providerId is a typed InvalidProviderId error");
+}
+
+void testRejectsProviderIdOverLength(Expectations& expectations) {
+    const std::string overLong(bloom::document::kMaxNamespacedIdentifierBytes + 1, 'a');
+    const std::string requirement =
+        requirementJson("\"" + overLong + "\"", R"("provider.cap")", validVersion10Json(), "[]");
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + requirement + "]"),
+                        ManifestDecodeError::InvalidProviderId, "/requirements/0/providerId",
+                        "a providerId over 128 bytes is a typed InvalidProviderId error");
+}
+
+void testRejectsProviderIdEmpty(Expectations& expectations) {
+    const std::string requirement =
+        requirementJson(R"("")", R"("provider.cap")", validVersion10Json(), "[]");
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + requirement + "]"),
+                        ManifestDecodeError::InvalidProviderId, "/requirements/0/providerId",
+                        "an empty providerId is a typed InvalidProviderId error");
+}
+
+void testRejectsCapabilityIdUppercase(Expectations& expectations) {
+    const std::string requirement =
+        requirementJson(R"("provider")", R"("Provider.Cap")", validVersion10Json(), "[]");
+    expectDecodeFailure(expectations, manifestWithRequirements("[" + requirement + "]"),
+                        ManifestDecodeError::InvalidCapabilityId, "/requirements/0/capabilityId",
+                        "an uppercase capabilityId is a typed InvalidCapabilityId error");
+}
+
+void testRejectsProvidedNodeTypeIdUppercase(Expectations& expectations) {
+    const std::string requirement = requirementJson(R"("provider.a")", R"("provider.a.cap")",
+                                                    validVersion10Json(), R"(["Provider.Type"])");
+    expectDecodeFailure(
+        expectations, manifestWithRequirements("[" + requirement + "]"),
+        ManifestDecodeError::InvalidProvidedNodeTypeId, "/requirements/0/providedNodeTypeIds/0",
+        "an uppercase providedNodeTypeIds entry is a typed InvalidProvidedNodeTypeId error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// `requirements` not an array
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsRequirementsNotArray(Expectations& expectations) {
+    expectDecodeFailure(expectations, manifestWithRequirements("{}"),
+                        ManifestDecodeError::WrongValueKind, "/requirements",
+                        "a non-array requirements value is a typed WrongValueKind error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Identity before version: a wrong or non-string `format` must fail outright even when
+// containerVersion would otherwise classify as newer-minor PreservationRequired -- a manifest that
+// does not declare itself as this format is never a "newer Bloom manifest."
+// ---------------------------------------------------------------------------------------------
+
+void testRejectsWrongFormatEvenWithNewerMinorContainerVersion(Expectations& expectations) {
+    expectDecodeFailure(
+        expectations,
+        manifestWithFormatAndContainerVersion(R"("org.other.thing")", versionJson("1", "1")),
+        ManifestDecodeError::InvalidFormat, "/format",
+        "a wrong format string fails outright even under a newer-minor containerVersion, rather "
+        "than classifying as PreservationRequired");
+}
+
+void testRejectsNonStringFormatEvenWithNewerMinorContainerVersion(Expectations& expectations) {
+    expectDecodeFailure(
+        expectations, manifestWithFormatAndContainerVersion("1", versionJson("1", "1")),
+        ManifestDecodeError::WrongValueKind, "/format",
+        "a non-string format fails outright even under a newer-minor containerVersion, rather "
+        "than classifying as PreservationRequired");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Newer-minor classification: containerVersion {1,1}, with and without unknown members, both
+// PreservationRequired -- pinned distinctly from every error above.
+// ---------------------------------------------------------------------------------------------
+
+void testAcceptsContainerVersionMinor1WithoutUnknownMembers(Expectations& expectations) {
+    expectPreservationRequired(expectations, manifestWithContainerVersion(versionJson("1", "1")),
+                               "/containerVersion/minor",
+                               "containerVersion {1,1} without unknown members classifies as "
+                               "PreservationRequired, not Decoded");
+}
+
+void testAcceptsContainerVersionMinor1WithUnknownMembersEverywhere(Expectations& expectations) {
+    // Unknown members at the root, inside containerVersion itself, inside document, and inside a
+    // requirement -- none of them inspected, since decodeManifestEnvelope short-circuits to
+    // PreservationRequired immediately once containerVersion.minor > 0 is known (see
+    // manifest_decode.hpp's file comment).
+    std::string document = validDocumentJson();
+    document.pop_back();
+    document += R"(,"docExtra":true})";
+    std::string requirement = defaultRequirementJson();
+    requirement.pop_back();
+    requirement += R"(,"reqExtra":true})";
+    std::string root = "{\"format\":";
+    root += kValidFormatJson;
+    root += ",\"containerVersion\":{\"major\":1,\"minor\":1,\"cvExtra\":true},\"document\":";
+    root += document;
+    root += ",\"requirements\":[";
+    root += requirement;
+    root += "],\"rootExtra\":true}";
+    expectPreservationRequired(expectations, root, "/containerVersion/minor",
+                               "containerVersion {1,1} with unknown members everywhere still "
+                               "classifies as PreservationRequired, not an UnknownMember error");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Document schemaVersion {1,1} inside an otherwise-{1,0} manifest: decodes (exposed value
+// checked), NOT refused. Manifest/document agreement is a later chain-layer concern.
+// ---------------------------------------------------------------------------------------------
+
+void testAcceptsDocumentSchemaVersionMinor1(Expectations& expectations) {
+    const auto decoded = decodeText(
+        manifestWithDocument(documentSectionJson(R"("document.json")", versionJson("1", "1"))));
+    expectations.expect(
+        static_cast<bool>(decoded) && decoded.value() != nullptr,
+        "a document schemaVersion of {1,1} inside a {1,0} manifest decodes successfully");
+    if (decoded.value() == nullptr) {
+        return;
+    }
+    expectations.expect(decoded.value()->documentSchemaVersion == SchemaVersion{1, 1},
+                        "the newer document schemaVersion minor is exposed exactly, not refused");
+    expectations.expect(decoded.value()->containerVersion == SchemaVersion{1, 0},
+                        "the manifest's own containerVersion stays {1,0} in this fixture");
+}
+
+} // namespace
+
+int main() try {
+    Expectations expectations;
+
+    testRoundTripEmptyRequirements(expectations);
+    testRoundTripPopulatedRequirements(expectations);
+
+    testBaselineDecodesSuccessfully(expectations);
+
+    testRejectsWrongFormat(expectations);
+    testRejectsWrongDocumentPath(expectations);
+
+    testRejectsRootMissingRequirements(expectations);
+    testRejectsContainerVersionMissingMinor(expectations);
+    testRejectsDocumentMissingSchemaVersion(expectations);
+    testRejectsRequirementMissingProvidedNodeTypeIds(expectations);
+
+    testRejectsRootUnknownMember(expectations);
+    testRejectsContainerVersionUnknownMember(expectations);
+    testRejectsDocumentUnknownMember(expectations);
+    testRejectsRequirementUnknownMember(expectations);
+
+    testRejectsRootMemberOrder(expectations);
+    testRejectsContainerVersionMemberOrder(expectations);
+    testRejectsDocumentMemberOrder(expectations);
+    testRejectsRequirementMemberOrder(expectations);
+
+    testRejectsNegativeVersionNumber(expectations);
+    testRejectsFractionalVersionNumber(expectations);
+    testRejectsExponentVersionNumber(expectations);
+    testRejectsStringTypedVersionNumber(expectations);
+    testRejectsOverflowVersionNumber(expectations);
+
+    testRejectsContainerVersionMajorZero(expectations);
+    testRejectsContainerVersionMajorTwo(expectations);
+    testRejectsDocumentSchemaVersionMajorZero(expectations);
+    testRejectsDocumentSchemaVersionMajorTwo(expectations);
+
+    testRejectsUnsortedRequirementsByProviderId(expectations);
+    testRejectsUnsortedRequirementsByCapabilityId(expectations);
+    testRejectsDuplicateRequirementIdentity(expectations);
+
+    testRejectsUnsortedProvidedNodeTypeIds(expectations);
+    testRejectsDuplicateProvidedNodeTypeIds(expectations);
+
+    testRejectsProviderIdUppercase(expectations);
+    testRejectsProviderIdLeadingDot(expectations);
+    testRejectsProviderIdOverLength(expectations);
+    testRejectsProviderIdEmpty(expectations);
+    testRejectsCapabilityIdUppercase(expectations);
+    testRejectsProvidedNodeTypeIdUppercase(expectations);
+
+    testRejectsRequirementsNotArray(expectations);
+
+    testRejectsWrongFormatEvenWithNewerMinorContainerVersion(expectations);
+    testRejectsNonStringFormatEvenWithNewerMinorContainerVersion(expectations);
+
+    testAcceptsContainerVersionMinor1WithoutUnknownMembers(expectations);
+    testAcceptsContainerVersionMinor1WithUnknownMembersEverywhere(expectations);
+
+    testAcceptsDocumentSchemaVersionMinor1(expectations);
+
+    if (expectations.failures() != 0) {
+        std::cerr << expectations.failures() << " expectation(s) failed\n";
+        return 1;
+    }
+    return 0;
+} catch (const std::exception& exception) {
+    std::cerr << "Unexpected test exception: " << exception.what() << '\n';
+    return 1;
+} catch (...) {
+    std::cerr << "Unexpected non-standard test exception\n";
+    return 1;
+}


### PR DESCRIPTION
Closes #49.

The typed manifest decoder (`decodeManifestEnvelope`), unblocking the save/reopen verification chain: `manifest.json`'s parsed strict DOM in, typed manifest truth out, or a typed rejection with a member path.

**The document decoder's model at manifest scale**: exact canonical member order over closed shapes, every value constructed through the same checked surfaces the writer-side validator uses, member-path diagnostics, and a three-way outcome (decoded / preservation-required / typed error).

**Identity before version**: the exact `format` string is validated before the container version is classified, so a file declaring itself a different format fails as `InvalidFormat` rather than being misclassified as a newer Bloom manifest.

**Staged exactly like the document side**: an exact `{1,0}` container decodes strictly — unknown members anywhere are typed errors; a same-major newer-minor container classifies as a typed `PreservationRequired` outcome, with manifest round-trip capture deferred to a later slice just as the document side shipped strict decode before capture. A newer document `schemaVersion` inside the manifest is exposed, not refused — manifest/document agreement belongs to the chain layer.

**No duplicated semantics**: decode-time checks are exactly the lexical/structural requirement invariants (three-key sort order, duplicate provider/capability pairs, sorted duplicate-free `providedNodeTypeIds`, namespaced-ID domains); semantic coverage stays in `validateManifestRequirements`, which consumes the decoded truth directly via the reused `ManifestRequirement` shape.

Testing: 42 test functions — round-trips against canonical-writer bytes, an adversarial corpus pinning every typed error, and newer-minor classification pinned distinctly including the identity-precedence cases. Full ci-linux-native suite 61/61 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (one review round).