### PR TITLE
feat: publish saves through intent-ordered leases

### DIFF
--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -5,16 +5,24 @@ target_sources(
     PRIVATE
         project_session.cpp
         publication_coordinator.cpp
+        save_publication.cpp
     PUBLIC
         FILE_SET HEADERS
         BASE_DIRS include
         FILES
             include/bloom/host/project_session.hpp
             include/bloom/host/publication_coordinator.hpp
+            include/bloom/host/save_publication.hpp
 )
 
 target_compile_features(bloom_host PUBLIC cxx_std_20)
-target_link_libraries(bloom_host PUBLIC bloom_commands bloom_core bloom_document)
+# bloom_project and bloom_platform are PUBLIC: include/bloom/host/save_publication.hpp declares
+# SavePublicationRequest/SavePublicationResult carrying both modules' types (CanonicalManifestV1/
+# CanonicalDocumentV1/SaveArchiveLimits/StagedSaveFailure, ArtifactOverwritePolicy/
+# ArtifactTargetObservation/StagedArtifactCoordinator/StagedArtifactPublicationResult) in its
+# public signatures, so anything including that header needs both modules' headers visible too.
+target_link_libraries(bloom_host PUBLIC bloom_commands bloom_core bloom_document bloom_project
+                                        bloom_platform)
 bloom_enable_warnings(bloom_host)
 
 if(BUILD_TESTING)
@@ -39,4 +47,18 @@ if(BUILD_TESTING)
         COMMAND bloom_host_project_session_test
         LABELS unit host project commands
     )
+
+    # Gated Linux-only exactly as bloom.project.staged_save is gated: this exercises a real
+    # platform::StagedArtifactCoordinator over per-test temporary directories, and only the Linux
+    # platform backend is implemented today (see src/platform/staged_artifact_unsupported.cpp).
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_executable(bloom_host_save_publication_test tests/save_publication_tests.cpp)
+        target_link_libraries(bloom_host_save_publication_test PRIVATE bloom_host)
+        bloom_enable_warnings(bloom_host_save_publication_test)
+        bloom_add_test(
+            NAME bloom.host.save-publication
+            COMMAND bloom_host_save_publication_test
+            LABELS unit host persistence security
+        )
+    endif()
 endif()

