### PR TITLE
feat: wire session saves to publication

### DIFF
--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
         project_session.cpp
         publication_coordinator.cpp
         save_publication.cpp
+        session_save.cpp
     PUBLIC
         FILE_SET HEADERS
         BASE_DIRS include
@@ -13,6 +14,7 @@ target_sources(
             include/bloom/host/project_session.hpp
             include/bloom/host/publication_coordinator.hpp
             include/bloom/host/save_publication.hpp
+            include/bloom/host/session_save.hpp
 )
 
 target_compile_features(bloom_host PUBLIC cxx_std_20)
@@ -58,6 +60,17 @@ if(BUILD_TESTING)
         bloom_add_test(
             NAME bloom.host.save-publication
             COMMAND bloom_host_save_publication_test
+            LABELS unit host persistence security
+        )
+
+        # Gated Linux-only exactly as bloom.host.save-publication is gated: saveProjectSession()
+        # drives the same real platform::StagedArtifactCoordinator.
+        add_executable(bloom_host_session_save_test tests/session_save_tests.cpp)
+        target_link_libraries(bloom_host_session_save_test PRIVATE bloom_host)
+        bloom_enable_warnings(bloom_host_session_save_test)
+        bloom_add_test(
+            NAME bloom.host.session-save
+            COMMAND bloom_host_session_save_test
             LABELS unit host persistence security
         )
     endif()

--- a/src/host/include/bloom/host/project_session.hpp
+++ b/src/host/include/bloom/host/project_session.hpp
@@ -5,11 +5,14 @@
 #include <bloom/commands/transaction.hpp>
 #include <bloom/core/id.hpp>
 #include <bloom/core/rational_time.hpp>
+#include <bloom/document/color_settings.hpp>
 #include <bloom/document/composition_settings.hpp>
 #include <bloom/document/document.hpp>
 #include <bloom/document/ids.hpp>
 #include <bloom/document/project.hpp>
 #include <bloom/host/publication_coordinator.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/round_trip_state.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -19,6 +22,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace bloom::host {
 
