### PR TITLE
feat: open project archives into installed-ready state

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -19,8 +19,10 @@ target_sources(
         document_reconstruct.cpp
         manifest_decode.cpp
         manifest_requirements.cpp
+        open_archive.cpp
         project_io_memory.cpp
         project_io_memory_resource.cpp
+        reopen_chain_internal.hpp
         round_trip_state.cpp
         save_archive.cpp
         save_archive_internal.hpp
@@ -47,6 +49,7 @@ target_sources(
             include/bloom/project/document_reconstruct.hpp
             include/bloom/project/manifest_decode.hpp
             include/bloom/project/manifest_requirements.hpp
+            include/bloom/project/open_archive.hpp
             include/bloom/project/project_io_memory.hpp
             include/bloom/project/project_io_memory_resource.hpp
             include/bloom/project/round_trip_state.hpp
@@ -300,6 +303,19 @@ if(BUILD_TESTING)
     bloom_add_test(
         NAME bloom.project.save_archive
         COMMAND bloom_project_save_archive_test
+        LABELS unit project persistence security
+    )
+
+    add_executable(bloom_project_open_archive_test tests/open_archive_tests.cpp)
+    target_include_directories(
+        bloom_project_open_archive_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(bloom_project_open_archive_test PRIVATE bloom_project ZLIB::ZLIB)
+    bloom_enable_warnings(bloom_project_open_archive_test)
+    bloom_add_test(
+        NAME bloom.project.open_archive
+        COMMAND bloom_project_open_archive_test
         LABELS unit project persistence security
     )
 

--- a/src/project/include/bloom/project/document_decode.hpp
+++ b/src/project/include/bloom/project/document_decode.hpp
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 // Typed decode of the document.json envelope from a parsed strict JSON DOM (see
@@ -390,6 +391,19 @@ class [[nodiscard]] DocumentDecodeResult final {
         return roundTrip_.has_value() ? &*roundTrip_ : nullptr;
     }
     [[nodiscard]] const RoundTripState* roundTrip() const&& = delete;
+    // Move-only companion to roundTrip() above, for a caller that must own the retained
+    // RoundTripState past this result's own lifetime instead of merely observing it (see
+    // bloom::project::detail::runReopenChain in reopen_chain_internal.hpp / save_archive.cpp: the
+    // production Open path installs this into a long-lived result rather than cloning it --
+    // RoundTripState is deliberately move-only precisely so a caller cannot casually duplicate
+    // opaque retained payload data). Additive: every existing caller keeps using the const*
+    // roundTrip() accessor above unchanged. Mirrors this codebase's other move-out takeX() &&
+    // idiom (e.g. SaveArchiveVerificationResult::takeFailure() in save_archive.hpp). Moves whatever
+    // is held -- nullopt when classification() is not EditableWithRoundTrip -- and never throws
+    // (RoundTripState's move constructor is noexcept).
+    [[nodiscard]] std::optional<RoundTripState> takeRoundTrip() && noexcept {
+        return std::move(roundTrip_);
+    }
 
   private:
     DocumentDecodeResult() = default;

--- a/src/project/include/bloom/project/open_archive.hpp
+++ b/src/project/include/bloom/project/open_archive.hpp
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/round_trip_state.hpp>
+#include <bloom/project/save_archive.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <vector>
+
+// openProjectArchive(): the Open-side counterpart to verifySaveArchive()/buildVerifiedSaveArchive()
+// (save_archive.hpp). Both reuse the exact same bounded reopen/decode/reconstruct/validate chain
+// (bloom::project::detail::runReopenChain, reopen_chain_internal.hpp): container read, strict parse
+// of both entries under one shared JSON value budget, manifest decode, version agreement, document
+// decode, reconstruction, and manifest-requirements validation against the reconstructed project.
+// Open omits Save's re-encode and byte-comparison stages (there is nothing to compare an Open
+// against) and Save's captured-input version leg of VersionAgreement (there is no prior in-memory
+// value for Open to agree with) -- see docs/architecture/project-format.md, "Versions, Migrations,
+// And Preservation".
+//
+// This is a pure decode/reconstruct composition boundary: no file I/O, no async work, no
+// migration, and no Save Copy. It performs no session/host wiring and depends on no host type --
+// OpenedArchive's shape mirrors what bloom::host::DecodedProjectSessionRequest
+// (project_session.hpp) needs one-to-one (minus host-owned concerns this module cannot determine,
+// such as editability from unavailable providers, or display path) so a future session Open can
+// install it directly.
+
+namespace bloom::project {
+
+// Which side of the reopen chain classified an archive as requiring preserved-read-only handling
+// (see docs/architecture/project-format.md, "Versions, Migrations, And Preservation": "Open
+// returns a preserved-read-only result containing the bounded original archive and diagnostics").
+enum class OpenArchivePreservedReadOnlySide : std::uint8_t {
+    None,
+    // decodeManifestEnvelope() classified containerVersion as same-major newer-minor
+    // (ManifestDecodeOutcome::PreservationRequired). Manifest round-trip capture is a later slice
+    // (see manifest_decode.hpp's file comment), so this side never reaches document decode at all.
+    Manifest,
+    // decodeDocumentEnvelope() classified the document itself as PreservedReadOnlyRequired (an
+    // unknown core discriminator or an out-of-subset unknown number; see document_decode.hpp's
+    // RoundTripPreservationReason).
+    Document,
+};
+
+// A successfully opened archive: every decoded/reconstructed value a future session Open needs to
+// install editable (or degraded-editable) content. Owns every ProjectIoMemoryReservation the
+// shared reopen chain accrued for this resident state -- document, colorSettings, roundTrip, and
+// the manifest-derived fields below are each backed by one of the three reservations, which
+// release only when this struct is destroyed (see docs/architecture/project-format.md, "Resource
+// Limits": "Moving storage between stages transfers its charge"). The caller keeps this struct
+// alive for as long as the opened document stays resident.
+struct OpenedArchive final {
+    std::unique_ptr<document::Document> document;
+    document::ColorSettings colorSettings;
+    // Present only for a same-major newer-minor (schema {1, minor > 0}) document whose unknown
+    // additive members were all safely captured; nullopt for an exact {1,0} document.
+    std::optional<RoundTripState> roundTrip;
+    // The document root's decoded schemaVersion.minor (0 for an exact {1,0} document).
+    std::uint32_t schemaMinor = 0;
+    // Verbatim from the decoded manifest's requirement set (manifest_requirements.hpp); coverage
+    // against the reconstructed project has already been validated by the shared chain.
+    std::vector<ManifestRequirement> requirements;
+    document::SchemaVersion containerVersion;
+    document::SchemaVersion documentSchemaVersion;
+
+    ProjectIoMemoryReservation manifestReservation;
+    ProjectIoMemoryReservation decodeReservation;
+    ProjectIoMemoryReservation reconstructionReservation;
+};
+
+// Diagnostics for a PreservedReadOnlyRequired outcome. Per the format contract the application
+// keeps the bounded original archive itself for Save Copy: the caller already holds `archive` (the
+// span passed to openProjectArchive()), so this result deliberately does not copy or retain any
+// archive bytes.
+struct OpenArchivePreservedReadOnly final {
+    OpenArchivePreservedReadOnlySide side = OpenArchivePreservedReadOnlySide::None;
+    // Valid only when side == Document; None when side == Manifest (manifest-side preservation
+    // carries no finer-grained reason than "same-major newer-minor" -- see
+    // ManifestDecodeOutcome::PreservationRequired).
+    RoundTripPreservationReason documentReason = RoundTripPreservationReason::None;
+    SaveArchiveErrorPath path;
+};
+
+enum class OpenArchiveOutcome : std::uint8_t {
+    Opened,
+    PreservedReadOnlyRequired,
+    Failed,
+};
+
+// [[nodiscard]] three-way, move-only result (OpenedArchive and ProjectIoMemoryReservation are each
+// move-only). outcome() names which of Opened/PreservedReadOnlyRequired/Failed is populated.
+class [[nodiscard]] OpenArchiveResult final {
+  public:
+    OpenArchiveResult(OpenArchiveResult&&) noexcept = default;
+    OpenArchiveResult& operator=(OpenArchiveResult&&) noexcept = default;
+    OpenArchiveResult(const OpenArchiveResult&) = delete;
+    OpenArchiveResult& operator=(const OpenArchiveResult&) = delete;
+    ~OpenArchiveResult() = default;
+
+    [[nodiscard]] static OpenArchiveResult opened(OpenedArchive value);
+    [[nodiscard]] static OpenArchiveResult
+    preservedReadOnlyRequired(OpenArchivePreservedReadOnly value);
+    [[nodiscard]] static OpenArchiveResult failure(SaveArchiveFailure failure);
+
+    [[nodiscard]] OpenArchiveOutcome outcome() const noexcept { return outcome_; }
+
+    [[nodiscard]] const OpenedArchive* opened() const& noexcept {
+        return opened_.has_value() ? &*opened_ : nullptr;
+    }
+    [[nodiscard]] const OpenedArchive* opened() const&& = delete;
+    [[nodiscard]] OpenedArchive takeOpened() &&;
+
+    [[nodiscard]] const OpenArchivePreservedReadOnly* preservedReadOnly() const& noexcept {
+        return preservedReadOnly_.has_value() ? &*preservedReadOnly_ : nullptr;
+    }
+    [[nodiscard]] const OpenArchivePreservedReadOnly* preservedReadOnly() const&& = delete;
+
+    [[nodiscard]] const SaveArchiveFailure* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const SaveArchiveFailure* failure() const&& = delete;
+    [[nodiscard]] SaveArchiveFailure takeFailure() &&;
+
+  private:
+    OpenArchiveResult() = default;
+
+    OpenArchiveOutcome outcome_ = OpenArchiveOutcome::Failed;
+    std::optional<OpenedArchive> opened_;
+    std::optional<OpenArchivePreservedReadOnly> preservedReadOnly_;
+    std::optional<SaveArchiveFailure> failure_;
+};
+
+// Runs the shared reopen/decode/reconstruct/validate chain against `archive` with no captured-input
+// version leg, then classifies the outcome into Opened / PreservedReadOnlyRequired / Failed (see
+// the file comment above). Every allocation is charged through `operation`; on Opened, every
+// reservation the chain accrued for the returned resident state transfers into the result (see
+// OpenedArchive above). `archive` need not outlive the call except when the result is
+// PreservedReadOnlyRequired, in which case the contract is that the CALLER retains it (this result
+// never copies archive bytes). Never throws.
+[[nodiscard]] OpenArchiveResult openProjectArchive(std::span<const std::byte> archive,
+                                                   const SaveArchiveLimits& limits,
+                                                   ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::project

--- a/src/project/open_archive.cpp
+++ b/src/project/open_archive.cpp
@@ -1,0 +1,101 @@
+#include <bloom/project/open_archive.hpp>
+
+#include "reopen_chain_internal.hpp"
+
+#include <exception>
+#include <optional>
+#include <utility>
+
+namespace bloom::project {
+
+OpenArchiveResult OpenArchiveResult::opened(OpenedArchive value) {
+    OpenArchiveResult result;
+    result.outcome_ = OpenArchiveOutcome::Opened;
+    result.opened_.emplace(std::move(value));
+    return result;
+}
+
+OpenArchiveResult OpenArchiveResult::preservedReadOnlyRequired(OpenArchivePreservedReadOnly value) {
+    OpenArchiveResult result;
+    result.outcome_ = OpenArchiveOutcome::PreservedReadOnlyRequired;
+    // OpenArchivePreservedReadOnly is trivially copyable (two enums plus a fixed-capacity
+    // SaveArchiveErrorPath), so std::move() here would have no effect over a plain copy.
+    result.preservedReadOnly_.emplace(value);
+    return result;
+}
+
+OpenArchiveResult OpenArchiveResult::failure(SaveArchiveFailure failureValue) {
+    OpenArchiveResult result;
+    result.outcome_ = OpenArchiveOutcome::Failed;
+    result.failure_.emplace(std::move(failureValue));
+    return result;
+}
+
+OpenedArchive OpenArchiveResult::takeOpened() && {
+    if (!opened_.has_value()) {
+        std::terminate();
+    }
+    return std::move(*opened_);
+}
+
+SaveArchiveFailure OpenArchiveResult::takeFailure() && {
+    if (!failure_.has_value()) {
+        return {};
+    }
+    return std::move(*failure_);
+}
+
+// By-value `operation` is this module's uniform public-entry-point contract (matching
+// buildSaveArchive(), buildVerifiedSaveArchive(), and verifySaveArchive() in save_archive.hpp, and
+// this task's own frozen signature) even though, unlike those, this function has no final sink of
+// its own to move it into: runReopenChain() takes `operation` by const reference (see
+// reopen_chain_internal.hpp's own rationale), since it is the only Project I/O work
+// openProjectArchive() does.
+OpenArchiveResult openProjectArchive(const std::span<const std::byte> archive,
+                                     const SaveArchiveLimits& limits,
+                                     // NOLINTNEXTLINE(performance-unnecessary-value-param)
+                                     ProjectIoOperationMemory operation) noexcept {
+    auto chainResult = detail::runReopenChain(archive, limits, std::nullopt, operation);
+    switch (chainResult.outcome()) {
+    case detail::ReopenChainOutcome::Failed:
+        return OpenArchiveResult::failure(std::move(chainResult).takeFailure());
+    case detail::ReopenChainOutcome::ManifestPreservationRequired: {
+        const auto* preservation = chainResult.manifestPreservation();
+        return OpenArchiveResult::preservedReadOnlyRequired(OpenArchivePreservedReadOnly{
+            .side = OpenArchivePreservedReadOnlySide::Manifest,
+            .documentReason = RoundTripPreservationReason::None,
+            .path = preservation != nullptr ? preservation->path : SaveArchiveErrorPath{},
+        });
+    }
+    case detail::ReopenChainOutcome::DocumentPreservedReadOnlyRequired: {
+        const auto* preservation = chainResult.documentPreservation();
+        return OpenArchiveResult::preservedReadOnlyRequired(OpenArchivePreservedReadOnly{
+            .side = OpenArchivePreservedReadOnlySide::Document,
+            .documentReason =
+                preservation != nullptr ? preservation->reason : RoundTripPreservationReason::None,
+            .path = preservation != nullptr ? preservation->path : SaveArchiveErrorPath{},
+        });
+    }
+    case detail::ReopenChainOutcome::Success: {
+        auto success = std::move(chainResult).takeSuccess();
+        OpenedArchive opened{
+            .document = std::move(success.document.document),
+            .colorSettings = std::move(success.document.colorSettings),
+            .roundTrip = std::move(success.roundTrip),
+            .schemaMinor =
+                success.documentRootVersion.has_value() ? success.documentRootVersion->minor : 0,
+            .requirements = std::move(success.manifest.requirements),
+            .containerVersion = success.manifest.containerVersion,
+            .documentSchemaVersion = success.manifest.documentSchemaVersion,
+            .manifestReservation = std::move(success.manifestReservation),
+            .decodeReservation = std::move(success.decodeReservation),
+            .reconstructionReservation = std::move(success.reconstructionReservation),
+        };
+        return OpenArchiveResult::opened(std::move(opened));
+    }
+    }
+    return OpenArchiveResult::failure(
+        SaveArchiveFailure(SaveArchiveStage::None, SaveArchiveUnexpectedFailure{}));
+}
+
+} // namespace bloom::project

--- a/src/project/reopen_chain_internal.hpp
+++ b/src/project/reopen_chain_internal.hpp
@@ -1,0 +1,165 @@
+#ifndef BLOOM_PROJECT_REOPEN_CHAIN_INTERNAL_HPP
+#define BLOOM_PROJECT_REOPEN_CHAIN_INTERNAL_HPP
+
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/document_decode.hpp>
+#include <bloom/project/document_reconstruct.hpp>
+#include <bloom/project/manifest_decode.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/round_trip_state.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/zip_container.hpp>
+
+#include <optional>
+#include <span>
+#include <utility>
+
+// Shared reopen/decode/reconstruct implementation behind verifySaveArchive() (save_archive.cpp)
+// and openProjectArchive() (open_archive.cpp). Not a public Project I/O contract: only these two
+// translation units include this header, matching the save_archive_internal.hpp /
+// document_decode_internal.hpp / canonical_json_string_detail.hpp precedent for a private
+// cross-file implementation seam within one CMake target.
+//
+// runReopenChain() runs exactly the prefix the two callers share: container read, strict parse of
+// both entries under one shared JSON value budget, manifest decode, version agreement, document
+// decode, reconstruction, and manifest-requirements validation against the reconstructed project
+// (see save_archive.hpp's SaveArchiveStage enum, whose ContainerRead..RequirementsValidation
+// members name this exact prefix). Save's own re-encode and byte-comparison stages
+// (ManifestReencode..DocumentByteComparison) are not part of this routine; they run only in
+// verifySaveArchive() against the state this routine hands back. Every allocation is charged
+// through `operation`, identically to the pre-split verifySaveArchive() this was extracted from.
+//
+// Implemented in save_archive.cpp (reusing that file's existing anonymous-namespace helpers
+// directly) rather than a separate .cpp, mirroring save_archive_internal.hpp's own
+// buildSaveArchiveEntries() precedent: the shared *declaration* lives in a sibling header, but the
+// implementation stays colocated with the helpers it composes.
+namespace bloom::project::detail {
+
+enum class ReopenChainOutcome : std::uint8_t {
+    // A hard failure occurred; failure() names the stage-scoped SaveArchiveFailure. Both callers
+    // treat this identically.
+    Failed,
+    // decodeManifestEnvelope() classified containerVersion as same-major newer-minor
+    // (ManifestDecodeOutcome::PreservationRequired). No document parsing result beyond the raw DOM
+    // is inspected further. Save folds this into a SaveArchiveManifestDecodeFailure (behavior
+    // unchanged from before this split); Open surfaces it as a distinct non-error outcome.
+    ManifestPreservationRequired,
+    // decodeDocumentEnvelope() classified the document as PreservedReadOnlyRequired (an unknown
+    // core discriminator or an out-of-subset unknown number). Save folds this into a
+    // SaveArchiveDocumentDecodeFailure (behavior unchanged from before this split); Open surfaces
+    // it as a distinct non-error outcome.
+    DocumentPreservedReadOnlyRequired,
+    // The complete shared prefix succeeded; value() names the decoded/reconstructed state.
+    Success,
+};
+
+// Everything the shared prefix decoded and reconstructed, with every reservation that charges its
+// resident footprint transferred into this struct (see docs/architecture/project-format.md,
+// "Resource Limits": "Moving storage between stages transfers its charge"). The caller decides how
+// long to keep this alive; every reservation -- and the archive-entry buffers `zipRead` still
+// backs -- releases when this struct is destroyed. Move-only (ZipContainerReadResult,
+// ReconstructedDocument, and ProjectIoMemoryReservation are each move-only).
+struct ReopenChainSuccess final {
+    // Backs the raw manifest.json/document.json entry bytes (ZipContainerReadResult::document()).
+    // Only verifySaveArchive()'s own byte-comparison stages need these; openProjectArchive() reads
+    // the state below and lets this drop when it returns, per its documented contract that Open
+    // does not copy or retain the archive bytes.
+    ZipContainerReadResult zipRead;
+    ReconstructedDocument document;
+    // Copied (not moved) out of the local ManifestDecodeResult: DecodedManifest is an ordinary
+    // copyable value (unlike RoundTripState, it holds no deliberately move-only/opaque payload
+    // data), and ManifestDecodeResult -- unlike DocumentDecodeResult -- exposes no move-out
+    // accessor to begin with, so this is the only way to carry it past this function's return.
+    DecodedManifest manifest;
+    // The document root's raw decoded {major, minor}, read once during VersionAgreement; nullopt
+    // only when the root's schemaVersion member itself could not be lexically read (in which case
+    // DocumentDecode below fails with a typed error before Success is ever reached with this still
+    // nullopt -- see documentRootVersion() in save_archive.cpp).
+    std::optional<document::SchemaVersion> documentRootVersion;
+    // Moved out of the local DocumentDecodeResult via its takeRoundTrip() && accessor (the one
+    // sanctioned addition to document_decode.hpp this task makes -- see its declaration). Present
+    // only when classification() was EditableWithRoundTrip.
+    std::optional<RoundTripState> roundTrip;
+
+    ProjectIoMemoryReservation manifestReservation;
+    ProjectIoMemoryReservation decodeReservation;
+    ProjectIoMemoryReservation reconstructionReservation;
+};
+
+// Diagnostics for a manifest-side ManifestPreservationRequired outcome.
+struct ReopenChainManifestPreservation final {
+    SaveArchiveErrorPath path;
+};
+
+// Diagnostics for a document-side DocumentPreservedReadOnlyRequired outcome.
+struct ReopenChainDocumentPreservation final {
+    RoundTripPreservationReason reason = RoundTripPreservationReason::None;
+    SaveArchiveErrorPath path;
+};
+
+// [[nodiscard]] four-way result (Failed / ManifestPreservationRequired /
+// DocumentPreservedReadOnlyRequired / Success). Move-only, since ReopenChainSuccess is.
+class [[nodiscard]] ReopenChainResult final {
+  public:
+    ReopenChainResult(ReopenChainResult&&) noexcept = default;
+    ReopenChainResult& operator=(ReopenChainResult&&) noexcept = default;
+    ReopenChainResult(const ReopenChainResult&) = delete;
+    ReopenChainResult& operator=(const ReopenChainResult&) = delete;
+    ~ReopenChainResult() = default;
+
+    [[nodiscard]] static ReopenChainResult success(ReopenChainSuccess value);
+    [[nodiscard]] static ReopenChainResult failure(SaveArchiveFailure failure);
+    [[nodiscard]] static ReopenChainResult manifestPreservationRequired(SaveArchiveErrorPath path);
+    [[nodiscard]] static ReopenChainResult
+    documentPreservedReadOnlyRequired(RoundTripPreservationReason reason,
+                                      SaveArchiveErrorPath path);
+
+    [[nodiscard]] ReopenChainOutcome outcome() const noexcept { return outcome_; }
+
+    [[nodiscard]] const SaveArchiveFailure* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const SaveArchiveFailure* failure() const&& = delete;
+    [[nodiscard]] SaveArchiveFailure takeFailure() &&;
+
+    [[nodiscard]] const ReopenChainManifestPreservation* manifestPreservation() const& noexcept {
+        return manifestPreservation_.has_value() ? &*manifestPreservation_ : nullptr;
+    }
+    [[nodiscard]] const ReopenChainManifestPreservation* manifestPreservation() const&& = delete;
+
+    [[nodiscard]] const ReopenChainDocumentPreservation* documentPreservation() const& noexcept {
+        return documentPreservation_.has_value() ? &*documentPreservation_ : nullptr;
+    }
+    [[nodiscard]] const ReopenChainDocumentPreservation* documentPreservation() const&& = delete;
+
+    // Valid only when outcome() == Success. Every reservation and buffer above transfers to the
+    // caller through this move.
+    [[nodiscard]] ReopenChainSuccess takeSuccess() &&;
+
+  private:
+    ReopenChainResult() = default;
+
+    ReopenChainOutcome outcome_ = ReopenChainOutcome::Failed;
+    std::optional<ReopenChainSuccess> success_;
+    std::optional<SaveArchiveFailure> failure_;
+    std::optional<ReopenChainManifestPreservation> manifestPreservation_;
+    std::optional<ReopenChainDocumentPreservation> documentPreservation_;
+};
+
+// Runs the shared reopen/decode/reconstruct/validate prefix against `archive`.
+// `capturedInputVersion` is verifySaveArchive()'s expected-content documentSchemaVersion leg of
+// VersionAgreement; it is std::nullopt for openProjectArchive(), which has no captured-input
+// version to compare against (see docs/architecture/project-format.md "Versions, Migrations, And
+// Preservation" and this task's own design decision on Open's narrower VersionAgreement leg). Every
+// allocation is charged through `operation`, which this routine only ever reads (every downstream
+// call it drives -- readZipContainer, parseStrictJsonDom, reserve() -- takes or copies its own
+// handle); unlike buildSaveArchiveEntries() (save_archive_internal.hpp), this routine never sinks a
+// final move of it, so it takes it by const reference rather than by value. Never throws.
+[[nodiscard]] ReopenChainResult
+runReopenChain(std::span<const std::byte> archive, const SaveArchiveLimits& limits,
+               std::optional<document::SchemaVersion> capturedInputVersion,
+               const ProjectIoOperationMemory& operation) noexcept;
+
+} // namespace bloom::project::detail
+
+#endif // BLOOM_PROJECT_REOPEN_CHAIN_INTERNAL_HPP

--- a/src/project/save_archive.cpp
+++ b/src/project/save_archive.cpp
@@ -1,5 +1,6 @@
 #include <bloom/project/save_archive.hpp>
 
+#include "reopen_chain_internal.hpp"
 #include "save_archive_internal.hpp"
 
 #include <bloom/document/document.hpp>
@@ -289,15 +290,66 @@ SaveArchiveResult SaveArchiveResult::failure(SaveArchiveFailure failureValue) {
     return result;
 }
 
-SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte> archive,
-                                                const SaveArchiveExpectedContent& expected,
-                                                const SaveArchiveLimits& limits,
-                                                ProjectIoOperationMemory operation) noexcept {
+namespace detail {
+
+ReopenChainResult ReopenChainResult::success(ReopenChainSuccess value) {
+    ReopenChainResult result;
+    result.outcome_ = ReopenChainOutcome::Success;
+    result.success_.emplace(std::move(value));
+    return result;
+}
+
+ReopenChainResult ReopenChainResult::failure(SaveArchiveFailure failureValue) {
+    ReopenChainResult result;
+    result.outcome_ = ReopenChainOutcome::Failed;
+    result.failure_.emplace(std::move(failureValue));
+    return result;
+}
+
+ReopenChainResult ReopenChainResult::manifestPreservationRequired(SaveArchiveErrorPath path) {
+    ReopenChainResult result;
+    result.outcome_ = ReopenChainOutcome::ManifestPreservationRequired;
+    result.manifestPreservation_.emplace(ReopenChainManifestPreservation{path});
+    return result;
+}
+
+ReopenChainResult
+ReopenChainResult::documentPreservedReadOnlyRequired(const RoundTripPreservationReason reason,
+                                                     SaveArchiveErrorPath path) {
+    ReopenChainResult result;
+    result.outcome_ = ReopenChainOutcome::DocumentPreservedReadOnlyRequired;
+    result.documentPreservation_.emplace(ReopenChainDocumentPreservation{reason, path});
+    return result;
+}
+
+SaveArchiveFailure ReopenChainResult::takeFailure() && {
+    if (!failure_.has_value()) {
+        return {};
+    }
+    return std::move(*failure_);
+}
+
+ReopenChainSuccess ReopenChainResult::takeSuccess() && {
+    if (!success_.has_value()) {
+        std::terminate();
+    }
+    return std::move(*success_);
+}
+
+// The shared reopen/decode/reconstruct/validate prefix. See reopen_chain_internal.hpp for the
+// exact stage list and the charge-transfer contract `ReopenChainSuccess` upholds. This is the
+// pre-split verifySaveArchive() body from ContainerRead through RequirementsValidation, unchanged
+// in logic, now returning its decoded/reconstructed state instead of falling straight into
+// save-only re-encode/byte-comparison.
+ReopenChainResult runReopenChain(const std::span<const std::byte> archive,
+                                 const SaveArchiveLimits& limits,
+                                 const std::optional<document::SchemaVersion> capturedInputVersion,
+                                 const ProjectIoOperationMemory& operation) noexcept {
     auto stage = SaveArchiveStage::ContainerRead;
     try {
         auto reopened = readZipContainer(archive, limits.container, operation);
         if (!reopened) {
-            return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+            return ReopenChainResult::failure(SaveArchiveFailure(
                 stage, SaveArchiveContainerReadFailure{reopened.error(), reopened.byteOffset()}));
         }
         const auto* entries = reopened.document();
@@ -306,7 +358,7 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
         auto manifestDom =
             parseStrictJsonDom(entries->manifestBytes(), manifestJsonLimits(limits), operation);
         if (!manifestDom) {
-            return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+            return ReopenChainResult::failure(SaveArchiveFailure(
                 stage,
                 SaveArchiveJsonParseFailure{manifestDom.error(), manifestDom.byteOffset(),
                                             SaveArchiveErrorPath::from(manifestDom.memberPath())}));
@@ -315,7 +367,7 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
 
         stage = SaveArchiveStage::DocumentParse;
         if (manifestValueCount >= limits.json.maximumValues) {
-            return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+            return ReopenChainResult::failure(SaveArchiveFailure(
                 stage, SaveArchiveJsonParseFailure{.error = StrictJsonDomError::ValueLimitExceeded,
                                                    .byteOffset = 0,
                                                    .path = SaveArchiveErrorPath{}}));
@@ -324,7 +376,7 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
         auto documentDom = parseStrictJsonDom(
             entries->documentBytes(), documentJsonLimits(limits, remainingValues), operation);
         if (!documentDom) {
-            return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+            return ReopenChainResult::failure(SaveArchiveFailure(
                 stage,
                 SaveArchiveJsonParseFailure{documentDom.error(), documentDom.byteOffset(),
                                             SaveArchiveErrorPath::from(documentDom.memberPath())}));
@@ -335,12 +387,16 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
         auto manifestReservation =
             reserveRepresentation(operation, entries->manifestBytes().size(), manifestValueCount);
         if (!manifestReservation.has_value()) {
-            return SaveArchiveVerificationResult::failure(
+            return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
         }
         auto decodedManifest = decodeManifestEnvelope(manifestDom.document()->root());
+        if (decodedManifest.outcome() == ManifestDecodeOutcome::PreservationRequired) {
+            return ReopenChainResult::manifestPreservationRequired(
+                SaveArchiveErrorPath::from(decodedManifest.path()));
+        }
         if (!decodedManifest) {
-            return SaveArchiveVerificationResult::failure(
+            return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveManifestDecodeFailure{
                                               decodedManifest.outcome(), decodedManifest.error(),
                                               SaveArchiveErrorPath::from(decodedManifest.path())}));
@@ -349,26 +405,35 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
         stage = SaveArchiveStage::VersionAgreement;
         const auto decodedDocumentVersion = documentRootVersion(documentDom.document()->root());
         const auto& manifestValue = *decodedManifest.value();
-        if (manifestValue.documentSchemaVersion != expected.documentSchemaVersion ||
-            (decodedDocumentVersion.has_value() &&
-             manifestValue.documentSchemaVersion != *decodedDocumentVersion)) {
-            return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+        const bool disagreesWithCapturedInput =
+            capturedInputVersion.has_value() &&
+            manifestValue.documentSchemaVersion != *capturedInputVersion;
+        const bool disagreesWithDocumentRoot =
+            decodedDocumentVersion.has_value() &&
+            manifestValue.documentSchemaVersion != *decodedDocumentVersion;
+        if (disagreesWithCapturedInput || disagreesWithDocumentRoot) {
+            return ReopenChainResult::failure(SaveArchiveFailure(
                 stage, SaveArchiveVersionAgreementFailure{
                            manifestValue.documentSchemaVersion,
                            decodedDocumentVersion.value_or(manifestValue.documentSchemaVersion),
-                           expected.documentSchemaVersion}));
+                           capturedInputVersion.value_or(manifestValue.documentSchemaVersion)}));
         }
 
         stage = SaveArchiveStage::DocumentDecode;
         auto decodeReservation =
             reserveRepresentation(operation, entries->documentBytes().size(), documentValueCount);
         if (!decodeReservation.has_value()) {
-            return SaveArchiveVerificationResult::failure(
+            return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
         }
         auto decodedDocument = decodeDocumentEnvelope(documentDom.document()->root());
+        if (decodedDocument.outcome() == DocumentDecodeOutcome::PreservedReadOnlyRequired) {
+            return ReopenChainResult::documentPreservedReadOnlyRequired(
+                decodedDocument.preservationReason(),
+                SaveArchiveErrorPath::from(decodedDocument.path()));
+        }
         if (!decodedDocument) {
-            return SaveArchiveVerificationResult::failure(
+            return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveDocumentDecodeFailure{
                                               decodedDocument.outcome(), decodedDocument.error(),
                                               decodedDocument.preservationReason(),
@@ -379,13 +444,12 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
         auto reconstructionReservation =
             reserveRepresentation(operation, entries->documentBytes().size(), documentValueCount);
         if (!reconstructionReservation.has_value()) {
-            return SaveArchiveVerificationResult::failure(
+            return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
         }
         auto reconstructed = reconstructDocument(*decodedDocument.value());
         if (!reconstructed) {
-            return SaveArchiveVerificationResult::failure(
-                SaveArchiveFailure(stage, reconstructed.rejection()));
+            return ReopenChainResult::failure(SaveArchiveFailure(stage, reconstructed.rejection()));
         }
 
         // validateManifestRequirements() currently accepts only live Project truth, not the
@@ -396,17 +460,94 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
             operation, entries->manifestBytes().size() + entries->documentBytes().size(),
             manifestValueCount);
         if (!requirementsReservation.has_value()) {
-            return SaveArchiveVerificationResult::failure(
+            return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
         }
         auto reconstructedSnapshot = reconstructed.value()->document->snapshot();
         auto requirementValidation = validateManifestRequirements(reconstructedSnapshot.project(),
                                                                   manifestValue.requirements);
         if (!requirementValidation.ok()) {
-            return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+            return ReopenChainResult::failure(SaveArchiveFailure(
                 stage, SaveArchiveRequirementsFailure{std::move(requirementValidation)}));
         }
         requirementsReservation.reset();
+
+        // Moves only the RoundTripState out of `decodedDocument` (via the one sanctioned move-out
+        // accessor this task adds to DocumentDecodeResult); `decodedDocument`'s own remaining
+        // members are not referenced again, so nothing else needs to survive this function.
+        auto roundTrip = std::move(decodedDocument).takeRoundTrip();
+
+        // Every reservation reserved above (except the already-released requirementsReservation)
+        // charges resident state that must keep charging after this function returns: `manifest`
+        // and `roundTrip` are copied/moved from `decodedManifest`/`decodedDocument`'s memory
+        // footprint (manifestReservation/decodeReservation), and `document` is the reconstructed
+        // model reconstructionReservation charges. Transferring them into ReopenChainSuccess -- not
+        // releasing them here -- is what "moving storage between stages transfers its charge"
+        // (docs/architecture/project-format.md, "Resource Limits") means for this boundary.
+        return ReopenChainResult::success(ReopenChainSuccess{
+            .zipRead = std::move(reopened),
+            .document = std::move(*reconstructed.value()),
+            .manifest = *decodedManifest.value(),
+            .documentRootVersion = decodedDocumentVersion,
+            .roundTrip = std::move(roundTrip),
+            .manifestReservation = std::move(*manifestReservation),
+            .decodeReservation = std::move(*decodeReservation),
+            .reconstructionReservation = std::move(*reconstructionReservation),
+        });
+    } catch (const std::bad_alloc&) {
+        return ReopenChainResult::failure(
+            SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
+    } catch (...) {
+        return ReopenChainResult::failure(
+            SaveArchiveFailure(stage, SaveArchiveUnexpectedFailure{}));
+    }
+}
+
+} // namespace detail
+
+SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte> archive,
+                                                const SaveArchiveExpectedContent& expected,
+                                                const SaveArchiveLimits& limits,
+                                                ProjectIoOperationMemory operation) noexcept {
+    // runReopenChain() takes `operation` by const reference (it never sinks a final move of its
+    // own), so this function's own `operation` stays intact for the re-encode stages below, which
+    // the shared chain does not run.
+    auto chainResult =
+        detail::runReopenChain(archive, limits, expected.documentSchemaVersion, operation);
+    if (chainResult.outcome() == detail::ReopenChainOutcome::Failed) {
+        return SaveArchiveVerificationResult::failure(std::move(chainResult).takeFailure());
+    }
+    if (chainResult.outcome() == detail::ReopenChainOutcome::ManifestPreservationRequired) {
+        // Folded into the same SaveArchiveManifestDecodeFailure shape pre-split verifySaveArchive()
+        // produced for this outcome (its ManifestDecodeOutcome::PreservationRequired branch never
+        // populated error(), so ManifestDecodeError::None here is exactly what
+        // decodedManifest.error() would have read).
+        const auto* preservation = chainResult.manifestPreservation();
+        return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+            SaveArchiveStage::ManifestDecode,
+            SaveArchiveManifestDecodeFailure{
+                ManifestDecodeOutcome::PreservationRequired, ManifestDecodeError::None,
+                preservation != nullptr ? preservation->path : SaveArchiveErrorPath{}}));
+    }
+    if (chainResult.outcome() == detail::ReopenChainOutcome::DocumentPreservedReadOnlyRequired) {
+        // Folded into the same SaveArchiveDocumentDecodeFailure shape pre-split verifySaveArchive()
+        // produced for this outcome, for the same reason as above.
+        const auto* preservation = chainResult.documentPreservation();
+        return SaveArchiveVerificationResult::failure(SaveArchiveFailure(
+            SaveArchiveStage::DocumentDecode,
+            SaveArchiveDocumentDecodeFailure{
+                DocumentDecodeOutcome::PreservedReadOnlyRequired, DocumentDecodeError::None,
+                preservation != nullptr ? preservation->reason : RoundTripPreservationReason::None,
+                preservation != nullptr ? preservation->path : SaveArchiveErrorPath{}}));
+    }
+
+    auto stage = SaveArchiveStage::ManifestReencode;
+    try {
+        auto success = std::move(chainResult).takeSuccess();
+        const auto* entries = success.zipRead.document();
+        if (entries == nullptr) {
+            std::terminate();
+        }
 
         // Final use of `operation` in this function: every earlier stage above needed the shared
         // handle again for a later call, so those uses stayed copies (ProjectIoOperationMemory is a
@@ -415,13 +556,12 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
         std::pmr::vector<char> manifestReencoded(&reencodeResource);
         std::pmr::vector<char> documentReencoded(&reencodeResource);
 
-        stage = SaveArchiveStage::ManifestReencode;
         const CanonicalManifestV1 manifestRequest{
             .format = kCanonicalManifestFormat,
-            .containerVersion = manifestValue.containerVersion,
-            .documentPath = manifestValue.documentPath,
-            .documentSchemaVersion = manifestValue.documentSchemaVersion,
-            .requirements = manifestValue.requirements,
+            .containerVersion = success.manifest.containerVersion,
+            .documentPath = success.manifest.documentPath,
+            .documentSchemaVersion = success.manifest.documentSchemaVersion,
+            .requirements = success.manifest.requirements,
         };
         if (auto failure =
                 encodeManifest(manifestRequest, limits.manifest, manifestReencoded, stage);
@@ -430,11 +570,13 @@ SaveArchiveVerificationResult verifySaveArchive(const std::span<const std::byte>
         }
 
         stage = SaveArchiveStage::DocumentReencode;
+        auto reconstructedSnapshot = success.document.document->snapshot();
         const CanonicalDocumentV1 documentRequest{
             .snapshot = &reconstructedSnapshot,
-            .colorSettings = &reconstructed.value()->colorSettings,
-            .roundTrip = decodedDocument.roundTrip(),
-            .schemaMinor = decodedDocumentVersion.has_value() ? decodedDocumentVersion->minor : 0,
+            .colorSettings = &success.document.colorSettings,
+            .roundTrip = success.roundTrip.has_value() ? &*success.roundTrip : nullptr,
+            .schemaMinor =
+                success.documentRootVersion.has_value() ? success.documentRootVersion->minor : 0,
         };
         if (auto failure = encodeDocument(documentRequest, limits.document, &reencodeResource,
                                           documentReencoded, stage);

--- a/src/project/tests/open_archive_tests.cpp
+++ b/src/project/tests/open_archive_tests.cpp
@@ -1,0 +1,1099 @@
+#include <bloom/project/open_archive.hpp>
+
+#include <bloom/core/color.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/animation.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/extension_records.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/ids.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/document_decode.hpp>
+#include <bloom/project/document_reconstruct.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/round_trip_state.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+#include <bloom/project/zip_container.hpp>
+
+#include "zip_container_test_support.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using bloom::project::buildSaveArchive;
+using bloom::project::buildVerifiedSaveArchive;
+using bloom::project::canonicalDocumentSize;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::canonicalManifestSize;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::DocumentDecodeResult;
+using bloom::project::encodeCanonicalDocument;
+using bloom::project::encodeCanonicalManifest;
+using bloom::project::ManifestRequirement;
+using bloom::project::OpenArchiveOutcome;
+using bloom::project::OpenArchivePreservedReadOnlySide;
+using bloom::project::OpenedArchive;
+using bloom::project::openProjectArchive;
+using bloom::project::parseStrictJsonDom;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::RoundTripPreservationReason;
+using bloom::project::SaveArchiveContainerReadFailure;
+using bloom::project::SaveArchiveDocumentDecodeFailure;
+using bloom::project::SaveArchiveJsonParseFailure;
+using bloom::project::SaveArchiveLimits;
+using bloom::project::SaveArchiveRequirementsFailure;
+using bloom::project::SaveArchiveResourceExhausted;
+using bloom::project::SaveArchiveStage;
+using bloom::project::SaveArchiveVersionAgreementFailure;
+using bloom::project::ZipContainerError;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Shared plumbing (mirrors save_archive_tests.cpp's fixtures; deliberately not shared across test
+// binaries, matching this codebase's existing per-test-file fixture duplication precedent, e.g.
+// neutralColorSettings() also appears in session_save_tests.cpp).
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U; // 32 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    return makeOperation(kGenerousOperationBudget);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+// Byte-compares two archives (this test file's own "were these two Opens/Saves the same
+// content" oracle).
+[[nodiscard]] bool sameBytes(const std::span<const std::byte> left,
+                             const std::span<const std::byte> right) noexcept {
+    return left.size() == right.size() &&
+           (left.empty() || std::memcmp(left.data(), right.data(), left.size()) == 0);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Open-what-save-wrote round trips: build a verified archive through the exact same save
+// fixtures save_archive_tests.cpp uses, open it, assert the decoded values, then re-save the
+// opened state through the save chain and require the republished bytes equal the originals
+// byte-for-byte -- the full open-to-save cycle this task's test plan calls for.
+// ---------------------------------------------------------------------------------------------
+
+void testOpenMinimalRoundTrip(Expectations& expectations) {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "open minimal: fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built),
+                        "open minimal: buildVerifiedSaveArchive succeeds");
+    if (!built) {
+        return;
+    }
+    const auto* archive = built.archive();
+    expectations.expect(archive != nullptr, "open minimal: a successful build exposes its archive");
+    if (archive == nullptr) {
+        return;
+    }
+
+    auto opened = openProjectArchive(archive->bytes(), SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Opened,
+                        "open minimal: openProjectArchive opens the archive save just wrote");
+    if (opened.outcome() != OpenArchiveOutcome::Opened) {
+        return;
+    }
+    auto openedValue = std::move(opened).takeOpened();
+    expectations.expect(openedValue.document != nullptr, "open minimal: Opened owns a Document");
+    if (!openedValue.document) {
+        return;
+    }
+
+    auto openedSnapshot = openedValue.document->snapshot();
+    expectations.expect(openedSnapshot.project().name() == "Untitled Project",
+                        "open minimal: project name decodes exactly");
+    expectations.expect(openedSnapshot.project().compositions().size() == 1,
+                        "open minimal: one composition decodes");
+    expectations.expect(openedValue.colorSettings == colorSettings,
+                        "open minimal: colorSettings decode equal to what was saved");
+    expectations.expect(openedValue.schemaMinor == 0, "open minimal: schemaMinor decodes to 0");
+    expectations.expect(!openedValue.roundTrip.has_value(),
+                        "open minimal: no RoundTripState for an exact {1,0} document");
+    expectations.expect(openedValue.requirements.empty(),
+                        "open minimal: the empty requirement set decodes empty");
+    expectations.expect(openedValue.containerVersion == bloom::document::SchemaVersion{1, 0} &&
+                            openedValue.documentSchemaVersion ==
+                                bloom::document::SchemaVersion{1, 0},
+                        "open minimal: container/document schema versions decode to {1,0}");
+
+    const CanonicalManifestV1 resaveManifest{.documentSchemaVersion =
+                                                 openedValue.documentSchemaVersion,
+                                             .requirements = openedValue.requirements};
+    const CanonicalDocumentV1 resaveDocumentInput{
+        .snapshot = &openedSnapshot,
+        .colorSettings = &openedValue.colorSettings,
+        .roundTrip = openedValue.roundTrip.has_value() ? &*openedValue.roundTrip : nullptr,
+        .schemaMinor = openedValue.schemaMinor,
+    };
+    auto resaved = buildVerifiedSaveArchive(resaveManifest, resaveDocumentInput,
+                                            SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(resaved),
+                        "open minimal: re-saving the opened state through the save chain succeeds");
+    if (!resaved) {
+        return;
+    }
+    expectations.expect(sameBytes(archive->bytes(), resaved.archive()->bytes()),
+                        "open minimal: the full open->save cycle reproduces the original archive "
+                        "byte-for-byte");
+}
+
+void testOpenComposedRoundTrip(Expectations& expectations) {
+    using namespace bloom::document;
+    using bloom::core::Color4d;
+    using bloom::core::PixelAspectRatio;
+    using bloom::core::RationalTime;
+
+    const auto duration = RationalTime::create(48, 24);
+    const auto frameRate = FrameRate::create(24000, 1001);
+    const auto pixelAspect = PixelAspectRatio::create(2, 1);
+    const auto format =
+        CompositionFormat::create(1280, 720, pixelAspect.value_or(PixelAspectRatio::square()),
+                                  frameRate.value_or(FrameRate::framesPerSecond24()));
+    expectations.expect(duration.has_value() && format.has_value(),
+                        "open composed: fixture values are constructible");
+    if (!duration.has_value() || !format.has_value()) {
+        return;
+    }
+
+    CanonicalGraph graph{NodeId::fromRaw(1)};
+    const NodeRecord layerOutputNode{
+        NodeId::fromRaw(3),
+        std::string(kLayerOutputNodeType),
+        {{"opacity", ParameterId::fromRaw(3)}, {"position", ParameterId::fromRaw(5)}},
+        kLayerOutputNodeSchemaVersion};
+    const NodeRecord layerStackNode{
+        NodeId::fromRaw(1), std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion};
+    const NodeRecord compositionOutputNode{NodeId::fromRaw(4),
+                                           std::string(kCompositionOutputNodeType),
+                                           {},
+                                           kCompositionOutputNodeSchemaVersion};
+    const NodeRecord solidSourceNode{NodeId::fromRaw(2),
+                                     std::string(kSolidSourceNodeType),
+                                     {{"color", ParameterId::fromRaw(7)}},
+                                     kSolidSourceNodeSchemaVersion};
+    const NodeRecord customNode{NodeId::fromRaw(5), "vendor.nodes.blur", {}, 1};
+    const bool nodesAdded = graph.addNode(layerOutputNode) && graph.addNode(layerStackNode) &&
+                            graph.addNode(compositionOutputNode) &&
+                            graph.addNode(solidSourceNode) && graph.addNode(customNode);
+    const EdgeRecord stackToOutputEdge{
+        EdgeId::fromRaw(3),
+        {NodeId::fromRaw(1), std::string(kLayerStackOutputPort)},
+        NodeInputRef{NodeId::fromRaw(4), std::string(kCompositionOutputInputPort)}};
+    const EdgeRecord solidToLayerEdge{
+        EdgeId::fromRaw(1),
+        {NodeId::fromRaw(2), std::string(kSolidSourceOutputPort)},
+        NodeInputRef{NodeId::fromRaw(3), std::string(kLayerOutputContentInputPort)}};
+    const EdgeRecord layerToStackEdge{EdgeId::fromRaw(2),
+                                      {NodeId::fromRaw(3), std::string(kLayerOutputOutputPort)},
+                                      LayerStackInputRef{NodeId::fromRaw(1),
+                                                         LayerSlotId::fromRaw(1),
+                                                         std::string(kLayerStackContentInputRole)}};
+    const bool edgesAdded = graph.addEdge(stackToOutputEdge) && graph.addEdge(solidToLayerEdge) &&
+                            graph.addEdge(layerToStackEdge);
+    const bool boundariesAdded =
+        graph.addLayerOutput({NodeId::fromRaw(3), LayerId::fromRaw(1), "Hero Plate",
+                              std::string(kLayerOutputOutputPort)});
+    expectations.expect(
+        nodesAdded && edgesAdded && boundariesAdded &&
+            graph.layerStack().append({LayerSlotId::fromRaw(1), LayerId::fromRaw(1)}),
+        "open composed: fixture graph accepts its parts");
+
+    graph.setCompositionOutput({NodeId::fromRaw(4), std::string(kCompositionOutputOutputPort)});
+    Composition composition{CompositionId::fromRaw(1), "Hero Shot", *duration, std::move(graph),
+                            *format};
+    expectations.expect(composition.parameters().insert(
+                            {ParameterId::fromRaw(7), std::string(kSolidColorParameterSchemaKey),
+                             ConstantValueSource{Color4d{0.0, 0.5, 1.0, 1.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(5), std::string(kPositionParameterSchemaKey),
+                                 ConstantValueSource{Vec2d{96.0, -48.0}}}) &&
+                            composition.parameters().insert(
+                                {ParameterId::fromRaw(3), std::string(kOpacityParameterSchemaKey),
+                                 AnimationCurveSource{AnimationCurveId::fromRaw(9)}}),
+                        "open composed: fixture parameters insert");
+
+    ScalarAnimationCurve curve;
+    curve.id = AnimationCurveId::fromRaw(9);
+    curve.keyframes.push_back(
+        {KeyframeId::fromRaw(21), RationalTime{}, 0.25, KeyframeInterpolation::Hold});
+    curve.keyframes.push_back({KeyframeId::fromRaw(22), RationalTime::fromInteger(48), 1.0,
+                               KeyframeInterpolation::Linear});
+    expectations.expect(composition.animationCurves().insert(curve),
+                        "open composed: fixture animation curve inserts");
+
+    Project project{ProjectId::fromRaw(1), "Spot Check"};
+    const ExtensionRecord markerRecord{
+        ExtensionRecordId::fromRaw(1), "vendor.module",
+        "vendor.module.marker",        {1, 0},
+        CompositionId::fromRaw(1),     "application/octet-stream",
+        NoExtensionReferences{},       OpaqueExtensionPayload{std::byte{0x2A}}};
+    expectations.expect(project.addComposition(std::move(composition)) &&
+                            project.addExtensionRecord(markerRecord),
+                        "open composed: fixture composition/extension record add");
+
+    const IdAllocatorHighWater highWater{.composition = 1,
+                                         .node = 5,
+                                         .edge = 3,
+                                         .layer = 1,
+                                         .layerSlot = 1,
+                                         .parameter = 7,
+                                         .animationCurve = 9,
+                                         .keyframe = 22,
+                                         .driverBinding = 0,
+                                         .extensionRecord = 1};
+    Document document{std::move(project), highWater};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    const std::vector<ManifestRequirement> requirements{
+        {.providerId = "vendor.module",
+         .capabilityId = "vendor.module.marker-capability",
+         .schemaVersion = {1, 0},
+         .providedNodeTypeIds = {}},
+        {.providerId = "vendor.nodes",
+         .capabilityId = "vendor.nodes.blur-capability",
+         .schemaVersion = {1, 0},
+         .providedNodeTypeIds = {"vendor.nodes.blur"}},
+    };
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0},
+                                       .requirements = requirements};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built),
+                        "open composed: buildVerifiedSaveArchive succeeds");
+    if (!built) {
+        return;
+    }
+    const auto* archive = built.archive();
+    expectations.expect(archive != nullptr,
+                        "open composed: a successful build exposes its archive");
+    if (archive == nullptr) {
+        return;
+    }
+
+    auto opened = openProjectArchive(archive->bytes(), SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Opened,
+                        "open composed: openProjectArchive opens the archive save just wrote");
+    if (opened.outcome() != OpenArchiveOutcome::Opened) {
+        return;
+    }
+    auto openedValue = std::move(opened).takeOpened();
+    expectations.expect(openedValue.document != nullptr, "open composed: Opened owns a Document");
+    if (!openedValue.document) {
+        return;
+    }
+    auto openedSnapshot = openedValue.document->snapshot();
+    expectations.expect(openedSnapshot.project().name() == "Spot Check",
+                        "open composed: project name decodes exactly");
+    expectations.expect(openedSnapshot.project().compositions().size() == 1,
+                        "open composed: one composition decodes");
+    expectations.expect(openedValue.colorSettings == colorSettings,
+                        "open composed: colorSettings decode equal to what was saved");
+    expectations.expect(openedValue.requirements.size() == requirements.size(),
+                        "open composed: both manifest requirements decode");
+
+    const CanonicalManifestV1 resaveManifest{.documentSchemaVersion =
+                                                 openedValue.documentSchemaVersion,
+                                             .requirements = openedValue.requirements};
+    const CanonicalDocumentV1 resaveDocumentInput{
+        .snapshot = &openedSnapshot,
+        .colorSettings = &openedValue.colorSettings,
+        .roundTrip = openedValue.roundTrip.has_value() ? &*openedValue.roundTrip : nullptr,
+        .schemaMinor = openedValue.schemaMinor,
+    };
+    auto resaved = buildVerifiedSaveArchive(resaveManifest, resaveDocumentInput,
+                                            SaveArchiveLimits{}, makeOperation());
+    expectations.expect(
+        static_cast<bool>(resaved),
+        "open composed: re-saving the opened state through the save chain succeeds");
+    if (!resaved) {
+        return;
+    }
+    expectations.expect(sameBytes(archive->bytes(), resaved.archive()->bytes()),
+                        "open composed: the full open->save cycle reproduces the original archive "
+                        "byte-for-byte");
+}
+
+// A same-major newer-minor (1.1) document with one captured unknown root member, saved through
+// the chain, then opened -- proving Open's RoundTripState round-trips both through decode and
+// through a subsequent re-save, exactly mirroring save_archive_tests.cpp's own
+// testRoundTrippedNewerMinorGreenChain fixture.
+void testOpenRoundTrippedNewerMinorRoundTrip(Expectations& expectations) {
+    using bloom::project::RoundTripAttachmentPath;
+
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "open RT: fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document sourceDocument{std::move(newProject.project)};
+    auto sourceSnapshot = sourceDocument.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    const CanonicalDocumentV1 baselineRequest{.snapshot = &sourceSnapshot,
+                                              .colorSettings = &colorSettings,
+                                              .payloadScratch = payloadScratch,
+                                              .sortScratch = sortScratch};
+    const auto size = canonicalDocumentSize(baselineRequest);
+    expectations.expect(static_cast<bool>(size), "open RT: baseline document sizes");
+    if (!size) {
+        return;
+    }
+    std::string text(*size.value(), '\0');
+    const auto written =
+        encodeCanonicalDocument(baselineRequest, std::span<char>(text.data(), text.size()));
+    expectations.expect(static_cast<bool>(written), "open RT: baseline document encodes");
+    if (!written) {
+        return;
+    }
+
+    const std::string anchor = "\"minor\": 0\n  },\n  \"project\"";
+    const auto anchorPos = text.find(anchor);
+    expectations.expect(anchorPos != std::string::npos,
+                        "open RT: root schemaVersion anchor is located in the baseline");
+    if (anchorPos == std::string::npos) {
+        return;
+    }
+    text.replace(anchorPos, std::string_view("\"minor\": 0").size(), "\"minor\": 1");
+
+    expectations.expect(text.size() >= 2 && text.back() == '\n' && text[text.size() - 2] == '}',
+                        "open RT: baseline ends with the root's closing brace and final LF");
+    if (text.size() < 2 || text.back() != '\n' || text[text.size() - 2] != '}') {
+        return;
+    }
+    text.resize(text.size() - 2);
+    text += R"(,"zzzFutureField":42})";
+    text += '\n';
+
+    auto parsed = parseStrictJsonDom(asBytes(text), {}, makeOperation());
+    expectations.expect(static_cast<bool>(parsed), "open RT: spliced 1.1 document parses");
+    if (!parsed) {
+        return;
+    }
+    DocumentDecodeResult decoded =
+        bloom::project::decodeDocumentEnvelope(parsed.document()->root());
+    expectations.expect(decoded.outcome() == bloom::project::DocumentDecodeOutcome::Decoded &&
+                            decoded.value() != nullptr,
+                        "open RT: spliced 1.1 document decodes");
+    if (decoded.value() == nullptr || decoded.roundTrip() == nullptr) {
+        return;
+    }
+    auto reconstructed = bloom::project::reconstructDocument(*decoded.value());
+    expectations.expect(static_cast<bool>(reconstructed), "open RT: spliced document reconstructs");
+    if (!reconstructed) {
+        return;
+    }
+    auto reconstructedSnapshot = reconstructed.value()->document->snapshot();
+
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 1}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &reconstructedSnapshot,
+                                            .colorSettings = &reconstructed.value()->colorSettings,
+                                            .roundTrip = decoded.roundTrip(),
+                                            .schemaMinor = 1};
+
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built), "open RT: buildVerifiedSaveArchive succeeds");
+    if (!built) {
+        return;
+    }
+    const auto* archive = built.archive();
+    expectations.expect(archive != nullptr, "open RT: a successful build exposes its archive");
+    if (archive == nullptr) {
+        return;
+    }
+
+    auto opened = openProjectArchive(archive->bytes(), SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Opened,
+                        "open RT: openProjectArchive opens the round-tripped newer-minor archive");
+    if (opened.outcome() != OpenArchiveOutcome::Opened) {
+        return;
+    }
+    auto openedValue = std::move(opened).takeOpened();
+    expectations.expect(openedValue.schemaMinor == 1, "open RT: schemaMinor decodes to 1");
+    expectations.expect(openedValue.roundTrip.has_value(),
+                        "open RT: RoundTripState is present for the newer-minor document");
+    if (!openedValue.roundTrip.has_value()) {
+        return;
+    }
+    const auto* members = openedValue.roundTrip->find(RoundTripAttachmentPath{});
+    expectations.expect(members != nullptr && members->size() == 1 &&
+                            (*members)[0].key() == "zzzFutureField",
+                        "open RT: the retained unknown root member survives Open exactly");
+
+    auto openedSnapshot = openedValue.document->snapshot();
+    const CanonicalManifestV1 resaveManifest{.documentSchemaVersion =
+                                                 openedValue.documentSchemaVersion,
+                                             .requirements = openedValue.requirements};
+    const CanonicalDocumentV1 resaveDocumentInput{
+        .snapshot = &openedSnapshot,
+        .colorSettings = &openedValue.colorSettings,
+        .roundTrip = &*openedValue.roundTrip,
+        .schemaMinor = openedValue.schemaMinor,
+    };
+    auto resaved = buildVerifiedSaveArchive(resaveManifest, resaveDocumentInput,
+                                            SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(resaved),
+                        "open RT: re-saving the opened round-tripped state through the save chain "
+                        "succeeds");
+    if (!resaved) {
+        return;
+    }
+    expectations.expect(sameBytes(archive->bytes(), resaved.archive()->bytes()),
+                        "open RT: the full open->save cycle reproduces the original archive "
+                        "byte-for-byte");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Shared byte-level fixtures for the preserved-read-only and corruption/version tests below.
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] std::vector<std::byte> minimalCanonicalDocumentBytesOrAbort() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &colorSettings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch};
+    const auto documentSize = canonicalDocumentSize(request);
+    if (!documentSize) {
+        std::abort();
+    }
+    std::vector<char> documentText(*documentSize.value());
+    if (!encodeCanonicalDocument(request, documentText)) {
+        std::abort();
+    }
+    std::vector<std::byte> documentBytes(documentText.size());
+    std::memcpy(documentBytes.data(), documentText.data(), documentText.size());
+    return documentBytes;
+}
+
+[[nodiscard]] std::vector<std::byte>
+manifestBytesOrAbort(const bloom::document::SchemaVersion documentSchemaVersion) {
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = documentSchemaVersion,
+                                       .requirements = {}};
+    const auto manifestSize = canonicalManifestSize(manifest);
+    if (!manifestSize) {
+        std::abort();
+    }
+    std::vector<char> manifestText(*manifestSize.value());
+    if (!encodeCanonicalManifest(manifest, manifestText)) {
+        std::abort();
+    }
+    std::vector<std::byte> manifestBytes(manifestText.size());
+    std::memcpy(manifestBytes.data(), manifestText.data(), manifestText.size());
+    return manifestBytes;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Preserved-read-only, both sides: a manifest with containerVersion {1,1} over an otherwise valid
+// document classifies on the manifest side; a document with an unknown OCIO locator discriminator
+// classifies on the document side. Both are distinct from every Failed outcome.
+// ---------------------------------------------------------------------------------------------
+
+void testManifestSidePreservedReadOnly(Expectations& expectations) {
+    using bloom::project::test::buildConformingArchive;
+    using bloom::project::test::makeStoredEntry;
+
+    // Hand-assembled compact manifest JSON (mirrors manifest_decode_tests.cpp's own fixture
+    // technique): strict JSON parsing does not require canonical pretty-printing, only
+    // encodeCanonicalManifest()'s writer-side comparisons do.
+    const std::string manifestText =
+        R"({"format":"org.kinetik.bloom.project","containerVersion":{"major":1,"minor":1},)"
+        R"("document":{"path":"document.json","schemaVersion":{"major":1,"minor":0}},)"
+        R"("requirements":[]})";
+    std::vector<std::byte> manifestBytes(manifestText.size());
+    std::memcpy(manifestBytes.data(), manifestText.data(), manifestText.size());
+    const auto documentBytes = minimalCanonicalDocumentBytesOrAbort();
+
+    auto manifestEntry = makeStoredEntry("manifest.json", manifestBytes);
+    auto documentEntry = makeStoredEntry("document.json", documentBytes);
+    const auto archive = buildConformingArchive(manifestEntry, documentEntry);
+
+    auto opened = openProjectArchive(archive, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::PreservedReadOnlyRequired,
+                        "manifest-side preservation: a same-major newer-minor containerVersion "
+                        "classifies PreservedReadOnlyRequired, not Opened or Failed");
+    const auto* preservation = opened.preservedReadOnly();
+    expectations.expect(preservation != nullptr &&
+                            preservation->side == OpenArchivePreservedReadOnlySide::Manifest &&
+                            preservation->path.view() == "/containerVersion/minor",
+                        "manifest-side preservation: the result names the manifest side and the "
+                        "exact diagnostic path");
+}
+
+void testDocumentSidePreservedReadOnly(Expectations& expectations) {
+    using bloom::project::test::buildConformingArchive;
+    using bloom::project::test::makeStoredEntry;
+
+    auto documentBytes = minimalCanonicalDocumentBytesOrAbort();
+    std::string text(reinterpret_cast<const char*>(documentBytes.data()), documentBytes.size());
+
+    const std::string minorAnchor = "\"minor\": 0\n  },\n  \"project\"";
+    const auto minorPos = text.find(minorAnchor);
+    expectations.expect(minorPos != std::string::npos,
+                        "document-side preservation: root schemaVersion anchor is located");
+    if (minorPos == std::string::npos) {
+        return;
+    }
+    text.replace(minorPos, std::string_view("\"minor\": 0").size(), "\"minor\": 1");
+
+    const std::string kindAnchor = R"("kind": "builtin")";
+    const auto kindPos = text.find(kindAnchor);
+    expectations.expect(kindPos != std::string::npos,
+                        "document-side preservation: the OCIO locator kind anchor is located");
+    if (kindPos == std::string::npos) {
+        return;
+    }
+    text.replace(kindPos, kindAnchor.size(), R"("kind": "future-locator-kind")");
+
+    std::vector<std::byte> splicedDocumentBytes(text.size());
+    std::memcpy(splicedDocumentBytes.data(), text.data(), text.size());
+    const auto manifestBytes = manifestBytesOrAbort({1, 1});
+
+    auto manifestEntry = makeStoredEntry("manifest.json", manifestBytes);
+    auto documentEntry = makeStoredEntry("document.json", splicedDocumentBytes);
+    const auto archive = buildConformingArchive(manifestEntry, documentEntry);
+
+    auto opened = openProjectArchive(archive, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::PreservedReadOnlyRequired,
+                        "document-side preservation: an unknown OCIO locator kind classifies "
+                        "PreservedReadOnlyRequired, not Opened or Failed");
+    const auto* preservation = opened.preservedReadOnly();
+    expectations.expect(
+        preservation != nullptr &&
+            preservation->side == OpenArchivePreservedReadOnlySide::Document &&
+            preservation->documentReason == RoundTripPreservationReason::UnknownDiscriminatorKind &&
+            preservation->path.view() == "/project/colorSettings/ocioConfig/locator/kind",
+        "document-side preservation: the result names the document side, the exact reason, and "
+        "the exact diagnostic path");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Failures: a representative subset of the corruption corpus, pinned to the same stages Save's
+// own verification uses (save_archive_tests.cpp's testCorruptionInjection/testVersionDisagreement/
+// testRequirementsCoverageFailure).
+// ---------------------------------------------------------------------------------------------
+
+void testContainerCrcFailure(Expectations& expectations) {
+    using bloom::project::test::buildConformingArchive;
+    using bloom::project::test::makeStoredEntry;
+
+    const auto manifestBytes = manifestBytesOrAbort({1, 0});
+    const auto documentBytes = minimalCanonicalDocumentBytesOrAbort();
+
+    auto manifestEntry = makeStoredEntry("manifest.json", manifestBytes);
+    auto docEntry = makeStoredEntry("document.json", documentBytes);
+    docEntry.localCrc = docEntry.centralCrc ^= 0xFFFFFFFFU;
+    const auto archive = buildConformingArchive(manifestEntry, docEntry);
+
+    auto opened = openProjectArchive(archive, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Failed,
+                        "open corruption: container-level CRC tamper is rejected");
+    const auto* failure = opened.failure();
+    expectations.expect(failure != nullptr && failure->stage() == SaveArchiveStage::ContainerRead,
+                        "open corruption: CRC tamper is pinned to the ContainerRead stage");
+    if (failure != nullptr) {
+        const auto* payload = failure->payloadAs<SaveArchiveContainerReadFailure>();
+        expectations.expect(payload != nullptr && payload->error == ZipContainerError::CrcMismatch,
+                            "open corruption: CRC tamper reports CrcMismatch");
+    }
+}
+
+void testJsonSyntaxFailure(Expectations& expectations) {
+    using bloom::project::test::buildConformingArchive;
+    using bloom::project::test::makeStoredEntry;
+    using bloom::project::test::toBytes;
+
+    const auto manifestBytes = manifestBytesOrAbort({1, 0});
+    const auto documentBytes = minimalCanonicalDocumentBytesOrAbort();
+    std::string corrupted(reinterpret_cast<const char*>(documentBytes.data()),
+                          documentBytes.size());
+    expectations.expect(corrupted.size() >= 2 && corrupted[corrupted.size() - 2] == '}',
+                        "open corruption: fixture ends with a root closing brace to corrupt");
+    if (corrupted.size() < 2 || corrupted[corrupted.size() - 2] != '}') {
+        return;
+    }
+    corrupted[corrupted.size() - 2] = ']'; // mismatched bracket: invalid JSON syntax.
+
+    auto manifestEntry = makeStoredEntry("manifest.json", manifestBytes);
+    auto docEntry = makeStoredEntry("document.json", toBytes(corrupted));
+    const auto archive = buildConformingArchive(manifestEntry, docEntry);
+
+    auto opened = openProjectArchive(archive, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Failed,
+                        "open corruption: JSON-level syntax tamper is rejected");
+    const auto* failure = opened.failure();
+    expectations.expect(failure != nullptr && failure->stage() == SaveArchiveStage::DocumentParse,
+                        "open corruption: JSON syntax tamper is pinned to the DocumentParse stage");
+    if (failure != nullptr) {
+        const auto* payload = failure->payloadAs<SaveArchiveJsonParseFailure>();
+        expectations.expect(payload != nullptr &&
+                                payload->error == bloom::project::StrictJsonDomError::InvalidSyntax,
+                            "open corruption: JSON syntax tamper reports InvalidSyntax");
+    }
+}
+
+void testSemanticDecodeFailure(Expectations& expectations) {
+    using bloom::project::test::buildConformingArchive;
+    using bloom::project::test::makeStoredEntry;
+    using bloom::project::test::toBytes;
+
+    const auto manifestBytes = manifestBytesOrAbort({1, 0});
+    const auto documentBytes = minimalCanonicalDocumentBytesOrAbort();
+    std::string corrupted(reinterpret_cast<const char*>(documentBytes.data()),
+                          documentBytes.size());
+    const std::string_view needle = "lin_rec709_scene";
+    const auto pos = corrupted.find(needle);
+    expectations.expect(pos != std::string::npos,
+                        "open corruption: fixture contains the process color space id to corrupt");
+    if (pos == std::string::npos) {
+        return;
+    }
+    corrupted.replace(pos, needle.size(), "lin_rec709_scenex");
+
+    auto manifestEntry = makeStoredEntry("manifest.json", manifestBytes);
+    auto docEntry = makeStoredEntry("document.json", toBytes(corrupted));
+    const auto archive = buildConformingArchive(manifestEntry, docEntry);
+
+    auto opened = openProjectArchive(archive, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Failed,
+                        "open corruption: semantic tamper is rejected");
+    const auto* failure = opened.failure();
+    expectations.expect(failure != nullptr && failure->stage() == SaveArchiveStage::DocumentDecode,
+                        "open corruption: semantic tamper is pinned to the DocumentDecode stage");
+    if (failure != nullptr) {
+        const auto* payload = failure->payloadAs<SaveArchiveDocumentDecodeFailure>();
+        expectations.expect(payload != nullptr &&
+                                payload->error ==
+                                    bloom::project::DocumentDecodeError::DomainViolation,
+                            "open corruption: semantic tamper reports DomainViolation");
+    }
+}
+
+void testVersionDisagreementFailure(Expectations& expectations) {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(),
+                        "open version disagreement: fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    // manifest declares {1,0}; the document is written with root schemaVersion.minor = 1. No
+    // captured-input leg exists for Open (see docs/architecture/project-format.md, "Versions,
+    // Migrations, And Preservation"), so only this manifest-vs-document-root disagreement is
+    // exercised here.
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{
+        .snapshot = &snapshot, .colorSettings = &colorSettings, .schemaMinor = 1};
+    auto built = buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built),
+                        "open version disagreement: fixture archive builds (unverified)");
+    if (!built) {
+        return;
+    }
+
+    auto opened =
+        openProjectArchive(built.archive()->bytes(), SaveArchiveLimits{}, makeOperation());
+    expectations.expect(
+        opened.outcome() == OpenArchiveOutcome::Failed,
+        "open version disagreement: manifest {1,0} vs. document root minor 1 fails");
+    const auto* failure = opened.failure();
+    expectations.expect(
+        failure != nullptr && failure->stage() == SaveArchiveStage::VersionAgreement,
+        "open version disagreement: failure is scoped to the VersionAgreement stage");
+    if (failure != nullptr) {
+        const auto* payload = failure->payloadAs<SaveArchiveVersionAgreementFailure>();
+        expectations.expect(
+            payload != nullptr &&
+                payload->manifestVersion == bloom::document::SchemaVersion{1, 0} &&
+                payload->documentVersion == bloom::document::SchemaVersion{1, 1},
+            "open version disagreement: failure names the exact mismatched versions");
+    }
+}
+
+void testUncoveredRequirementFailure(Expectations& expectations) {
+    using bloom::document::CompositionId;
+    using bloom::document::NodeId;
+
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(),
+                        "open uncovered requirement: fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    auto* composition = newProject.project.findComposition(newProject.initialCompositionId);
+    expectations.expect(composition != nullptr,
+                        "open uncovered requirement: fixture composition is present");
+    if (composition == nullptr) {
+        return;
+    }
+    const bool nodeAdded =
+        composition->graph().addNode({NodeId::fromRaw(100), "vendor.nodes.blur", {}, 1});
+    expectations.expect(nodeAdded, "open uncovered requirement: fixture custom node adds");
+    if (!nodeAdded) {
+        return;
+    }
+
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    auto built = buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built),
+                        "open uncovered requirement: fixture archive builds (unverified)");
+    if (!built) {
+        return;
+    }
+
+    auto opened =
+        openProjectArchive(built.archive()->bytes(), SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Failed,
+                        "open uncovered requirement: an uncovered non-foundation node type fails");
+    const auto* failure = opened.failure();
+    expectations.expect(
+        failure != nullptr && failure->stage() == SaveArchiveStage::RequirementsValidation,
+        "open uncovered requirement: failure is scoped to the RequirementsValidation stage");
+    if (failure != nullptr) {
+        const auto* payload = failure->payloadAs<SaveArchiveRequirementsFailure>();
+        expectations.expect(payload != nullptr && !payload->validation.ok(),
+                            "open uncovered requirement: the validation result carries the "
+                            "coverage issue");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Budget exhaustion at parse and reconstruction, with a zeroed snapshot once the failed result
+// goes out of scope. Uses the same wide bulk fixture save_archive_tests.cpp's own budget probes
+// use, so the pipeline's stage-by-stage memory needs are spread widely enough to isolate each
+// stage.
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] std::vector<std::byte> bulkArchiveBytesOrAbort(Expectations& expectations) {
+    using bloom::document::ExtensionRecord;
+    using bloom::document::ExtensionRecordId;
+    using bloom::document::NoExtensionReferences;
+    using bloom::document::OpaqueExtensionPayload;
+
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    constexpr std::uint64_t kRecordCount = 4000;
+    for (std::uint64_t index = 1; index <= kRecordCount; ++index) {
+        ExtensionRecord record{ExtensionRecordId::fromRaw(index),
+                               "vendor.bulk",
+                               "vendor.bulk.record",
+                               {1, 0},
+                               std::nullopt,
+                               "application/octet-stream",
+                               NoExtensionReferences{},
+                               OpaqueExtensionPayload{std::byte{0x01}, std::byte{0x02}}};
+        if (!newProject.project.addExtensionRecord(std::move(record))) {
+            std::abort();
+        }
+    }
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const std::vector<ManifestRequirement> requirements{{.providerId = "vendor.bulk",
+                                                         .capabilityId = "vendor.bulk.cap",
+                                                         .schemaVersion = {1, 0},
+                                                         .providedNodeTypeIds = {}}};
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0},
+                                       .requirements = requirements};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+
+    // Built (and verified) under a generous, independent operation: only the subsequent
+    // openProjectArchive() call in each probe below runs under a constrained budget.
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built), "open budget exhaustion: bulk fixture builds");
+    if (!built) {
+        std::abort();
+    }
+    const auto bytes = built.archive()->bytes();
+    return {bytes.begin(), bytes.end()};
+}
+
+template <typename CheckPayload>
+void expectOpenResourceExhausted(Expectations& expectations,
+                                 const std::vector<std::byte>& archiveBytes,
+                                 const std::uint64_t operationBudget,
+                                 const SaveArchiveStage expectedStage, CheckPayload&& checkPayload,
+                                 const std::string_view message) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(64ULL << 20U);
+    expectations.expect(coordinator.has_value(), message);
+    if (!coordinator.has_value()) {
+        return;
+    }
+    auto operation = coordinator->createOperation(operationBudget, operationBudget);
+    expectations.expect(operation.has_value(), message);
+    if (!operation.has_value()) {
+        return;
+    }
+    {
+        auto opened = openProjectArchive(archiveBytes, SaveArchiveLimits{}, std::move(*operation));
+        expectations.expect(opened.outcome() == OpenArchiveOutcome::Failed, message);
+        const auto* failure = opened.failure();
+        expectations.expect(failure != nullptr && failure->stage() == expectedStage, message);
+        if (failure != nullptr) {
+            expectations.expect(checkPayload(*failure), message);
+        }
+    } // `opened` (holding no resident state on failure) is destroyed before the snapshot check.
+    const auto snapshot = coordinator->snapshot();
+    expectations.expect(snapshot.currentBytes == 0, message);
+}
+
+void testBudgetExhaustion(Expectations& expectations) {
+    const auto archiveBytes = bulkArchiveBytesOrAbort(expectations);
+
+    // Budgets calibrated empirically against this exact bulk fixture (4000 extension records, one
+    // covering manifest requirement): under ~6 MB the shared chain's own ContainerRead working-set
+    // reservation dominates (matches save_archive_tests.cpp's own ContainerWrite/ContainerRead
+    // note); 6-13 MB isolates DocumentParse; 18-22 MB isolates Reconstruction.
+    expectOpenResourceExhausted(
+        expectations, archiveBytes, 8'000'000, SaveArchiveStage::DocumentParse,
+        [](const auto& failure) {
+            const auto* payload = failure.template payloadAs<SaveArchiveJsonParseFailure>();
+            return payload != nullptr &&
+                   payload->error == bloom::project::StrictJsonDomError::ResourceExhausted;
+        },
+        "open budget exhaustion: a budget large enough to read the container and parse "
+        "manifest.json but too small to parse document.json fails at DocumentParse with a typed "
+        "ResourceExhausted and a zeroed snapshot on return");
+    expectOpenResourceExhausted(
+        expectations, archiveBytes, 20'000'000, SaveArchiveStage::Reconstruction,
+        [](const auto& failure) {
+            return failure.template payloadAs<SaveArchiveResourceExhausted>() != nullptr;
+        },
+        "open budget exhaustion: a budget large enough to decode but too small for the "
+        "composition layer's own reconstruction-footprint reservation fails at Reconstruction "
+        "with SaveArchiveResourceExhausted and a zeroed snapshot on return");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Determinism: two independent opens of the same archive bytes decode to the same values (proven
+// by re-encoding each Opened result and byte-comparing, mirroring
+// save_archive_tests.cpp's own testDeterminism oracle).
+// ---------------------------------------------------------------------------------------------
+
+void testDeterminism(Expectations& expectations) {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "open determinism: fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built), "open determinism: fixture archive builds");
+    if (!built) {
+        return;
+    }
+    const auto archiveBytes = built.archive()->bytes();
+
+    auto openedFirst = openProjectArchive(archiveBytes, SaveArchiveLimits{}, makeOperation());
+    auto openedSecond = openProjectArchive(archiveBytes, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(openedFirst.outcome() == OpenArchiveOutcome::Opened &&
+                            openedSecond.outcome() == OpenArchiveOutcome::Opened,
+                        "open determinism: both independent opens succeed");
+    if (openedFirst.outcome() != OpenArchiveOutcome::Opened ||
+        openedSecond.outcome() != OpenArchiveOutcome::Opened) {
+        return;
+    }
+    auto first = std::move(openedFirst).takeOpened();
+    auto second = std::move(openedSecond).takeOpened();
+
+    auto firstSnapshot = first.document->snapshot();
+    auto secondSnapshot = second.document->snapshot();
+    std::vector<char> payloadScratch1(64, '\0');
+    std::vector<std::size_t> sortScratch1(64, 0);
+    std::vector<char> payloadScratch2(64, '\0');
+    std::vector<std::size_t> sortScratch2(64, 0);
+    const CanonicalDocumentV1 firstRequest{
+        .snapshot = &firstSnapshot,
+        .colorSettings = &first.colorSettings,
+        .payloadScratch = payloadScratch1,
+        .sortScratch = sortScratch1,
+        .roundTrip = first.roundTrip.has_value() ? &*first.roundTrip : nullptr,
+        .schemaMinor = first.schemaMinor};
+    const CanonicalDocumentV1 secondRequest{
+        .snapshot = &secondSnapshot,
+        .colorSettings = &second.colorSettings,
+        .payloadScratch = payloadScratch2,
+        .sortScratch = sortScratch2,
+        .roundTrip = second.roundTrip.has_value() ? &*second.roundTrip : nullptr,
+        .schemaMinor = second.schemaMinor};
+
+    const auto firstSize = canonicalDocumentSize(firstRequest);
+    const auto secondSize = canonicalDocumentSize(secondRequest);
+    expectations.expect(static_cast<bool>(firstSize) && static_cast<bool>(secondSize),
+                        "open determinism: both decoded values re-encode");
+    if (!firstSize || !secondSize) {
+        return;
+    }
+    std::vector<char> firstText(*firstSize.value());
+    std::vector<char> secondText(*secondSize.value());
+    expectations.expect(static_cast<bool>(encodeCanonicalDocument(firstRequest, firstText)) &&
+                            static_cast<bool>(encodeCanonicalDocument(secondRequest, secondText)),
+                        "open determinism: both decoded values re-encode without error");
+    expectations.expect(firstText == secondText,
+                        "open determinism: two opens of the same archive decode to identical "
+                        "values (re-encoded bytes match)");
+    expectations.expect(first.colorSettings == second.colorSettings &&
+                            first.schemaMinor == second.schemaMinor &&
+                            first.requirements == second.requirements &&
+                            first.containerVersion == second.containerVersion &&
+                            first.documentSchemaVersion == second.documentSchemaVersion,
+                        "open determinism: every other decoded field is also identical");
+}
+
+} // namespace
+
+// function-try-block: ColorSettings::operator==() recurses into std::variant::operator==(), whose
+// standard-library implementation is conservatively flagged as exception-throwing (a
+// valueless-by-exception variant, which this test suite never produces) -- see
+// color_settings_tests.cpp's identical precedent.
+int main() try {
+    Expectations expectations;
+    testOpenMinimalRoundTrip(expectations);
+    testOpenComposedRoundTrip(expectations);
+    testOpenRoundTrippedNewerMinorRoundTrip(expectations);
+    testManifestSidePreservedReadOnly(expectations);
+    testDocumentSidePreservedReadOnly(expectations);
+    testContainerCrcFailure(expectations);
+    testJsonSyntaxFailure(expectations);
+    testSemanticDecodeFailure(expectations);
+    testVersionDisagreementFailure(expectations);
+    testUncoveredRequirementFailure(expectations);
+    testBudgetExhaustion(expectations);
+    testDeterminism(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+} catch (const std::exception& exception) {
+    std::cerr << "FAILED: unexpected exception: " << exception.what() << '\n';
+    return EXIT_FAILURE;
+} catch (...) {
+    std::cerr << "FAILED: unexpected non-standard exception\n";
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Closes #61.

The Open side of the persistence chain: archive bytes in, an installed-ready opened project out — or a preserved-read-only classification, or a typed stage-scoped rejection. With this, **both directions of the persistence story exist as compositions over one shared chain**.

**One chain, two drivers**: the reopen/decode/reconstruct/validate prefix is extracted into a single shared implementation. The save side folds preservation outcomes back into its exact pre-split failure payloads — behavior-preserving, with its test suite passing byte-for-byte unmodified — while Open surfaces them as a distinct three-way outcome (opened / preserved-read-only with side and reason / failed).

**Installed-ready means owned**: an Opened result carries the live document, color settings, moved-out round-trip state with its schema minor, and the decoded requirement set — plus every memory reservation the chain accrued for that resident state, so charges transfer with ownership per the contract. One additive move-out accessor on the decode result lets production Open take the round-trip state without a deep copy.

**Preserved-read-only retains nothing**: the caller already holds the archive bytes the contract says the application keeps for Save Copy; the result deliberately never copies them.

Testing: twelve functions, headlined by the full open→save cycle — open what save wrote, re-save it, and the republished archive must equal the original byte-for-byte — for minimal, composed, and round-tripped newer-minor archives; both preservation sides pinned distinctly; the failure corpus at the same stages as save verification; budget exhaustion; determinism. Full ci-linux-native suite 66/66 and format check green, independently re-verified after rebase.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).