--- a/src/host/include/bloom/host/save_publication.hpp
+++ b/src/host/include/bloom/host/save_publication.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/staged_save.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <variant>
+
+// The application-host composition of docs/architecture/project-format.md's "Staging And Atomic
+// Publication" nine-step sequence with docs/architecture/project-session.md's "Per-Target
+// Ordering And Publication": this module owns steps 1-2 (admission and preflight) and 6-8
+// (publication ordering against the application-wide PublicationCoordinator, then the platform
+// publication lease), composing project::stageSaveArchive() (steps 3-5) and
+// platform::StagedArtifactLease::publish() (the rest of 6-8) in between. It is the synchronous,
+// caller-threaded executor primitive only: session/executor threading, Save As path-authority
+// state, and session result acceptance are a later slice (see docs/architecture/project-session.md
+// "Save Result Acceptance").
+namespace bloom::host {
+
+// Every stage this executor's own pipeline can fail at, distinct from the outcome of a publish()
+// call that was actually reached (see SavePublicationResult::publication()). "Cancelled" is one
+// stage shared by every cancellation checkpoint between admission and the publication guard: the
+// checkpoint that observed the flag is not separately distinguished because none of them run
+// publish() and the caller-observable contract (no replacement occurred) is identical at all of
+// them.
+enum class SavePublicationStage : std::uint8_t {
+    None,
+    Admission,
+    Preflight,
+    Registration,
+    Staging,
+    StagedSave,
+    Guard,
+    Cancelled,
+};
+
+// SavePublicationStage::ResourceExhausted/UnexpectedFailure are not stage-scoped enumerators of
+// their own; a resource-exhausted or unexpected-exception failure is reported at whichever
+// SavePublicationStage was current when it happened, the same established pattern as
+// bloom/project/staged_save.hpp's StagedSaveStage tracking. These two payload types name that a
+// failure of this kind occurred without duplicating one payload type per stage.
+struct SavePublicationResourceExhausted final {};
+struct SavePublicationUnexpectedFailure final {};
+
+// Guard statuses other than Entered/Superseded (InvalidClaim/TargetBusy/AlreadyEntered) are
+// internal-protocol failures for this single-executor composition: this function's own claim is
+// always freshly registered and entered at most once, so InvalidClaim/AlreadyEntered cannot occur,
+// and no other guard is ever held concurrently against the same claim's target from within one
+// call, so TargetBusy cannot occur either. They are still handled (typed failure, no publish()
+// call) because a concurrent multi-executor flow -- out of scope here -- can reach them; see the
+// implementor's report for the full unreachability argument.
+using SavePublicationFailurePayload =
+    std::variant<std::monostate, PublicationAdmissionStatus, platform::StagedArtifactError,
+                 PublicationRegistrationStatus, project::StagedSaveFailure, PublicationGuardStatus,
+                 SavePublicationResourceExhausted, SavePublicationUnexpectedFailure>;
+
+class SavePublicationFailure final {
+  public:
+    SavePublicationFailure() = default;
+
+    template <typename Payload>
+    SavePublicationFailure(const SavePublicationStage stage, Payload payload)
+        : stage_(stage), payload_(std::move(payload)) {}
+
+    [[nodiscard]] SavePublicationStage stage() const noexcept { return stage_; }
+    [[nodiscard]] const SavePublicationFailurePayload& payload() const noexcept { return payload_; }
+
+    template <typename Payload> [[nodiscard]] const Payload* payloadAs() const noexcept {
+        return std::get_if<Payload>(&payload_);
+    }
+
+  private:
+    SavePublicationStage stage_ = SavePublicationStage::None;
+    SavePublicationFailurePayload payload_;
+};
+
+// The synchronous save-publication executor's result. Exactly one of `failure()`/`publication()`
+// is non-null: `publication()` is set only for the two guard outcomes (Entered, Superseded) that
+// actually call platform::StagedArtifactLease::publish(); every earlier pipeline stage reports a
+// typed SavePublicationFailure instead and never calls publish().
+class [[nodiscard]] SavePublicationResult final {
+  public:
+    SavePublicationResult(SavePublicationResult&&) noexcept = default;
+    SavePublicationResult& operator=(SavePublicationResult&&) noexcept = default;
+    SavePublicationResult(const SavePublicationResult&) = delete;
+    SavePublicationResult& operator=(const SavePublicationResult&) = delete;
+    ~SavePublicationResult() = default;
+
+    // The pipeline reached and called lease.publish(): `publication` carries the platform's exact
+    // six-outcome contract (see project-format.md's outcome table) and `intentId` is this
+    // executor's own claim's PublicationIntentId -- the winning intent on Entered/Published, the
+    // superseded loser on Superseded -- for the caller's session bookkeeping (the future session
+    // layer keys its own in-flight Save operation by the intent its admission was assigned).
+    [[nodiscard]] static SavePublicationResult
+    published(platform::StagedArtifactPublicationResult publication,
+              PublicationIntentId intentId) noexcept;
+
+    // A typed pipeline failure before publish() was ever called. `rejectDiagnostic`, when set,
+    // is StagedSaveResult::rejectDiagnostic() forwarded verbatim (SavePublicationStage::StagedSave
+    // only): a secondary diagnostic from a lease.rejectVerification() call that itself failed,
+    // never the primary reason staging failed.
+    [[nodiscard]] static SavePublicationResult
+    failure(SavePublicationFailure failure,
+            std::optional<platform::StagedArtifactError> rejectDiagnostic = std::nullopt) noexcept;
+
+    // True when the pipeline reached publish() without an internal protocol failure -- NOT
+    // whether the target was actually replaced (Superseded/ExternalModificationConflict/
+    // FailedBeforePublication also return true here). Check publication()->targetWasPublished()
+    // for that.
+    [[nodiscard]] explicit operator bool() const noexcept { return !failure_.has_value(); }
+
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const& noexcept {
+        return publication_.has_value() ? &*publication_ : nullptr;
+    }
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const&& = delete;
+    [[nodiscard]] std::optional<PublicationIntentId> intentId() const noexcept { return intentId_; }
+    [[nodiscard]] const SavePublicationFailure* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const SavePublicationFailure* failure() const&& = delete;
+    [[nodiscard]] std::optional<platform::StagedArtifactError> rejectDiagnostic() const noexcept {
+        return rejectDiagnostic_;
+    }
+
+  private:
+    SavePublicationResult() = default;
+
+    std::optional<platform::StagedArtifactPublicationResult> publication_;
+    std::optional<PublicationIntentId> intentId_;
+    std::optional<SavePublicationFailure> failure_;
+    std::optional<platform::StagedArtifactError> rejectDiagnostic_;
+};
+
+struct SavePublicationRequest final {
+    std::filesystem::path targetPath;
+    platform::ArtifactOverwritePolicy overwritePolicy =
+        platform::ArtifactOverwritePolicy::CreateOrReplace;
+    std::optional<platform::ArtifactTargetObservation> expectedTarget;
+    const project::CanonicalManifestV1* manifest = nullptr; // non-owning, caller-kept-alive
+    const project::CanonicalDocumentV1* document = nullptr; // non-owning, caller-kept-alive
+    project::SaveArchiveLimits limits;
+
+    // When set, executeSavePublication() takes ownership of *preAdmitted (moves from it) instead
+    // of calling coordinator.admit() itself, and never touches admission internally otherwise.
+    // The contract assigns a Save's PublicationIntentId at admission time, before path
+    // resolution/worker dispatch -- the future session layer admits at Save-request time on its
+    // own thread and hands the admission to this synchronous executor later, so this seam is not
+    // solely a test convenience. Caller-owned; must outlive the call; left moved-from afterward.
+    PublicationAdmission* preAdmitted = nullptr;
+
+    // Optional caller-checked cancellation, observed between pipeline stages up to (never after)
+    // the publication guard attempt; a caller-owned atomic checked at each boundary. Left null,
+    // cancellation is never observed here -- full session-level cancellation semantics are a
+    // later slice.
+    const std::atomic_bool* cancellationFlag = nullptr;
+};
+
+// See the namespace-level comment above for the composition this performs. noexcept top level;
+// an internal std::bad_alloc or other exception is reported as a typed
+// SavePublicationResourceExhausted/UnexpectedFailure failure at whichever stage was current (the
+// established bloom/project/staged_save.hpp pattern). RAII (PublicationAdmission/
+// PublicationTargetClaim/PublicationGuard/StagedArtifactTarget/StagedArtifactLease) unwinds
+// correctly on every path; a run that never reaches publish() leaves both the coordinator and the
+// platform artifact coordinator with no unresolved admissions, claims, guards, or active targets
+// once this call returns and every handle it produced has been dropped.
+[[nodiscard]] SavePublicationResult executeSavePublication(
+    PublicationCoordinator& coordinator, platform::StagedArtifactCoordinator& artifacts,
+    const SavePublicationRequest& request, project::ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::host

--- a/src/host/save_publication.cpp
+++ b/src/host/save_publication.cpp
@@ -1,0 +1,181 @@
+#include <bloom/host/save_publication.hpp>
+
+#include <new>
+#include <optional>
+#include <utility>
+
+namespace bloom::host {
+
+SavePublicationResult
+SavePublicationResult::published(platform::StagedArtifactPublicationResult publication,
+                                 const PublicationIntentId intentId) noexcept {
+    SavePublicationResult result;
+    result.publication_ = publication;
+    result.intentId_ = intentId;
+    return result;
+}
+
+SavePublicationResult SavePublicationResult::failure(
+    SavePublicationFailure failureValue,
+    const std::optional<platform::StagedArtifactError> rejectDiagnostic) noexcept {
+    SavePublicationResult result;
+    result.failure_.emplace(std::move(failureValue));
+    result.rejectDiagnostic_ = rejectDiagnostic;
+    return result;
+}
+
+namespace {
+
+[[nodiscard]] bool cancelled(const std::atomic_bool* flag) noexcept {
+    return flag != nullptr && flag->load(std::memory_order_relaxed);
+}
+
+[[nodiscard]] SavePublicationResult cancelledResult() noexcept {
+    return SavePublicationResult::failure(
+        SavePublicationFailure(SavePublicationStage::Cancelled, std::monostate{}));
+}
+
+} // namespace
+
+SavePublicationResult executeSavePublication(PublicationCoordinator& coordinator,
+                                             platform::StagedArtifactCoordinator& artifacts,
+                                             const SavePublicationRequest& request,
+                                             project::ProjectIoOperationMemory operation) noexcept {
+    auto stage = SavePublicationStage::Admission;
+    try {
+        // Step 1 (project-format.md step 1's admission half; the contract requires admission
+        // before any path work): take ownership of a caller-supplied admission, or admit here.
+        std::optional<PublicationAdmission> admission;
+        if (request.preAdmitted != nullptr) {
+            admission.emplace(std::move(*request.preAdmitted));
+        } else {
+            auto admissionResult = coordinator.admit();
+            if (!admissionResult) {
+                return SavePublicationResult::failure(SavePublicationFailure(
+                    SavePublicationStage::Admission, admissionResult.status()));
+            }
+            admission.emplace(std::move(admissionResult).takeAdmission());
+        }
+        // A pre-admitted admission that is invalid or foreign to `coordinator` is not rejected
+        // here: coordinator.registerTarget() below already performs that exact check and reports
+        // it as a typed Registration-stage PublicationRegistrationStatus::InvalidAdmission
+        // failure, so duplicating the check here would only duplicate the failure path.
+
+        if (cancelled(request.cancellationFlag)) {
+            return cancelledResult();
+            // `admission` goes out of scope here and abandons via RAII.
+        }
+
+        // Step 2: platform preflight (project-format.md steps 1-2's path-resolution/rejection
+        // half).
+        stage = SavePublicationStage::Preflight;
+        auto preflightResult = artifacts.preflight({.targetPath = request.targetPath,
+                                                    .overwritePolicy = request.overwritePolicy,
+                                                    .expectedTarget = request.expectedTarget});
+        if (!preflightResult) {
+            return SavePublicationResult::failure(
+                SavePublicationFailure(SavePublicationStage::Preflight, preflightResult.error()));
+            // `admission` abandons via RAII; nothing else was obtained yet.
+        }
+        auto target = std::move(preflightResult).takeTarget();
+        const auto targetKey = target.targetKey();
+
+        if (cancelled(request.cancellationFlag)) {
+            return cancelledResult();
+            // `admission` abandons and `target` releases its platform active-target admission.
+        }
+
+        // Step 3: register the admission for this target, consuming it into a target claim
+        // (project-session.md's "the coordinator registers that intent for the target key
+        // returned by ... preflight").
+        stage = SavePublicationStage::Registration;
+        auto registrationResult = coordinator.registerTarget(std::move(*admission), targetKey);
+        if (!registrationResult) {
+            return SavePublicationResult::failure(SavePublicationFailure(
+                SavePublicationStage::Registration, registrationResult.status()));
+            // registerTarget() already consumed or abandoned `admission` itself; `target`
+            // releases its platform active-target admission.
+        }
+        auto claim = std::move(registrationResult).takeClaim();
+        const auto intentId = claim.intentId();
+
+        // Step 4: stage the artifact, exchanging the preflight target for a writable lease.
+        stage = SavePublicationStage::Staging;
+        auto stageResult = artifacts.stage(std::move(target));
+        if (!stageResult) {
+            return SavePublicationResult::failure(
+                SavePublicationFailure(SavePublicationStage::Staging, stageResult.error()));
+            // `claim` releases its target-claim record.
+        }
+        auto lease = std::move(stageResult).takeLease();
+
+        if (cancelled(request.cancellationFlag)) {
+            return cancelledResult();
+            // `lease` cleans its unpublished stage; `claim` releases its target-claim record.
+        }
+
+        // Step 5: build/write/verify the archive over the staged lease (project-format.md steps
+        // 3-5, owned by project::stageSaveArchive()).
+        stage = SavePublicationStage::StagedSave;
+        auto stagedSaveResult = project::stageSaveArchive(
+            lease, *request.manifest, *request.document, request.limits, std::move(operation));
+        if (!stagedSaveResult) {
+            // Wrap the StagedSaveResult's failure verbatim: the nested project::StagedSaveFailure
+            // is copied as-is into this stage's payload, and its own rejectDiagnostic (relevant
+            // only for StagedSaveStage::Verification) is forwarded alongside it.
+            return SavePublicationResult::failure(
+                SavePublicationFailure(SavePublicationStage::StagedSave,
+                                       *stagedSaveResult.failure()),
+                stagedSaveResult.rejectDiagnostic());
+            // `lease` cleans its unpublished/rejected stage; `claim` releases its target-claim
+            // record.
+        }
+
+        // Step 6: attempt to enter the non-cancellable publication lease at the winning intent
+        // (project-session.md: "Immediately before the platform coordinator grants its
+        // non-cancellable publication lease, the staged artifact must still own the application
+        // coordinator's winning intent for that target").
+        stage = SavePublicationStage::Guard;
+        auto guardResult = claim.tryEnterPublication();
+        switch (guardResult.status()) {
+        case PublicationGuardStatus::Entered: {
+            // Held only for the duration of publish(): `guard` releases its publication-guard
+            // record when this case's scope ends, after publish() has already run.
+            auto guard = std::move(guardResult).takeGuard();
+            auto publication = lease.publish(platform::PublicationDisposition::Proceed);
+            return SavePublicationResult::published(publication, intentId);
+        }
+        case PublicationGuardStatus::Superseded:
+            // No guard is granted on Superseded (a newer same-target intent already owns
+            // publication order), but the lease must still run its publish path so the platform
+            // records the superseded outcome and cleans up the stage -- it does not know about
+            // application-coordinator intents on its own.
+            return SavePublicationResult::published(
+                lease.publish(platform::PublicationDisposition::Superseded), intentId);
+        case PublicationGuardStatus::InvalidClaim:
+        case PublicationGuardStatus::TargetBusy:
+        case PublicationGuardStatus::AlreadyEntered:
+            // Unreachable in this single-executor composition (see the header's PublicationGuard
+            // status comment): `claim` is always freshly registered and entered at most once by
+            // this one call, so InvalidClaim/AlreadyEntered cannot occur, and this call never
+            // holds a concurrent guard against its own claim's target, so TargetBusy cannot
+            // occur either. Still handled as a typed protocol failure -- never calling publish()
+            // -- because a future concurrent multi-executor flow can reach them for real.
+            return SavePublicationResult::failure(
+                SavePublicationFailure(SavePublicationStage::Guard, guardResult.status()));
+            // `lease` cleans its unpublished stage; `claim` releases its target-claim record.
+        }
+        // All PublicationGuardStatus enumerators are handled above; this is unreachable but keeps
+        // the function's control flow provably total for the compiler.
+        return SavePublicationResult::failure(
+            SavePublicationFailure(SavePublicationStage::Guard, guardResult.status()));
+    } catch (const std::bad_alloc&) {
+        return SavePublicationResult::failure(
+            SavePublicationFailure(stage, SavePublicationResourceExhausted{}));
+    } catch (...) {
+        return SavePublicationResult::failure(
+            SavePublicationFailure(stage, SavePublicationUnexpectedFailure{}));
+    }
+}
+
+} // namespace bloom::host

--- a/src/host/tests/save_publication_tests.cpp
+++ b/src/host/tests/save_publication_tests.cpp
@@ -1,0 +1,1078 @@
+#include <bloom/host/save_publication.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/extension_records.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/staged_save.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Drives executeSavePublication() -- the host-side composition of the application
+// PublicationCoordinator with the platform StagedArtifactCoordinator over
+// project::stageSaveArchive() -- against REAL coordinators on per-test temporary directories,
+// following src/project/tests/staged_save_tests.cpp's pattern (TempDirectory RAII helper, a thin
+// coordinator/request-building layer, an independent buildSaveArchive()/verifySaveArchive()
+// oracle for published bytes) one composition layer up.
+
+namespace {
+
+using bloom::host::executeSavePublication;
+using bloom::host::PublicationAdmission;
+using bloom::host::PublicationCoordinator;
+using bloom::host::PublicationCoordinatorConfig;
+using bloom::host::SavePublicationFailure;
+using bloom::host::SavePublicationRequest;
+using bloom::host::SavePublicationStage;
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::ArtifactTargetObservation;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+using bloom::platform::StagedArtifactError;
+using bloom::platform::StagedArtifactFaultPoint;
+using bloom::platform::StagedArtifactPublicationOutcome;
+
+using bloom::project::buildSaveArchive;
+using bloom::project::canonicalDocumentSize;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::canonicalManifestSize;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::encodeCanonicalDocument;
+using bloom::project::encodeCanonicalManifest;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::SaveArchiveContainerReadFailure;
+using bloom::project::SaveArchiveExpectedContent;
+using bloom::project::SaveArchiveFailure;
+using bloom::project::SaveArchiveLimits;
+using bloom::project::SaveArchiveStage;
+using bloom::project::StagedSaveFailure;
+using bloom::project::StagedSaveLeaseCall;
+using bloom::project::StagedSavePlatformFailure;
+using bloom::project::StagedSaveStage;
+using bloom::project::verifySaveArchive;
+using bloom::project::ZipContainerError;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-save-publication-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Shared plumbing
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U; // 32 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    return makeOperation(kGenerousOperationBudget);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::span<const char> bytes) noexcept {
+    return {reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::optional<PublicationCoordinator>
+makePublicationCoordinator(Expectations& expectations,
+                           const PublicationCoordinatorConfig config = {}) {
+    auto result = PublicationCoordinator::create(config);
+    expectations.expect(result.has_value(), "the publication coordinator is created");
+    return result;
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeArtifactsCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-artifact coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+[[nodiscard]] std::optional<PublicationAdmission> admitIntent(PublicationCoordinator& coordinator,
+                                                              Expectations& expectations,
+                                                              const std::string_view context) {
+    auto result = coordinator.admit();
+    expectations.expect(static_cast<bool>(result), context);
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeAdmission();
+}
+
+[[nodiscard]] SavePublicationRequest
+makeRequest(const std::filesystem::path& targetPath, const ArtifactOverwritePolicy policy,
+            const std::optional<ArtifactTargetObservation>& expectedTarget,
+            const CanonicalManifestV1& manifest, const CanonicalDocumentV1& document,
+            const SaveArchiveLimits& limits = {}, PublicationAdmission* preAdmitted = nullptr,
+            const std::atomic_bool* cancellationFlag = nullptr) {
+    return SavePublicationRequest{.targetPath = targetPath,
+                                  .overwritePolicy = policy,
+                                  .expectedTarget = expectedTarget,
+                                  .manifest = &manifest,
+                                  .document = &document,
+                                  .limits = limits,
+                                  .preAdmitted = preAdmitted,
+                                  .cancellationFlag = cancellationFlag};
+}
+
+// Builds one save/reopen chain input (a fresh minimal document under `projectName`), mirroring
+// src/project/tests/staged_save_tests.cpp's withDocumentInput fixture. Everything the resulting
+// CanonicalManifestV1/CanonicalDocumentV1 point into stays alive for `use`'s duration as locals of
+// this function (see that file's own comments on why this matters -- the input structs hold raw
+// pointers, not owning storage).
+void withDocumentInput(
+    Expectations& expectations, const std::string_view projectName,
+    const std::function<void(const CanonicalManifestV1&, const CanonicalDocumentV1&)>& use) {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject(std::string(projectName), "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    use(manifest, documentInput);
+}
+
+// A larger fixture for budget-exhaustion probing, mirroring staged_save_tests.cpp's
+// withBulkDocumentInput exactly (same record count/payload size: those numbers were derived there
+// empirically so that a budget just above buildSaveArchive()'s own peak charge reliably exhausts
+// at Verification/ContainerRead rather than anywhere else in the chain -- see that file's own long
+// comment on why ReadBackAllocation specifically is not reachable this way).
+void withBulkDocumentInput(
+    Expectations& expectations,
+    const std::function<void(const CanonicalManifestV1&, const CanonicalDocumentV1&)>& use) {
+    using bloom::document::ExtensionRecord;
+    using bloom::document::ExtensionRecordId;
+    using bloom::document::NoExtensionReferences;
+    using bloom::document::OpaqueExtensionPayload;
+
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "bulk fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Bulk Budget Project", "Main Composition", *duration);
+    constexpr std::uint64_t kRecordCount = 60;
+    constexpr std::size_t kPayloadBytes = 200'000;
+    std::uint64_t xorshiftState = 0x9E3779B97F4A7C15ULL;
+    const auto nextPseudoRandomByte = [&xorshiftState]() noexcept {
+        xorshiftState ^= xorshiftState << 13U;
+        xorshiftState ^= xorshiftState >> 7U;
+        xorshiftState ^= xorshiftState << 17U;
+        return static_cast<std::byte>(xorshiftState & 0xFFU);
+    };
+    for (std::uint64_t index = 1; index <= kRecordCount; ++index) {
+        std::vector<std::byte> payloadBytes(kPayloadBytes);
+        std::ranges::generate(payloadBytes, nextPseudoRandomByte);
+        ExtensionRecord record{ExtensionRecordId::fromRaw(index),
+                               "vendor.bulk",
+                               "vendor.bulk.record",
+                               {1, 0},
+                               std::nullopt,
+                               "application/octet-stream",
+                               NoExtensionReferences{},
+                               OpaqueExtensionPayload{std::move(payloadBytes)}};
+        const bool added = newProject.project.addExtensionRecord(std::move(record));
+        expectations.expect(added, "bulk fixture extension record adds");
+        if (!added) {
+            return;
+        }
+    }
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const std::vector<bloom::project::ManifestRequirement> requirements{
+        {.providerId = "vendor.bulk",
+         .capabilityId = "vendor.bulk.cap",
+         .schemaVersion = {1, 0},
+         .providedNodeTypeIds = {}}};
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0},
+                                       .requirements = requirements};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    use(manifest, documentInput);
+}
+
+// Independently encodes manifest.json/document.json straight from canonical_manifest.hpp/
+// canonical_document.hpp -- never through save_archive.hpp/staged_save.hpp/save_publication.hpp
+// -- to serve as an oracle for the byte content executeSavePublication() should have published.
+struct OracleEntries final {
+    std::vector<char> manifestBytes;
+    std::vector<char> documentBytes;
+};
+
+[[nodiscard]] std::optional<OracleEntries>
+buildOracleEntries(Expectations& expectations, const CanonicalManifestV1& manifest,
+                   const CanonicalDocumentV1& documentInput) {
+    const auto manifestSize = canonicalManifestSize(manifest);
+    expectations.expect(static_cast<bool>(manifestSize), "oracle: manifest sizes");
+    if (!manifestSize) {
+        return std::nullopt;
+    }
+    std::vector<char> manifestBytes(*manifestSize.value());
+    expectations.expect(static_cast<bool>(encodeCanonicalManifest(manifest, manifestBytes)),
+                        "oracle: manifest encodes");
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    CanonicalDocumentV1 oracleRequest = documentInput;
+    oracleRequest.payloadScratch = payloadScratch;
+    oracleRequest.sortScratch = sortScratch;
+    const auto documentSize = canonicalDocumentSize(oracleRequest);
+    expectations.expect(static_cast<bool>(documentSize), "oracle: document sizes");
+    if (!documentSize) {
+        return std::nullopt;
+    }
+    std::vector<char> documentBytes(*documentSize.value());
+    expectations.expect(static_cast<bool>(encodeCanonicalDocument(oracleRequest, documentBytes)),
+                        "oracle: document encodes");
+    return OracleEntries{std::move(manifestBytes), std::move(documentBytes)};
+}
+
+void expectIdleSnapshots(Expectations& expectations, const PublicationCoordinator& coordinator,
+                         const StagedArtifactCoordinator& artifacts,
+                         const std::string_view context) {
+    const auto coordinatorSnapshot = coordinator.snapshot();
+    expectations.expect(coordinatorSnapshot.unresolvedAdmissionCount == 0 &&
+                            coordinatorSnapshot.targetRecordCount == 0 &&
+                            coordinatorSnapshot.activeTargetClaimCount == 0 &&
+                            coordinatorSnapshot.activePublicationGuardCount == 0,
+                        std::string(context) + ": the publication coordinator snapshot is idle");
+    const auto artifactSnapshot = artifacts.snapshot();
+    expectations.expect(artifactSnapshot.activeTargetCount == 0,
+                        std::string(context) +
+                            ": the platform artifact coordinator snapshot has no active targets");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Green path: absent target, CreateOnly -> Published. Published bytes are compared against an
+// independently built archive (buildSaveArchive() over the same input) and separately
+// re-verified in place with verifySaveArchive() against independently canonical-encoded entry
+// bytes, mirroring staged_save_tests.cpp's testGreenPathEndToEnd two-oracle structure one layer up.
+// ---------------------------------------------------------------------------------------------
+
+void testGreenPath(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "green path: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Green Path Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            auto request = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly,
+                                       std::nullopt, manifest, documentInput);
+            auto result =
+                executeSavePublication(*coordinator, *artifacts, request, makeOperation());
+            expectations.expect(static_cast<bool>(result),
+                                "green path: the executor reaches publish without a protocol "
+                                "failure");
+            const auto* publication = result.publication();
+            expectations.expect(publication != nullptr &&
+                                    publication->outcome ==
+                                        StagedArtifactPublicationOutcome::Published,
+                                "green path: publish reaches Published");
+            expectations.expect(result.intentId().has_value() && result.intentId()->value() == 1,
+                                "green path: the winning intent is reported");
+            if (publication == nullptr ||
+                publication->outcome != StagedArtifactPublicationOutcome::Published) {
+                return;
+            }
+
+            auto oracleArchive =
+                buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+            expectations.expect(static_cast<bool>(oracleArchive),
+                                "green path: independent buildSaveArchive oracle succeeds");
+            if (!oracleArchive) {
+                return;
+            }
+            const auto oracleBytes = oracleArchive.archive()->bytes();
+            const auto published = readFile(targetPath);
+            expectations.expect(
+                published.size() == oracleBytes.size() &&
+                    std::memcmp(published.data(), oracleBytes.data(), published.size()) == 0,
+                "green path: the published file is byte-identical to the independently built "
+                "archive");
+
+            const auto oracleEntries = buildOracleEntries(expectations, manifest, documentInput);
+            if (!oracleEntries.has_value()) {
+                return;
+            }
+            const SaveArchiveExpectedContent expected{
+                .manifestBytes = asBytes(oracleEntries->manifestBytes),
+                .documentBytes = asBytes(oracleEntries->documentBytes),
+                .documentSchemaVersion = manifest.documentSchemaVersion,
+            };
+            auto reverified = verifySaveArchive(asBytes(published), expected, SaveArchiveLimits{},
+                                                makeOperation());
+            expectations.expect(static_cast<bool>(reverified),
+                                "green path: verifySaveArchive independently re-verifies the "
+                                "published file's bytes as the final oracle");
+
+            expectIdleSnapshots(expectations, *coordinator, *artifacts, "green path");
+        });
+}
+
+// ---------------------------------------------------------------------------------------------
+// ReplaceExisting: publish once, observe the published fingerprint, save+publish a second
+// (distinct) archive with that fingerprint as the expected observation, verify the replacement.
+// ---------------------------------------------------------------------------------------------
+
+void testReplaceExistingPath(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "replace existing: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Replace First Project",
+        [&](const CanonicalManifestV1& manifest1, const CanonicalDocumentV1& documentInput1) {
+            auto request1 = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly,
+                                        std::nullopt, manifest1, documentInput1);
+            auto result1 =
+                executeSavePublication(*coordinator, *artifacts, request1, makeOperation());
+            expectations.expect(static_cast<bool>(result1) && result1.publication() != nullptr &&
+                                    result1.publication()->outcome ==
+                                        StagedArtifactPublicationOutcome::Published,
+                                "replace existing: first publish reaches Published");
+            if (!result1 || result1.publication() == nullptr ||
+                result1.publication()->outcome != StagedArtifactPublicationOutcome::Published) {
+                return;
+            }
+
+            std::optional<ArtifactTargetObservation> observedFingerprint;
+            {
+                // Scoped so this peek-only preflight token is released before request2's own
+                // preflight (below) inspects the same identity again for real.
+                auto peek = artifacts->preflight(
+                    {.targetPath = targetPath,
+                     .overwritePolicy = ArtifactOverwritePolicy::ReplaceExisting,
+                     .expectedTarget = std::nullopt});
+                expectations.expect(peek && peek.target()->observation().exists,
+                                    "replace existing: preflight observes the published target's "
+                                    "fingerprint");
+                if (!peek) {
+                    return;
+                }
+                observedFingerprint = peek.target()->observation();
+            }
+
+            withDocumentInput(
+                expectations, "Replace Second Project",
+                [&](const CanonicalManifestV1& manifest2,
+                    const CanonicalDocumentV1& documentInput2) {
+                    auto request2 =
+                        makeRequest(targetPath, ArtifactOverwritePolicy::ReplaceExisting,
+                                    observedFingerprint, manifest2, documentInput2);
+                    auto result2 =
+                        executeSavePublication(*coordinator, *artifacts, request2, makeOperation());
+                    expectations.expect(static_cast<bool>(result2) &&
+                                            result2.publication() != nullptr &&
+                                            result2.publication()->outcome ==
+                                                StagedArtifactPublicationOutcome::Published,
+                                        "replace existing: second publish reaches Published");
+                    if (!result2 || result2.publication() == nullptr ||
+                        result2.publication()->outcome !=
+                            StagedArtifactPublicationOutcome::Published) {
+                        return;
+                    }
+
+                    auto oracleArchive = buildSaveArchive(manifest2, documentInput2,
+                                                          SaveArchiveLimits{}, makeOperation());
+                    expectations.expect(static_cast<bool>(oracleArchive),
+                                        "replace existing: independent oracle build succeeds");
+                    if (!oracleArchive) {
+                        return;
+                    }
+                    const auto oracleBytes = oracleArchive.archive()->bytes();
+                    const auto published = readFile(targetPath);
+                    expectations.expect(
+                        published.size() == oracleBytes.size() &&
+                            std::memcmp(published.data(), oracleBytes.data(), published.size()) ==
+                                0,
+                        "replace existing: the replaced file's bytes match the independently "
+                        "built second archive");
+
+                    expectIdleSnapshots(expectations, *coordinator, *artifacts, "replace existing");
+                });
+        });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Supersession: a competing higher intent registers for the same target key between this
+// executor's own (lower) admission and its guard attempt. The FROZEN arrangement from the task
+// package: pre-admit and hand the executor its own (lower) admission via
+// SavePublicationRequest::preAdmitted, then -- before invoking the executor -- admit+register a
+// competing HIGHER intent directly against the coordinator for the identical target key (obtained
+// by a scoped peek preflight, released before the executor's own real preflight runs). The
+// competing claim is then dropped immediately: PublicationTargetClaim::tryEnterPublication()'s
+// Superseded test is purely "does the target record's highestRegisteredIntent still equal MY
+// intent", which the coordinator's tombstone semantics keep true regardless of whether the
+// competing claim object itself is still alive (see docs/architecture/project-session.md's
+// "Per-Target Ordering And Publication": the record persists as a tombstone while any unresolved
+// intent below the high-water mark could still arrive -- exactly this executor's lower admission).
+// ---------------------------------------------------------------------------------------------
+
+void testSupersession(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "supersession: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    bloom::host::ArtifactTargetKey targetKey;
+    {
+        auto peek = artifacts->preflight({.targetPath = targetPath,
+                                          .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                          .expectedTarget = std::nullopt});
+        expectations.expect(static_cast<bool>(peek), "supersession: the peek preflight succeeds");
+        if (!peek) {
+            return;
+        }
+        targetKey = peek.target()->targetKey();
+    } // Released before the executor's own real preflight runs against the same identity.
+
+    auto lowerAdmission = admitIntent(*coordinator, expectations,
+                                      "supersession: the executor's own (lower) intent "
+                                      "is admitted first");
+    auto competitorAdmission = admitIntent(*coordinator, expectations,
+                                           "supersession: the competing (higher) intent is "
+                                           "admitted second");
+    if (!lowerAdmission.has_value() || !competitorAdmission.has_value()) {
+        return;
+    }
+    expectations.expect(lowerAdmission->intentId().value() <
+                            competitorAdmission->intentId().value(),
+                        "supersession: the competitor's intent is strictly higher");
+
+    auto competitorRegistration =
+        coordinator->registerTarget(std::move(*competitorAdmission), targetKey);
+    expectations.expect(static_cast<bool>(competitorRegistration),
+                        "supersession: the competitor registers the higher intent for the "
+                        "identical target key");
+    if (!competitorRegistration) {
+        return;
+    }
+    // Dropped immediately: the target record retains highestRegisteredIntent as a tombstone (see
+    // the comment above), and `lowerAdmission` is still unresolved below it, so pruning does not
+    // remove the record.
+    std::move(competitorRegistration).takeClaim().reset();
+
+    // Captured before the call below: executeSavePublication() takes ownership of *preAdmitted by
+    // moving from it, which resets the moved-from PublicationAdmission's own intentId() to
+    // invalid (see PublicationAdmission's move constructor) -- reading it afterward would not
+    // observe the intent this test is asserting about.
+    const auto lowerIntentId = lowerAdmission->intentId();
+
+    withDocumentInput(
+        expectations, "Supersession Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            auto request =
+                makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly, std::nullopt, manifest,
+                            documentInput, SaveArchiveLimits{}, &(*lowerAdmission));
+            auto result =
+                executeSavePublication(*coordinator, *artifacts, request, makeOperation());
+            expectations.expect(static_cast<bool>(result),
+                                "supersession: the executor still reaches publish (Superseded is "
+                                "a publish outcome, not a pipeline failure)");
+            const auto* publication = result.publication();
+            expectations.expect(publication != nullptr &&
+                                    publication->outcome ==
+                                        StagedArtifactPublicationOutcome::Superseded,
+                                "supersession: the outcome is Superseded");
+            expectations.expect(result.intentId().has_value() &&
+                                    result.intentId()->value() == lowerIntentId.value(),
+                                "supersession: the reported intent is the executor's own (lower, "
+                                "losing) intent");
+            expectations.expect(!std::filesystem::exists(targetPath),
+                                "supersession: the original (absent) target remains untouched");
+        });
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "supersession");
+}
+
+// ---------------------------------------------------------------------------------------------
+// External modification: publish once, capture the published fingerprint, modify the target
+// directly on disk, then run again with that now-stale expected observation. The caller-supplied
+// expectedTarget is compared against a fresh inspection inside preflight() itself (see
+// src/platform/tests/staged_artifact_tests.cpp's testTargetChecksAndExpectedState, the same
+// public-API path this reaches), so this surfaces as a typed Preflight-stage failure carrying
+// platform::StagedArtifactError::ExternalModificationConflict -- the identical error the
+// project-format.md outcome table's ExternalModificationConflict row names, reached at the
+// earliest point the public contract can report it for a caller-supplied stale expectation
+// (see the implementor's report for why the OTHER reachable path -- publish()'s own final
+// revalidation against what preflight itself just observed -- needs a genuine mid-call race and
+// is not reachable through one synchronous executeSavePublication() call without a forbidden test
+// seam).
+// ---------------------------------------------------------------------------------------------
+
+void testExternalModification(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "external modification: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "External Modification First",
+        [&](const CanonicalManifestV1& manifest1, const CanonicalDocumentV1& documentInput1) {
+            auto request1 = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly,
+                                        std::nullopt, manifest1, documentInput1);
+            auto result1 =
+                executeSavePublication(*coordinator, *artifacts, request1, makeOperation());
+            expectations.expect(static_cast<bool>(result1) && result1.publication() != nullptr &&
+                                    result1.publication()->outcome ==
+                                        StagedArtifactPublicationOutcome::Published,
+                                "external modification: first publish reaches Published");
+            if (!result1 || result1.publication() == nullptr ||
+                result1.publication()->outcome != StagedArtifactPublicationOutcome::Published) {
+                return;
+            }
+
+            std::optional<ArtifactTargetObservation> staleFingerprint;
+            {
+                auto peek = artifacts->preflight(
+                    {.targetPath = targetPath,
+                     .overwritePolicy = ArtifactOverwritePolicy::ReplaceExisting,
+                     .expectedTarget = std::nullopt});
+                expectations.expect(peek && peek.target()->observation().exists,
+                                    "external modification: the fingerprint is observed before "
+                                    "the external change");
+                if (!peek) {
+                    return;
+                }
+                staleFingerprint = peek.target()->observation();
+            }
+
+            {
+                std::ofstream mutate(targetPath, std::ios::binary | std::ios::app);
+                expectations.expect(static_cast<bool>(mutate),
+                                    "external modification: the target opens for an external "
+                                    "append");
+                mutate << "external-modification-marker";
+            }
+            const auto tamperedBytes = readFile(targetPath);
+
+            withDocumentInput(
+                expectations, "External Modification Second",
+                [&](const CanonicalManifestV1& manifest2,
+                    const CanonicalDocumentV1& documentInput2) {
+                    auto request2 =
+                        makeRequest(targetPath, ArtifactOverwritePolicy::ReplaceExisting,
+                                    staleFingerprint, manifest2, documentInput2);
+                    auto result2 =
+                        executeSavePublication(*coordinator, *artifacts, request2, makeOperation());
+                    expectations.expect(!static_cast<bool>(result2),
+                                        "external modification: the executor reports a typed "
+                                        "pipeline failure, never reaching publish");
+                    const auto* failure = result2.failure();
+                    expectations.expect(failure != nullptr &&
+                                            failure->stage() == SavePublicationStage::Preflight,
+                                        "external modification: reported at the Preflight stage");
+                    const auto* platformError =
+                        failure != nullptr ? failure->payloadAs<StagedArtifactError>() : nullptr;
+                    expectations.expect(platformError != nullptr &&
+                                            *platformError ==
+                                                StagedArtifactError::ExternalModificationConflict,
+                                        "external modification: the payload names "
+                                        "ExternalModificationConflict");
+
+                    expectations.expect(readFile(targetPath) == tamperedBytes,
+                                        "external modification: the externally modified target "
+                                        "is left untouched");
+                });
+
+            expectIdleSnapshots(expectations, *coordinator, *artifacts, "external modification");
+        });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Failure stages: invalid target path (Preflight), a fault injected at StageWrite (StagedSave,
+// verbatim project::StagedSaveFailure payload), a fault at AtomicPublication (reaches publish;
+// FailedBeforePublication + the platform error), and a fault at ParentDurability
+// (PublishedWithDurabilityWarning -- a PUBLISHED outcome with a warning). After every case the
+// coordinator and platform snapshots are asserted idle.
+// ---------------------------------------------------------------------------------------------
+
+void testInvalidTargetPath(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "invalid target path: fixture is available");
+        return;
+    }
+    // A trailing separator makes filename() empty, which platform preflight rejects as
+    // StagedArtifactError::InvalidTargetPath before any parent resolution or admission bookkeeping
+    // (see src/platform/staged_artifact_linux.cpp's preflightChecked()).
+    const auto invalidTargetPath = std::filesystem::path(directory.path().string() + "/");
+
+    withDocumentInput(
+        expectations, "Invalid Target Path Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            auto request = makeRequest(invalidTargetPath, ArtifactOverwritePolicy::CreateOnly,
+                                       std::nullopt, manifest, documentInput);
+            auto result =
+                executeSavePublication(*coordinator, *artifacts, request, makeOperation());
+            expectations.expect(!static_cast<bool>(result),
+                                "invalid target path: the executor reports a typed pipeline "
+                                "failure");
+            const auto* failure = result.failure();
+            expectations.expect(failure != nullptr &&
+                                    failure->stage() == SavePublicationStage::Preflight,
+                                "invalid target path: reported at the Preflight stage");
+            const auto* platformError =
+                failure != nullptr ? failure->payloadAs<StagedArtifactError>() : nullptr;
+            expectations.expect(platformError != nullptr &&
+                                    *platformError == StagedArtifactError::InvalidTargetPath,
+                                "invalid target path: the payload names InvalidTargetPath");
+        });
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "invalid target path");
+}
+
+void testStagedSaveFaultInjection(Expectations& expectations) {
+    TempDirectory directory;
+    StagedArtifactConfig config;
+    config.faults = {.point = StagedArtifactFaultPoint::StageWrite, .occurrence = 1};
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations, config);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "staged-save fault: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Staged Save Fault Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            auto request = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly,
+                                       std::nullopt, manifest, documentInput);
+            auto result =
+                executeSavePublication(*coordinator, *artifacts, request, makeOperation());
+            expectations.expect(!static_cast<bool>(result),
+                                "staged-save fault: the executor reports a typed pipeline "
+                                "failure");
+            const auto* failure = result.failure();
+            expectations.expect(failure != nullptr &&
+                                    failure->stage() == SavePublicationStage::StagedSave,
+                                "staged-save fault: reported at the StagedSave stage");
+            const auto* nested =
+                failure != nullptr ? failure->payloadAs<StagedSaveFailure>() : nullptr;
+            expectations.expect(nested != nullptr && nested->stage() == StagedSaveStage::StageWrite,
+                                "staged-save fault: the nested project::StagedSaveFailure names "
+                                "StageWrite verbatim");
+            const auto* platformFailure =
+                nested != nullptr ? nested->payloadAs<StagedSavePlatformFailure>() : nullptr;
+            expectations.expect(
+                platformFailure != nullptr &&
+                    platformFailure->error == StagedArtifactError::FaultInjected &&
+                    platformFailure->call == StagedSaveLeaseCall::Write,
+                "staged-save fault: the platform failure payload names FaultInjected and the "
+                "exact lease call");
+        });
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "staged-save fault");
+}
+
+void testAtomicPublicationFault(Expectations& expectations) {
+    TempDirectory directory;
+    StagedArtifactConfig config;
+    config.faults = {.point = StagedArtifactFaultPoint::AtomicPublication, .occurrence = 1};
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations, config);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "atomic publication fault: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Atomic Publication Fault Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            auto request = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly,
+                                       std::nullopt, manifest, documentInput);
+            auto result =
+                executeSavePublication(*coordinator, *artifacts, request, makeOperation());
+            expectations.expect(static_cast<bool>(result),
+                                "atomic publication fault: the executor still reaches publish "
+                                "(no earlier pipeline failure)");
+            const auto* publication = result.publication();
+            expectations.expect(
+                publication != nullptr &&
+                    publication->outcome ==
+                        StagedArtifactPublicationOutcome::FailedBeforePublication &&
+                    publication->error == StagedArtifactError::FaultInjected &&
+                    !publication->targetWasPublished(),
+                "atomic publication fault: FailedBeforePublication with the injected platform "
+                "error");
+            expectations.expect(!std::filesystem::exists(targetPath),
+                                "atomic publication fault: the target was never created");
+        });
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "atomic publication fault");
+}
+
+void testParentDurabilityWarning(Expectations& expectations) {
+    TempDirectory directory;
+    StagedArtifactConfig config;
+    config.faults = {.point = StagedArtifactFaultPoint::ParentDurability, .occurrence = 1};
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations, config);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "parent durability warning: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Parent Durability Warning Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            auto request = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly,
+                                       std::nullopt, manifest, documentInput);
+            auto result =
+                executeSavePublication(*coordinator, *artifacts, request, makeOperation());
+            expectations.expect(static_cast<bool>(result),
+                                "parent durability warning: the executor reaches publish");
+            const auto* publication = result.publication();
+            expectations.expect(
+                publication != nullptr &&
+                    publication->outcome ==
+                        StagedArtifactPublicationOutcome::PublishedWithDurabilityWarning &&
+                    publication->error == StagedArtifactError::FaultInjected &&
+                    publication->targetWasPublished(),
+                "parent durability warning: PublishedWithDurabilityWarning is a PUBLISHED "
+                "outcome (targetWasPublished() is true) carrying the injected platform error");
+            expectations.expect(std::filesystem::exists(targetPath),
+                                "parent durability warning: the target was actually created");
+        });
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "parent durability warning");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Cancellation: an already-set caller-checked flag is observed at the first checkpoint (right
+// after admission, before any platform path work), reported as a typed Cancelled-stage failure
+// that never calls publish(). This is the request's optional, trivially-composed
+// SavePublicationRequest::cancellationFlag seam (see the header comment); the frozen test plan
+// does not require this case, but the implementation carries the feature so it is exercised here.
+// ---------------------------------------------------------------------------------------------
+
+void testCancellationBeforePreflight(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "cancellation: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    std::atomic_bool cancelled{true};
+
+    withDocumentInput(
+        expectations, "Cancellation Project",
+        [&](const CanonicalManifestV1& manifest, const CanonicalDocumentV1& documentInput) {
+            auto request =
+                makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly, std::nullopt, manifest,
+                            documentInput, SaveArchiveLimits{}, nullptr, &cancelled);
+            auto result =
+                executeSavePublication(*coordinator, *artifacts, request, makeOperation());
+            expectations.expect(!static_cast<bool>(result),
+                                "cancellation: the executor reports a typed pipeline failure, "
+                                "never reaching publish");
+            const auto* failure = result.failure();
+            expectations.expect(failure != nullptr &&
+                                    failure->stage() == SavePublicationStage::Cancelled,
+                                "cancellation: reported at the Cancelled stage");
+            expectations.expect(!std::filesystem::exists(targetPath),
+                                "cancellation: no target was ever created");
+        });
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "cancellation");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Budget exhaustion, threaded through the StagedSave stage. Mirrors
+// staged_save_tests.cpp::testBudgetExhaustion's two-pass technique (probe buildSaveArchive()'s
+// own peak charge with a generous budget, then constrain the real operation to just above that
+// peak) one composition layer up: see that file's own long comment for why the resulting failure
+// lands at Verification/ContainerRead rather than ReadBackAllocation.
+// ---------------------------------------------------------------------------------------------
+
+void testBudgetExhaustion(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "budget exhaustion: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    withBulkDocumentInput(expectations, [&](const CanonicalManifestV1& manifest,
+                                            const CanonicalDocumentV1& documentInput) {
+        constexpr std::uint64_t kBulkProbeBudget = 256ULL << 20U;
+        auto probeMemory = ProjectIoMemoryCoordinator::create(kBulkProbeBudget);
+        expectations.expect(probeMemory.has_value(),
+                            "budget exhaustion: probe coordinator constructs");
+        if (!probeMemory.has_value()) {
+            return;
+        }
+        auto probeOperation = probeMemory->createOperation(kBulkProbeBudget, kBulkProbeBudget);
+        expectations.expect(probeOperation.has_value(),
+                            "budget exhaustion: probe operation constructs");
+        if (!probeOperation.has_value()) {
+            return;
+        }
+        std::uint64_t buildPeakBytes = 0;
+        {
+            auto probeBuild =
+                buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, *probeOperation);
+            expectations.expect(static_cast<bool>(probeBuild),
+                                "budget exhaustion: probe build succeeds");
+            if (!probeBuild) {
+                return;
+            }
+            buildPeakBytes = probeOperation->snapshot().peakBytes;
+        }
+
+        constexpr std::uint64_t kMargin = 64;
+        const auto budget = buildPeakBytes + kMargin;
+        auto memory = ProjectIoMemoryCoordinator::create(kBulkProbeBudget);
+        expectations.expect(memory.has_value(), "budget exhaustion: coordinator constructs");
+        if (!memory.has_value()) {
+            return;
+        }
+        auto operation = memory->createOperation(budget, budget);
+        expectations.expect(operation.has_value(),
+                            "budget exhaustion: constrained operation constructs");
+        if (!operation.has_value()) {
+            return;
+        }
+
+        auto request = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly, std::nullopt,
+                                   manifest, documentInput);
+        auto result =
+            executeSavePublication(*coordinator, *artifacts, request, std::move(*operation));
+        expectations.expect(!static_cast<bool>(result),
+                            "budget exhaustion: a budget just above the build's own peak still "
+                            "fails somewhere in the chain");
+        const auto* failure = result.failure();
+        expectations.expect(failure != nullptr &&
+                                failure->stage() == SavePublicationStage::StagedSave,
+                            "budget exhaustion: reported at the StagedSave stage");
+        const auto* nested = failure != nullptr ? failure->payloadAs<StagedSaveFailure>() : nullptr;
+        expectations.expect(nested != nullptr && nested->stage() == StagedSaveStage::Verification,
+                            "budget exhaustion: the nested StagedSaveFailure is scoped to "
+                            "Verification");
+        const auto* saveFailure =
+            nested != nullptr ? nested->payloadAs<SaveArchiveFailure>() : nullptr;
+        expectations.expect(saveFailure != nullptr &&
+                                saveFailure->stage() == SaveArchiveStage::ContainerRead,
+                            "budget exhaustion: the doubly-nested SaveArchiveFailure is scoped "
+                            "to ContainerRead");
+        const auto* containerReadFailure =
+            saveFailure != nullptr ? saveFailure->payloadAs<SaveArchiveContainerReadFailure>()
+                                   : nullptr;
+        expectations.expect(containerReadFailure != nullptr &&
+                                containerReadFailure->error == ZipContainerError::ResourceExhausted,
+                            "budget exhaustion: the innermost failure is a typed ResourceExhausted "
+                            "from the container reader");
+
+        const auto memorySnapshot = memory->snapshot();
+        expectations.expect(memorySnapshot.currentBytes == 0,
+                            "budget exhaustion: the constrained coordinator's charge returns to "
+                            "zero");
+    });
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "budget exhaustion");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Determinism: two full green executeSavePublication() runs to two different targets produce
+// byte-identical published files.
+// ---------------------------------------------------------------------------------------------
+
+void testDeterminism(Expectations& expectations) {
+    TempDirectory directoryA;
+    TempDirectory directoryB;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directoryA.isValid() || !directoryB.isValid() || !coordinator.has_value() ||
+        !artifacts.has_value()) {
+        expectations.expect(false, "determinism: fixture is available");
+        return;
+    }
+    const auto targetPathA = directoryA.path() / "project.bloom";
+    const auto targetPathB = directoryB.path() / "project.bloom";
+
+    withDocumentInput(
+        expectations, "Determinism Project",
+        [&](const CanonicalManifestV1& manifestA, const CanonicalDocumentV1& documentInputA) {
+            auto requestA = makeRequest(targetPathA, ArtifactOverwritePolicy::CreateOnly,
+                                        std::nullopt, manifestA, documentInputA);
+            auto resultA =
+                executeSavePublication(*coordinator, *artifacts, requestA, makeOperation());
+            expectations.expect(static_cast<bool>(resultA) && resultA.publication() != nullptr &&
+                                    resultA.publication()->outcome ==
+                                        StagedArtifactPublicationOutcome::Published,
+                                "determinism: first publish reaches Published");
+        });
+    withDocumentInput(
+        expectations, "Determinism Project",
+        [&](const CanonicalManifestV1& manifestB, const CanonicalDocumentV1& documentInputB) {
+            auto requestB = makeRequest(targetPathB, ArtifactOverwritePolicy::CreateOnly,
+                                        std::nullopt, manifestB, documentInputB);
+            auto resultB =
+                executeSavePublication(*coordinator, *artifacts, requestB, makeOperation());
+            expectations.expect(static_cast<bool>(resultB) && resultB.publication() != nullptr &&
+                                    resultB.publication()->outcome ==
+                                        StagedArtifactPublicationOutcome::Published,
+                                "determinism: second publish reaches Published");
+        });
+
+    const auto bytesA = readFile(targetPathA);
+    const auto bytesB = readFile(targetPathB);
+    expectations.expect(!bytesA.empty() && bytesA == bytesB,
+                        "determinism: two executeSavePublication runs of the same input produce "
+                        "byte-identical published files");
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "determinism");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testGreenPath(expectations);
+    testReplaceExistingPath(expectations);
+    testSupersession(expectations);
+    testExternalModification(expectations);
+    testInvalidTargetPath(expectations);
+    testStagedSaveFaultInjection(expectations);
+    testAtomicPublicationFault(expectations);
+    testParentDurabilityWarning(expectations);
+    testCancellationBeforePreflight(expectations);
+    testBudgetExhaustion(expectations);
+    testDeterminism(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tools/quality/repository_checks/repository_checks.cpp
+++ b/tools/quality/repository_checks/repository_checks.cpp
@@ -333,18 +333,19 @@ constexpr auto kKnownModules = std::to_array<std::string_view>(
      "output", "host", "scripting"});
 constexpr auto kAllowedModuleDependencies =
     std::to_array<std::pair<std::string_view, std::string_view>>({
-        {"platform", "core"},      {"document", "core"},      {"commands", "core"},
-        {"commands", "document"},  {"project", "core"},       {"project", "document"},
-        {"project", "platform"},   {"render", "core"},        {"runtime", "core"},
-        {"runtime", "document"},   {"runtime", "render"},     {"media", "core"},
-        {"media", "platform"},     {"media", "render"},       {"media", "runtime"},
-        {"color", "core"},         {"color", "platform"},     {"color", "render"},
-        {"color", "runtime"},      {"output", "color"},       {"output", "core"},
-        {"output", "document"},    {"output", "platform"},    {"output", "render"},
-        {"output", "runtime"},     {"host", "commands"},      {"host", "core"},
-        {"host", "document"},      {"host", "output"},        {"host", "project"},
-        {"host", "runtime"},       {"scripting", "commands"}, {"scripting", "core"},
-        {"scripting", "document"}, {"scripting", "host"},     {"scripting", "runtime"},
+        {"platform", "core"},     {"document", "core"},      {"commands", "core"},
+        {"commands", "document"}, {"project", "core"},       {"project", "document"},
+        {"project", "platform"},  {"render", "core"},        {"runtime", "core"},
+        {"runtime", "document"},  {"runtime", "render"},     {"media", "core"},
+        {"media", "platform"},    {"media", "render"},       {"media", "runtime"},
+        {"color", "core"},        {"color", "platform"},     {"color", "render"},
+        {"color", "runtime"},     {"output", "color"},       {"output", "core"},
+        {"output", "document"},   {"output", "platform"},    {"output", "render"},
+        {"output", "runtime"},    {"host", "commands"},      {"host", "core"},
+        {"host", "document"},     {"host", "output"},        {"host", "platform"},
+        {"host", "project"},      {"host", "runtime"},       {"scripting", "commands"},
+        {"scripting", "core"},    {"scripting", "document"}, {"scripting", "host"},
+        {"scripting", "runtime"},
     });
 
 [[nodiscard]] constexpr auto isAllowedDependency(const std::string_view module,


### PR DESCRIPTION
Closes #56.

The host-side save publication executor — with it, the first **complete Save** exists: captured input → verified staged archive → intent-ordered, disposition-gated, durably published file with one of the contract's six typed outcomes.

**The full nine-step sequence, composed synchronously**: coordinator admission strictly before any path work (with a pre-admitted-admission injection matching the contract's assign-at-admission model the session layer will need), platform preflight to the canonical target, intent registration into a target claim, staging, staged save execution over the lease, guard entry at the winning intent, and disposition-mapped publish. The `Superseded` guard status still runs the lease's publish path so the platform records the outcome and cleans the stage; the remaining guard statuses are typed protocol failures documented as unreachable in this single-executor flow but kept for the future concurrent one.

**Nothing collapsed**: stage-scoped failures carry each layer's own typed surface — admission/registration statuses, platform errors, the staged-save failure verbatim with its secondary reject diagnostic. Optional caller-checked cancellation at three pre-guard boundaries, never after guard entry. RAII releases admissions, claims, guards, and stages on every path.

**Architecture**: the boundary allowlist gains the `host → platform` edge this composition requires (`host → project` already existed) — the application host is the intended composition layer per the ownership docs.

Testing: eleven functions against real coordinators on per-test temporary directories, including supersession with the original file untouched, external-modification conflict, publish-time fault injection (with the durability-warning case asserting a publication still occurred), and idle-snapshot leak checks after every failure. Full ci-linux-native suite 64/64 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).