@@ -289,9 +293,25 @@ struct NewProjectSessionRequest final {
 
 struct DecodedProjectSessionRequest final {
     document::Project project;
+    // REQUIRED for a decoded session: the canonical writer (project::CanonicalDocumentV1) takes
+    // color settings as explicit caller input by contract -- bloom::document::Project does not
+    // itself own color settings. Unlike a brand-new project (see createNew()), a decoded project
+    // always has a real opened value to carry forward, so no synthesized default is needed here.
+    document::ColorSettings colorSettings;
     DecodedProjectEditability editability = DecodedProjectEditability::Editable;
     std::optional<ProjectDisplayPath> displayPath;
     std::optional<document::IdAllocatorHighWater> persistedAllocatorHighWater;
+    // Present only for a same-major newer-minor (schema {1, minor > 0}) decoded document (see
+    // docs/architecture/project-format.md, "Versions, Migrations, And Preservation"); absent for
+    // an exact-{1,0} decoded document. project::RoundTripState is move-only, which makes this
+    // whole request move-only. A request with roundTrip present and schemaMinor == 0 is a typed
+    // create failure (see createDecoded()).
+    std::optional<project::RoundTripState> roundTrip = std::nullopt;
+    std::uint32_t schemaMinor = 0;
+    // Verbatim from the opened manifest's requirement set; empty for a new project using only
+    // foundation types and no extension-owned truth. The save chain recomputes node-type coverage
+    // at save time (project-format.md, "Manifest Shape"), so this is stored, never re-derived.
+    std::vector<project::ManifestRequirement> retainedRequirements{};
 };
 
 enum class ProjectSessionCreateStatus : std::uint8_t {
@@ -382,6 +402,111 @@ class [[nodiscard]] DecodedProjectSnapshotResult final {
     std::optional<document::Snapshot> snapshot_;
 };
 
+// Typed statuses for ProjectSession::captureSaveInput(). ColorSettingsUnavailable is not part of
+// docs/architecture/project-session.md's normative text; it exists because a session installed
+// through createNew() has no color settings and no qualified build-profile default currently
+// exists to synthesize one (see color_settings.hpp's makeBloomNeutralColorSettingsV1(), which
+// requires a real caller-supplied content-revision digest). Rather than inventing a default, a
+// createNew() session is gated unsaveable-pending-color until a decoded/installed session
+// supplies real color settings -- see the implementor's report for the full reasoning.
+enum class SessionSaveInputStatus : std::uint8_t {
+    Captured,
+    ReadOnly,
+    InvalidSession,
+    ColorSettingsUnavailable,
+    PathRequired,
+    StaleIntent,
+};
+
+// One immutable capture of everything a synchronous Save needs from a ProjectSession, per
+// docs/architecture/project-session.md's "Save Inputs And Intent". `roundTrip()` is a non-owning
+// view into the session's own installed project::RoundTripState (null when the session has none):
+// valid only while the originating ProjectSession stays alive and is not replaced with new
+// installed content, exactly as project::CanonicalDocumentV1::roundTrip documents for its own
+// pointee. The synchronous save flow in this slice satisfies that trivially (the session is a
+// caller-owned reference for the whole call); an asynchronous slice revisits this as the
+// contract's "immutable round-trip view" (project-session.md, "Save Inputs And Intent").
+class SessionSaveInput final {
+  public:
+    [[nodiscard]] const document::Snapshot& snapshot() const& noexcept { return snapshot_; }
+    const document::Snapshot& snapshot() const&& = delete;
+    [[nodiscard]] document::Revision revision() const noexcept { return snapshot_.revision(); }
+    [[nodiscard]] const document::ColorSettings& colorSettings() const& noexcept {
+        return colorSettings_;
+    }
+    const document::ColorSettings& colorSettings() const&& = delete;
+    // Non-owning; see the class comment above for the exact lifetime contract.
+    [[nodiscard]] const project::RoundTripState* roundTrip() const noexcept { return roundTrip_; }
+    [[nodiscard]] std::uint32_t schemaMinor() const noexcept { return schemaMinor_; }
+    [[nodiscard]] const std::vector<project::ManifestRequirement>&
+    retainedRequirements() const& noexcept {
+        return retainedRequirements_;
+    }
+    const std::vector<project::ManifestRequirement>& retainedRequirements() const&& = delete;
+    // Absent for a Save As replacement intent before its publication is accepted.
+    [[nodiscard]] const std::optional<ProjectDisplayPath>& displayPath() const& noexcept {
+        return displayPath_;
+    }
+    const std::optional<ProjectDisplayPath>& displayPath() const&& = delete;
+    [[nodiscard]] SessionPathIntentCapture pathIntent() const noexcept { return pathIntent_; }
+    [[nodiscard]] SessionResultAcceptanceCapture resultAcceptance() const noexcept {
+        return resultAcceptance_;
+    }
+
+    friend class ProjectSession;
+
+  private:
+    SessionSaveInput(document::Snapshot snapshot, document::ColorSettings colorSettings,
+                     const project::RoundTripState* roundTrip, std::uint32_t schemaMinor,
+                     std::vector<project::ManifestRequirement> retainedRequirements,
+                     std::optional<ProjectDisplayPath> displayPath,
+                     SessionPathIntentCapture pathIntent,
+                     SessionResultAcceptanceCapture resultAcceptance) noexcept
+        : snapshot_(std::move(snapshot)), colorSettings_(std::move(colorSettings)),
+          roundTrip_(roundTrip), schemaMinor_(schemaMinor),
+          retainedRequirements_(std::move(retainedRequirements)),
+          displayPath_(std::move(displayPath)), pathIntent_(pathIntent),
+          resultAcceptance_(resultAcceptance) {}
+
+    document::Snapshot snapshot_;
+    document::ColorSettings colorSettings_;
+    const project::RoundTripState* roundTrip_ = nullptr;
+    std::uint32_t schemaMinor_ = 0;
+    std::vector<project::ManifestRequirement> retainedRequirements_;
+    std::optional<ProjectDisplayPath> displayPath_;
+    SessionPathIntentCapture pathIntent_;
+    SessionResultAcceptanceCapture resultAcceptance_;
+};
+
+class [[nodiscard]] SessionSaveInputResult final {
+  public:
+    SessionSaveInputResult(SessionSaveInputResult&&) noexcept = default;
+    SessionSaveInputResult& operator=(SessionSaveInputResult&&) noexcept = default;
+    SessionSaveInputResult(const SessionSaveInputResult&) = delete;
+    SessionSaveInputResult& operator=(const SessionSaveInputResult&) = delete;
+    ~SessionSaveInputResult() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return status_ == SessionSaveInputStatus::Captured && input_.has_value();
+    }
+    [[nodiscard]] SessionSaveInputStatus status() const noexcept { return status_; }
+    [[nodiscard]] const SessionSaveInput* value() const& noexcept {
+        return input_.has_value() ? &*input_ : nullptr;
+    }
+    [[nodiscard]] const SessionSaveInput* value() const&& = delete;
+
+  private:
+    friend class ProjectSession;
+
+    explicit SessionSaveInputResult(const SessionSaveInputStatus status) noexcept
+        : status_(status) {}
+    explicit SessionSaveInputResult(SessionSaveInput input) noexcept
+        : status_(SessionSaveInputStatus::Captured), input_(std::move(input)) {}
+
+    SessionSaveInputStatus status_ = SessionSaveInputStatus::InvalidSession;
+    std::optional<SessionSaveInput> input_;
+};
+
 class ProjectSessionCreateResult;
 
 class ProjectSession final {
@@ -426,6 +551,12 @@ class ProjectSession final {
                     document::Revision publishedRevision,
                     std::optional<ProjectDisplayPath> publishedPath = std::nullopt);
 
+    // Captures everything a synchronous Save needs (see docs/architecture/project-session.md,
+    // "Save Inputs And Intent") without mutating the session. `intent` is normally either
+    // capturePlainSavePathIntent() or an advancePathIntentForSaveAs() capture. See
+    // SessionSaveInput's class comment for the returned round-trip pointer's lifetime contract.
+    [[nodiscard]] SessionSaveInputResult captureSaveInput(SessionPathIntentCapture intent) const;
+
   private:
     friend class ProjectSessionCreateResult;
     friend class ProjectSessionTestAccess;
@@ -433,7 +564,10 @@ class ProjectSession final {
     ProjectSession(ProjectSessionId projectSessionId, std::unique_ptr<document::Document> document,
                    std::unique_ptr<commands::CommandStack> commandStack,
                    DecodedProjectEditability editability, document::Revision cleanRevision,
-                   std::optional<ProjectDisplayPath> displayPath) noexcept;
+                   std::optional<ProjectDisplayPath> displayPath,
+                   std::optional<document::ColorSettings> colorSettings,
+                   std::optional<project::RoundTripState> roundTrip, std::uint32_t schemaMinor,
+                   std::vector<project::ManifestRequirement> retainedRequirements) noexcept;
     ProjectSession(ProjectSessionId projectSessionId,
                    ProjectDisplayPath preservedDisplayPath) noexcept;
 
@@ -456,6 +590,12 @@ class ProjectSession final {
     std::optional<DecodedProjectEditability> editability_;
     std::optional<ProjectDisplayPath> displayPath_;
     std::optional<document::Revision> cleanRevision_;
+    // Absent for a createNew() session: see SessionSaveInputStatus::ColorSettingsUnavailable's
+    // comment above. Always present for a createDecoded() session (required by that request).
+    std::optional<document::ColorSettings> colorSettings_;
+    std::optional<project::RoundTripState> roundTrip_;
+    std::uint32_t schemaMinor_ = 0;
+    std::vector<project::ManifestRequirement> retainedRequirements_;
     std::unique_ptr<document::Document> document_;
     std::unique_ptr<commands::CommandStack> commandStack_;
     bool valid_ = false;

--- a/src/host/include/bloom/host/session_save.hpp
+++ b/src/host/include/bloom/host/session_save.hpp
@@ -1,0 +1,212 @@
+#pragma once
+
+#include <bloom/host/project_session.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/host/save_publication.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <variant>
+
+// The synchronous session-level Save orchestration: composes ProjectSession::captureSaveInput()
+// (docs/architecture/project-session.md, "Save Inputs And Intent") with executeSavePublication()
+// (save_publication.hpp -- the application PublicationCoordinator ordered against the platform
+// StagedArtifactCoordinator over project::stageSaveArchive()) and, on a published outcome, the
+// existing ProjectSession::acceptSavepoint() seam (project-session.md, "Save Result Acceptance").
+// This module owns none of those three seams' own semantics; it only wires them together on the
+// caller's thread. An asynchronous/Jobs-driven Save is a later slice (see AGENTS.md's boundary and
+// this task's non-goals): every step here runs synchronously on the calling thread.
+namespace bloom::host {
+
+// Where a saveProjectSession() call stopped. Capture: captureSaveInput() itself did not produce a
+// value (see SessionSaveResult::captureOutcome()). Publication: executeSavePublication() reported
+// a typed pipeline failure before ever calling publish() (see
+// SessionSaveResult::publicationFailure()). Savepoint: the executor reached a real publication
+// outcome (see SessionSaveResult::publication()) -- for Published/PublishedWithDurabilityWarning
+// this includes the acceptSavepoint() attempt (SessionSaveResult::savepointStatus()), unless the
+// local acceptSavepoint() call itself never completed (see
+// SessionSaveResult::savepointBookkeepingFailure()); for every other outcome (Superseded/
+// CancelledBeforePublication/ExternalModificationConflict/FailedBeforePublication) the session is
+// left untouched and no acceptSavepoint() attempt is made (savepointStatus() is then absent) --
+// per the frozen design, abandoning a Save As replacement intent after a non-published outcome is
+// the CALLER's choice, never automatic here.
+enum class SessionSaveStage : std::uint8_t {
+    None,
+    Capture,
+    Publication,
+    Savepoint,
+};
+
+// Payload types for a Capture-stage failure that is not one of ProjectSession::captureSaveInput()'s
+// own typed SessionSaveInputStatus values: captureSaveInput() is not noexcept (it may copy
+// document::ColorSettings and the retained-requirements vector, both real allocations), and this
+// module's own entry point is noexcept, so a thrown std::bad_alloc (or, defensively, any other
+// exception a composed throwing surface should never emit) is reported here rather than escaping.
+struct SessionSaveResourceExhausted final {};
+struct SessionSaveUnexpectedFailure final {};
+
+using SessionSaveCaptureOutcome =
+    std::variant<std::monostate, SessionSaveInputStatus, SessionSaveResourceExhausted,
+                 SessionSaveUnexpectedFailure>;
+
+// Names why a Savepoint-stage acceptSavepoint() call did not run to completion after a real
+// Published/PublishedWithDurabilityWarning outcome. acceptSavepoint() is not itself noexcept (it
+// can allocate -- e.g. a std::filesystem::path copy for a Save As replacement path), so its own
+// std::bad_alloc (or, defensively, any other exception) is caught here rather than escaping this
+// module's noexcept entry point. Crucially, the file WAS durably published at this point: a real
+// replacement must never be reported as not-published just because the LOCAL bookkeeping call
+// about it failed -- the same truthfulness principle the platform layer applies to a late
+// cancellation against an already-visible replacement. See
+// SessionSaveResult::publishedSavepointBookkeepingFailed().
+enum class SessionSaveSavepointBookkeepingFailure : std::uint8_t {
+    ResourceExhausted,
+    UnexpectedFailure,
+};
+
+struct SessionSaveRequest final {
+    std::filesystem::path targetPath;
+    platform::ArtifactOverwritePolicy overwritePolicy =
+        platform::ArtifactOverwritePolicy::CreateOrReplace;
+    std::optional<platform::ArtifactTargetObservation> expectedTarget;
+    project::SaveArchiveLimits limits;
+    // Normally session.capturePlainSavePathIntent() or an already-obtained
+    // session.advancePathIntentForSaveAs() capture; forwarded verbatim to both
+    // captureSaveInput() and, on a published outcome, acceptSavepoint().
+    SessionPathIntentCapture intent;
+    // Same seam as SavePublicationRequest::preAdmitted; forwarded verbatim. Caller-owned; must
+    // outlive the call; left moved-from afterward when non-null.
+    PublicationAdmission* preAdmitted = nullptr;
+    // Same seam as SavePublicationRequest::cancellationFlag; forwarded verbatim.
+    const std::atomic_bool* cancellationFlag = nullptr;
+};
+
+// See SessionSaveStage above for the three stages this result distinguishes. Exactly one of
+// captureOutcome()/publicationFailure()/publication() is populated, matching `stage()`. At
+// Savepoint, savepointStatus() and savepointBookkeepingFailure() are mutually exclusive: at most
+// one is present, and both are absent for a non-published outcome (unpublished()).
+class [[nodiscard]] SessionSaveResult final {
+  public:
+    SessionSaveResult(SessionSaveResult&&) noexcept = default;
+    SessionSaveResult& operator=(SessionSaveResult&&) noexcept = default;
+    SessionSaveResult(const SessionSaveResult&) = delete;
+    SessionSaveResult& operator=(const SessionSaveResult&) = delete;
+    ~SessionSaveResult() = default;
+
+    [[nodiscard]] static SessionSaveResult
+    captureFailure(SessionSaveCaptureOutcome outcome) noexcept;
+    [[nodiscard]] static SessionSaveResult
+    publicationFailure(SavePublicationFailure failure,
+                       std::optional<platform::StagedArtifactError> rejectDiagnostic) noexcept;
+    // A publication outcome that never publishes (Superseded/CancelledBeforePublication/
+    // ExternalModificationConflict/FailedBeforePublication): session untouched, no
+    // acceptSavepoint() attempt, so savepointStatus() stays absent.
+    [[nodiscard]] static SessionSaveResult
+    unpublished(platform::StagedArtifactPublicationResult publication,
+                PublicationIntentId intentId) noexcept;
+    // Published/PublishedWithDurabilityWarning: acceptSavepoint() was attempted and its exact
+    // status (Accepted or a refusal -- surfaced faithfully, never masked) is carried here.
+    [[nodiscard]] static SessionSaveResult
+    published(platform::StagedArtifactPublicationResult publication, PublicationIntentId intentId,
+              ProjectSessionSavepointStatus savepointStatus) noexcept;
+    // Published/PublishedWithDurabilityWarning, but the LOCAL acceptSavepoint() call itself never
+    // returned a status (see SessionSaveSavepointBookkeepingFailure above). `publication`/
+    // `intentId` name the real, already-durable replacement -- never relabeled as unpublished --
+    // while operator bool() stays false and savepointStatus() stays absent, since no
+    // ProjectSessionSavepointStatus was ever obtained.
+    [[nodiscard]] static SessionSaveResult
+    publishedSavepointBookkeepingFailed(platform::StagedArtifactPublicationResult publication,
+                                        PublicationIntentId intentId,
+                                        SessionSaveSavepointBookkeepingFailure failure) noexcept;
+
+    // True only for the single fully-succeeded path: a Published/PublishedWithDurabilityWarning
+    // outcome whose acceptSavepoint() call returned Accepted. Every other case -- including a
+    // real file publish whose savepoint acceptance was refused -- is false here; inspect stage(),
+    // publication(), and savepointStatus() for the exact typed reason.
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return stage_ == SessionSaveStage::Savepoint && publication_.has_value() &&
+               publication_->targetWasPublished() && savepointStatus_.has_value() &&
+               *savepointStatus_ == ProjectSessionSavepointStatus::Accepted;
+    }
+
+    [[nodiscard]] SessionSaveStage stage() const noexcept { return stage_; }
+
+    // Valid only when stage() == Capture.
+    [[nodiscard]] const SessionSaveCaptureOutcome* captureOutcome() const& noexcept {
+        return stage_ == SessionSaveStage::Capture ? &captureOutcome_ : nullptr;
+    }
+    [[nodiscard]] const SessionSaveCaptureOutcome* captureOutcome() const&& = delete;
+
+    // Valid only when stage() == Publication (the executor's own typed pipeline failure,
+    // verbatim; publish() was never called).
+    [[nodiscard]] const SavePublicationFailure* publicationFailure() const& noexcept {
+        return publicationFailure_.has_value() ? &*publicationFailure_ : nullptr;
+    }
+    [[nodiscard]] const SavePublicationFailure* publicationFailure() const&& = delete;
+    [[nodiscard]] std::optional<platform::StagedArtifactError> rejectDiagnostic() const noexcept {
+        return rejectDiagnostic_;
+    }
+
+    // Valid only when stage() == Savepoint (the executor reached a real publish() outcome).
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const& noexcept {
+        return publication_.has_value() ? &*publication_ : nullptr;
+    }
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const&& = delete;
+    [[nodiscard]] std::optional<PublicationIntentId> intentId() const noexcept { return intentId_; }
+    // Present only when publication()->targetWasPublished() triggered an acceptSavepoint() call
+    // that ran to completion; absent for a non-published outcome (unpublished()) and for a
+    // published outcome whose local acceptSavepoint() call itself failed (see
+    // savepointBookkeepingFailure() below).
+    [[nodiscard]] std::optional<ProjectSessionSavepointStatus> savepointStatus() const noexcept {
+        return savepointStatus_;
+    }
+    // Present only for publishedSavepointBookkeepingFailed(): the file was durably published, but
+    // the local acceptSavepoint() call never returned a status. See
+    // SessionSaveSavepointBookkeepingFailure's comment above.
+    [[nodiscard]] std::optional<SessionSaveSavepointBookkeepingFailure>
+    savepointBookkeepingFailure() const noexcept {
+        return savepointBookkeepingFailure_;
+    }
+
+  private:
+    SessionSaveResult() = default;
+
+    SessionSaveStage stage_ = SessionSaveStage::None;
+    SessionSaveCaptureOutcome captureOutcome_;
+    std::optional<SavePublicationFailure> publicationFailure_;
+    std::optional<platform::StagedArtifactError> rejectDiagnostic_;
+    std::optional<platform::StagedArtifactPublicationResult> publication_;
+    std::optional<PublicationIntentId> intentId_;
+    std::optional<ProjectSessionSavepointStatus> savepointStatus_;
+    std::optional<SessionSaveSavepointBookkeepingFailure> savepointBookkeepingFailure_;
+};
+
+// Pipeline: session.captureSaveInput(request.intent) -> assemble one CanonicalManifestV1 (format/
+// containerVersion constants, documentSchemaVersion {1, schemaMinor}, the captured retained
+// requirements) and one CanonicalDocumentV1 (the captured snapshot, colorSettings, roundTrip,
+// schemaMinor) -> executeSavePublication() -> outcome handling exactly as documented on
+// SessionSaveResult's factory functions above.
+//
+// On Published/PublishedWithDurabilityWarning, acceptSavepoint() is called with `request.intent`,
+// the winning PublicationIntentId, the captured revision, and -- per the frozen design -- the
+// request's target path for a ReplacementPath intent (nullopt for ExistingPath, matching
+// acceptSavepoint()'s own path-authority contract). Save As abandonment on a non-published outcome
+// is deliberately left to the caller (session.abandonSaveAsIntent()); this function never calls it.
+//
+// noexcept top level: neither captureSaveInput() nor acceptSavepoint() is itself noexcept (both
+// can allocate -- copying document::ColorSettings/retained requirements, or a
+// std::filesystem::path -- and are wrapped accordingly; see SessionSaveResourceExhausted above).
+// executeSavePublication() is already noexcept.
+[[nodiscard]] SessionSaveResult
+saveProjectSession(ProjectSession& session, PublicationCoordinator& coordinator,
+                   platform::StagedArtifactCoordinator& artifacts,
+                   const SessionSaveRequest& request,
+                   project::ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::host

--- a/src/host/project_session.cpp
+++ b/src/host/project_session.cpp
@@ -78,15 +78,19 @@ const document::Snapshot& DecodedProjectSnapshotResult::snapshot() const& {
     return *snapshot_;
 }
 
-ProjectSession::ProjectSession(const ProjectSessionId projectSessionId,
-                               std::unique_ptr<document::Document> document,
-                               std::unique_ptr<commands::CommandStack> commandStack,
-                               const DecodedProjectEditability editability,
-                               const document::Revision cleanRevision,
-                               std::optional<ProjectDisplayPath> displayPath) noexcept
+ProjectSession::ProjectSession(
+    const ProjectSessionId projectSessionId, std::unique_ptr<document::Document> document,
+    std::unique_ptr<commands::CommandStack> commandStack,
+    const DecodedProjectEditability editability, const document::Revision cleanRevision,
+    std::optional<ProjectDisplayPath> displayPath,
+    std::optional<document::ColorSettings> colorSettings,
+    std::optional<project::RoundTripState> roundTrip, const std::uint32_t schemaMinor,
+    std::vector<project::ManifestRequirement> retainedRequirements) noexcept
     : projectSessionId_(projectSessionId), contentKind_(ProjectSessionContentKind::DecodedDocument),
       editability_(editability), displayPath_(std::move(displayPath)),
-      cleanRevision_(cleanRevision), document_(std::move(document)),
+      cleanRevision_(cleanRevision), colorSettings_(std::move(colorSettings)),
+      roundTrip_(std::move(roundTrip)), schemaMinor_(schemaMinor),
+      retainedRequirements_(std::move(retainedRequirements)), document_(std::move(document)),
       commandStack_(std::move(commandStack)), valid_(true) {}
 
 ProjectSession::ProjectSession(const ProjectSessionId projectSessionId,
@@ -107,6 +111,9 @@ ProjectSession::ProjectSession(ProjectSession&& other) noexcept
           std::exchange(other.newestAcceptedPublicationIntent_, PublicationIntentId{})),
       contentKind_(other.contentKind_), editability_(other.editability_),
       displayPath_(std::move(other.displayPath_)), cleanRevision_(other.cleanRevision_),
+      colorSettings_(std::move(other.colorSettings_)), roundTrip_(std::move(other.roundTrip_)),
+      schemaMinor_(std::exchange(other.schemaMinor_, std::uint32_t{0})),
+      retainedRequirements_(std::move(other.retainedRequirements_)),
       document_(std::move(other.document_)), commandStack_(std::move(other.commandStack_)),
       valid_(std::exchange(other.valid_, false)) {}
 
@@ -123,9 +130,16 @@ ProjectSessionCreateResult ProjectSession::createNew(ProjectSessionIdentitySourc
         if (!projectSessionId.has_value()) {
             return ProjectSessionCreateResult(ProjectSessionCreateStatus::RuntimeIdentityExhausted);
         }
+        // No colorSettings/roundTrip/schemaMinor/retainedRequirements: a brand-new project has no
+        // qualified color-settings default to synthesize (see color_settings.hpp's
+        // makeBloomNeutralColorSettingsV1(), which requires a real caller-supplied content-
+        // revision digest that no build profile currently wires up here). The resulting session
+        // is gated unsaveable-pending-color -- see
+        // SessionSaveInputStatus::ColorSettingsUnavailable.
         return ProjectSessionCreateResult(
             ProjectSession(*projectSessionId, std::move(document), std::move(commandStack),
-                           DecodedProjectEditability::Editable, cleanRevision, std::nullopt));
+                           DecodedProjectEditability::Editable, cleanRevision, std::nullopt,
+                           std::nullopt, std::nullopt, 0, {}));
     } catch (const std::bad_alloc&) {
         return ProjectSessionCreateResult(ProjectSessionCreateStatus::ResourceUnavailable);
     } catch (const std::logic_error&) {
@@ -137,6 +151,12 @@ ProjectSessionCreateResult
 ProjectSession::createDecoded(ProjectSessionIdentitySource& identitySource,
                               DecodedProjectSessionRequest request) {
     if (!isKnownEditability(request.editability)) {
+        return ProjectSessionCreateResult(ProjectSessionCreateStatus::InvalidDecodedProject);
+    }
+    // A roundTrip view with schemaMinor 0 cannot name the newer minor it was captured against
+    // (see canonical_document.hpp's CanonicalDocumentV1::schemaMinor comment): typed create
+    // failure rather than silently writing it back at {1, 0}.
+    if (request.roundTrip.has_value() && request.schemaMinor == 0) {
         return ProjectSessionCreateResult(ProjectSessionCreateStatus::InvalidDecodedProject);
     }
     try {
@@ -155,7 +175,9 @@ ProjectSession::createDecoded(ProjectSessionIdentitySource& identitySource,
         }
         return ProjectSessionCreateResult(
             ProjectSession(*projectSessionId, std::move(document), std::move(commandStack),
-                           request.editability, cleanRevision, std::move(request.displayPath)));
+                           request.editability, cleanRevision, std::move(request.displayPath),
+                           std::move(request.colorSettings), std::move(request.roundTrip),
+                           request.schemaMinor, std::move(request.retainedRequirements)));
     } catch (const std::bad_alloc&) {
         return ProjectSessionCreateResult(ProjectSessionCreateStatus::ResourceUnavailable);
     } catch (const std::invalid_argument&) {
@@ -427,6 +449,33 @@ ProjectSessionSavepointStatus ProjectSession::acceptSavepoint(
     cleanRevision_ = publishedRevision;
     newestAcceptedPublicationIntent_ = publicationIntent;
     return ProjectSessionSavepointStatus::Accepted;
+}
+
+SessionSaveInputResult
+ProjectSession::captureSaveInput(const SessionPathIntentCapture intent) const {
+    if (!isValid()) {
+        return SessionSaveInputResult(SessionSaveInputStatus::InvalidSession);
+    }
+    if (contentKind_ != ProjectSessionContentKind::DecodedDocument) {
+        return SessionSaveInputResult(SessionSaveInputStatus::ReadOnly);
+    }
+    if (!colorSettings_.has_value()) {
+        return SessionSaveInputResult(SessionSaveInputStatus::ColorSettingsUnavailable);
+    }
+    // Mirrors acceptSavepoint()'s own ExistingPath/no-displayPath check, but reported first and
+    // distinctly from StaleIntent: this is the ordinary pathless-plain-save shape (a
+    // capturePlainSavePathIntent() call on a pathless session always returns this exact invalid
+    // capture), not a generation mismatch, so callers get an actionable "route to Save As"
+    // diagnosis rather than a generic staleness report.
+    if (intent.kind() == SessionPathIntentKind::ExistingPath && !displayPath_.has_value()) {
+        return SessionSaveInputResult(SessionSaveInputStatus::PathRequired);
+    }
+    if (!matchesPathIntent(intent)) {
+        return SessionSaveInputResult(SessionSaveInputStatus::StaleIntent);
+    }
+    return SessionSaveInputResult(SessionSaveInput(
+        document_->snapshot(), *colorSettings_, roundTrip_.has_value() ? &*roundTrip_ : nullptr,
+        schemaMinor_, retainedRequirements_, displayPath_, intent, captureResultAcceptance()));
 }
 
 ProjectSessionCommandResult ProjectSession::unavailableCommandResult() const noexcept {

--- a/src/host/session_save.cpp
+++ b/src/host/session_save.cpp
@@ -1,0 +1,167 @@
+#include <bloom/host/session_save.hpp>
+
+#include <new>
+#include <utility>
+#include <vector>
+
+namespace bloom::host {
+
+SessionSaveResult SessionSaveResult::captureFailure(SessionSaveCaptureOutcome outcome) noexcept {
+    SessionSaveResult result;
+    result.stage_ = SessionSaveStage::Capture;
+    result.captureOutcome_ = outcome;
+    return result;
+}
+
+SessionSaveResult SessionSaveResult::publicationFailure(
+    SavePublicationFailure failure,
+    const std::optional<platform::StagedArtifactError> rejectDiagnostic) noexcept {
+    SessionSaveResult result;
+    result.stage_ = SessionSaveStage::Publication;
+    result.publicationFailure_.emplace(std::move(failure));
+    result.rejectDiagnostic_ = rejectDiagnostic;
+    return result;
+}
+
+SessionSaveResult
+SessionSaveResult::unpublished(platform::StagedArtifactPublicationResult publication,
+                               const PublicationIntentId intentId) noexcept {
+    SessionSaveResult result;
+    result.stage_ = SessionSaveStage::Savepoint;
+    result.publication_ = publication;
+    result.intentId_ = intentId;
+    return result;
+}
+
+SessionSaveResult
+SessionSaveResult::published(platform::StagedArtifactPublicationResult publication,
+                             const PublicationIntentId intentId,
+                             const ProjectSessionSavepointStatus savepointStatus) noexcept {
+    SessionSaveResult result;
+    result.stage_ = SessionSaveStage::Savepoint;
+    result.publication_ = publication;
+    result.intentId_ = intentId;
+    result.savepointStatus_ = savepointStatus;
+    return result;
+}
+
+SessionSaveResult SessionSaveResult::publishedSavepointBookkeepingFailed(
+    platform::StagedArtifactPublicationResult publication, const PublicationIntentId intentId,
+    const SessionSaveSavepointBookkeepingFailure failure) noexcept {
+    SessionSaveResult result;
+    result.stage_ = SessionSaveStage::Savepoint;
+    result.publication_ = publication;
+    result.intentId_ = intentId;
+    result.savepointBookkeepingFailure_ = failure;
+    return result;
+}
+
+namespace {
+
+// The one allocation this module performs itself, ahead of executeSavePublication() (which is
+// already noexcept and reports its own allocation failures as a typed SavePublicationFailure): a
+// copy of the captured retained-requirements vector, kept alive for CanonicalManifestV1's span for
+// the duration of the executeSavePublication() call. A failure here is attributed to the
+// Publication stage at SavePublicationStage::None -- honestly "failed before the publication
+// pipeline was ever entered, while assembling its input" -- reusing SavePublicationFailure's own
+// resource-exhausted payload rather than inventing a fourth stage for one allocation.
+[[nodiscard]] SessionSaveResult assemblyResourceExhausted() noexcept {
+    return SessionSaveResult::publicationFailure(
+        SavePublicationFailure(SavePublicationStage::None, SavePublicationResourceExhausted{}),
+        std::nullopt);
+}
+
+} // namespace
+
+SessionSaveResult saveProjectSession(ProjectSession& session, PublicationCoordinator& coordinator,
+                                     platform::StagedArtifactCoordinator& artifacts,
+                                     const SessionSaveRequest& request,
+                                     project::ProjectIoOperationMemory operation) noexcept {
+    std::optional<SessionSaveInputResult> captured;
+    try {
+        captured.emplace(session.captureSaveInput(request.intent));
+    } catch (const std::bad_alloc&) {
+        return SessionSaveResult::captureFailure(SessionSaveResourceExhausted{});
+    } catch (...) {
+        return SessionSaveResult::captureFailure(SessionSaveUnexpectedFailure{});
+    }
+    if (!*captured) {
+        return SessionSaveResult::captureFailure(captured->status());
+    }
+    const auto* input = captured->value();
+    if (input == nullptr) {
+        // Unreachable: `*captured` above already proved status() == Captured, which guarantees
+        // value() is non-null (see SessionSaveInputResult::operator bool()). Handled anyway so
+        // this function's control flow stays provably total.
+        return SessionSaveResult::captureFailure(SessionSaveUnexpectedFailure{});
+    }
+
+    std::vector<project::ManifestRequirement> requirements;
+    try {
+        requirements = input->retainedRequirements();
+    } catch (const std::bad_alloc&) {
+        return assemblyResourceExhausted();
+    }
+
+    const project::CanonicalManifestV1 manifest{
+        .documentSchemaVersion = {1, input->schemaMinor()},
+        .requirements = requirements,
+    };
+    const project::CanonicalDocumentV1 documentInput{
+        .snapshot = &input->snapshot(),
+        .colorSettings = &input->colorSettings(),
+        .roundTrip = input->roundTrip(),
+        .schemaMinor = input->schemaMinor(),
+    };
+    const SavePublicationRequest publicationRequest{
+        .targetPath = request.targetPath,
+        .overwritePolicy = request.overwritePolicy,
+        .expectedTarget = request.expectedTarget,
+        .manifest = &manifest,
+        .document = &documentInput,
+        .limits = request.limits,
+        .preAdmitted = request.preAdmitted,
+        .cancellationFlag = request.cancellationFlag,
+    };
+
+    auto publicationResult =
+        executeSavePublication(coordinator, artifacts, publicationRequest, std::move(operation));
+    if (!publicationResult) {
+        return SessionSaveResult::publicationFailure(*publicationResult.failure(),
+                                                     publicationResult.rejectDiagnostic());
+    }
+
+    const auto* publication = publicationResult.publication();
+    const auto intentId = publicationResult.intentId().value_or(PublicationIntentId{});
+    if (publication == nullptr || !publication->targetWasPublished()) {
+        // Superseded / CancelledBeforePublication / ExternalModificationConflict /
+        // FailedBeforePublication: session untouched, no acceptSavepoint() attempt (frozen
+        // design: Save As abandonment on a non-published outcome is the caller's choice).
+        return SessionSaveResult::unpublished(
+            publication != nullptr ? *publication : platform::StagedArtifactPublicationResult{},
+            intentId);
+    }
+
+    try {
+        std::optional<ProjectDisplayPath> publishedPath;
+        if (request.intent.kind() == SessionPathIntentKind::ReplacementPath) {
+            publishedPath = ProjectDisplayPath::create(request.targetPath);
+        }
+        const auto savepointStatus =
+            session.acceptSavepoint(request.intent, intentId, input->revision(), publishedPath);
+        return SessionSaveResult::published(*publication, intentId, savepointStatus);
+    } catch (const std::bad_alloc&) {
+        // The file was already durably published (`*publication`/`intentId` are both still in
+        // scope and name the real replacement); only the LOCAL acceptSavepoint() bookkeeping
+        // allocation failed before returning a status. Never relabeled as a publication failure
+        // or silently dropped -- see SessionSaveResult::publishedSavepointBookkeepingFailed()'s
+        // comment for the truthfulness principle this preserves.
+        return SessionSaveResult::publishedSavepointBookkeepingFailed(
+            *publication, intentId, SessionSaveSavepointBookkeepingFailure::ResourceExhausted);
+    } catch (...) {
+        return SessionSaveResult::publishedSavepointBookkeepingFailed(
+            *publication, intentId, SessionSaveSavepointBookkeepingFailure::UnexpectedFailure);
+    }
+}
+
+} // namespace bloom::host

--- a/src/host/tests/project_session_tests.cpp
+++ b/src/host/tests/project_session_tests.cpp
@@ -1,12 +1,17 @@
 #include <bloom/host/project_session.hpp>
 
 #include <bloom/commands/operations.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
 #include <bloom/document/new_project.hpp>
+#include <bloom/project/round_trip_state.hpp>
 
+#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
 #include <limits>
+#include <numeric>
 #include <optional>
 #include <source_location>
 #include <stdexcept>
@@ -83,6 +88,7 @@ using bloom::host::SessionPathIntentAbandonStatus;
 using bloom::host::SessionPathIntentAdvanceStatus;
 using bloom::host::SessionPathIntentKind;
 using bloom::host::SessionResultAcceptanceAdvanceStatus;
+using bloom::host::SessionSaveInputStatus;
 
 static_assert(!std::is_copy_constructible_v<ProjectSessionIdentitySource>);
 static_assert(!std::is_move_constructible_v<ProjectSessionIdentitySource>);
@@ -100,6 +106,13 @@ static_assert(
         throw std::logic_error("Expected a forwarded command result");
     }
     return result.command->status;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    std::array<std::uint8_t, 32> digestBytes{};
+    std::iota(digestBytes.begin(), digestBytes.end(), std::uint8_t{0});
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(digestBytes));
 }
 
 [[nodiscard]] NewProjectSessionRequest newProjectRequest() {
@@ -132,6 +145,7 @@ decodedSessionWithPath(Expectations& expectations, ProjectSessionIdentitySource&
     }
     auto result = ProjectSession::createDecoded(identitySource,
                                                 {.project = std::move(created.project),
+                                                 .colorSettings = neutralColorSettings(),
                                                  .editability = DecodedProjectEditability::Editable,
                                                  .displayPath = std::move(path),
                                                  .persistedAllocatorHighWater = std::nullopt});
@@ -205,6 +219,7 @@ void testIdentitySourceAndExactExhaustion(Expectations& expectations) {
         "Decoded identity", "Main", bloom::core::RationalTime::fromInteger(5));
     auto secondResult = ProjectSession::createDecoded(
         identitySource, {.project = std::move(decodedProject.project),
+                         .colorSettings = neutralColorSettings(),
                          .editability = DecodedProjectEditability::Editable,
                          .displayPath = std::nullopt,
                          .persistedAllocatorHighWater = std::nullopt});
@@ -885,6 +900,7 @@ void testDegradedEditableAuthorization(Expectations& expectations,
     auto result = ProjectSession::createDecoded(
         identitySource, {
                             .project = std::move(createdProject.project),
+                            .colorSettings = neutralColorSettings(),
                             .editability = DecodedProjectEditability::DegradedEditable,
                             .displayPath = path,
                             .persistedAllocatorHighWater = std::nullopt,
@@ -979,6 +995,7 @@ void testInvalidConstruction(Expectations& expectations,
     bloom::document::Project invalidProject(bloom::document::ProjectId{}, "Invalid");
     expectations.expect(ProjectSession::createDecoded(
                             identitySource, {.project = std::move(invalidProject),
+                                             .colorSettings = neutralColorSettings(),
                                              .editability = DecodedProjectEditability::Editable,
                                              .displayPath = std::nullopt,
                                              .persistedAllocatorHighWater = std::nullopt})
@@ -990,6 +1007,7 @@ void testInvalidConstruction(Expectations& expectations,
     expectations.expect(
         ProjectSession::createDecoded(
             identitySource, {.project = std::move(unknownEditability.project),
+                             .colorSettings = neutralColorSettings(),
                              // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
                              .editability = static_cast<DecodedProjectEditability>(255),
                              .displayPath = std::nullopt,
@@ -1004,6 +1022,7 @@ void testInvalidConstruction(Expectations& expectations,
             identitySource,
             {
                 .project = std::move(insufficientHighWater.project),
+                .colorSettings = neutralColorSettings(),
                 .editability = DecodedProjectEditability::Editable,
                 .displayPath = std::nullopt,
                 .persistedAllocatorHighWater = bloom::document::IdAllocatorHighWater{},
@@ -1014,6 +1033,65 @@ void testInvalidConstruction(Expectations& expectations,
     expectations.expect(afterInvalid.lastIssuedSessionId == beforeInvalid.lastIssuedSessionId &&
                             afterInvalid.identityExhausted == beforeInvalid.identityExhausted,
                         "invalid construction never consumes a runtime session identity");
+}
+
+void testColorSettingsGatingAndRoundTripValidation(Expectations& expectations,
+                                                   ProjectSessionIdentitySource& identitySource) {
+    // createNew() has no color settings to synthesize (see color_settings.hpp's
+    // makeBloomNeutralColorSettingsV1(), which requires a real caller-supplied content-revision
+    // digest); such a session is gated unsaveable-pending-color.
+    auto session = newSession(expectations, identitySource);
+    const auto plainSave = session.capturePlainSavePathIntent();
+    expectations.expect(session.captureSaveInput(plainSave).status() ==
+                            SessionSaveInputStatus::ColorSettingsUnavailable,
+                        "a createNew session has no color settings and is gated "
+                        "unsaveable-pending-color");
+
+    // A decoded session's captureSaveInput carries the exact captured fields.
+    auto decoded = decodedSessionWithPath(expectations, identitySource, "capture.bloom");
+    const auto decodedIntent = decoded.capturePlainSavePathIntent();
+    const auto decodedCaptured = decoded.captureSaveInput(decodedIntent);
+    expectations.expect(static_cast<bool>(decodedCaptured) && decodedCaptured.value() != nullptr &&
+                            decodedCaptured.value()->revision() == currentRevision(decoded) &&
+                            decodedCaptured.value()->roundTrip() == nullptr &&
+                            decodedCaptured.value()->schemaMinor() == 0 &&
+                            decodedCaptured.value()->retainedRequirements().empty() &&
+                            decodedCaptured.value()->displayPath().has_value() &&
+                            decodedCaptured.value()->displayPath()->value() ==
+                                std::filesystem::path("capture.bloom") &&
+                            decodedCaptured.value()->pathIntent() == decodedIntent &&
+                            decodedCaptured.value()->resultAcceptance() ==
+                                decoded.captureResultAcceptance(),
+                        "captureSaveInput carries the exact captured save-input fields");
+
+    // ReadOnly for preserved content.
+    auto preservedResult =
+        ProjectSession::createPreservedReadOnly(identitySource, "preserved-capture.bloom");
+    expectations.expect(static_cast<bool>(preservedResult),
+                        "the preserved-capture fixture installs");
+    if (preservedResult) {
+        auto preserved = std::move(preservedResult).takeSession();
+        expectations.expect(preserved.captureSaveInput({}).status() ==
+                                SessionSaveInputStatus::ReadOnly,
+                            "preserved-read-only content cannot capture save input");
+    }
+
+    // A present roundTrip with schemaMinor 0 cannot name the newer minor it was captured
+    // against: typed create failure.
+    auto rtProject = bloom::document::makeNewProject("RT invalid", "Main",
+                                                     bloom::core::RationalTime::fromInteger(5));
+    bloom::project::RoundTripState roundTrip;
+    const auto invalidRoundTrip = ProjectSession::createDecoded(
+        identitySource, {.project = std::move(rtProject.project),
+                         .colorSettings = neutralColorSettings(),
+                         .editability = DecodedProjectEditability::Editable,
+                         .displayPath = std::nullopt,
+                         .persistedAllocatorHighWater = std::nullopt,
+                         .roundTrip = std::move(roundTrip),
+                         .schemaMinor = 0});
+    expectations.expect(invalidRoundTrip.status() ==
+                            ProjectSessionCreateStatus::InvalidDecodedProject,
+                        "a present roundTrip with schemaMinor 0 is a typed create failure");
 }
 
 void testMoveAndLifetimeSafety(Expectations& expectations,
@@ -1101,6 +1179,7 @@ int main() {
         testDegradedEditableAuthorization(expectations, identitySource);
         testPreservedReadOnlyState(expectations, identitySource);
         testInvalidConstruction(expectations, identitySource);
+        testColorSettingsGatingAndRoundTripValidation(expectations, identitySource);
         testMoveAndLifetimeSafety(expectations, identitySource);
     } catch (const std::exception& error) {
         std::cerr << "FAILED: unexpected fixture exception: " << error.what() << '\n';

--- a/src/host/tests/session_save_tests.cpp
+++ b/src/host/tests/session_save_tests.cpp
@@ -1,0 +1,1167 @@
+#include <bloom/host/session_save.hpp>
+
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/extension_records.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/host/project_session.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/document_decode.hpp>
+#include <bloom/project/document_reconstruct.hpp>
+#include <bloom/project/manifest_decode.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/round_trip_state.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+#include <bloom/project/zip_container.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+// Drives saveProjectSession() -- the synchronous session-save orchestration composing
+// ProjectSession::captureSaveInput(), executeSavePublication(), and ProjectSession::
+// acceptSavepoint() -- against REAL coordinators on per-test temporary directories, following
+// src/host/tests/save_publication_tests.cpp's pattern one composition layer up (a
+// ProjectSession replaces that file's bare CanonicalManifestV1/CanonicalDocumentV1 inputs).
+
+namespace {
+
+using bloom::commands::SetProjectName;
+using bloom::commands::Transaction;
+
+using bloom::host::ArtifactTargetKey;
+using bloom::host::DecodedProjectEditability;
+using bloom::host::DecodedProjectSessionRequest;
+using bloom::host::ProjectDisplayPath;
+using bloom::host::ProjectSession;
+using bloom::host::ProjectSessionIdentitySource;
+using bloom::host::ProjectSessionSavepointStatus;
+using bloom::host::PublicationAdmission;
+using bloom::host::PublicationCoordinator;
+using bloom::host::PublicationCoordinatorConfig;
+using bloom::host::PublicationIntentId;
+using bloom::host::saveProjectSession;
+using bloom::host::SavePublicationStage;
+using bloom::host::SessionPathIntentAbandonStatus;
+using bloom::host::SessionPathIntentKind;
+using bloom::host::SessionSaveInputStatus;
+using bloom::host::SessionSaveRequest;
+using bloom::host::SessionSaveResult;
+using bloom::host::SessionSaveSavepointBookkeepingFailure;
+using bloom::host::SessionSaveStage;
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::ArtifactTargetObservation;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+using bloom::platform::StagedArtifactFaultPoint;
+using bloom::platform::StagedArtifactPublicationOutcome;
+
+using bloom::project::buildSaveArchive;
+using bloom::project::canonicalDocumentSize;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::canonicalManifestSize;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::decodeDocumentEnvelope;
+using bloom::project::decodeManifestEnvelope;
+using bloom::project::DocumentClassification;
+using bloom::project::DocumentDecodeOutcome;
+using bloom::project::DocumentDecodeResult;
+using bloom::project::encodeCanonicalDocument;
+using bloom::project::encodeCanonicalManifest;
+using bloom::project::ManifestRequirement;
+using bloom::project::parseStrictJsonDom;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::readZipContainer;
+using bloom::project::reconstructDocument;
+using bloom::project::RoundTripAttachmentPath;
+using bloom::project::RoundTripState;
+using bloom::project::SaveArchiveExpectedContent;
+using bloom::project::SaveArchiveLimits;
+using bloom::project::SaveArchiveStage;
+using bloom::project::verifySaveArchive;
+using bloom::project::ZipContainerLimits;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-session-save-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Shared plumbing (mirrors save_publication_tests.cpp)
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U;
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    return makeOperation(kGenerousOperationBudget);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::span<const char> bytes) noexcept {
+    return {reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::optional<PublicationCoordinator>
+makePublicationCoordinator(Expectations& expectations,
+                           const PublicationCoordinatorConfig config = {}) {
+    auto result = PublicationCoordinator::create(config);
+    expectations.expect(result.has_value(), "the publication coordinator is created");
+    return result;
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeArtifactsCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-artifact coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+[[nodiscard]] std::optional<PublicationAdmission> admitIntent(PublicationCoordinator& coordinator,
+                                                              Expectations& expectations,
+                                                              const std::string_view context) {
+    auto result = coordinator.admit();
+    expectations.expect(static_cast<bool>(result), context);
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeAdmission();
+}
+
+// ---------------------------------------------------------------------------------------------
+// Session-level fixtures
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] bloom::document::Revision currentRevision(const ProjectSession& session) {
+    const auto state = session.stateSnapshot();
+    if (!state.currentRevision.has_value()) {
+        throw std::logic_error("Expected a decoded revision");
+    }
+    return *state.currentRevision;
+}
+
+[[nodiscard]] Transaction rename(std::string value, const ProjectSession& session,
+                                 std::string label = "Rename") {
+    Transaction transaction(std::move(label), currentRevision(session));
+    transaction.emplace<SetProjectName>(std::move(value));
+    return transaction;
+}
+
+[[nodiscard]] ProjectSession
+makeDecodedSession(Expectations& expectations, ProjectSessionIdentitySource& identitySource,
+                   const std::string& projectName,
+                   const std::optional<std::filesystem::path>& displayPath = std::nullopt) {
+    auto created = bloom::document::makeNewProject(projectName, "Main Composition",
+                                                   bloom::core::RationalTime::fromInteger(10));
+    std::optional<ProjectDisplayPath> path;
+    if (displayPath.has_value()) {
+        path = ProjectDisplayPath::create(*displayPath);
+        expectations.expect(path.has_value(), "the display-path fixture is valid");
+    }
+    auto result = ProjectSession::createDecoded(identitySource,
+                                                {.project = std::move(created.project),
+                                                 .colorSettings = neutralColorSettings(),
+                                                 .editability = DecodedProjectEditability::Editable,
+                                                 .displayPath = std::move(path),
+                                                 .persistedAllocatorHighWater = std::nullopt});
+    expectations.expect(static_cast<bool>(result), "the decoded session fixture must be valid");
+    if (!result) {
+        throw std::logic_error("Could not create decoded project-session fixture");
+    }
+    return std::move(result).takeSession();
+}
+
+// Independently encodes manifest.json/document.json straight from canonical_manifest.hpp/
+// canonical_document.hpp -- never through saveProjectSession()/executeSavePublication()/
+// save_archive.hpp -- to serve as an oracle for the byte content saveProjectSession() should
+// have published.
+struct OracleEntries final {
+    std::vector<char> manifestBytes;
+    std::vector<char> documentBytes;
+};
+
+[[nodiscard]] std::optional<OracleEntries>
+buildOracleEntries(Expectations& expectations, const CanonicalManifestV1& manifest,
+                   const CanonicalDocumentV1& documentInput) {
+    const auto manifestSize = canonicalManifestSize(manifest);
+    expectations.expect(static_cast<bool>(manifestSize), "oracle: manifest sizes");
+    if (!manifestSize) {
+        return std::nullopt;
+    }
+    std::vector<char> manifestBytes(*manifestSize.value());
+    expectations.expect(static_cast<bool>(encodeCanonicalManifest(manifest, manifestBytes)),
+                        "oracle: manifest encodes");
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    CanonicalDocumentV1 oracleRequest = documentInput;
+    oracleRequest.payloadScratch = payloadScratch;
+    oracleRequest.sortScratch = sortScratch;
+    const auto documentSize = canonicalDocumentSize(oracleRequest);
+    expectations.expect(static_cast<bool>(documentSize), "oracle: document sizes");
+    if (!documentSize) {
+        return std::nullopt;
+    }
+    std::vector<char> documentBytes(*documentSize.value());
+    expectations.expect(static_cast<bool>(encodeCanonicalDocument(oracleRequest, documentBytes)),
+                        "oracle: document encodes");
+    return OracleEntries{std::move(manifestBytes), std::move(documentBytes)};
+}
+
+// Clones a RoundTripState through its public API only (RoundTripState is deliberately move-only
+// and exposes no owning "take" accessor from a decode result -- see document_decode.hpp -- so a
+// caller that needs to install an owned copy re-attaches every entry rather than reaching past the
+// encapsulation).
+[[nodiscard]] RoundTripState cloneRoundTrip(const RoundTripState& source) {
+    RoundTripState clone;
+    for (const auto& entry : source.entries()) {
+        clone.attach(entry.path, entry.members);
+    }
+    return clone;
+}
+
+// ---------------------------------------------------------------------------------------------
+// End to end: createDecoded with color settings + empty requirements -> an edit transaction ->
+// Save As advance -> saveProjectSession -> Published -> acceptSavepoint Accepted -> session state
+// reflects the accepted savepoint -> the published file verifies via verifySaveArchive() against
+// independently-encoded entries.
+// ---------------------------------------------------------------------------------------------
+
+void testEndToEndSaveAs(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "end to end: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    const auto colorSettings = neutralColorSettings();
+
+    auto session = makeDecodedSession(expectations, identitySource, "End To End Project");
+    expectations.expect(session.execute(rename("Renamed", session)).changed(),
+                        "end to end: the edit commits");
+    const auto editedRevision = currentRevision(session);
+
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "end to end: Save As advances path authority");
+    if (!saveAs) {
+        return;
+    }
+
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto result = saveProjectSession(session, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(result),
+                        "end to end: saveProjectSession fully succeeds (Published + Accepted)");
+    expectations.expect(
+        result.stage() == SessionSaveStage::Savepoint && result.publication() != nullptr &&
+            result.publication()->outcome == StagedArtifactPublicationOutcome::Published &&
+            result.savepointStatus() == ProjectSessionSavepointStatus::Accepted,
+        "end to end: the result names Published + Accepted verbatim");
+
+    const auto state = session.stateSnapshot();
+    expectations.expect(state.cleanRevision == editedRevision && state.dirty == false &&
+                            state.displayPath.has_value() &&
+                            state.displayPath->value() == targetPath &&
+                            result.intentId().has_value() &&
+                            state.newestAcceptedPublicationIntent == *result.intentId(),
+                        "end to end: session state reflects the accepted savepoint");
+
+    const auto decodedSnapshot = session.decodedSnapshot();
+    expectations.expect(static_cast<bool>(decodedSnapshot),
+                        "end to end: a decoded snapshot exists");
+    if (!decodedSnapshot) {
+        return;
+    }
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &decodedSnapshot.snapshot(),
+                                            .colorSettings = &colorSettings};
+    const auto oracleEntries = buildOracleEntries(expectations, manifest, documentInput);
+    if (!oracleEntries.has_value()) {
+        return;
+    }
+    const SaveArchiveExpectedContent expected{
+        .manifestBytes = asBytes(oracleEntries->manifestBytes),
+        .documentBytes = asBytes(oracleEntries->documentBytes),
+        .documentSchemaVersion = manifest.documentSchemaVersion,
+    };
+    const auto published = readFile(targetPath);
+    auto reverified =
+        verifySaveArchive(asBytes(published), expected, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(reverified),
+                        "end to end: verifySaveArchive independently re-verifies the published "
+                        "file's bytes as the final oracle");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Plain save after Save As: a second edit, a plain-save intent capture, save to the SAME path
+// (ExistingPath) -> published + accepted, path unchanged.
+// ---------------------------------------------------------------------------------------------
+
+void testPlainSaveAfterSaveAs(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "plain save after save as: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    auto session = makeDecodedSession(expectations, identitySource, "Plain Save After Save As");
+    expectations.expect(session.execute(rename("First", session)).changed(),
+                        "plain save after save as: the first edit commits");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs),
+                        "plain save after save as: Save As advances path authority");
+    if (!saveAs) {
+        return;
+    }
+    const SessionSaveRequest firstRequest{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto firstResult =
+        saveProjectSession(session, *coordinator, *artifacts, firstRequest, makeOperation());
+    expectations.expect(static_cast<bool>(firstResult),
+                        "plain save after save as: the Save As publish fully succeeds");
+    if (!firstResult) {
+        return;
+    }
+    const auto pathAfterSaveAs = session.stateSnapshot().displayPath;
+
+    expectations.expect(session.execute(rename("Second", session)).changed(),
+                        "plain save after save as: the second edit commits");
+    const auto secondRevision = currentRevision(session);
+    const auto plainIntent = session.capturePlainSavePathIntent();
+    expectations.expect(plainIntent.isValid() &&
+                            plainIntent.kind() == SessionPathIntentKind::ExistingPath,
+                        "plain save after save as: a plain-save intent captures existing-path "
+                        "authority");
+
+    std::optional<ArtifactTargetObservation> observedFingerprint;
+    {
+        auto peek =
+            artifacts->preflight({.targetPath = targetPath,
+                                  .overwritePolicy = ArtifactOverwritePolicy::ReplaceExisting,
+                                  .expectedTarget = std::nullopt});
+        expectations.expect(peek && peek.target()->observation().exists,
+                            "plain save after save as: preflight observes the published "
+                            "fingerprint");
+        if (!peek) {
+            return;
+        }
+        observedFingerprint = peek.target()->observation();
+    }
+    const SessionSaveRequest secondRequest{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::ReplaceExisting,
+        .expectedTarget = observedFingerprint,
+        .limits = {},
+        .intent = plainIntent,
+    };
+    auto secondResult =
+        saveProjectSession(session, *coordinator, *artifacts, secondRequest, makeOperation());
+    expectations.expect(static_cast<bool>(secondResult),
+                        "plain save after save as: the plain-save publish fully succeeds");
+    const auto state = session.stateSnapshot();
+    expectations.expect(state.cleanRevision == secondRevision && state.dirty == false &&
+                            state.displayPath == pathAfterSaveAs,
+                        "plain save after save as: published + accepted with the path unchanged");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Round-tripped newer minor: install a RoundTripState (built via the real document decode path
+// over a spliced 1.1 fixture, mirroring save_archive_tests.cpp) + schemaMinor 1 at creation ->
+// save -> the manifest in the published file declares {1,1} and the unknown member survives
+// (reopen + decode assert).
+// ---------------------------------------------------------------------------------------------
+
+void testRoundTrippedNewerMinorGreenChain(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "round-tripped newer minor: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    auto newProject = bloom::document::makeNewProject("Untitled Project", "Main Composition",
+                                                      bloom::core::RationalTime::fromInteger(10));
+    bloom::document::Document sourceDocument{std::move(newProject.project)};
+    auto sourceSnapshot = sourceDocument.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    const CanonicalDocumentV1 baselineRequest{.snapshot = &sourceSnapshot,
+                                              .colorSettings = &colorSettings,
+                                              .payloadScratch = payloadScratch,
+                                              .sortScratch = sortScratch};
+    const auto size = canonicalDocumentSize(baselineRequest);
+    expectations.expect(static_cast<bool>(size), "round-tripped newer minor: baseline sizes");
+    if (!size) {
+        return;
+    }
+    std::string text(*size.value(), '\0');
+    const auto written =
+        encodeCanonicalDocument(baselineRequest, std::span<char>(text.data(), text.size()));
+    expectations.expect(static_cast<bool>(written), "round-tripped newer minor: baseline encodes");
+    if (!written) {
+        return;
+    }
+
+    const std::string anchor = "\"minor\": 0\n  },\n  \"project\"";
+    const auto anchorPos = text.find(anchor);
+    expectations.expect(anchorPos != std::string::npos,
+                        "round-tripped newer minor: root schemaVersion anchor is located");
+    if (anchorPos == std::string::npos) {
+        return;
+    }
+    text.replace(anchorPos, std::string_view("\"minor\": 0").size(), "\"minor\": 1");
+    expectations.expect(text.size() >= 2 && text.back() == '\n' && text[text.size() - 2] == '}',
+                        "round-tripped newer minor: baseline ends with the root's closing brace");
+    if (text.size() < 2 || text.back() != '\n' || text[text.size() - 2] != '}') {
+        return;
+    }
+    text.resize(text.size() - 2);
+    text += R"(,"zzzFutureField":42})";
+    text += '\n';
+
+    auto parsed = parseStrictJsonDom(asBytes(text), {}, makeOperation());
+    expectations.expect(static_cast<bool>(parsed), "round-tripped newer minor: spliced document "
+                                                   "parses");
+    if (!parsed) {
+        return;
+    }
+    DocumentDecodeResult decoded = decodeDocumentEnvelope(parsed.document()->root());
+    expectations.expect(
+        decoded.outcome() == DocumentDecodeOutcome::Decoded &&
+            decoded.classification() == DocumentClassification::EditableWithRoundTrip &&
+            decoded.value() != nullptr && decoded.roundTrip() != nullptr,
+        "round-tripped newer minor: spliced document decodes with round-trip state");
+    if (decoded.value() == nullptr || decoded.roundTrip() == nullptr) {
+        return;
+    }
+
+    auto reconstructed = reconstructDocument(*decoded.value());
+    expectations.expect(static_cast<bool>(reconstructed),
+                        "round-tripped newer minor: spliced document reconstructs");
+    if (!reconstructed) {
+        return;
+    }
+    auto* reconstructedValue = reconstructed.value();
+    const auto persistedHighWater = reconstructedValue->document->snapshot().ids().highWater();
+    auto project = reconstructedValue->document->snapshot().project();
+    auto roundTrip = cloneRoundTrip(*decoded.roundTrip());
+
+    auto sessionResult = ProjectSession::createDecoded(
+        identitySource, {.project = std::move(project),
+                         .colorSettings = reconstructedValue->colorSettings,
+                         .editability = DecodedProjectEditability::Editable,
+                         .displayPath = std::nullopt,
+                         .persistedAllocatorHighWater = persistedHighWater,
+                         .roundTrip = std::move(roundTrip),
+                         .schemaMinor = 1,
+                         .retainedRequirements = {}});
+    expectations.expect(static_cast<bool>(sessionResult),
+                        "round-tripped newer minor: the session installs the round-tripped "
+                        "content");
+    if (!sessionResult) {
+        return;
+    }
+    auto session = std::move(sessionResult).takeSession();
+
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs),
+                        "round-tripped newer minor: Save As advances path authority");
+    if (!saveAs) {
+        return;
+    }
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto result = saveProjectSession(session, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(result),
+                        "round-tripped newer minor: saveProjectSession fully succeeds (the "
+                        "editable-reopen boundary tolerates our own schemaMinor > 0 archive)");
+    if (!result) {
+        return;
+    }
+
+    const auto published = readFile(targetPath);
+    auto reopened = readZipContainer(asBytes(published), ZipContainerLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(reopened),
+                        "round-tripped newer minor: the published archive reopens");
+    if (!reopened) {
+        return;
+    }
+
+    auto manifestDom =
+        parseStrictJsonDom(reopened.document()->manifestBytes(), {}, makeOperation());
+    expectations.expect(static_cast<bool>(manifestDom),
+                        "round-tripped newer minor: reopened manifest.json parses");
+    if (manifestDom) {
+        auto decodedManifest = decodeManifestEnvelope(manifestDom.document()->root());
+        expectations.expect(
+            static_cast<bool>(decodedManifest) && decodedManifest.value() != nullptr &&
+                decodedManifest.value()->documentSchemaVersion ==
+                    bloom::document::SchemaVersion{1, 1},
+            "round-tripped newer minor: the published manifest declares document schema {1,1}");
+    }
+
+    auto documentDom =
+        parseStrictJsonDom(reopened.document()->documentBytes(), {}, makeOperation());
+    expectations.expect(static_cast<bool>(documentDom),
+                        "round-tripped newer minor: reopened document.json parses");
+    if (!documentDom) {
+        return;
+    }
+    DocumentDecodeResult redecoded = decodeDocumentEnvelope(documentDom.document()->root());
+    expectations.expect(redecoded.outcome() == DocumentDecodeOutcome::Decoded &&
+                            redecoded.classification() ==
+                                DocumentClassification::EditableWithRoundTrip,
+                        "round-tripped newer minor: the reopened archive still classifies "
+                        "EditableWithRoundTrip, never PreservedReadOnlyRequired");
+    if (redecoded.roundTrip() == nullptr) {
+        expectations.expect(false, "round-tripped newer minor: the reopened archive retains "
+                                   "RoundTripState");
+        return;
+    }
+    const auto* members = redecoded.roundTrip()->find(RoundTripAttachmentPath{});
+    expectations.expect(members != nullptr && members->size() == 1 &&
+                            (*members)[0].key() == "zzzFutureField",
+                        "round-tripped newer minor: the unknown root member survives the "
+                        "save/reopen chain byte-exactly");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Refusals: preserved-read-only session -> ReadOnly; pathless plain save -> PathRequired; stale
+// path intent (advance Save As twice, use the first capture) -> StaleIntent. Capture after
+// session replacement has no test: no session-replacement/installation API exists yet in this
+// slice (see the task package's non-goals) -- noted rather than fabricated.
+// ---------------------------------------------------------------------------------------------
+
+void testRefusals(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "refusals: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    {
+        auto preservedResult =
+            ProjectSession::createPreservedReadOnly(identitySource, "preserved.bloom");
+        expectations.expect(static_cast<bool>(preservedResult),
+                            "refusals: the preserved fixture installs");
+        if (preservedResult) {
+            auto preserved = std::move(preservedResult).takeSession();
+            const SessionSaveRequest request{.targetPath = targetPath,
+                                             .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                             .expectedTarget = std::nullopt,
+                                             .limits = {},
+                                             .intent = {}};
+            auto result =
+                saveProjectSession(preserved, *coordinator, *artifacts, request, makeOperation());
+            expectations.expect(!static_cast<bool>(result) &&
+                                    result.stage() == SessionSaveStage::Capture,
+                                "refusals: preserved content is refused at the Capture stage");
+            const auto* outcome = result.captureOutcome();
+            const auto* status =
+                outcome != nullptr ? std::get_if<SessionSaveInputStatus>(outcome) : nullptr;
+            expectations.expect(status != nullptr && *status == SessionSaveInputStatus::ReadOnly,
+                                "refusals: the capture outcome names ReadOnly");
+        }
+    }
+
+    {
+        auto session = makeDecodedSession(expectations, identitySource, "Pathless Refusal");
+        const auto plainIntent = session.capturePlainSavePathIntent();
+        const SessionSaveRequest request{.targetPath = targetPath,
+                                         .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                         .expectedTarget = std::nullopt,
+                                         .limits = {},
+                                         .intent = plainIntent};
+        auto result =
+            saveProjectSession(session, *coordinator, *artifacts, request, makeOperation());
+        expectations.expect(!static_cast<bool>(result) &&
+                                result.stage() == SessionSaveStage::Capture,
+                            "refusals: a pathless plain save is refused at the Capture stage");
+        const auto* outcome = result.captureOutcome();
+        const auto* status =
+            outcome != nullptr ? std::get_if<SessionSaveInputStatus>(outcome) : nullptr;
+        expectations.expect(status != nullptr && *status == SessionSaveInputStatus::PathRequired,
+                            "refusals: the capture outcome names PathRequired");
+    }
+
+    {
+        auto session = makeDecodedSession(expectations, identitySource, "Stale Refusal");
+        const auto first = session.advancePathIntentForSaveAs();
+        const auto second = session.advancePathIntentForSaveAs();
+        expectations.expect(static_cast<bool>(first) && static_cast<bool>(second),
+                            "refusals: both Save As advances succeed");
+        const SessionSaveRequest request{.targetPath = targetPath,
+                                         .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                         .expectedTarget = std::nullopt,
+                                         .limits = {},
+                                         .intent = first.capture()};
+        auto result =
+            saveProjectSession(session, *coordinator, *artifacts, request, makeOperation());
+        expectations.expect(!static_cast<bool>(result) &&
+                                result.stage() == SessionSaveStage::Capture,
+                            "refusals: a superseded Save As capture is refused at the Capture "
+                            "stage");
+        const auto* outcome = result.captureOutcome();
+        const auto* status =
+            outcome != nullptr ? std::get_if<SessionSaveInputStatus>(outcome) : nullptr;
+        expectations.expect(status != nullptr && *status == SessionSaveInputStatus::StaleIntent,
+                            "refusals: the capture outcome names StaleIntent");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Non-published outcomes leave the session untouched: FailedBeforePublication (a platform fault
+// injected at AtomicPublication) and Superseded (a competing higher intent registered via the
+// executor's preAdmitted seam, exactly as save_publication_tests.cpp's testSupersession drives
+// the coordinator directly). Both leave dirty/clean-revision/path/newestAcceptedPublicationIntent
+// unchanged; the Superseded case then abandons its Save As intent, returning path authority to
+// ExistingPath without fabricating a path.
+// ---------------------------------------------------------------------------------------------
+
+void testFailedBeforePublicationLeavesSessionUntouched(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    StagedArtifactConfig config;
+    config.faults = {.point = StagedArtifactFaultPoint::AtomicPublication, .occurrence = 1};
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations, config);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "failed before publication: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    auto session =
+        makeDecodedSession(expectations, identitySource, "Failed Before Publication", targetPath);
+    expectations.expect(session.execute(rename("Edited", session)).changed(),
+                        "failed before publication: the edit commits");
+    const auto beforeState = session.stateSnapshot();
+    const auto plainIntent = session.capturePlainSavePathIntent();
+    const SessionSaveRequest request{.targetPath = targetPath,
+                                     .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                     .expectedTarget = std::nullopt,
+                                     .limits = {},
+                                     .intent = plainIntent};
+    auto result = saveProjectSession(session, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(
+        !static_cast<bool>(result) && result.stage() == SessionSaveStage::Savepoint &&
+            result.publication() != nullptr &&
+            result.publication()->outcome ==
+                StagedArtifactPublicationOutcome::FailedBeforePublication &&
+            !result.savepointStatus().has_value(),
+        "failed before publication: FailedBeforePublication triggers no acceptSavepoint attempt");
+    const auto afterState = session.stateSnapshot();
+    expectations.expect(
+        afterState.dirty == true && afterState.cleanRevision == beforeState.cleanRevision &&
+            afterState.displayPath == beforeState.displayPath &&
+            afterState.newestAcceptedPublicationIntent ==
+                beforeState.newestAcceptedPublicationIntent,
+        "failed before publication: session state is untouched by a non-published outcome");
+}
+
+void testSupersededLeavesSessionUntouchedThenAbandons(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "supersession: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    auto session = makeDecodedSession(expectations, identitySource, "Supersession Project");
+    expectations.expect(session.execute(rename("Edited", session)).changed(),
+                        "supersession: the edit commits");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "supersession: Save As advances");
+    if (!saveAs) {
+        return;
+    }
+    const auto beforeState = session.stateSnapshot();
+
+    ArtifactTargetKey targetKey;
+    {
+        auto peek = artifacts->preflight({.targetPath = targetPath,
+                                          .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                          .expectedTarget = std::nullopt});
+        expectations.expect(static_cast<bool>(peek), "supersession: the peek preflight succeeds");
+        if (!peek) {
+            return;
+        }
+        targetKey = peek.target()->targetKey();
+    }
+
+    auto lowerAdmission = admitIntent(*coordinator, expectations,
+                                      "supersession: the executor's own (lower) intent is admitted "
+                                      "first");
+    auto competitorAdmission = admitIntent(*coordinator, expectations,
+                                           "supersession: the competing (higher) intent is "
+                                           "admitted second");
+    if (!lowerAdmission.has_value() || !competitorAdmission.has_value()) {
+        return;
+    }
+    auto competitorRegistration =
+        coordinator->registerTarget(std::move(*competitorAdmission), targetKey);
+    expectations.expect(static_cast<bool>(competitorRegistration),
+                        "supersession: the competitor registers for the identical target key");
+    if (!competitorRegistration) {
+        return;
+    }
+    std::move(competitorRegistration).takeClaim().reset();
+
+    const SessionSaveRequest request{.targetPath = targetPath,
+                                     .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                     .expectedTarget = std::nullopt,
+                                     .limits = {},
+                                     .intent = saveAs.capture(),
+                                     .preAdmitted = &(*lowerAdmission)};
+    auto result = saveProjectSession(session, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(
+        !static_cast<bool>(result) && result.stage() == SessionSaveStage::Savepoint &&
+            result.publication() != nullptr &&
+            result.publication()->outcome == StagedArtifactPublicationOutcome::Superseded &&
+            !result.savepointStatus().has_value(),
+        "supersession: Superseded triggers no acceptSavepoint attempt");
+
+    const auto afterState = session.stateSnapshot();
+    expectations.expect(afterState.dirty == true &&
+                            afterState.cleanRevision == beforeState.cleanRevision &&
+                            !afterState.displayPath.has_value() &&
+                            afterState.newestAcceptedPublicationIntent ==
+                                beforeState.newestAcceptedPublicationIntent &&
+                            afterState.pathIntentKind == SessionPathIntentKind::ReplacementPath,
+                        "supersession: session state is untouched by a non-published outcome");
+
+    expectations.expect(
+        session.abandonSaveAsIntent(saveAs.capture()) == SessionPathIntentAbandonStatus::Abandoned,
+        "supersession: the still-current replacement intent can be abandoned after a "
+        "non-published outcome");
+    const auto abandonedState = session.stateSnapshot();
+    expectations.expect(abandonedState.pathIntentKind == SessionPathIntentKind::ExistingPath &&
+                            !abandonedState.displayPath.has_value(),
+                        "supersession: abandonment restores existing-path authority without "
+                        "fabricating a path");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Savepoint refusal surfaced: forcing a genuine acceptSavepoint() refusal AFTER a real
+// executeSavePublication() publish() requires racing session state against the executor between
+// its Guard stage and the caller's own acceptSavepoint() call -- no seam in this synchronous
+// slice exposes that window (the frozen non-goals forbid adding one: "acceptSavepoint and the
+// path-authority machinery are EXISTING semantics -- wire them, do not redefine them"). Every
+// acceptSavepoint() refusal status (ReadOnly, InvalidPublicationIntent, StaleIntent,
+// UnknownRevision, PathRequired, PathAuthorityMismatch) is already pinned directly against
+// ProjectSession in src/host/tests/project_session_tests.cpp (testSavepointPathAuthority,
+// testPublicationCallbackOrdering, testPublicationFrontierScopesToPathGeneration,
+// testDirtySavepointBranching, testPreservedReadOnlyState) -- verified present, not duplicated
+// here. SessionSaveResult::savepointStatus() forwards whatever acceptSavepoint() returns
+// verbatim (see saveProjectSession()'s implementation), so this module adds no additional
+// masking risk beyond what those tests already cover.
+//
+// A DIFFERENT truthfulness risk lives in the same catch block: if the LOCAL acceptSavepoint()
+// call itself throws (std::bad_alloc from its own bookkeeping, e.g. a Save As replacement path
+// copy) AFTER a real Published/PublishedWithDurabilityWarning outcome, the file has already been
+// durably replaced -- reporting that as an unpublished/failed result would be untruthful. This is
+// handled by SessionSaveResult::publishedSavepointBookkeepingFailed() (see saveProjectSession()'s
+// final catch block). Forcing that exact allocation to fail deterministically has no seam either
+// (acceptSavepoint()'s own allocations are tiny -- a filesystem::path copy at most -- and this
+// slice adds no fault-injection hook per the frozen non-goals), so the trigger is not exercised
+// here. Its RESULT SHAPE is pinned directly below instead, mirroring how the refusal statuses
+// above are pinned without needing the exact runtime condition that produces them.
+// ---------------------------------------------------------------------------------------------
+
+void testPublishedSavepointBookkeepingFailedShape(Expectations& expectations) {
+    const bloom::platform::StagedArtifactPublicationResult publication{
+        .outcome = StagedArtifactPublicationOutcome::Published,
+        .error = bloom::platform::StagedArtifactError::None,
+    };
+    const auto intentId = PublicationIntentId::fromRaw(7);
+
+    for (const auto failure : {SessionSaveSavepointBookkeepingFailure::ResourceExhausted,
+                               SessionSaveSavepointBookkeepingFailure::UnexpectedFailure}) {
+        auto result =
+            SessionSaveResult::publishedSavepointBookkeepingFailed(publication, intentId, failure);
+        expectations.expect(
+            !static_cast<bool>(result) && result.stage() == SessionSaveStage::Savepoint &&
+                result.publication() != nullptr &&
+                result.publication()->outcome == StagedArtifactPublicationOutcome::Published &&
+                result.publication()->targetWasPublished() && result.intentId() == intentId &&
+                !result.savepointStatus().has_value() &&
+                result.savepointBookkeepingFailure() == failure,
+            "publishedSavepointBookkeepingFailed: the real publication and intent survive "
+            "verbatim, operator bool() is false, savepointStatus() is absent, and the exact "
+            "bookkeeping-failure kind is named");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Budget exhaustion pass-through: a budget just above buildSaveArchive()'s own peak charge for a
+// bulk fixture (mirroring save_publication_tests.cpp's withBulkDocumentInput/testBudgetExhaustion
+// two-pass technique) still fails somewhere in saveProjectSession()'s composed chain, reported
+// verbatim at the Publication stage.
+// ---------------------------------------------------------------------------------------------
+
+struct BulkFixture final {
+    ProjectSession session;
+    bloom::document::ColorSettings colorSettings;
+    std::vector<ManifestRequirement> requirements;
+};
+
+[[nodiscard]] std::optional<BulkFixture>
+makeBulkFixture(Expectations& expectations, ProjectSessionIdentitySource& identitySource) {
+    using bloom::document::ExtensionRecord;
+    using bloom::document::ExtensionRecordId;
+    using bloom::document::NoExtensionReferences;
+    using bloom::document::OpaqueExtensionPayload;
+
+    auto newProject = bloom::document::makeNewProject("Bulk Budget Project", "Main Composition",
+                                                      bloom::core::RationalTime::fromInteger(10));
+    constexpr std::uint64_t kRecordCount = 60;
+    constexpr std::size_t kPayloadBytes = 200'000;
+    std::uint64_t xorshiftState = 0x9E3779B97F4A7C15ULL;
+    const auto nextPseudoRandomByte = [&xorshiftState]() noexcept {
+        xorshiftState ^= xorshiftState << 13U;
+        xorshiftState ^= xorshiftState >> 7U;
+        xorshiftState ^= xorshiftState << 17U;
+        return static_cast<std::byte>(xorshiftState & 0xFFU);
+    };
+    for (std::uint64_t index = 1; index <= kRecordCount; ++index) {
+        std::vector<std::byte> payloadBytes(kPayloadBytes);
+        std::ranges::generate(payloadBytes, nextPseudoRandomByte);
+        ExtensionRecord record{ExtensionRecordId::fromRaw(index),
+                               "vendor.bulk",
+                               "vendor.bulk.record",
+                               {1, 0},
+                               std::nullopt,
+                               "application/octet-stream",
+                               NoExtensionReferences{},
+                               OpaqueExtensionPayload{std::move(payloadBytes)}};
+        const bool added = newProject.project.addExtensionRecord(std::move(record));
+        expectations.expect(added, "bulk fixture extension record adds");
+        if (!added) {
+            return std::nullopt;
+        }
+    }
+    std::vector<ManifestRequirement> requirements{{.providerId = "vendor.bulk",
+                                                   .capabilityId = "vendor.bulk.cap",
+                                                   .schemaVersion = {1, 0},
+                                                   .providedNodeTypeIds = {}}};
+    auto colorSettings = neutralColorSettings();
+    auto sessionResult = ProjectSession::createDecoded(
+        identitySource, {.project = std::move(newProject.project),
+                         .colorSettings = colorSettings,
+                         .editability = DecodedProjectEditability::Editable,
+                         .displayPath = std::nullopt,
+                         .persistedAllocatorHighWater = std::nullopt,
+                         .roundTrip = std::nullopt,
+                         .schemaMinor = 0,
+                         .retainedRequirements = requirements});
+    expectations.expect(static_cast<bool>(sessionResult), "the bulk fixture session installs");
+    if (!sessionResult) {
+        return std::nullopt;
+    }
+    return BulkFixture{std::move(sessionResult).takeSession(), std::move(colorSettings),
+                       std::move(requirements)};
+}
+
+void testBudgetExhaustionPassThrough(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "budget exhaustion: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    auto fixture = makeBulkFixture(expectations, identitySource);
+    if (!fixture.has_value()) {
+        return;
+    }
+    const auto saveAs = fixture->session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "budget exhaustion: Save As advances");
+    if (!saveAs) {
+        return;
+    }
+    const auto decodedSnapshot = fixture->session.decodedSnapshot();
+    expectations.expect(static_cast<bool>(decodedSnapshot),
+                        "budget exhaustion: a decoded snapshot exists");
+    if (!decodedSnapshot) {
+        return;
+    }
+
+    const CanonicalManifestV1 probeManifest{.documentSchemaVersion = {1, 0},
+                                            .requirements = fixture->requirements};
+    const CanonicalDocumentV1 probeDocument{.snapshot = &decodedSnapshot.snapshot(),
+                                            .colorSettings = &fixture->colorSettings};
+
+    constexpr std::uint64_t kBulkProbeBudget = 256ULL << 20U;
+    auto probeMemory = ProjectIoMemoryCoordinator::create(kBulkProbeBudget);
+    expectations.expect(probeMemory.has_value(), "budget exhaustion: probe coordinator constructs");
+    if (!probeMemory.has_value()) {
+        return;
+    }
+    auto probeOperation = probeMemory->createOperation(kBulkProbeBudget, kBulkProbeBudget);
+    expectations.expect(probeOperation.has_value(),
+                        "budget exhaustion: probe operation constructs");
+    if (!probeOperation.has_value()) {
+        return;
+    }
+    std::uint64_t buildPeakBytes = 0;
+    {
+        auto probeBuild =
+            buildSaveArchive(probeManifest, probeDocument, SaveArchiveLimits{}, *probeOperation);
+        expectations.expect(static_cast<bool>(probeBuild),
+                            "budget exhaustion: probe build succeeds");
+        if (!probeBuild) {
+            return;
+        }
+        buildPeakBytes = probeOperation->snapshot().peakBytes;
+    }
+
+    constexpr std::uint64_t kMargin = 64;
+    const auto budget = buildPeakBytes + kMargin;
+    auto memory = ProjectIoMemoryCoordinator::create(kBulkProbeBudget);
+    expectations.expect(memory.has_value(), "budget exhaustion: coordinator constructs");
+    if (!memory.has_value()) {
+        return;
+    }
+    auto operation = memory->createOperation(budget, budget);
+    expectations.expect(operation.has_value(),
+                        "budget exhaustion: constrained operation constructs");
+    if (!operation.has_value()) {
+        return;
+    }
+
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto result = saveProjectSession(fixture->session, *coordinator, *artifacts, request,
+                                     std::move(*operation));
+    expectations.expect(
+        !static_cast<bool>(result) && result.stage() == SessionSaveStage::Publication,
+        "budget exhaustion: a budget just above the build's own peak still fails somewhere in "
+        "the chain, reported at the Publication stage");
+    const auto* failure = result.publicationFailure();
+    expectations.expect(failure != nullptr && failure->stage() == SavePublicationStage::StagedSave,
+                        "budget exhaustion: the wrapped SavePublicationFailure is scoped to "
+                        "StagedSave");
+
+    const auto memorySnapshot = memory->snapshot();
+    expectations.expect(memorySnapshot.currentBytes == 0,
+                        "budget exhaustion: the constrained coordinator's charge returns to zero");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Determinism: two independently-built sessions with identical content, each saved once through
+// saveProjectSession() to a distinct target, produce byte-identical published files.
+// ---------------------------------------------------------------------------------------------
+
+void testDeterminism(Expectations& expectations) {
+    TempDirectory directoryA;
+    TempDirectory directoryB;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directoryA.isValid() || !directoryB.isValid() || !coordinator.has_value() ||
+        !artifacts.has_value()) {
+        expectations.expect(false, "determinism: fixture is available");
+        return;
+    }
+    const auto targetPathA = directoryA.path() / "project.bloom";
+    const auto targetPathB = directoryB.path() / "project.bloom";
+
+    auto sessionA = makeDecodedSession(expectations, identitySource, "Determinism Project");
+    const auto saveAsA = sessionA.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAsA), "determinism: A's Save As advances");
+    if (saveAsA) {
+        const SessionSaveRequest requestA{
+            .targetPath = targetPathA,
+            .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+            .expectedTarget = std::nullopt,
+            .limits = {},
+            .intent = saveAsA.capture(),
+        };
+        auto resultA =
+            saveProjectSession(sessionA, *coordinator, *artifacts, requestA, makeOperation());
+        expectations.expect(static_cast<bool>(resultA), "determinism: A's publish fully succeeds");
+    }
+
+    auto sessionB = makeDecodedSession(expectations, identitySource, "Determinism Project");
+    const auto saveAsB = sessionB.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAsB), "determinism: B's Save As advances");
+    if (saveAsB) {
+        const SessionSaveRequest requestB{
+            .targetPath = targetPathB,
+            .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+            .expectedTarget = std::nullopt,
+            .limits = {},
+            .intent = saveAsB.capture(),
+        };
+        auto resultB =
+            saveProjectSession(sessionB, *coordinator, *artifacts, requestB, makeOperation());
+        expectations.expect(static_cast<bool>(resultB), "determinism: B's publish fully succeeds");
+    }
+
+    const auto bytesA = readFile(targetPathA);
+    const auto bytesB = readFile(targetPathB);
+    expectations.expect(!bytesA.empty() && bytesA == bytesB,
+                        "determinism: two saveProjectSession runs of identical content produce "
+                        "byte-identical published files");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testEndToEndSaveAs(expectations);
+        testPlainSaveAfterSaveAs(expectations);
+        testRoundTrippedNewerMinorGreenChain(expectations);
+        testRefusals(expectations);
+        testFailedBeforePublicationLeavesSessionUntouched(expectations);
+        testSupersededLeavesSessionUntouchedThenAbandons(expectations);
+        testPublishedSavepointBookkeepingFailedShape(expectations);
+        testBudgetExhaustionPassThrough(expectations);
+        testDeterminism(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "FAILED: unexpected fixture exception: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Closes #58.

Session save-input capture and savepoint wiring — a real decoded session now saves end to end: capture the contract's single immutable operation input, publish through the intent-ordered executor (#57), and accept the savepoint into clean/path state through the existing acceptance seam.

**Session content grows the save-side values** the contract installs with replacement content: explicitly supplied color settings, optional move-only round-trip state with its schema minor, and the retained manifest requirement set — installed at creation, immutable for the session's lifetime. New projects currently have no qualified default color settings (the Bloom Neutral config's content digest lacks asset wiring), so they gate as a typed refusal rather than inventing a digest — a follow-up item, not a silent gap.

**`captureSaveInput`** produces the operation input with typed refusals that diagnose accurately: a pathless plain save reports path-required before staleness, since that capture shape is the ordinary route-to-Save-As case, not a generation mismatch.

**`saveProjectSession`** composes capture, assembly, and publication: published outcomes accept the savepoint (Save As installs the target path); non-published outcomes leave the session provably untouched with abandonment remaining the caller's choice; and a savepoint bookkeeping failure after a real publication reports the true publication outcome alongside a typed bookkeeping failure — **a visible replacement is never relabeled as unpublished**.

Testing: nine functions covering the full end-to-end cycle (including the round-tripped newer-minor path from session creation to a published file retaining its unknown member), typed refusals, untouched-session guarantees under failure and supersession, the bookkeeping-failure shape pinned directly, and byte-identical determinism. Full ci-linux-native suite 65/65 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (one review round).