### PR TITLE
feat: execute staged saves over the artifact lease

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(
         project_io_memory_resource.cpp
         round_trip_state.cpp
         save_archive.cpp
+        save_archive_internal.hpp
+        staged_save.cpp
         strict_json_dom.cpp
         strict_json_preflight.cpp
         strict_json_preflight.hpp
@@ -49,6 +51,7 @@ target_sources(
             include/bloom/project/project_io_memory_resource.hpp
             include/bloom/project/round_trip_state.hpp
             include/bloom/project/save_archive.hpp
+            include/bloom/project/staged_save.hpp
             include/bloom/project/strict_json_dom.hpp
             include/bloom/project/unknown_json_number.hpp
             include/bloom/project/zip_container.hpp
@@ -56,7 +59,12 @@ target_sources(
 )
 
 target_compile_features(bloom_project PUBLIC cxx_std_20)
-target_link_libraries(bloom_project PUBLIC bloom_core bloom_document)
+# bloom_platform is PUBLIC (not PRIVATE, despite the allowed dependency edge being unqualified):
+# include/bloom/project/staged_save.hpp declares stageSaveArchive() taking a
+# platform::StagedArtifactLease& in its public signature, so anything that includes that header
+# needs bloom_platform's headers visible too. Every other bloom_project header stays
+# platform-free; only this one new public header drives the PUBLIC requirement.
+target_link_libraries(bloom_project PUBLIC bloom_core bloom_document bloom_platform)
 target_link_libraries(bloom_project PRIVATE yyjson::yyjson libzip::zip)
 bloom_enable_warnings(bloom_project)
 
@@ -286,4 +294,15 @@ if(BUILD_TESTING)
         COMMAND bloom_project_save_archive_test
         LABELS unit project persistence security
     )
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_executable(bloom_project_staged_save_test tests/staged_save_tests.cpp)
+        target_link_libraries(bloom_project_staged_save_test PRIVATE bloom_project)
+        bloom_enable_warnings(bloom_project_staged_save_test)
+        bloom_add_test(
+            NAME bloom.project.staged_save
+            COMMAND bloom_project_staged_save_test
+            LABELS unit project persistence security
+        )
+    endif()
 endif()

--- a/src/project/include/bloom/project/save_archive.hpp
+++ b/src/project/include/bloom/project/save_archive.hpp
@@ -224,10 +224,28 @@ class [[nodiscard]] SaveArchiveResult final {
 verifySaveArchive(std::span<const std::byte> archive, const SaveArchiveExpectedContent& expected,
                   const SaveArchiveLimits& limits, ProjectIoOperationMemory operation) noexcept;
 
+// Encodes the captured manifest/document values and writes the two-entry archive; does NOT verify
+// it by reopening/decoding/reconstructing/re-encoding (see buildVerifiedSaveArchive() for that).
+// On success transfers ownership of the still-charged archive buffer into the result. The input's
+// scratch spans are not used: this composition allocates and charges exact scratch requirements
+// through `operation`.
+//
+// This is the build half that stageSaveArchive() (bloom/project/staged_save.hpp) pipelines over a
+// platform::StagedArtifactLease instead: staged execution verifies the staged/read-back bytes
+// rather than the in-memory ones, so it does not call buildVerifiedSaveArchive() here.
+[[nodiscard]] SaveArchiveResult buildSaveArchive(const CanonicalManifestV1& manifest,
+                                                 const CanonicalDocumentV1& document,
+                                                 const SaveArchiveLimits& limits,
+                                                 ProjectIoOperationMemory operation) noexcept;
+
 // Encodes the captured values, writes the archive, reopens it through verifySaveArchive(), and on
 // success transfers ownership of the still-charged archive buffer into the result. The input's
 // scratch spans are not used: this composition allocates and charges exact scratch requirements
 // through `operation` for both the captured and reconstructed writes.
+//
+// Implemented as buildSaveArchive()'s shared build step (see save_archive_internal.hpp) followed by
+// verifySaveArchive() over the in-memory archive; this is a pure refactor and its behavior is
+// unchanged from before the split.
 [[nodiscard]] SaveArchiveResult
 buildVerifiedSaveArchive(const CanonicalManifestV1& manifest, const CanonicalDocumentV1& document,
                          const SaveArchiveLimits& limits,

--- a/src/project/include/bloom/project/staged_save.hpp
+++ b/src/project/include/bloom/project/staged_save.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+
+// Staged execution of the save/reopen chain over a platform::StagedArtifactLease -- the "steps
+// 3-5 and 9" half of docs/architecture/project-format.md's "Staging And Atomic Publication" that
+// this package owns (steps 1-2, the preflight, and steps 6-8, publication ordering, belong to the
+// application-layer caller; see that document's "Staging And Atomic Publication" section for the
+// complete nine-step sequence this is embedded in).
+namespace bloom::project {
+
+enum class StagedSaveStage : std::uint8_t {
+    None,
+    // buildSaveArchive() failed while encoding manifest.json/document.json or writing the
+    // in-memory archive. Payload: SaveArchiveFailure (its own .stage() names the exact encode
+    // step).
+    Build,
+    // lease.write(archiveBytes) failed. Payload: StagedSavePlatformFailure.
+    StageWrite,
+    // lease.finishWriting() failed. Payload: StagedSavePlatformFailure.
+    StageFinish,
+    // lease.stageBytes() disagreed with the built archive's size, or exceeded
+    // limits.container.maxArchiveBytes, before any read-back allocation was attempted. Payload:
+    // StagedSaveSizeDisagreement.
+    StagedSizeDisagreement,
+    // The PMR-charged read-back buffer (sized to the built archive) could not be allocated within
+    // `operation`'s budget. Payload: SaveArchiveResourceExhausted.
+    ReadBackAllocation,
+    // lease.readForVerification() failed, or returned a short/zero/over-sized read inconsistent
+    // with the requested bound. Payload: StagedSavePlatformFailure.
+    StageRead,
+    // verifySaveArchive() over the staged/read-back bytes failed. lease.rejectVerification() was
+    // already called (best-effort; see StagedSaveResult::rejectDiagnostic()). Payload:
+    // SaveArchiveFailure (its own .stage() names the exact verification step).
+    Verification,
+    // lease.acceptVerification() failed. Payload: StagedSavePlatformFailure.
+    Accept,
+};
+
+// Names the exact StagedArtifactLease call a StagedSaveStage::StageWrite/StageFinish/StageRead/
+// Accept platform-stage failure occurred at.
+enum class StagedSaveLeaseCall : std::uint8_t {
+    None,
+    Write,
+    FinishWriting,
+    ReadForVerification,
+    AcceptVerification,
+};
+
+struct StagedSavePlatformFailure final {
+    platform::StagedArtifactError error = platform::StagedArtifactError::None;
+    StagedSaveLeaseCall call = StagedSaveLeaseCall::None;
+};
+
+struct StagedSaveSizeDisagreement final {
+    std::uint64_t builtArchiveBytes = 0;
+    std::uint64_t stageBytes = 0;
+};
+
+using StagedSaveFailurePayload =
+    std::variant<std::monostate, SaveArchiveFailure, StagedSavePlatformFailure,
+                 StagedSaveSizeDisagreement, SaveArchiveResourceExhausted,
+                 SaveArchiveUnexpectedFailure>;
+
+class StagedSaveFailure final {
+  public:
+    StagedSaveFailure() = default;
+
+    template <typename Payload>
+    StagedSaveFailure(const StagedSaveStage stage, Payload payload)
+        : stage_(stage), payload_(std::move(payload)) {}
+
+    [[nodiscard]] StagedSaveStage stage() const noexcept { return stage_; }
+    [[nodiscard]] const StagedSaveFailurePayload& payload() const noexcept { return payload_; }
+
+    template <typename Payload> [[nodiscard]] const Payload* payloadAs() const noexcept {
+        return std::get_if<Payload>(&payload_);
+    }
+
+  private:
+    StagedSaveStage stage_ = StagedSaveStage::None;
+    StagedSaveFailurePayload payload_;
+};
+
+class [[nodiscard]] StagedSaveResult final {
+  public:
+    StagedSaveResult(StagedSaveResult&&) noexcept = default;
+    StagedSaveResult& operator=(StagedSaveResult&&) noexcept = default;
+    StagedSaveResult(const StagedSaveResult&) = delete;
+    StagedSaveResult& operator=(const StagedSaveResult&) = delete;
+    ~StagedSaveResult() = default;
+
+    [[nodiscard]] static StagedSaveResult success() noexcept;
+    // `rejectDiagnostic`, when set, names a StagedArtifactError from a lease.rejectVerification()
+    // call that itself failed while reacting to this failure (StagedSaveStage::Verification
+    // only). It is always secondary to `failure` and never replaces it: rejectVerification()'s
+    // own failure is best-effort diagnostic information, not the reason staging failed.
+    [[nodiscard]] static StagedSaveResult
+    failure(StagedSaveFailure failure,
+            std::optional<platform::StagedArtifactError> rejectDiagnostic = std::nullopt);
+
+    [[nodiscard]] explicit operator bool() const noexcept { return !failure_.has_value(); }
+    [[nodiscard]] const StagedSaveFailure* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const StagedSaveFailure* failure() const&& = delete;
+    [[nodiscard]] std::optional<platform::StagedArtifactError> rejectDiagnostic() const noexcept {
+        return rejectDiagnostic_;
+    }
+
+  private:
+    StagedSaveResult() = default;
+
+    std::optional<StagedSaveFailure> failure_;
+    std::optional<platform::StagedArtifactError> rejectDiagnostic_;
+};
+
+// Drives the composed build/write/verify chain over an already-staged platform::StagedArtifactLease
+// (the caller has already run the coordinator's preflight() and stage(), i.e.
+// project-format.md's steps 1-2): builds the archive in memory (no in-memory verification), writes
+// it to the stage, reads the staged bytes back, and runs the exact same verifySaveArchive() chain
+// Save always ran -- but over those staged/read-back bytes rather than the in-memory ones, because
+// the verification that matters is over what was actually durably staged. On success the lease has
+// accepted verification and is exactly one lease.publish() away from durable publication; this
+// function NEVER calls publish() itself -- publication ordering (steps 6-8, the winning
+// PublicationIntentId, disposition) is the application-layer publication coordinator's job, not
+// this module's.
+//
+// On any failure, the lease is left in a state its destructor can safely clean up (RAII owns
+// stage cleanup; this function does not attempt to clean the stage itself, except that a
+// verification-content failure calls lease.rejectVerification() as documented above). Top-level
+// noexcept: an internal std::bad_alloc or budget rejection is reported as a typed
+// SaveArchiveResourceExhausted/ResourceExhausted-equivalent failure at whichever stage was current.
+[[nodiscard]] StagedSaveResult stageSaveArchive(platform::StagedArtifactLease& lease,
+                                                const CanonicalManifestV1& manifest,
+                                                const CanonicalDocumentV1& document,
+                                                const SaveArchiveLimits& limits,
+                                                ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::project

--- a/src/project/save_archive.cpp
+++ b/src/project/save_archive.cpp
@@ -1,5 +1,7 @@
 #include <bloom/project/save_archive.hpp>
 
+#include "save_archive_internal.hpp"
+
 #include <bloom/document/document.hpp>
 #include <bloom/project/canonical_base64.hpp>
 #include <bloom/project/canonical_decimal.hpp>
@@ -9,7 +11,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <exception>
 #include <limits>
+#include <memory>
 #include <memory_resource>
 #include <new>
 #include <optional>
@@ -463,57 +467,146 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
     }
 }
 
+SaveArchiveResult buildSaveArchive(const CanonicalManifestV1& manifest,
+                                   const CanonicalDocumentV1& document,
+                                   const SaveArchiveLimits& limits,
+                                   ProjectIoOperationMemory operation) noexcept {
+    auto outcome =
+        detail::buildSaveArchiveEntries(manifest, document, limits, std::move(operation));
+    if (!outcome) {
+        return SaveArchiveResult::failure(std::move(outcome).takeFailure());
+    }
+    return SaveArchiveResult::success(std::move(outcome).takeArchive());
+}
+
 SaveArchiveResult buildVerifiedSaveArchive(const CanonicalManifestV1& manifest,
                                            const CanonicalDocumentV1& document,
                                            const SaveArchiveLimits& limits,
                                            ProjectIoOperationMemory operation) noexcept {
+    // `operation` is a cheap shared_ptr-backed handle (see verifySaveArchive()'s own final-use
+    // comment above), so the copy passed to the shared build routine and the moved-from final use
+    // in the verifySaveArchive() call below are both safe.
+    auto outcome = detail::buildSaveArchiveEntries(manifest, document, limits, operation);
+    if (!outcome) {
+        return SaveArchiveResult::failure(std::move(outcome).takeFailure());
+    }
+
+    const auto expected = outcome.expectedContent(manifest.documentSchemaVersion);
+    auto verified =
+        verifySaveArchive(outcome.archiveBytes(), expected, limits, std::move(operation));
+    if (!verified) {
+        return SaveArchiveResult::failure(std::move(verified).takeFailure());
+    }
+    return SaveArchiveResult::success(std::move(outcome).takeArchive());
+}
+
+namespace detail {
+
+std::span<const std::byte> SaveArchiveBuiltEntries::manifestByteSpan() const noexcept {
+    return asBytes(manifestBytes);
+}
+
+std::span<const std::byte> SaveArchiveBuiltEntries::documentByteSpan() const noexcept {
+    return asBytes(documentBytes);
+}
+
+SaveArchiveFailure SaveArchiveBuildOutcome::takeFailure() && noexcept {
+    if (!failure.has_value()) {
+        std::terminate();
+    }
+    // operator*() (unlike value()) cannot throw, which is why it -- not value() -- is used on
+    // every already-checked access below: value()'s own always-noexcept-incompatible throwing
+    // contract trips bugprone-exception-escape even when, as here, the has_value() guard above
+    // makes the empty case provably unreachable.
+    return std::move(*failure);
+}
+
+ZipContainerWriteResult SaveArchiveBuildOutcome::takeArchive() && noexcept {
+    if (!archive.has_value()) {
+        std::terminate();
+    }
+    return std::move(*archive);
+}
+
+std::span<const std::byte> SaveArchiveBuildOutcome::archiveBytes() const& noexcept {
+    if (!archive.has_value()) {
+        std::terminate();
+    }
+    return archive->archive()->bytes();
+}
+
+SaveArchiveExpectedContent SaveArchiveBuildOutcome::expectedContent(
+    const document::SchemaVersion documentSchemaVersion) const& noexcept {
+    if (!entries.has_value()) {
+        std::terminate();
+    }
+    return SaveArchiveExpectedContent{
+        .manifestBytes = entries->manifestByteSpan(),
+        .documentBytes = entries->documentByteSpan(),
+        .documentSchemaVersion = documentSchemaVersion,
+    };
+}
+
+SaveArchiveBuildOutcome buildSaveArchiveEntries(const CanonicalManifestV1& manifest,
+                                                const CanonicalDocumentV1& document,
+                                                const SaveArchiveLimits& limits,
+                                                ProjectIoOperationMemory operation) noexcept {
     auto stage = SaveArchiveStage::ManifestEncode;
     try {
-        ProjectIoMemoryResource encodingResource(operation);
-        std::pmr::vector<char> manifestBytes(&encodingResource);
-        std::pmr::vector<char> documentBytes(&encodingResource);
+        // Heap-allocated so its address stays stable once SaveArchiveBuiltEntries is returned and
+        // moved by the caller (see save_archive_internal.hpp's file comment).
+        auto resource = std::make_unique<ProjectIoMemoryResource>(operation);
+        std::pmr::vector<char> manifestBytes(resource.get());
+        std::pmr::vector<char> documentBytes(resource.get());
 
         if (auto failure = encodeManifest(manifest, limits.manifest, manifestBytes, stage);
             failure.has_value()) {
-            return SaveArchiveResult::failure(std::move(*failure));
+            SaveArchiveBuildOutcome outcome;
+            outcome.failure = std::move(failure);
+            return outcome;
         }
 
         stage = SaveArchiveStage::DocumentEncode;
         if (auto failure =
-                encodeDocument(document, limits.document, &encodingResource, documentBytes, stage);
+                encodeDocument(document, limits.document, resource.get(), documentBytes, stage);
             failure.has_value()) {
-            return SaveArchiveResult::failure(std::move(*failure));
+            SaveArchiveBuildOutcome outcome;
+            outcome.failure = std::move(failure);
+            return outcome;
         }
 
         stage = SaveArchiveStage::ContainerWrite;
-        auto written = writeZipContainer(asBytes(manifestBytes), asBytes(documentBytes),
-                                         limits.container, operation);
-        if (!written) {
-            return SaveArchiveResult::failure(SaveArchiveFailure(
-                stage, SaveArchiveContainerWriteFailure{written.error(), written.entryInError()}));
-        }
-
-        const SaveArchiveExpectedContent expected{
-            .manifestBytes = asBytes(manifestBytes),
-            .documentBytes = asBytes(documentBytes),
-            .documentSchemaVersion = manifest.documentSchemaVersion,
-        };
-        // Final use of `operation` in this function: encodingResource above already holds its own
+        // Final use of `operation` in this function: `resource` above already holds its own
         // independent copy of the shared handle (constructed before this point), so moving the
         // local parameter away here is safe.
-        auto verified =
-            verifySaveArchive(written.archive()->bytes(), expected, limits, std::move(operation));
-        if (!verified) {
-            return SaveArchiveResult::failure(std::move(verified).takeFailure());
+        auto written = writeZipContainer(asBytes(manifestBytes), asBytes(documentBytes),
+                                         limits.container, std::move(operation));
+        if (!written) {
+            SaveArchiveBuildOutcome outcome;
+            outcome.failure = SaveArchiveFailure(
+                stage, SaveArchiveContainerWriteFailure{written.error(), written.entryInError()});
+            return outcome;
         }
-        return SaveArchiveResult::success(std::move(written));
+
+        SaveArchiveBuildOutcome outcome;
+        outcome.entries = SaveArchiveBuiltEntries{
+            .resource = std::move(resource),
+            .manifestBytes = std::move(manifestBytes),
+            .documentBytes = std::move(documentBytes),
+        };
+        outcome.archive = std::move(written);
+        return outcome;
     } catch (const std::bad_alloc&) {
-        return SaveArchiveResult::failure(
-            SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
+        SaveArchiveBuildOutcome outcome;
+        outcome.failure = SaveArchiveFailure(stage, SaveArchiveResourceExhausted{});
+        return outcome;
     } catch (...) {
-        return SaveArchiveResult::failure(
-            SaveArchiveFailure(stage, SaveArchiveUnexpectedFailure{}));
+        SaveArchiveBuildOutcome outcome;
+        outcome.failure = SaveArchiveFailure(stage, SaveArchiveUnexpectedFailure{});
+        return outcome;
     }
 }
+
+} // namespace detail
 
 } // namespace bloom::project

--- a/src/project/save_archive_internal.hpp
+++ b/src/project/save_archive_internal.hpp
@@ -1,0 +1,84 @@
+#ifndef BLOOM_PROJECT_SAVE_ARCHIVE_INTERNAL_HPP
+#define BLOOM_PROJECT_SAVE_ARCHIVE_INTERNAL_HPP
+
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/project_io_memory_resource.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/zip_container_writer.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <memory_resource>
+#include <optional>
+#include <span>
+#include <vector>
+
+// Shared build-without-verify implementation behind buildSaveArchive(), buildVerifiedSaveArchive()
+// (both save_archive.cpp) and stageSaveArchive() (staged_save.cpp). Not a public Project I/O
+// contract: only these two translation units include this header, matching the existing
+// document_decode_internal.hpp / canonical_json_string_detail.hpp precedent for a private
+// cross-file implementation seam within one CMake target.
+//
+// buildSaveArchive() only needs the finished archive bytes and discards everything else.
+// buildVerifiedSaveArchive() and stageSaveArchive() both additionally need the exact manifest.json
+// and document.json entry bytes that were encoded, to build a SaveArchiveExpectedContent for
+// verifySaveArchive() -- stageSaveArchive() runs that verification over the staged/read-back
+// bytes instead of the in-memory archive, but it is the same expected-content shape either way. So
+// this routine hands back the entry bytes alongside the archive rather than just the archive, and
+// each of the three callers uses only what it needs.
+namespace bloom::project::detail {
+
+// The entry-byte pmr::vector<char> buffers below are backed by a heap-allocated
+// ProjectIoMemoryResource at a stable address, mirroring ZipContainerArchive's own ownership
+// pattern (project/include/bloom/project/zip_container_writer.hpp): a constructed pmr::vector
+// remembers its originating memory_resource's address, so that resource must outlive every use of
+// the vectors and must never move once a vector is bound to it. A stack-local resource (as
+// buildVerifiedSaveArchive used before this split) cannot outlive its constructing function, so a
+// struct returned by value needs the resource on the heap instead.
+struct SaveArchiveBuiltEntries final {
+    std::unique_ptr<ProjectIoMemoryResource> resource;
+    std::pmr::vector<char> manifestBytes;
+    std::pmr::vector<char> documentBytes;
+
+    [[nodiscard]] std::span<const std::byte> manifestByteSpan() const noexcept;
+    [[nodiscard]] std::span<const std::byte> documentByteSpan() const noexcept;
+};
+
+// Exactly one of {archive, failure} is engaged. `entries` is engaged if and only if `archive` is
+// (they are produced together on success and never separately).
+struct SaveArchiveBuildOutcome final {
+    std::optional<ZipContainerWriteResult> archive;
+    std::optional<SaveArchiveBuiltEntries> entries;
+    std::optional<SaveArchiveFailure> failure;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return archive.has_value(); }
+
+    // Every accessor below re-checks its own optional immediately before using it, even though
+    // every caller is only meant to reach it after its own operator bool() check: this keeps every
+    // access statically guarded (never an unchecked std::optional dereference) and fails closed --
+    // via std::terminate(), matching this codebase's existing precedent for a provably-impossible
+    // internal invariant break (see LinuxSharedState::releaseActiveTarget() in
+    // staged_artifact_linux.cpp) -- rather than silently reading an empty optional if the
+    // {archive, entries} XOR {failure} invariant above were ever violated by a future edit.
+    [[nodiscard]] SaveArchiveFailure takeFailure() && noexcept;
+    [[nodiscard]] ZipContainerWriteResult takeArchive() && noexcept;
+    [[nodiscard]] std::span<const std::byte> archiveBytes() const& noexcept;
+    [[nodiscard]] SaveArchiveExpectedContent
+    expectedContent(document::SchemaVersion documentSchemaVersion) const& noexcept;
+};
+
+// Encodes manifest.json and document.json and writes the two-entry Constrained ZIP Profile
+// container from their bytes; never reopens, decodes, reconstructs, or re-encodes anything (that
+// is verifySaveArchive()'s job, run by callers that want it against whichever bytes they hold).
+// Charges every allocation through `operation`, exactly as buildVerifiedSaveArchive() did before
+// this split. Never throws.
+[[nodiscard]] SaveArchiveBuildOutcome
+buildSaveArchiveEntries(const CanonicalManifestV1& manifest, const CanonicalDocumentV1& document,
+                        const SaveArchiveLimits& limits,
+                        ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::project::detail
+
+#endif // BLOOM_PROJECT_SAVE_ARCHIVE_INTERNAL_HPP

--- a/src/project/staged_save.cpp
+++ b/src/project/staged_save.cpp
@@ -1,0 +1,163 @@
+#include <bloom/project/staged_save.hpp>
+
+#include "save_archive_internal.hpp"
+
+#include <bloom/project/project_io_memory_resource.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory_resource>
+#include <new>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace bloom::project {
+
+StagedSaveResult StagedSaveResult::success() noexcept {
+    StagedSaveResult result;
+    return result;
+}
+
+StagedSaveResult
+StagedSaveResult::failure(StagedSaveFailure failureValue,
+                          const std::optional<platform::StagedArtifactError> rejectDiagnostic) {
+    StagedSaveResult result;
+    result.failure_.emplace(std::move(failureValue));
+    result.rejectDiagnostic_ = rejectDiagnostic;
+    return result;
+}
+
+StagedSaveResult stageSaveArchive(platform::StagedArtifactLease& lease,
+                                  const CanonicalManifestV1& manifest,
+                                  const CanonicalDocumentV1& document,
+                                  const SaveArchiveLimits& limits,
+                                  ProjectIoOperationMemory operation) noexcept {
+    auto stage = StagedSaveStage::Build;
+    try {
+        // Step 1: build the archive in memory. No in-memory verification here -- the
+        // verification that matters is over the staged bytes (steps 3-4 below). `operation` is a
+        // cheap shared_ptr-backed handle (see save_archive.cpp's equivalent comment), so this
+        // copy and the later move into verifySaveArchive() are both safe; buildSaveArchiveEntries
+        // is the same shared build routine buildSaveArchive()/buildVerifiedSaveArchive() use (see
+        // save_archive_internal.hpp), returned here with the manifest/document entry bytes still
+        // attached because step 4 needs them for SaveArchiveExpectedContent.
+        auto outcome = detail::buildSaveArchiveEntries(manifest, document, limits, operation);
+        if (!outcome) {
+            return StagedSaveResult::failure(
+                StagedSaveFailure(StagedSaveStage::Build, std::move(outcome).takeFailure()));
+        }
+        const auto archiveBytes = outcome.archiveBytes();
+
+        // Step 2: write the built archive to the stage and close/reopen it for verification.
+        stage = StagedSaveStage::StageWrite;
+        const auto writeResult = lease.write(archiveBytes);
+        if (!writeResult) {
+            return StagedSaveResult::failure(StagedSaveFailure(
+                StagedSaveStage::StageWrite,
+                StagedSavePlatformFailure{writeResult.error, StagedSaveLeaseCall::Write}));
+        }
+
+        stage = StagedSaveStage::StageFinish;
+        const auto finishResult = lease.finishWriting();
+        if (!finishResult) {
+            return StagedSaveResult::failure(StagedSaveFailure(
+                StagedSaveStage::StageFinish,
+                StagedSavePlatformFailure{finishResult.error, StagedSaveLeaseCall::FinishWriting}));
+        }
+
+        // Step 3: read the staged bytes back. Validate the platform's own accounting of what got
+        // staged against the archive this function built and wrote, and fail closed before
+        // allocating a read-back buffer sized from a value that disagrees with what was written.
+        // This is defense in depth: the real platform coordinator only reports stageBytes() as
+        // the sum of accepted write() calls, and this function issues exactly one write() of
+        // `archiveBytes`, so the two are not expected to disagree in practice (see the
+        // implementor's report for why this path is believed unreachable through the public
+        // lease API and shipped fault points).
+        stage = StagedSaveStage::StagedSizeDisagreement;
+        const auto stagedBytes = lease.stageBytes();
+        if (stagedBytes != archiveBytes.size() ||
+            archiveBytes.size() > limits.container.maxArchiveBytes) {
+            return StagedSaveResult::failure(
+                StagedSaveFailure(StagedSaveStage::StagedSizeDisagreement,
+                                  StagedSaveSizeDisagreement{archiveBytes.size(), stagedBytes}));
+        }
+
+        stage = StagedSaveStage::ReadBackAllocation;
+        ProjectIoMemoryResource readBackResource(operation);
+        std::pmr::vector<std::byte> readBack(&readBackResource);
+        // ProjectIoMemoryResource::do_allocate() throws on budget rejection (see
+        // project_io_memory_resource.hpp); the catch clauses below translate that into a typed
+        // ResourceExhausted failure at this stage.
+        readBack.resize(static_cast<std::size_t>(stagedBytes));
+
+        stage = StagedSaveStage::StageRead;
+        std::uint64_t offset = 0;
+        const std::uint64_t total = readBack.size();
+        while (offset < total) {
+            const auto remaining = total - offset;
+            const auto destination = std::span<std::byte>(readBack).subspan(offset, remaining);
+            const auto readResult = lease.readForVerification(offset, destination);
+            if (!readResult) {
+                return StagedSaveResult::failure(StagedSaveFailure(
+                    StagedSaveStage::StageRead,
+                    StagedSavePlatformFailure{readResult.error,
+                                              StagedSaveLeaseCall::ReadForVerification}));
+            }
+            if (readResult.bytesRead == 0 || readResult.bytesRead > remaining) {
+                // A zero-progress or over-bound "successful" read is inconsistent with the
+                // requested span; the platform contract has no dedicated error for this
+                // (StagedArtifactError enumerates real platform failure causes, not caller-side
+                // protocol violations it cannot itself commit), so it is reported at this call
+                // using the closest existing verification-read error.
+                return StagedSaveResult::failure(StagedSaveFailure(
+                    StagedSaveStage::StageRead,
+                    StagedSavePlatformFailure{
+                        platform::StagedArtifactError::StageVerificationReadFailed,
+                        StagedSaveLeaseCall::ReadForVerification}));
+            }
+            offset += readResult.bytesRead;
+        }
+
+        // Step 4: verify the staged/read-back bytes against the in-memory entries this function
+        // built (not against the archive it wrote -- the whole point is to verify what actually
+        // reached the stage).
+        stage = StagedSaveStage::Verification;
+        const auto expected = outcome.expectedContent(manifest.documentSchemaVersion);
+        // Final use of `operation` in this function.
+        auto verified = verifySaveArchive(std::span<const std::byte>(readBack), expected, limits,
+                                          std::move(operation));
+        if (!verified) {
+            auto verificationFailure = std::move(verified).takeFailure();
+            // Best-effort: a rejectVerification() failure is a secondary diagnostic that must
+            // never mask the primary verification failure above. The lease destructor still owns
+            // stage cleanup either way (see the header comment), so this call's only job is to
+            // move the lease to its correct terminal state when it can.
+            const auto rejectResult = lease.rejectVerification();
+            const std::optional<platform::StagedArtifactError> rejectDiagnostic =
+                rejectResult ? std::nullopt : std::optional(rejectResult.error);
+            return StagedSaveResult::failure(
+                StagedSaveFailure(StagedSaveStage::Verification, std::move(verificationFailure)),
+                rejectDiagnostic);
+        }
+
+        // Step 5: accept. The lease is now exactly one publish() away; that call belongs to the
+        // application-layer publication coordinator, never to this module.
+        stage = StagedSaveStage::Accept;
+        const auto acceptResult = lease.acceptVerification();
+        if (!acceptResult) {
+            return StagedSaveResult::failure(StagedSaveFailure(
+                StagedSaveStage::Accept,
+                StagedSavePlatformFailure{acceptResult.error,
+                                          StagedSaveLeaseCall::AcceptVerification}));
+        }
+        return StagedSaveResult::success();
+    } catch (const std::bad_alloc&) {
+        return StagedSaveResult::failure(StagedSaveFailure(stage, SaveArchiveResourceExhausted{}));
+    } catch (...) {
+        return StagedSaveResult::failure(StagedSaveFailure(stage, SaveArchiveUnexpectedFailure{}));
+    }
+}
+
+} // namespace bloom::project

--- a/src/project/tests/staged_save_tests.cpp
+++ b/src/project/tests/staged_save_tests.cpp
@@ -1,0 +1,871 @@
+#include <bloom/project/staged_save.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/extension_records.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Drives a REAL bloom::platform::StagedArtifactCoordinator over a per-test temporary directory,
+// following the pattern (not the file) of src/platform/tests/staged_artifact_tests.cpp: a
+// TempDirectory RAII helper and a thin coordinator/request-building layer, reused here because
+// stageSaveArchive() only makes sense exercised against the real platform lease state machine
+// (see the type's own file comment) and its fault-injection hooks.
+
+namespace {
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::PublicationDisposition;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+using bloom::platform::StagedArtifactError;
+using bloom::platform::StagedArtifactFaultPoint;
+using bloom::platform::StagedArtifactLease;
+using bloom::platform::StagedArtifactPreflightRequest;
+using bloom::platform::StagedArtifactPublicationOutcome;
+
+using bloom::project::buildSaveArchive;
+using bloom::project::canonicalDocumentSize;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::canonicalManifestSize;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::encodeCanonicalDocument;
+using bloom::project::encodeCanonicalManifest;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::SaveArchiveContainerReadFailure;
+using bloom::project::SaveArchiveExpectedContent;
+using bloom::project::SaveArchiveFailure;
+using bloom::project::SaveArchiveLimits;
+using bloom::project::SaveArchiveStage;
+using bloom::project::StagedSaveLeaseCall;
+using bloom::project::StagedSavePlatformFailure;
+using bloom::project::StagedSaveResult;
+using bloom::project::StagedSaveStage;
+using bloom::project::stageSaveArchive;
+using bloom::project::verifySaveArchive;
+using bloom::project::ZipContainerError;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-staged-save-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Shared plumbing
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U; // 32 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    return makeOperation(kGenerousOperationBudget);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::span<const char> bytes) noexcept {
+    return {reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-save coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+[[nodiscard]] StagedArtifactPreflightRequest makeRequest(
+    std::filesystem::path targetPath,
+    const ArtifactOverwritePolicy overwritePolicy = ArtifactOverwritePolicy::CreateOrReplace,
+    std::optional<bloom::platform::ArtifactTargetObservation> expectedTarget = std::nullopt) {
+    return {.targetPath = std::move(targetPath),
+            .overwritePolicy = overwritePolicy,
+            .expectedTarget = expectedTarget};
+}
+
+// Builds one save/reopen chain input (a fresh minimal document under `projectName`, mirroring
+// src/project/tests/save_archive_tests.cpp's testMinimalGreenChain fixture) and invokes `use`
+// with it. Everything the resulting CanonicalManifestV1/CanonicalDocumentV1 point into (the
+// Snapshot, the ColorSettings) stays alive for the duration of `use` as locals of this function,
+// never returned by value -- see that file's own comments on why a Document need not itself
+// outlive snapshot() (Snapshot is backed by shared_ptr'd immutable state) but the manifest/
+// document *input* structs, which hold raw pointers, do need their pointees to stay put.
+void withDocumentInput(
+    Expectations& expectations, const std::string_view projectName,
+    const std::function<void(const CanonicalManifestV1&, const CanonicalDocumentV1&)>& use) {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject(std::string(projectName), "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    use(manifest, documentInput);
+}
+
+// A larger fixture (few extension records, but each carrying a sizeable, poorly-compressible
+// opaque payload, all owned by one provider so a single manifest requirement covers them) needed
+// for budget-exhaustion probing. For a small document, the container writer's own documented
+// worst-case qualified-dependency working-memory reservation (a transient, held only within its
+// own stage) dwarfs the actual content, so a budget large enough to clear it during build always
+// has slack left over for the tiny read-back allocation too -- the ReadBackAllocation stage is not
+// reachable as a *specific* failure point for a small fixture (see the implementor's report). This
+// fixture instead makes the built archive itself several times larger than that transient
+// reservation, so a budget just above what build needs is provably short of what an additional,
+// archive-sized read-back allocation needs.
+void withBulkDocumentInput(
+    Expectations& expectations,
+    const std::function<void(const CanonicalManifestV1&, const CanonicalDocumentV1&)>& use) {
+    using bloom::document::ExtensionRecord;
+    using bloom::document::ExtensionRecordId;
+    using bloom::document::NoExtensionReferences;
+    using bloom::document::OpaqueExtensionPayload;
+
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "bulk fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Bulk Budget Project", "Main Composition", *duration);
+    constexpr std::uint64_t kRecordCount = 60;
+    constexpr std::size_t kPayloadBytes = 200'000;
+    // A cheap xorshift-derived pattern, not a real PRNG: just needs to resist deflate collapsing
+    // the archive back down to a small compressed size the way a repeated-byte payload would.
+    std::uint64_t xorshiftState = 0x9E3779B97F4A7C15ULL;
+    const auto nextPseudoRandomByte = [&xorshiftState]() noexcept {
+        xorshiftState ^= xorshiftState << 13U;
+        xorshiftState ^= xorshiftState >> 7U;
+        xorshiftState ^= xorshiftState << 17U;
+        return static_cast<std::byte>(xorshiftState & 0xFFU);
+    };
+    for (std::uint64_t index = 1; index <= kRecordCount; ++index) {
+        std::vector<std::byte> payloadBytes(kPayloadBytes);
+        std::ranges::generate(payloadBytes, nextPseudoRandomByte);
+        ExtensionRecord record{ExtensionRecordId::fromRaw(index),
+                               "vendor.bulk",
+                               "vendor.bulk.record",
+                               {1, 0},
+                               std::nullopt,
+                               "application/octet-stream",
+                               NoExtensionReferences{},
+                               OpaqueExtensionPayload{std::move(payloadBytes)}};
+        const bool added = newProject.project.addExtensionRecord(std::move(record));
+        expectations.expect(added, "bulk fixture extension record adds");
+        if (!added) {
+            return;
+        }
+    }
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const std::vector<bloom::project::ManifestRequirement> requirements{
+        {.providerId = "vendor.bulk",
+         .capabilityId = "vendor.bulk.cap",
+         .schemaVersion = {1, 0},
+         .providedNodeTypeIds = {}}};
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0},
+                                       .requirements = requirements};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    use(manifest, documentInput);
+}
+
+struct StageAttempt final {
+    std::optional<StagedArtifactLease> lease;
+    std::optional<StagedSaveResult> result;
+};
+
+// preflight() -> stage() -> stageSaveArchive() against a real coordinator; leaves the lease (if
+// one was obtained) in `lease` for the caller to publish, replay, or simply drop for RAII cleanup.
+[[nodiscard]] StageAttempt
+attemptStage(Expectations& expectations, StagedArtifactCoordinator& coordinator,
+             const std::filesystem::path& targetPath, const ArtifactOverwritePolicy policy,
+             const std::optional<bloom::platform::ArtifactTargetObservation>& expectedTarget,
+             const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput,
+             const SaveArchiveLimits& limits, ProjectIoOperationMemory operation) {
+    StageAttempt attempt;
+    auto preflight = coordinator.preflight(makeRequest(targetPath, policy, expectedTarget));
+    if (!preflight) {
+        expectations.expect(false, "attemptStage: preflight succeeds");
+        return attempt;
+    }
+    auto stageResult = coordinator.stage(std::move(preflight).takeTarget());
+    if (!stageResult) {
+        expectations.expect(false, "attemptStage: stage succeeds");
+        return attempt;
+    }
+    attempt.lease = std::move(stageResult).takeLease();
+    attempt.result =
+        stageSaveArchive(*attempt.lease, manifest, documentInput, limits, std::move(operation));
+    return attempt;
+}
+
+// Independently encodes manifest.json/document.json straight from canonical_manifest.hpp /
+// canonical_document.hpp -- never through save_archive.hpp/staged_save.hpp -- to serve as an
+// oracle for the byte content stageSaveArchive() should have staged, mirroring
+// save_archive_tests.cpp's testMinimalGreenChain oracle.
+struct OracleEntries final {
+    std::vector<char> manifestBytes;
+    std::vector<char> documentBytes;
+};
+
+[[nodiscard]] std::optional<OracleEntries>
+buildOracleEntries(Expectations& expectations, const CanonicalManifestV1& manifest,
+                   const CanonicalDocumentV1& documentInput) {
+    const auto manifestSize = canonicalManifestSize(manifest);
+    expectations.expect(static_cast<bool>(manifestSize), "oracle: manifest sizes");
+    if (!manifestSize) {
+        return std::nullopt;
+    }
+    std::vector<char> manifestBytes(*manifestSize.value());
+    expectations.expect(static_cast<bool>(encodeCanonicalManifest(manifest, manifestBytes)),
+                        "oracle: manifest encodes");
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    CanonicalDocumentV1 oracleRequest = documentInput;
+    oracleRequest.payloadScratch = payloadScratch;
+    oracleRequest.sortScratch = sortScratch;
+    const auto documentSize = canonicalDocumentSize(oracleRequest);
+    expectations.expect(static_cast<bool>(documentSize), "oracle: document sizes");
+    if (!documentSize) {
+        return std::nullopt;
+    }
+    std::vector<char> documentBytes(*documentSize.value());
+    expectations.expect(static_cast<bool>(encodeCanonicalDocument(oracleRequest, documentBytes)),
+                        "oracle: document encodes");
+    return OracleEntries{std::move(manifestBytes), std::move(documentBytes)};
+}
+
+// ---------------------------------------------------------------------------------------------
+// Green path: preflight (CreateOnly, absent target) -> stage -> stageSaveArchive -> success ->
+// caller-side publish(Proceed) -> Published. The published file is byte-compared against an
+// independently built archive (buildSaveArchive over the same input; determinism -- see
+// testDeterminism below and save_archive_tests.cpp's own determinism test -- makes this a valid
+// oracle) and, separately, re-verified in place with verifySaveArchive() against independently
+// canonical-encoded entry bytes as a second, deeper oracle.
+// ---------------------------------------------------------------------------------------------
+
+void testGreenPathEndToEnd(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "green path: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Green Path Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            {
+                // Scoped so this peek-only preflight token (and the active-target admission it
+                // holds) is released before attemptStage() below preflights the same identity
+                // again for real.
+                auto preflight = coordinator->preflight(
+                    makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly));
+                expectations.expect(preflight && !preflight.target()->observation().exists,
+                                    "green path: create-only preflight observes an absent target");
+                if (!preflight) {
+                    return;
+                }
+            }
+            auto attempt = attemptStage(expectations, *coordinator, targetPath,
+                                        ArtifactOverwritePolicy::CreateOnly, std::nullopt, manifest,
+                                        documentInput, SaveArchiveLimits{}, makeOperation());
+            expectations.expect(attempt.lease.has_value() && attempt.result.has_value() &&
+                                    static_cast<bool>(*attempt.result),
+                                "green path: stageSaveArchive succeeds");
+            if (!attempt.lease.has_value() || !attempt.result.has_value() || !*attempt.result) {
+                return;
+            }
+            const auto publication = attempt.lease->publish(PublicationDisposition::Proceed);
+            expectations.expect(publication.outcome == StagedArtifactPublicationOutcome::Published,
+                                "green path: publish reaches Published");
+            if (publication.outcome != StagedArtifactPublicationOutcome::Published) {
+                return;
+            }
+
+            auto oracleArchive =
+                buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+            expectations.expect(static_cast<bool>(oracleArchive),
+                                "green path: independent buildSaveArchive oracle succeeds");
+            if (!oracleArchive) {
+                return;
+            }
+            const auto oracleBytes = oracleArchive.archive()->bytes();
+            const auto published = readFile(targetPath);
+            expectations.expect(
+                published.size() == oracleBytes.size() &&
+                    std::memcmp(published.data(), oracleBytes.data(), published.size()) == 0,
+                "green path: the published file is byte-identical to the independently built "
+                "archive");
+
+            const auto oracleEntries = buildOracleEntries(expectations, manifest, documentInput);
+            if (!oracleEntries.has_value()) {
+                return;
+            }
+            const SaveArchiveExpectedContent expected{
+                .manifestBytes = asBytes(oracleEntries->manifestBytes),
+                .documentBytes = asBytes(oracleEntries->documentBytes),
+                .documentSchemaVersion = manifest.documentSchemaVersion,
+            };
+            auto reverified = verifySaveArchive(asBytes(published), expected, SaveArchiveLimits{},
+                                                makeOperation());
+            expectations.expect(static_cast<bool>(reverified),
+                                "green path: verifySaveArchive independently re-verifies the "
+                                "published file's bytes as the final oracle");
+        });
+}
+
+// ---------------------------------------------------------------------------------------------
+// ReplaceExisting: publish once, preflight again with the observed fingerprint, save+publish a
+// second (distinct) archive, verify the replacement bytes.
+// ---------------------------------------------------------------------------------------------
+
+void testReplaceExistingPath(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "replace existing: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Replace First Project",
+        [&](const CanonicalManifestV1& manifest1, const CanonicalDocumentV1& documentInput1) {
+            auto first = attemptStage(expectations, *coordinator, targetPath,
+                                      ArtifactOverwritePolicy::CreateOnly, std::nullopt, manifest1,
+                                      documentInput1, SaveArchiveLimits{}, makeOperation());
+            expectations.expect(first.lease.has_value() && first.result.has_value() &&
+                                    static_cast<bool>(*first.result),
+                                "replace existing: first stageSaveArchive succeeds");
+            if (!first.lease.has_value() || !first.result.has_value() || !*first.result) {
+                return;
+            }
+            const auto firstPublication = first.lease->publish(PublicationDisposition::Proceed);
+            expectations.expect(firstPublication.outcome ==
+                                    StagedArtifactPublicationOutcome::Published,
+                                "replace existing: first publish reaches Published");
+            if (firstPublication.outcome != StagedArtifactPublicationOutcome::Published) {
+                return;
+            }
+
+            auto observedPreflight = coordinator->preflight(
+                makeRequest(targetPath, ArtifactOverwritePolicy::ReplaceExisting));
+            expectations.expect(observedPreflight &&
+                                    observedPreflight.target()->observation().exists,
+                                "replace existing: preflight observes the published target's "
+                                "fingerprint");
+            if (!observedPreflight) {
+                return;
+            }
+            const auto observedFingerprint = observedPreflight.target()->observation();
+
+            withDocumentInput(
+                expectations, "Replace Second Project",
+                [&](const CanonicalManifestV1& manifest2,
+                    const CanonicalDocumentV1& documentInput2) {
+                    auto second = attemptStage(expectations, *coordinator, targetPath,
+                                               ArtifactOverwritePolicy::ReplaceExisting,
+                                               observedFingerprint, manifest2, documentInput2,
+                                               SaveArchiveLimits{}, makeOperation());
+                    expectations.expect(second.lease.has_value() && second.result.has_value() &&
+                                            static_cast<bool>(*second.result),
+                                        "replace existing: second stageSaveArchive succeeds");
+                    if (!second.lease.has_value() || !second.result.has_value() ||
+                        !*second.result) {
+                        return;
+                    }
+                    const auto secondPublication =
+                        second.lease->publish(PublicationDisposition::Proceed);
+                    expectations.expect(secondPublication.outcome ==
+                                            StagedArtifactPublicationOutcome::Published,
+                                        "replace existing: second publish reaches Published");
+                    if (secondPublication.outcome != StagedArtifactPublicationOutcome::Published) {
+                        return;
+                    }
+
+                    auto oracleArchive = buildSaveArchive(manifest2, documentInput2,
+                                                          SaveArchiveLimits{}, makeOperation());
+                    expectations.expect(static_cast<bool>(oracleArchive),
+                                        "replace existing: independent oracle build succeeds");
+                    if (!oracleArchive) {
+                        return;
+                    }
+                    const auto oracleBytes = oracleArchive.archive()->bytes();
+                    const auto published = readFile(targetPath);
+                    expectations.expect(
+                        published.size() == oracleBytes.size() &&
+                            std::memcmp(published.data(), oracleBytes.data(), published.size()) ==
+                                0,
+                        "replace existing: the replaced file's bytes match the independently "
+                        "built second archive");
+                });
+        });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Fault injection at StageWrite, StageWriterClose (finishWriting), StageVerificationRead, and
+// StageVerificationAccept: each surfaces the platform's typed FaultInjected error at the right
+// stage/lease-call of stageSaveArchive()'s result, and every lease -- once dropped -- releases its
+// active-target admission (RAII cleanup; no test seam or explicit cleanup call needed).
+// ---------------------------------------------------------------------------------------------
+
+void testFaultInjection(Expectations& expectations) {
+    struct FaultCase final {
+        StagedArtifactFaultPoint point;
+        StagedSaveStage expectedStage;
+        StagedSaveLeaseCall expectedCall;
+    };
+    const std::array<FaultCase, 4> cases{{
+        {StagedArtifactFaultPoint::StageWrite, StagedSaveStage::StageWrite,
+         StagedSaveLeaseCall::Write},
+        {StagedArtifactFaultPoint::StageWriterClose, StagedSaveStage::StageFinish,
+         StagedSaveLeaseCall::FinishWriting},
+        {StagedArtifactFaultPoint::StageVerificationRead, StagedSaveStage::StageRead,
+         StagedSaveLeaseCall::ReadForVerification},
+        {StagedArtifactFaultPoint::StageVerificationAccept, StagedSaveStage::Accept,
+         StagedSaveLeaseCall::AcceptVerification},
+    }};
+
+    for (const auto& testCase : cases) {
+        TempDirectory directory;
+        if (!directory.isValid()) {
+            expectations.expect(false, "fault injection: temp directory is available");
+            continue;
+        }
+        StagedArtifactConfig config;
+        config.faults = {.point = testCase.point, .occurrence = 1};
+        auto coordinator = makeCoordinator(expectations, config);
+        if (!coordinator.has_value()) {
+            continue;
+        }
+        const auto targetPath = directory.path() / "project.bloom";
+
+        withDocumentInput(
+            expectations, "Fault Injection Project",
+            [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+                auto attempt = attemptStage(
+                    expectations, *coordinator, targetPath, ArtifactOverwritePolicy::CreateOnly,
+                    std::nullopt, manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+                expectations.expect(attempt.lease.has_value(), "fault injection: a lease is "
+                                                               "obtained before the injected "
+                                                               "failure");
+                expectations.expect(attempt.result.has_value() && !*attempt.result,
+                                    "fault injection: stageSaveArchive reports failure");
+                if (!attempt.result.has_value()) {
+                    return;
+                }
+                const auto* failure = attempt.result->failure();
+                expectations.expect(failure != nullptr &&
+                                        failure->stage() == testCase.expectedStage,
+                                    "fault injection: the failure stage matches the injected "
+                                    "fault point");
+                const auto* platformFailure =
+                    failure != nullptr ? failure->payloadAs<StagedSavePlatformFailure>() : nullptr;
+                expectations.expect(
+                    platformFailure != nullptr &&
+                        platformFailure->error == StagedArtifactError::FaultInjected &&
+                        platformFailure->call == testCase.expectedCall,
+                    "fault injection: the platform failure payload names FaultInjected and the "
+                    "exact lease call");
+            });
+        // `attempt` (and its lease) is out of scope by now; the lease destructor already ran.
+        const auto snapshot = coordinator->snapshot();
+        expectations.expect(snapshot.activeTargetCount == 0,
+                            "fault injection: dropping the lease releases the active target "
+                            "admission");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Verification failure over the staged bytes. Directly tampering the staged file's content
+// through the lease API alone is not reachable: stageSaveArchive() runs write -> finish -> read
+// -> verify as one monolithic noexcept call with no callback seam between finishWriting() and its
+// own read-back loop, and adding one purely to make this test possible is explicitly out of scope
+// (the task package forbids a production test seam for this). Reaching the platform's staged
+// bytes from *outside* that call is therefore not possible without a seam either.
+//
+// Instead, this is reached through ordinary public parameters: a manifest whose
+// documentSchemaVersion disagrees with the document's own embedded schema version (which
+// CanonicalDocumentV1::schemaMinor controls, defaulted to 0 here) is a legitimate, seam-free way
+// to make verifySaveArchive() fail its VersionAgreement check over the exact bytes that were
+// staged and read back -- the encode step happily writes self-inconsistent input; only
+// verification catches it. This is a genuine failure of stageSaveArchive()'s verification-over-
+// staged-bytes step, not a redundant re-test of verifySaveArchive() in isolation (which
+// save_archive_tests.cpp's testVersionDisagreement already covers) -- it additionally proves this
+// module's own reject-on-failure wiring: lease.rejectVerification() is called and the lease
+// replays a terminal StageVerificationRejected outcome afterward.
+// ---------------------------------------------------------------------------------------------
+
+void testVerificationFailureOverStagedBytes(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "verification failure: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Version Mismatch Project",
+        [&](const CanonicalManifestV1& baseManifest, const CanonicalDocumentV1& documentInput) {
+            CanonicalManifestV1 manifest = baseManifest;
+            manifest.documentSchemaVersion = {1, 1}; // documentInput still encodes {1, 0}.
+
+            auto preflight = coordinator->preflight(
+                makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly));
+            expectations.expect(static_cast<bool>(preflight), "verification failure: preflight "
+                                                              "succeeds");
+            if (!preflight) {
+                return;
+            }
+            auto stageResult = coordinator->stage(std::move(preflight).takeTarget());
+            expectations.expect(static_cast<bool>(stageResult), "verification failure: stage "
+                                                                "succeeds");
+            if (!stageResult) {
+                return;
+            }
+            auto lease = std::move(stageResult).takeLease();
+
+            auto result = stageSaveArchive(lease, manifest, documentInput, SaveArchiveLimits{},
+                                           makeOperation());
+            expectations.expect(!result, "verification failure: stageSaveArchive reports failure");
+            const auto* failure = result.failure();
+            expectations.expect(failure != nullptr &&
+                                    failure->stage() == StagedSaveStage::Verification,
+                                "verification failure: reported at the Verification stage");
+            const auto* saveFailure =
+                failure != nullptr ? failure->payloadAs<SaveArchiveFailure>() : nullptr;
+            expectations.expect(saveFailure != nullptr &&
+                                    saveFailure->stage() == SaveArchiveStage::VersionAgreement,
+                                "verification failure: the nested SaveArchiveFailure names "
+                                "VersionAgreement");
+            expectations.expect(!result.rejectDiagnostic().has_value(),
+                                "verification failure: lease.rejectVerification() itself "
+                                "succeeded (no secondary diagnostic)");
+
+            const auto publication = lease.publish(PublicationDisposition::Proceed);
+            expectations.expect(
+                publication.outcome == StagedArtifactPublicationOutcome::FailedBeforePublication &&
+                    publication.error == StagedArtifactError::StageVerificationRejected,
+                "verification failure: the lease replays its rejected terminal state on publish");
+        });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Staged-size disagreement (StagedSaveStage::StagedSizeDisagreement): stageSaveArchive() issues
+// exactly one lease.write(archiveBytes) call with the complete built archive and then reads
+// lease.stageBytes() straight back from the platform lease, so the built size and the staged size
+// can only disagree if the platform itself misreports what it accepted. None of the shipped
+// StagedArtifactFaultPoint values corrupt stageBytes() (StageWrite/StageWriterClose faults return
+// a typed error instead and stageSaveArchive never reaches the size check on that path), and
+// there is no other public seam to desynchronize the two values. This path is therefore not
+// reachable from this test file without a production test seam, which the task package forbids
+// adding solely for this; it is documented here rather than covered by an automated test.
+// ---------------------------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------------------------
+// Budget exhaustion. A budget that covers the build but is exhausted by the next materially
+// larger allocation in the chain is not reachable as specifically "covers the build, fails at
+// ReadBackAllocation": see the long comment inside this test for why (short version:
+// writeZipContainer()'s own transient working-memory footprint already exceeds
+// steady-state-after-build plus one more archive-sized buffer, for any fixture size, so a budget
+// that clears the build always has slack left for the read-back allocation too). This test
+// instead pins the same typed-ResourceExhausted/zeroed-snapshot/safe-destruction contract at the
+// nearest stage where it IS reachable: Verification.
+// ---------------------------------------------------------------------------------------------
+
+void testBudgetExhaustion(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "budget exhaustion: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withBulkDocumentInput(expectations, [&](const CanonicalManifestV1& manifest,
+                                            const CanonicalDocumentV1& documentInput) {
+        // First pass: measure buildSaveArchive()'s own peak charge (manifest + document +
+        // archive bytes, all live at once) with a generous budget. The bulk fixture's payload
+        // is large enough that the ordinary 32 MiB "generous" budget used elsewhere in this
+        // file is not generous enough here.
+        constexpr std::uint64_t kBulkProbeBudget = 256ULL << 20U;
+        auto probeMemory = ProjectIoMemoryCoordinator::create(kBulkProbeBudget);
+        expectations.expect(probeMemory.has_value(), "budget exhaustion: probe coordinator "
+                                                     "constructs");
+        if (!probeMemory.has_value()) {
+            return;
+        }
+        auto probeOperation = probeMemory->createOperation(kBulkProbeBudget, kBulkProbeBudget);
+        expectations.expect(probeOperation.has_value(), "budget exhaustion: probe operation "
+                                                        "constructs");
+        if (!probeOperation.has_value()) {
+            return;
+        }
+        std::uint64_t buildPeakBytes = 0;
+        {
+            auto probeBuild =
+                buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, *probeOperation);
+            expectations.expect(static_cast<bool>(probeBuild), "budget exhaustion: probe "
+                                                               "build succeeds");
+            if (!probeBuild) {
+                return;
+            }
+            buildPeakBytes = probeOperation->snapshot().peakBytes;
+        }
+
+        // Second pass: a budget just above that build-only peak. Empirically (see the
+        // implementor's report), stageSaveArchive()'s ReadBackAllocation stage specifically is
+        // NOT reachable this way for this writer implementation: writeZipContainer() itself
+        // transiently holds a full document-entry-sized deflate-attempt buffer alongside the
+        // still-live manifest/document input bytes (plus its own documented qualified-
+        // compressor working-memory reservation), so its own peak already exceeds
+        // (steady-state-after-build + one more archive-sized read-back buffer) by roughly a
+        // constant multiple, for any fixture size -- a budget that clears the build always has
+        // slack left over for the tiny read-back allocation on top. The next stage that
+        // legitimately needs materially more memory than the build did is Verification
+        // (verifySaveArchive() reopens, parses, decodes, reconstructs, and re-encodes), so a
+        // budget just above the build's own peak reliably exhausts there instead. This still
+        // exercises the exact contract this test cares about -- typed ResourceExhausted,
+        // zeroed snapshot, a safely destructible lease -- just one stage later than
+        // ReadBackAllocation specifically.
+        constexpr std::uint64_t kMargin = 64;
+        const auto budget = buildPeakBytes + kMargin;
+        auto memory = ProjectIoMemoryCoordinator::create(kBulkProbeBudget);
+        expectations.expect(memory.has_value(), "budget exhaustion: coordinator constructs");
+        if (!memory.has_value()) {
+            return;
+        }
+        auto operation = memory->createOperation(budget, budget);
+        expectations.expect(operation.has_value(), "budget exhaustion: constrained operation "
+                                                   "constructs");
+        if (!operation.has_value()) {
+            return;
+        }
+
+        auto preflight =
+            coordinator->preflight(makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly));
+        expectations.expect(static_cast<bool>(preflight), "budget exhaustion: preflight "
+                                                          "succeeds");
+        if (!preflight) {
+            return;
+        }
+        auto stageResult = coordinator->stage(std::move(preflight).takeTarget());
+        expectations.expect(static_cast<bool>(stageResult), "budget exhaustion: stage "
+                                                            "succeeds");
+        if (!stageResult) {
+            return;
+        }
+        {
+            auto lease = std::move(stageResult).takeLease();
+            auto result = stageSaveArchive(lease, manifest, documentInput, SaveArchiveLimits{},
+                                           std::move(*operation));
+            expectations.expect(!result, "budget exhaustion: a budget just above the build's "
+                                         "own peak still fails somewhere in the chain");
+            const auto* failure = result.failure();
+            expectations.expect(failure != nullptr &&
+                                    failure->stage() == StagedSaveStage::Verification,
+                                "budget exhaustion: reported at the Verification stage (the "
+                                "next stage past the build with materially higher memory "
+                                "needs -- see the comment above)");
+            const auto* nestedFailure =
+                failure != nullptr ? failure->payloadAs<SaveArchiveFailure>() : nullptr;
+            expectations.expect(nestedFailure != nullptr &&
+                                    nestedFailure->stage() == SaveArchiveStage::ContainerRead,
+                                "budget exhaustion: the nested verifySaveArchive() failure is "
+                                "scoped to ContainerRead (reopening the staged bytes needs the "
+                                "reader's own qualified-decompressor working-memory "
+                                "reservation)");
+            const auto* containerReadFailure =
+                nestedFailure != nullptr
+                    ? nestedFailure->payloadAs<SaveArchiveContainerReadFailure>()
+                    : nullptr;
+            expectations.expect(
+                containerReadFailure != nullptr &&
+                    containerReadFailure->error == ZipContainerError::ResourceExhausted,
+                "budget exhaustion: the nested failure is a typed ResourceExhausted from the "
+                "container reader");
+        } // The lease is destroyed here; its stage cleanup is exercised by this scope exit.
+        const auto memorySnapshot = memory->snapshot();
+        expectations.expect(memorySnapshot.currentBytes == 0,
+                            "budget exhaustion: the constrained coordinator's charge returns "
+                            "to zero");
+        const auto artifactSnapshot = coordinator->snapshot();
+        expectations.expect(artifactSnapshot.activeTargetCount == 0,
+                            "budget exhaustion: the lease remained safely destructible after "
+                            "resource exhaustion");
+    });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Determinism: two staged saves of the same input, published to two distinct targets, produce
+// byte-identical published files.
+// ---------------------------------------------------------------------------------------------
+
+void testDeterminism(Expectations& expectations) {
+    TempDirectory directoryA;
+    TempDirectory directoryB;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directoryA.isValid() || !directoryB.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "determinism: fixture is available");
+        return;
+    }
+    const auto targetPathA = directoryA.path() / "project.bloom";
+    const auto targetPathB = directoryB.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Determinism Project",
+        [&](const CanonicalManifestV1& manifestA, const CanonicalDocumentV1& documentInputA) {
+            auto attemptA = attemptStage(
+                expectations, *coordinator, targetPathA, ArtifactOverwritePolicy::CreateOnly,
+                std::nullopt, manifestA, documentInputA, SaveArchiveLimits{}, makeOperation());
+            expectations.expect(attemptA.result.has_value() && static_cast<bool>(*attemptA.result),
+                                "determinism: first stageSaveArchive succeeds");
+            if (!attemptA.lease.has_value() || !attemptA.result.has_value() || !*attemptA.result) {
+                return;
+            }
+            const auto publicationA = attemptA.lease->publish(PublicationDisposition::Proceed);
+            expectations.expect(publicationA.outcome == StagedArtifactPublicationOutcome::Published,
+                                "determinism: first publish reaches Published");
+        });
+    withDocumentInput(
+        expectations, "Determinism Project",
+        [&](const CanonicalManifestV1& manifestB, const CanonicalDocumentV1& documentInputB) {
+            auto attemptB = attemptStage(
+                expectations, *coordinator, targetPathB, ArtifactOverwritePolicy::CreateOnly,
+                std::nullopt, manifestB, documentInputB, SaveArchiveLimits{}, makeOperation());
+            expectations.expect(attemptB.result.has_value() && static_cast<bool>(*attemptB.result),
+                                "determinism: second stageSaveArchive succeeds");
+            if (!attemptB.lease.has_value() || !attemptB.result.has_value() || !*attemptB.result) {
+                return;
+            }
+            const auto publicationB = attemptB.lease->publish(PublicationDisposition::Proceed);
+            expectations.expect(publicationB.outcome == StagedArtifactPublicationOutcome::Published,
+                                "determinism: second publish reaches Published");
+        });
+
+    const auto bytesA = readFile(targetPathA);
+    const auto bytesB = readFile(targetPathB);
+    expectations.expect(!bytesA.empty() && bytesA == bytesB,
+                        "determinism: two staged saves of the same input produce byte-identical "
+                        "published files");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testGreenPathEndToEnd(expectations);
+    testReplaceExistingPath(expectations);
+    testFaultInjection(expectations);
+    testVerificationFailureOverStagedBytes(expectations);
+    testBudgetExhaustion(expectations);
+    testDeterminism(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Closes #54.

Staged save execution — the format contract's Save sequence steps 3–5: write the built archive into the secure stage, close it, read the staged bytes back through the lease's verification reads, and run the complete reopen validation over **what actually reached the stage**, then accept or reject the lease's verification. Publication stays with the caller: the module leaves a verified lease exactly one `publish()` away and never enters the publication half itself.

**Build split, behavior-preserved**: `buildSaveArchive` exposes the archive build without the in-memory verification pass (the validation that matters runs on staged bytes); `buildVerifiedSaveArchive` keeps its exact behavior via a shared private seam that also hands back the entry bytes on a heap-stable memory resource.

**Fail-closed lease driving**: staged size validated against the built archive before any allocation sized from it; the read-back loop treats zero-progress and over-bound reads as protocol violations; a `rejectVerification` failure surfaces only as a secondary diagnostic, never masking the primary cause; every failure path leaves the lease safely destructible with stage cleanup owned by its destructor.

This uses the architecture's allowed `project → platform` module edge for the first time.

Testing: six scenario groups against a real staged-artifact coordinator on per-test temporary directories — end-to-end publish with independent byte oracles, replace-existing with fingerprint re-preflight, fault injection at four lease calls with no leaked targets, a seam-free verification failure over real staged bytes, budget exhaustion with zeroed snapshots, and byte-identical determinism. Two unreachabilities documented in place rather than force-tested. Full ci-linux-native suite 63/63 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).