### PR TITLE
feat: install opened archives into sessions

### DIFF
--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
         project_session.cpp
         publication_coordinator.cpp
         save_publication.cpp
+        session_open.cpp
         session_save.cpp
     PUBLIC
         FILE_SET HEADERS
@@ -14,6 +15,7 @@ target_sources(
             include/bloom/host/project_session.hpp
             include/bloom/host/publication_coordinator.hpp
             include/bloom/host/save_publication.hpp
+            include/bloom/host/session_open.hpp
             include/bloom/host/session_save.hpp
 )
 
@@ -71,6 +73,27 @@ if(BUILD_TESTING)
         bloom_add_test(
             NAME bloom.host.session-save
             COMMAND bloom_host_session_save_test
+            LABELS unit host persistence security
+        )
+
+        # Gated Linux-only exactly as bloom.host.session-save is gated: openSessionArchive()'s own
+        # full-cycle tests drive saveProjectSession() over the same real
+        # platform::StagedArtifactCoordinator to produce a published file to reopen.
+        #
+        # Links ZLIB::ZLIB directly for its own trimmed hand-rolled ZIP-writer fixture (a
+        # preserved-read-only archive builder) -- mirroring src/project/CMakeLists.txt's own test
+        # targets that link ZLIB::ZLIB for the identical reason. src/project/CMakeLists.txt already
+        # ran (project is add_subdirectory'd before host) and defines this target when
+        # BUILD_TESTING is set, exactly as it is here; guarded anyway for robustness.
+        if(NOT TARGET ZLIB::ZLIB)
+            find_package(ZLIB REQUIRED)
+        endif()
+        add_executable(bloom_host_session_open_test tests/session_open_tests.cpp)
+        target_link_libraries(bloom_host_session_open_test PRIVATE bloom_host ZLIB::ZLIB)
+        bloom_enable_warnings(bloom_host_session_open_test)
+        bloom_add_test(
+            NAME bloom.host.session-open
+            COMMAND bloom_host_session_open_test
             LABELS unit host persistence security
         )
     endif()

--- a/src/host/include/bloom/host/project_session.hpp
+++ b/src/host/include/bloom/host/project_session.hpp
@@ -12,6 +12,7 @@
 #include <bloom/document/project.hpp>
 #include <bloom/host/publication_coordinator.hpp>
 #include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
 #include <bloom/project/round_trip_state.hpp>
 
 #include <cstddef>
@@ -507,6 +508,96 @@ class [[nodiscard]] SessionSaveInputResult final {
     std::optional<SessionSaveInput> input_;
 };
 
+// Owns the three project::ProjectIoMemoryReservation charges an opened archive accrued for its
+// resident document/colorSettings/roundTrip/requirements state (see project::OpenedArchive's own
+// class comment: "Moving storage between stages transfers its charge"). A DecodedReplacementContent
+// carries this by value into ProjectSession::installDecodedReplacement(); on a successful install
+// ProjectSession keeps it for as long as the installed content stays resident (charge follows
+// residency -- see the task's frozen design decision 1), releasing it only when the session is
+// destroyed or replaced by a later installation. Deliberately opaque: nothing outside this module
+// inspects its members, it is only ever constructed once (from a real OpenedArchive, in
+// session_open.cpp) and moved along verbatim.
+class DecodedReplacementReservations final {
+  public:
+    DecodedReplacementReservations(
+        project::ProjectIoMemoryReservation manifestReservation,
+        project::ProjectIoMemoryReservation decodeReservation,
+        project::ProjectIoMemoryReservation reconstructionReservation) noexcept
+        : manifestReservation_(std::move(manifestReservation)),
+          decodeReservation_(std::move(decodeReservation)),
+          reconstructionReservation_(std::move(reconstructionReservation)) {}
+    DecodedReplacementReservations(DecodedReplacementReservations&&) noexcept = default;
+    DecodedReplacementReservations& operator=(DecodedReplacementReservations&&) noexcept = default;
+    DecodedReplacementReservations(const DecodedReplacementReservations&) = delete;
+    DecodedReplacementReservations& operator=(const DecodedReplacementReservations&) = delete;
+    ~DecodedReplacementReservations() = default;
+
+  private:
+    project::ProjectIoMemoryReservation manifestReservation_;
+    project::ProjectIoMemoryReservation decodeReservation_;
+    project::ProjectIoMemoryReservation reconstructionReservation_;
+};
+
+// Typed statuses for
+// ProjectSession::installDecodedReplacement()/installPreservedReadOnlyReplacement(). See
+// docs/architecture/project-session.md's "Session Publication" and "Open Intent" for the contract
+// this composes. RevisionChanged is the contract's edit-during-Open refusal: the decoded document
+// the session currently holds was edited (or undone/redone -- revisions are monotonic, so undo/redo
+// count as changes) after the Open intent was admitted, so the current project is kept.
+// InvalidContent covers a structurally unusable DecodedReplacementContent (a null document, an
+// unrecognized DecodedProjectEditability, or a RoundTripState paired with schemaMinor == 0 --
+// mirroring createDecoded()'s own request validation exactly, since a decoded install is otherwise
+// the same kind of content createDecoded() accepts).
+enum class SessionInstallStatus : std::uint8_t {
+    Installed,
+    InvalidSession,
+    StaleOpenIntent,
+    AcceptanceMismatch,
+    RevisionChanged,
+    InvalidContent,
+    RuntimeIdentityExhausted,
+};
+
+// Everything installDecodedReplacement() needs to replace a session's decoded content atomically
+// (see docs/architecture/project-session.md, "Session Publication"). Move-only
+// (unique_ptr<Document> and RoundTripState are each move-only, which makes this whole type
+// move-only). Mirrors project::OpenedArchive's shape one-to-one (see open_archive.hpp's file
+// comment) plus the two host-owned concerns OpenedArchive cannot determine on its own:
+// DecodedProjectEditability (this slice always installs Editable -- see session_open.cpp) and an
+// optional display path.
+class DecodedReplacementContent final {
+  public:
+    DecodedReplacementContent(std::unique_ptr<document::Document> document,
+                              document::ColorSettings colorSettings,
+                              std::optional<project::RoundTripState> roundTrip,
+                              std::uint32_t schemaMinor,
+                              std::vector<project::ManifestRequirement> requirements,
+                              DecodedProjectEditability editability,
+                              std::optional<ProjectDisplayPath> displayPath,
+                              std::optional<DecodedReplacementReservations> reservations) noexcept
+        : document_(std::move(document)), colorSettings_(std::move(colorSettings)),
+          roundTrip_(std::move(roundTrip)), schemaMinor_(schemaMinor),
+          requirements_(std::move(requirements)), editability_(editability),
+          displayPath_(std::move(displayPath)), reservations_(std::move(reservations)) {}
+    DecodedReplacementContent(DecodedReplacementContent&&) noexcept = default;
+    DecodedReplacementContent& operator=(DecodedReplacementContent&&) noexcept = default;
+    DecodedReplacementContent(const DecodedReplacementContent&) = delete;
+    DecodedReplacementContent& operator=(const DecodedReplacementContent&) = delete;
+    ~DecodedReplacementContent() = default;
+
+  private:
+    friend class ProjectSession;
+
+    std::unique_ptr<document::Document> document_;
+    document::ColorSettings colorSettings_;
+    std::optional<project::RoundTripState> roundTrip_;
+    std::uint32_t schemaMinor_ = 0;
+    std::vector<project::ManifestRequirement> requirements_;
+    DecodedProjectEditability editability_ = DecodedProjectEditability::Editable;
+    std::optional<ProjectDisplayPath> displayPath_;
+    std::optional<DecodedReplacementReservations> reservations_;
+};
+
 class ProjectSessionCreateResult;
 
 class ProjectSession final {
@@ -557,6 +648,22 @@ class ProjectSession final {
     // SessionSaveInput's class comment for the returned round-trip pointer's lifetime contract.
     [[nodiscard]] SessionSaveInputResult captureSaveInput(SessionPathIntentCapture intent) const;
 
+    // Atomically installs replacement session content from a successful Open (see
+    // docs/architecture/project-session.md's "Session Publication" and "Open Intent"). Acceptance
+    // is checked IN ORDER, all before any mutation -- see the .cpp file for the exact gate order
+    // and why it differs from a literal isDesiredOpenIntent() call. Not noexcept: constructing the
+    // fresh CommandStack the new content needs may throw std::bad_alloc; every allocation this
+    // method performs happens before its first mutation of session state, so a thrown exception
+    // leaves the session completely untouched (strong exception guarantee) -- see the .cpp file.
+    [[nodiscard]] SessionInstallStatus installDecodedReplacement(OpenIntentCapture intent,
+                                                                 DecodedReplacementContent content);
+    // Same acceptance gates as installDecodedReplacement(); on success the session's content
+    // becomes preserved-read-only at `displayPath`, mirroring createPreservedReadOnly()'s internal
+    // state (no document, no command stack, no color
+    // settings/round-trip/requirements/reservations).
+    [[nodiscard]] SessionInstallStatus
+    installPreservedReadOnlyReplacement(OpenIntentCapture intent, ProjectDisplayPath displayPath);
+
   private:
     friend class ProjectSessionCreateResult;
     friend class ProjectSessionTestAccess;
@@ -574,6 +681,12 @@ class ProjectSession final {
     [[nodiscard]] ProjectSessionCommandResult unavailableCommandResult() const noexcept;
     [[nodiscard]] SessionResultAcceptanceAdvanceStatus
     advanceResultAcceptanceForInstalledReplacement() noexcept;
+    // Shared install acceptance gates for installDecodedReplacement()/
+    // installPreservedReadOnlyReplacement(): std::nullopt means every gate passed (proceed);
+    // otherwise the returned status is the exact typed refusal to report. See the .cpp file for
+    // the gate order and its documented deviation from isDesiredOpenIntent()'s bundled boolean.
+    [[nodiscard]] std::optional<SessionInstallStatus>
+    checkInstallAcceptanceGates(OpenIntentCapture intent) const noexcept;
     [[nodiscard]] bool
     setGenerationsForTesting(SessionResultAcceptanceGeneration resultAcceptanceGeneration,
                              OpenIntentGeneration openIntentGeneration,
@@ -596,6 +709,10 @@ class ProjectSession final {
     std::optional<project::RoundTripState> roundTrip_;
     std::uint32_t schemaMinor_ = 0;
     std::vector<project::ManifestRequirement> retainedRequirements_;
+    // Present only for content installed via installDecodedReplacement() from a real opened
+    // archive (see DecodedReplacementReservations' class comment: charge follows residency).
+    // Absent for createNew()/createDecoded() sessions and for preserved-read-only content.
+    std::optional<DecodedReplacementReservations> decodedContentReservations_;
     std::unique_ptr<document::Document> document_;
     std::unique_ptr<commands::CommandStack> commandStack_;
     bool valid_ = false;

--- a/src/host/include/bloom/host/session_open.hpp
+++ b/src/host/include/bloom/host/session_open.hpp
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <bloom/host/project_session.hpp>
+#include <bloom/project/open_archive.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <variant>
+
+// The synchronous session-level Open orchestration: composes ProjectSession::admitOpenIntent()
+// (docs/architecture/project-session.md, "Open Intent") with project::openProjectArchive()
+// (open_archive.hpp -- the shared reopen/decode/reconstruct/validate chain) and, on a successful
+// or preserved-read-only classification, ProjectSession::installDecodedReplacement()/
+// installPreservedReadOnlyReplacement() (project_session.hpp, "Session Publication"). This module
+// owns none of those three seams' own semantics; it only wires them together on the caller's
+// thread. File reading stays OUT of this module (bytes-in span, matching every prior slice -- the
+// async/file package owns streaming and fingerprints later); an asynchronous/Jobs-driven Open is a
+// later slice (see AGENTS.md's boundary and this task's non-goals).
+namespace bloom::host {
+
+// Where an openSessionArchive() call stopped. Admission: session.admitOpenIntent() itself refused
+// (see SessionOpenResult::admissionStatus()). Opening: project::openProjectArchive() reported a
+// typed SaveArchiveFailure (see SessionOpenResult::openingFailure()) -- the session is untouched,
+// since no install*() call is ever made on this path. Installation: openProjectArchive() reached
+// either Opened or PreservedReadOnlyRequired, and this module attempted (or, for a pathless
+// PreservedReadOnlyRequired result, deliberately declined to attempt) an install*() call (see
+// SessionOpenResult::installOutcome()).
+enum class SessionOpenStage : std::uint8_t {
+    Admission,
+    Opening,
+    Installation,
+};
+
+// Wraps a thrown exception from ProjectSession::installDecodedReplacement()/
+// installPreservedReadOnlyReplacement() -- neither is noexcept (each may allocate; see their own
+// declaration comments on ProjectSession) -- so this module's noexcept entry point never lets an
+// exception escape. Mirrors session_save.hpp's SessionSaveResourceExhausted/
+// SessionSaveUnexpectedFailure precedent exactly. Per installDecodedReplacement()'s/
+// installPreservedReadOnlyReplacement()'s own strong exception guarantee, a caught exception here
+// means the session was left completely untouched.
+struct SessionOpenInstallResourceExhausted final {};
+struct SessionOpenInstallUnexpectedFailure final {};
+
+using SessionOpenInstallOutcome =
+    std::variant<SessionInstallStatus, SessionOpenInstallResourceExhausted,
+                 SessionOpenInstallUnexpectedFailure>;
+
+// See SessionOpenStage above for the three stages this result distinguishes. Exactly one of
+// admissionStatus()/openingFailure()/installOutcome() is populated, matching stage().
+class [[nodiscard]] SessionOpenResult final {
+  public:
+    SessionOpenResult(SessionOpenResult&&) noexcept = default;
+    SessionOpenResult& operator=(SessionOpenResult&&) noexcept = default;
+    SessionOpenResult(const SessionOpenResult&) = delete;
+    SessionOpenResult& operator=(const SessionOpenResult&) = delete;
+    ~SessionOpenResult() = default;
+
+    [[nodiscard]] static SessionOpenResult
+    admissionFailure(OpenIntentAdmissionStatus status) noexcept;
+    [[nodiscard]] static SessionOpenResult
+    openingFailure(project::SaveArchiveFailure failure) noexcept;
+    // `attemptedContentKind` names which content kind this pipeline attempted to install
+    // (DecodedDocument for an Opened archive, PreservedReadOnly for a PreservedReadOnlyRequired
+    // one) regardless of whether `outcome` is a real success. `preservedReadOnly` is present only
+    // for the PreservedReadOnlyRequired path (whether or not installation itself succeeded), per
+    // the frozen design: "the result carries the preservation side/reason diagnostics verbatim for
+    // the caller (who retains the archive bytes for Save Copy)".
+    [[nodiscard]] static SessionOpenResult
+    installation(SessionOpenInstallOutcome outcome, ProjectSessionContentKind attemptedContentKind,
+                 std::optional<project::OpenArchivePreservedReadOnly> preservedReadOnly) noexcept;
+
+    // True only for the single fully-succeeded path: Installation stage with a real
+    // SessionInstallStatus::Installed outcome. Every other case -- including a wrapped install
+    // exception -- is false; inspect stage() and installOutcome() for the exact typed reason.
+    [[nodiscard]] explicit operator bool() const noexcept {
+        if (stage_ != SessionOpenStage::Installation) {
+            return false;
+        }
+        const auto* status = std::get_if<SessionInstallStatus>(&installOutcome_);
+        return status != nullptr && *status == SessionInstallStatus::Installed;
+    }
+
+    [[nodiscard]] SessionOpenStage stage() const noexcept { return stage_; }
+
+    // Valid only when stage() == Admission.
+    [[nodiscard]] std::optional<OpenIntentAdmissionStatus> admissionStatus() const noexcept {
+        return admissionStatus_;
+    }
+
+    // Valid only when stage() == Opening (project::openProjectArchive()'s own Failed outcome,
+    // verbatim; no install*() call was ever made).
+    [[nodiscard]] const project::SaveArchiveFailure* openingFailure() const& noexcept {
+        return openingFailure_.has_value() ? &*openingFailure_ : nullptr;
+    }
+    [[nodiscard]] const project::SaveArchiveFailure* openingFailure() const&& = delete;
+
+    // Valid only when stage() == Installation: either the exact SessionInstallStatus an
+    // install*() call returned, or a wrapped exception from that (non-noexcept) call. For the
+    // pathless-PreservedReadOnlyRequired refusal (no ProjectDisplayPath supplied to
+    // openSessionArchive()), this holds SessionInstallStatus::InvalidContent synthesized directly
+    // -- installPreservedReadOnlyReplacement() is never called, since it requires a real
+    // ProjectDisplayPath by contract (matching createPreservedReadOnly()'s own requirement).
+    [[nodiscard]] const SessionOpenInstallOutcome* installOutcome() const& noexcept {
+        return stage_ == SessionOpenStage::Installation ? &installOutcome_ : nullptr;
+    }
+    [[nodiscard]] const SessionOpenInstallOutcome* installOutcome() const&& = delete;
+
+    // Valid only when stage() == Installation: which content kind this pipeline attempted to
+    // install, regardless of whether installation itself succeeded.
+    [[nodiscard]] std::optional<ProjectSessionContentKind> attemptedContentKind() const noexcept {
+        return attemptedContentKind_;
+    }
+
+    // Present whenever project::openProjectArchive() classified the archive
+    // PreservedReadOnlyRequired, whether or not installation succeeded -- see installation()'s
+    // comment above.
+    [[nodiscard]] const project::OpenArchivePreservedReadOnly* preservedReadOnly() const& noexcept {
+        return preservedReadOnly_.has_value() ? &*preservedReadOnly_ : nullptr;
+    }
+    [[nodiscard]] const project::OpenArchivePreservedReadOnly* preservedReadOnly() const&& = delete;
+
+  private:
+    SessionOpenResult() = default;
+
+    SessionOpenStage stage_ = SessionOpenStage::Admission;
+    std::optional<OpenIntentAdmissionStatus> admissionStatus_;
+    std::optional<project::SaveArchiveFailure> openingFailure_;
+    SessionOpenInstallOutcome installOutcome_ = SessionInstallStatus::InvalidSession;
+    std::optional<ProjectSessionContentKind> attemptedContentKind_;
+    std::optional<project::OpenArchivePreservedReadOnly> preservedReadOnly_;
+};
+
+// Pipeline: session.admitOpenIntent() -> project::openProjectArchive(archive, limits, operation) ->
+//   - Opened: build a DecodedReplacementContent from the OpenedArchive (editability is always
+//     Editable in this slice -- provider availability/degraded-editable detection needs a
+//     capability registry that does not exist yet) -> session.installDecodedReplacement().
+//   - PreservedReadOnlyRequired: requires `displayPath` (a pathless preserved-read-only install is
+//     refused as typed InvalidContent -- createPreservedReadOnly() requires a path too) ->
+//     session.installPreservedReadOnlyReplacement().
+//   - Failed: a typed wrap of the SaveArchiveFailure; session untouched.
+//
+// noexcept top level: neither install*() call is itself noexcept (each may allocate), so both are
+// wrapped exactly as session_save.hpp's saveProjectSession() wraps captureSaveInput()/
+// acceptSavepoint() -- see SessionOpenInstallResourceExhausted/SessionOpenInstallUnexpectedFailure
+// above. project::openProjectArchive() and session.admitOpenIntent() are already noexcept.
+[[nodiscard]] SessionOpenResult
+openSessionArchive(ProjectSession& session, std::span<const std::byte> archive,
+                   std::optional<ProjectDisplayPath> displayPath,
+                   const project::SaveArchiveLimits& limits,
+                   project::ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::host

--- a/src/host/project_session.cpp
+++ b/src/host/project_session.cpp
@@ -114,6 +114,7 @@ ProjectSession::ProjectSession(ProjectSession&& other) noexcept
       colorSettings_(std::move(other.colorSettings_)), roundTrip_(std::move(other.roundTrip_)),
       schemaMinor_(std::exchange(other.schemaMinor_, std::uint32_t{0})),
       retainedRequirements_(std::move(other.retainedRequirements_)),
+      decodedContentReservations_(std::move(other.decodedContentReservations_)),
       document_(std::move(other.document_)), commandStack_(std::move(other.commandStack_)),
       valid_(std::exchange(other.valid_, false)) {}
 
@@ -358,6 +359,142 @@ ProjectSession::advanceResultAcceptanceForInstalledReplacement() noexcept {
     pathIntentKind_ = SessionPathIntentKind::ExistingPath;
     newestAcceptedPublicationIntent_ = {};
     return SessionResultAcceptanceAdvanceStatus::Advanced;
+}
+
+std::optional<SessionInstallStatus>
+ProjectSession::checkInstallAcceptanceGates(const OpenIntentCapture intent) const noexcept {
+    if (!isValid()) {
+        return SessionInstallStatus::InvalidSession;
+    }
+    // Gate 1 (StaleOpenIntent): the same runtime-session/generation/content-kind identity check
+    // isDesiredOpenIntent() performs, but WITHOUT that method's bundled content-revision leg. A
+    // literal isDesiredOpenIntent(intent) call cannot be used to drive this gate order: that method
+    // already folds the decoded-revision comparison into its single boolean (see
+    // testOpenIntentBindsExactContent in project_session_tests.cpp, which pins that a successful
+    // edit alone makes isDesiredOpenIntent() false), so an edit-during-Open would be
+    // indistinguishable from a superseded/stale Open admission and could never report
+    // RevisionChanged -- the exact status the task's edit-during-Open test requires. Splitting the
+    // check into three orthogonal gates (identity/generation, result-acceptance, content-revision)
+    // also makes AcceptanceMismatch genuinely reachable: installing a capture taken before a
+    // successful prior install has an unchanged OpenIntentGeneration (installation never advances
+    // that counter) but a stale SessionResultAcceptanceGeneration, so it is refused here at Gate 2,
+    // not Gate 1. isDesiredOpenIntent() itself is completely unchanged -- this is new, install-only
+    // logic living beside it, not a redefinition of existing frozen semantics.
+    if (!intent.isValid() || intent.generation() != openIntentGeneration_ ||
+        intent.contentKind() != contentKind_) {
+        return SessionInstallStatus::StaleOpenIntent;
+    }
+    // Gate 2 (AcceptanceMismatch).
+    if (!matchesResultAcceptance(intent.resultAcceptance())) {
+        return SessionInstallStatus::AcceptanceMismatch;
+    }
+    // Gate 3 (RevisionChanged): only meaningful for a session currently holding decoded content --
+    // Gate 1 already proved intent.contentKind() == contentKind_, and OpenIntentCapture's own
+    // invariant (hasValidContentBinding) guarantees a PreservedReadOnly capture carries no decoded
+    // revision, so preserved-read-only current content has nothing further to check here (matching
+    // docs/architecture/project-session.md's "Open Intent": "preserved read-only content remains
+    // bound by its runtime session and acceptance generation without a decoded revision").
+    if (contentKind_ == ProjectSessionContentKind::DecodedDocument &&
+        commandStack_->trackedRevision() != intent.decodedRevision()) {
+        return SessionInstallStatus::RevisionChanged;
+    }
+    return std::nullopt;
+}
+
+SessionInstallStatus ProjectSession::installDecodedReplacement(const OpenIntentCapture intent,
+                                                               DecodedReplacementContent content) {
+    if (const auto gate = checkInstallAcceptanceGates(intent)) {
+        return *gate;
+    }
+    // Mirrors createDecoded()'s own request validation exactly (isKnownEditability(), and the
+    // roundTrip/schemaMinor pairing check) -- a decoded install is otherwise the same kind of
+    // content createDecoded() accepts. See SessionInstallStatus::InvalidContent's comment.
+    if (content.document_ == nullptr || !isKnownEditability(content.editability_) ||
+        (content.roundTrip_.has_value() && content.schemaMinor_ == 0)) {
+        return SessionInstallStatus::InvalidContent;
+    }
+    // Both generations this method advances must be checked for exhaustion BEFORE the allocation
+    // below, so a RuntimeIdentityExhausted refusal never allocates and the strong exception
+    // guarantee (see this method's declaration comment) covers the whole method, not just the
+    // allocating step.
+    if (resultAcceptanceGeneration_.value() == std::numeric_limits<std::uint64_t>::max() ||
+        pathIntentGeneration_.value() == std::numeric_limits<std::uint64_t>::max()) {
+        return SessionInstallStatus::RuntimeIdentityExhausted;
+    }
+
+    // The one allocation this method performs: a fresh CommandStack bound to the new document.
+    // Constructed before any session-state mutation below, so a thrown std::bad_alloc here leaves
+    // the session completely untouched (strong exception guarantee).
+    auto freshStack = std::make_unique<commands::CommandStack>(*content.document_);
+
+    // Atomic installation (docs/architecture/project-session.md, "Session Publication").
+    const auto advanceStatus = advanceResultAcceptanceForInstalledReplacement();
+    if (advanceStatus != SessionResultAcceptanceAdvanceStatus::Advanced) {
+        // Unreachable in practice: the exhaustion boundary was already checked above under the
+        // same single-threaded synchronous call, so resultAcceptanceGeneration_ cannot have changed
+        // in between. Handled anyway so this method's control flow stays provably total.
+        return SessionInstallStatus::RuntimeIdentityExhausted;
+    }
+    // A pending Save As replacement phase is cancelled by installation (project-session.md, "Save
+    // Inputs And Intent": "Installing replacement session content also cancels a pending
+    // replacement phase"). advanceResultAcceptanceForInstalledReplacement() already reset
+    // pathIntentKind_ to ExistingPath; advancing the generation too keeps every session generation
+    // moving forward on a real content replacement (both the old plain-save and the old Save As
+    // capture are already stale from the resultAcceptance change alone -- matchesPathIntent()
+    // requires resultAcceptance equality -- so this generation advance is state hygiene, not load-
+    // bearing for that exclusion).
+    pathIntentGeneration_ = SessionPathIntentGeneration::fromRaw(pathIntentGeneration_.value() + 1);
+
+    document_ = std::move(content.document_);
+    commandStack_ = std::move(freshStack);
+    colorSettings_ = std::move(content.colorSettings_);
+    roundTrip_ = std::move(content.roundTrip_);
+    schemaMinor_ = content.schemaMinor_;
+    retainedRequirements_ = std::move(content.requirements_);
+    contentKind_ = ProjectSessionContentKind::DecodedDocument;
+    editability_ = content.editability_;
+    displayPath_ = std::move(content.displayPath_);
+    decodedContentReservations_ = std::move(content.reservations_);
+    cleanRevision_ = commandStack_->trackedRevision();
+
+    return SessionInstallStatus::Installed;
+}
+
+SessionInstallStatus
+ProjectSession::installPreservedReadOnlyReplacement(const OpenIntentCapture intent,
+                                                    ProjectDisplayPath displayPath) {
+    if (const auto gate = checkInstallAcceptanceGates(intent)) {
+        return *gate;
+    }
+    if (resultAcceptanceGeneration_.value() == std::numeric_limits<std::uint64_t>::max() ||
+        pathIntentGeneration_.value() == std::numeric_limits<std::uint64_t>::max()) {
+        return SessionInstallStatus::RuntimeIdentityExhausted;
+    }
+
+    // No allocating step in this variant (releasing document_/commandStack_/etc. and moving
+    // displayPath cannot throw), so the strong exception guarantee is trivially satisfied by the
+    // mutation order alone -- there is nothing that can throw partway through.
+    const auto advanceStatus = advanceResultAcceptanceForInstalledReplacement();
+    if (advanceStatus != SessionResultAcceptanceAdvanceStatus::Advanced) {
+        return SessionInstallStatus::RuntimeIdentityExhausted; // unreachable; see the sibling
+                                                               // method
+    }
+    pathIntentGeneration_ = SessionPathIntentGeneration::fromRaw(pathIntentGeneration_.value() + 1);
+
+    // Mirrors createPreservedReadOnly()'s internal state exactly.
+    document_.reset();
+    commandStack_.reset();
+    colorSettings_.reset();
+    roundTrip_.reset();
+    schemaMinor_ = 0;
+    retainedRequirements_.clear();
+    cleanRevision_.reset();
+    editability_.reset();
+    decodedContentReservations_.reset();
+    contentKind_ = ProjectSessionContentKind::PreservedReadOnly;
+    displayPath_ = std::move(displayPath);
+
+    return SessionInstallStatus::Installed;
 }
 
 bool ProjectSession::setGenerationsForTesting(

--- a/src/host/session_open.cpp
+++ b/src/host/session_open.cpp
@@ -1,0 +1,136 @@
+#include <bloom/host/session_open.hpp>
+
+#include <new>
+#include <utility>
+
+namespace bloom::host {
+
+SessionOpenResult
+SessionOpenResult::admissionFailure(const OpenIntentAdmissionStatus status) noexcept {
+    SessionOpenResult result;
+    result.stage_ = SessionOpenStage::Admission;
+    result.admissionStatus_ = status;
+    return result;
+}
+
+SessionOpenResult SessionOpenResult::openingFailure(project::SaveArchiveFailure failure) noexcept {
+    SessionOpenResult result;
+    result.stage_ = SessionOpenStage::Opening;
+    result.openingFailure_ = std::move(failure);
+    return result;
+}
+
+SessionOpenResult SessionOpenResult::installation(
+    SessionOpenInstallOutcome outcome, const ProjectSessionContentKind attemptedContentKind,
+    std::optional<project::OpenArchivePreservedReadOnly> preservedReadOnly) noexcept {
+    SessionOpenResult result;
+    result.stage_ = SessionOpenStage::Installation;
+    result.installOutcome_ = outcome;
+    result.attemptedContentKind_ = attemptedContentKind;
+    result.preservedReadOnly_ = preservedReadOnly;
+    return result;
+}
+
+namespace {
+
+// Both install*() calls below are the only non-noexcept composed surfaces in this pipeline (each
+// may allocate -- see ProjectSession::installDecodedReplacement()'s/
+// installPreservedReadOnlyReplacement()'s declaration comments); each is wrapped individually so a
+// thrown exception is reported as a typed SessionOpenInstallOutcome alternative rather than
+// escaping this module's noexcept entry point. Per those methods' own strong exception guarantee, a
+// caught exception here means the session was left completely untouched.
+
+[[nodiscard]] SessionOpenResult
+installDecodedAndReport(ProjectSession& session, const OpenIntentCapture intent,
+                        DecodedReplacementContent content) noexcept {
+    try {
+        const auto status = session.installDecodedReplacement(intent, std::move(content));
+        return SessionOpenResult::installation(status, ProjectSessionContentKind::DecodedDocument,
+                                               std::nullopt);
+    } catch (const std::bad_alloc&) {
+        return SessionOpenResult::installation(SessionOpenInstallResourceExhausted{},
+                                               ProjectSessionContentKind::DecodedDocument,
+                                               std::nullopt);
+    } catch (...) {
+        return SessionOpenResult::installation(SessionOpenInstallUnexpectedFailure{},
+                                               ProjectSessionContentKind::DecodedDocument,
+                                               std::nullopt);
+    }
+}
+
+[[nodiscard]] SessionOpenResult
+installPreservedReadOnlyAndReport(ProjectSession& session, const OpenIntentCapture intent,
+                                  ProjectDisplayPath displayPath,
+                                  project::OpenArchivePreservedReadOnly diagnostics) noexcept {
+    try {
+        const auto status =
+            session.installPreservedReadOnlyReplacement(intent, std::move(displayPath));
+        return SessionOpenResult::installation(status, ProjectSessionContentKind::PreservedReadOnly,
+                                               diagnostics);
+    } catch (const std::bad_alloc&) {
+        return SessionOpenResult::installation(SessionOpenInstallResourceExhausted{},
+                                               ProjectSessionContentKind::PreservedReadOnly,
+                                               diagnostics);
+    } catch (...) {
+        return SessionOpenResult::installation(SessionOpenInstallUnexpectedFailure{},
+                                               ProjectSessionContentKind::PreservedReadOnly,
+                                               diagnostics);
+    }
+}
+
+} // namespace
+
+SessionOpenResult openSessionArchive(ProjectSession& session, std::span<const std::byte> archive,
+                                     std::optional<ProjectDisplayPath> displayPath,
+                                     const project::SaveArchiveLimits& limits,
+                                     project::ProjectIoOperationMemory operation) noexcept {
+    const auto admission = session.admitOpenIntent();
+    if (!admission) {
+        return SessionOpenResult::admissionFailure(admission.status());
+    }
+    const auto intent = admission.capture();
+
+    auto opened = project::openProjectArchive(archive, limits, std::move(operation));
+    if (opened.outcome() == project::OpenArchiveOutcome::Failed) {
+        // Session untouched: no install*() call is ever made on this path.
+        return SessionOpenResult::openingFailure(std::move(opened).takeFailure());
+    }
+
+    if (opened.outcome() == project::OpenArchiveOutcome::PreservedReadOnlyRequired) {
+        const auto* preservation = opened.preservedReadOnly();
+        // Defensive: openProjectArchive()'s own contract guarantees this is non-null on this
+        // outcome (see open_archive.hpp); handled anyway so this function stays provably total.
+        project::OpenArchivePreservedReadOnly diagnostics =
+            preservation != nullptr ? *preservation : project::OpenArchivePreservedReadOnly{};
+        if (!displayPath.has_value()) {
+            // createPreservedReadOnly() requires a path too: a pathless preserved-read-only
+            // install is refused here, without ever calling installPreservedReadOnlyReplacement()
+            // (which requires a real ProjectDisplayPath by contract) -- session untouched. The
+            // caller still gets the preservation diagnostics verbatim (it retains `archive` for
+            // Save Copy per this module's file comment).
+            return SessionOpenResult::installation(SessionInstallStatus::InvalidContent,
+                                                   ProjectSessionContentKind::PreservedReadOnly,
+                                                   diagnostics);
+        }
+        return installPreservedReadOnlyAndReport(session, intent, std::move(*displayPath),
+                                                 diagnostics);
+    }
+
+    // Opened: build a DecodedReplacementContent from the OpenedArchive, mirroring its shape
+    // one-to-one (see open_archive.hpp's file comment and DecodedReplacementContent's own comment).
+    auto openedValue = std::move(opened).takeOpened();
+    DecodedReplacementReservations reservations(std::move(openedValue.manifestReservation),
+                                                std::move(openedValue.decodeReservation),
+                                                std::move(openedValue.reconstructionReservation));
+    DecodedReplacementContent content(
+        std::move(openedValue.document), std::move(openedValue.colorSettings),
+        std::move(openedValue.roundTrip), openedValue.schemaMinor,
+        std::move(openedValue.requirements),
+        // Editability is always Editable in this slice: provider availability/degraded-editable
+        // detection needs a capability registry that does not exist yet (see this task's design
+        // decision 2) -- every opened archive installs as fully Editable here.
+        DecodedProjectEditability::Editable, std::move(displayPath), std::move(reservations));
+    return installDecodedAndReport(session, intent, std::move(content));
+}
+
+} // namespace bloom::host

--- a/src/host/tests/session_open_tests.cpp
+++ b/src/host/tests/session_open_tests.cpp
@@ -1,0 +1,1276 @@
+#include <bloom/host/session_open.hpp>
+
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/host/project_session.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/host/session_save.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/document_decode.hpp>
+#include <bloom/project/document_reconstruct.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/open_archive.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/round_trip_state.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <zlib.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+// Drives openSessionArchive() -- the synchronous session-level Open orchestration composing
+// ProjectSession::admitOpenIntent(), project::openProjectArchive(), and
+// ProjectSession::installDecodedReplacement()/installPreservedReadOnlyReplacement() -- following
+// session_save_tests.cpp's pattern one composition layer up. installDecodedReplacement()/
+// installPreservedReadOnlyReplacement() are ALSO exercised directly (they are public
+// ProjectSession members) for the gate-order scenarios (stale/mismatched/edit-during-open
+// captures) that require an OpenIntentCapture openSessionArchive() itself would never hand back,
+// since that pipeline always admits its own fresh intent.
+
+namespace {
+
+using bloom::commands::SetProjectName;
+using bloom::commands::Transaction;
+
+using bloom::host::ArtifactTargetKey;
+using bloom::host::DecodedProjectEditability;
+using bloom::host::DecodedProjectSessionRequest;
+using bloom::host::DecodedReplacementContent;
+using bloom::host::DecodedReplacementReservations;
+using bloom::host::OpenIntentCapture;
+using bloom::host::openSessionArchive;
+using bloom::host::ProjectDisplayPath;
+using bloom::host::ProjectSession;
+using bloom::host::ProjectSessionContentKind;
+using bloom::host::ProjectSessionIdentitySource;
+using bloom::host::PublicationCoordinator;
+using bloom::host::PublicationCoordinatorConfig;
+using bloom::host::saveProjectSession;
+using bloom::host::SessionInstallStatus;
+using bloom::host::SessionOpenInstallOutcome;
+using bloom::host::SessionOpenResult;
+using bloom::host::SessionOpenStage;
+using bloom::host::SessionPathIntentAbandonStatus;
+using bloom::host::SessionPathIntentKind;
+using bloom::host::SessionSaveInputStatus;
+using bloom::host::SessionSaveRequest;
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::ArtifactTargetObservation;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+
+using bloom::project::buildVerifiedSaveArchive;
+using bloom::project::canonicalDocumentSize;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::canonicalManifestSize;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::decodeDocumentEnvelope;
+using bloom::project::DocumentClassification;
+using bloom::project::DocumentDecodeOutcome;
+using bloom::project::DocumentDecodeResult;
+using bloom::project::encodeCanonicalDocument;
+using bloom::project::encodeCanonicalManifest;
+using bloom::project::ManifestRequirement;
+using bloom::project::OpenArchiveOutcome;
+using bloom::project::OpenArchivePreservedReadOnlySide;
+using bloom::project::openProjectArchive;
+using bloom::project::parseStrictJsonDom;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::RoundTripAttachmentPath;
+using bloom::project::RoundTripState;
+using bloom::project::SaveArchiveLimits;
+using bloom::project::SaveArchiveStage;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-session-open-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Shared plumbing (mirrors session_save_tests.cpp / open_archive_tests.cpp)
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U;
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    return makeOperation(kGenerousOperationBudget);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::span<const char> bytes) noexcept {
+    return {reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::optional<PublicationCoordinator>
+makePublicationCoordinator(Expectations& expectations,
+                           const PublicationCoordinatorConfig config = {}) {
+    auto result = PublicationCoordinator::create(config);
+    expectations.expect(result.has_value(), "the publication coordinator is created");
+    return result;
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeArtifactsCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-artifact coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+[[nodiscard]] bloom::document::Revision currentRevision(const ProjectSession& session) {
+    const auto state = session.stateSnapshot();
+    if (!state.currentRevision.has_value()) {
+        throw std::logic_error("Expected a decoded revision");
+    }
+    return *state.currentRevision;
+}
+
+[[nodiscard]] Transaction rename(std::string value, const ProjectSession& session,
+                                 std::string label = "Rename") {
+    Transaction transaction(std::move(label), currentRevision(session));
+    transaction.emplace<SetProjectName>(std::move(value));
+    return transaction;
+}
+
+[[nodiscard]] std::string projectName(const ProjectSession& session) {
+    const auto snapshot = session.decodedSnapshot();
+    if (!snapshot) {
+        throw std::logic_error("Expected a decoded document");
+    }
+    return std::string(snapshot.snapshot().project().name());
+}
+
+[[nodiscard]] ProjectSession
+makeDecodedSession(Expectations& expectations, ProjectSessionIdentitySource& identitySource,
+                   const std::string& projectName,
+                   const std::optional<std::filesystem::path>& displayPath = std::nullopt) {
+    auto created = bloom::document::makeNewProject(projectName, "Main Composition",
+                                                   bloom::core::RationalTime::fromInteger(10));
+    std::optional<ProjectDisplayPath> path;
+    if (displayPath.has_value()) {
+        path = ProjectDisplayPath::create(*displayPath);
+        expectations.expect(path.has_value(), "the display-path fixture is valid");
+    }
+    auto result = ProjectSession::createDecoded(identitySource,
+                                                {.project = std::move(created.project),
+                                                 .colorSettings = neutralColorSettings(),
+                                                 .editability = DecodedProjectEditability::Editable,
+                                                 .displayPath = std::move(path),
+                                                 .persistedAllocatorHighWater = std::nullopt});
+    expectations.expect(static_cast<bool>(result), "the decoded session fixture must be valid");
+    if (!result) {
+        throw std::logic_error("Could not create decoded project-session fixture");
+    }
+    return std::move(result).takeSession();
+}
+
+// A minimal, valid, unverified two-entry archive that always classifies Opened: used everywhere
+// a test needs to reach installDecodedReplacement()'s gates without caring about the document's
+// own content.
+[[nodiscard]] std::vector<std::byte>
+buildMinimalArchiveBytesOrAbort(const std::string& projectName = "Untitled Project") {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject = bloom::document::makeNewProject(projectName, "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    if (!built) {
+        std::abort();
+    }
+    const auto bytes = built.archive()->bytes();
+    return {bytes.begin(), bytes.end()};
+}
+
+// Builds the same DecodedReplacementContent openSessionArchive() itself builds from a real
+// OpenedArchive, exposing it directly so gate-order tests can call
+// ProjectSession::installDecodedReplacement() with a caller-chosen (possibly stale)
+// OpenIntentCapture -- openSessionArchive() always admits its own fresh intent, so it cannot
+// exercise a capture taken earlier against a session that has since moved on.
+[[nodiscard]] std::optional<DecodedReplacementContent>
+takeDecodedContent(Expectations& expectations, const std::span<const std::byte> archiveBytes,
+                   const std::string_view context) {
+    auto opened = openProjectArchive(archiveBytes, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(opened.outcome() == OpenArchiveOutcome::Opened, context);
+    if (opened.outcome() != OpenArchiveOutcome::Opened) {
+        return std::nullopt;
+    }
+    auto value = std::move(opened).takeOpened();
+    DecodedReplacementReservations reservations(std::move(value.manifestReservation),
+                                                std::move(value.decodeReservation),
+                                                std::move(value.reconstructionReservation));
+    return DecodedReplacementContent(
+        std::move(value.document), std::move(value.colorSettings), std::move(value.roundTrip),
+        value.schemaMinor, std::move(value.requirements), DecodedProjectEditability::Editable,
+        std::nullopt, std::move(reservations));
+}
+
+[[nodiscard]] std::vector<std::byte> minimalCanonicalDocumentBytesOrAbort() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    const CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                      .colorSettings = &colorSettings,
+                                      .payloadScratch = payloadScratch,
+                                      .sortScratch = sortScratch};
+    const auto documentSize = canonicalDocumentSize(request);
+    if (!documentSize) {
+        std::abort();
+    }
+    std::vector<char> documentText(*documentSize.value());
+    if (!encodeCanonicalDocument(request, documentText)) {
+        std::abort();
+    }
+    std::vector<std::byte> documentBytes(documentText.size());
+    std::memcpy(documentBytes.data(), documentText.data(), documentText.size());
+    return documentBytes;
+}
+
+// A trimmed, self-contained duplicate of src/project/tests/zip_container_test_support.hpp's
+// hand-rolled Constrained ZIP Profile writer (only the conforming-archive path this file needs --
+// no deflate, no deliberate deviations). src modules may not reach across a sibling module's
+// tests/ directory (architecture_boundaries), and open_archive_tests.cpp's own comment already
+// establishes per-test-file fixture duplication as this codebase's precedent (e.g.
+// neutralColorSettings() above).
+[[nodiscard]] std::uint32_t crc32Of(const std::span<const std::byte> payload) noexcept {
+    const auto value = crc32_z(0L, reinterpret_cast<const Bytef*>(payload.data()), payload.size());
+    return static_cast<std::uint32_t>(value);
+}
+
+struct EntrySpec final {
+    std::string localName;
+    std::string centralName;
+    std::uint16_t localFlags = 0x0800;
+    std::uint16_t centralFlags = 0x0800;
+    std::uint16_t localMethod = 0;
+    std::uint16_t centralMethod = 0;
+    std::vector<std::byte> data;
+    std::uint32_t localCompressedSize = 0;
+    std::uint32_t centralCompressedSize = 0;
+    std::uint32_t localUncompressedSize = 0;
+    std::uint32_t centralUncompressedSize = 0;
+    std::uint32_t localCrc = 0;
+    std::uint32_t centralCrc = 0;
+    std::vector<std::byte> localExtra;
+    std::vector<std::byte> centralExtra;
+    std::string centralComment;
+    std::uint16_t versionMadeBy = 0x0314;
+    std::uint32_t externalAttrs = 0100644U << 16U;
+    std::uint16_t diskNumberStart = 0;
+};
+
+[[nodiscard]] EntrySpec makeStoredEntry(const std::string& name,
+                                        const std::span<const std::byte> payload) {
+    EntrySpec spec;
+    spec.localName = name;
+    spec.centralName = name;
+    spec.data.assign(payload.begin(), payload.end());
+    spec.localCompressedSize = spec.centralCompressedSize =
+        static_cast<std::uint32_t>(payload.size());
+    spec.localUncompressedSize = spec.centralUncompressedSize =
+        static_cast<std::uint32_t>(payload.size());
+    spec.localCrc = spec.centralCrc = crc32Of(payload);
+    return spec;
+}
+
+class ArchiveWriter final {
+  public:
+    std::uint64_t appendLocal(const EntrySpec& entry) {
+        const auto offset = bytes_.size();
+        appendU32(0x04034b50U);
+        appendU16(20);
+        appendU16(entry.localFlags);
+        appendU16(entry.localMethod);
+        appendU16(0);
+        appendU16(0);
+        appendU32(entry.localCrc);
+        appendU32(entry.localCompressedSize);
+        appendU32(entry.localUncompressedSize);
+        appendU16(static_cast<std::uint16_t>(entry.localName.size()));
+        appendU16(static_cast<std::uint16_t>(entry.localExtra.size()));
+        appendText(entry.localName);
+        appendRaw(entry.localExtra);
+        appendRaw(entry.data);
+        return offset;
+    }
+
+    void appendCentral(const EntrySpec& entry, const std::uint32_t localHeaderOffset) {
+        appendU32(0x02014b50U);
+        appendU16(entry.versionMadeBy);
+        appendU16(20);
+        appendU16(entry.centralFlags);
+        appendU16(entry.centralMethod);
+        appendU16(0);
+        appendU16(0);
+        appendU32(entry.centralCrc);
+        appendU32(entry.centralCompressedSize);
+        appendU32(entry.centralUncompressedSize);
+        appendU16(static_cast<std::uint16_t>(entry.centralName.size()));
+        appendU16(static_cast<std::uint16_t>(entry.centralExtra.size()));
+        appendU16(static_cast<std::uint16_t>(entry.centralComment.size()));
+        appendU16(entry.diskNumberStart);
+        appendU16(0);
+        appendU32(entry.externalAttrs);
+        appendU32(localHeaderOffset);
+        appendText(entry.centralName);
+        appendRaw(entry.centralExtra);
+        appendText(entry.centralComment);
+    }
+
+    void appendEocd(const std::uint16_t diskNumber, const std::uint16_t diskWithCd,
+                    const std::uint16_t entriesThisDisk, const std::uint16_t entriesTotal,
+                    const std::uint32_t cdSize, const std::uint32_t cdOffset) {
+        appendU32(0x06054b50U);
+        appendU16(diskNumber);
+        appendU16(diskWithCd);
+        appendU16(entriesThisDisk);
+        appendU16(entriesTotal);
+        appendU32(cdSize);
+        appendU32(cdOffset);
+        appendU16(0);
+    }
+
+    [[nodiscard]] std::uint64_t size() const { return bytes_.size(); }
+    [[nodiscard]] const std::vector<std::byte>& bytes() const { return bytes_; }
+
+  private:
+    void appendU16(const std::uint16_t value) {
+        bytes_.push_back(static_cast<std::byte>(value & 0xFFU));
+        bytes_.push_back(static_cast<std::byte>((value >> 8U) & 0xFFU));
+    }
+    void appendU32(const std::uint32_t value) {
+        for (unsigned shift = 0; shift < 32U; shift += 8U) {
+            bytes_.push_back(static_cast<std::byte>((value >> shift) & 0xFFU));
+        }
+    }
+    void appendText(const std::string_view text) {
+        for (const char character : text) {
+            bytes_.push_back(static_cast<std::byte>(static_cast<unsigned char>(character)));
+        }
+    }
+    void appendRaw(const std::span<const std::byte> raw) {
+        bytes_.insert(bytes_.end(), raw.begin(), raw.end());
+    }
+
+    std::vector<std::byte> bytes_;
+};
+
+[[nodiscard]] std::vector<std::byte> buildConformingArchive(const EntrySpec& manifest,
+                                                            const EntrySpec& document) {
+    ArchiveWriter writer;
+    const auto manifestOffset = writer.appendLocal(manifest);
+    const auto documentOffset = writer.appendLocal(document);
+    const auto centralStart = writer.size();
+    writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+    writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+    const auto centralSize = writer.size() - centralStart;
+    writer.appendEocd(0, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                      static_cast<std::uint32_t>(centralStart));
+    return writer.bytes();
+}
+
+// A {1,1}-container archive (O1's fixture approach -- mirrors open_archive_tests.cpp's
+// testManifestSidePreservedReadOnly exactly): a manifest declaring containerVersion {1,1} over an
+// otherwise valid {1,0} document classifies PreservedReadOnlyRequired on the manifest side.
+[[nodiscard]] std::vector<std::byte> buildManifestSidePreservedReadOnlyArchiveOrAbort() {
+    const std::string manifestText =
+        R"({"format":"org.kinetik.bloom.project","containerVersion":{"major":1,"minor":1},)"
+        R"("document":{"path":"document.json","schemaVersion":{"major":1,"minor":0}},)"
+        R"("requirements":[]})";
+    std::vector<std::byte> manifestBytes(manifestText.size());
+    std::memcpy(manifestBytes.data(), manifestText.data(), manifestText.size());
+    const auto documentBytes = minimalCanonicalDocumentBytesOrAbort();
+
+    auto manifestEntry = makeStoredEntry("manifest.json", manifestBytes);
+    auto documentEntry = makeStoredEntry("document.json", documentBytes);
+    return buildConformingArchive(manifestEntry, documentEntry);
+}
+
+[[nodiscard]] const SessionInstallStatus* installedStatus(const SessionOpenResult& result) {
+    const auto* outcome = result.installOutcome();
+    return outcome != nullptr ? std::get_if<SessionInstallStatus>(outcome) : nullptr;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Full cycle: build session A -> edit -> save -> read published bytes -> openSessionArchive into
+// the SAME session -> Installed; fresh generations, clean at new baseline, not dirty, displayPath
+// set, undo history empty. Then edit + save again -> reopen -> content identical both hops.
+// ---------------------------------------------------------------------------------------------
+
+void testFullCycleSessionFileSession(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "full cycle: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    auto session = makeDecodedSession(expectations, identitySource, "Full Cycle Project");
+    expectations.expect(session.execute(rename("First Hop", session)).changed(),
+                        "full cycle: the first edit commits");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "full cycle: Save As advances path authority");
+    if (!saveAs) {
+        return;
+    }
+    const SessionSaveRequest firstSaveRequest{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto firstSaved =
+        saveProjectSession(session, *coordinator, *artifacts, firstSaveRequest, makeOperation());
+    expectations.expect(static_cast<bool>(firstSaved), "full cycle: the first save fully succeeds");
+    if (!firstSaved) {
+        return;
+    }
+
+    const auto firstPublishedBytes = readFile(targetPath);
+    expectations.expect(!firstPublishedBytes.empty(), "full cycle: the published file has bytes");
+
+    const auto beforeReopen = session.stateSnapshot();
+    const auto reopenPath = ProjectDisplayPath::create(targetPath);
+    expectations.expect(reopenPath.has_value(), "full cycle: the reopen display path constructs");
+    if (!reopenPath.has_value()) {
+        return;
+    }
+
+    auto reopened = openSessionArchive(session, asBytes(firstPublishedBytes), reopenPath,
+                                       SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(reopened) &&
+                            reopened.stage() == SessionOpenStage::Installation,
+                        "full cycle: openSessionArchive installs the just-published bytes into "
+                        "the SAME session");
+    const auto* status = installedStatus(reopened);
+    expectations.expect(status != nullptr && *status == SessionInstallStatus::Installed,
+                        "full cycle: the install outcome names Installed verbatim");
+    expectations.expect(reopened.attemptedContentKind() ==
+                            ProjectSessionContentKind::DecodedDocument,
+                        "full cycle: the attempted content kind names DecodedDocument");
+
+    const auto afterReopen = session.stateSnapshot();
+    // openIntentGeneration_ advances via admitOpenIntent() -- called unconditionally as
+    // openSessionArchive()'s first step -- so it is compared separately from the other
+    // generations below rather than folded into the "content untouched otherwise" checks.
+    expectations.expect(afterReopen.openIntentGeneration.value() ==
+                            beforeReopen.openIntentGeneration.value() + 1,
+                        "full cycle: admission advances OpenIntentGeneration exactly once");
+    expectations.expect(afterReopen.resultAcceptanceGeneration !=
+                                beforeReopen.resultAcceptanceGeneration &&
+                            afterReopen.pathIntentGeneration != beforeReopen.pathIntentGeneration,
+                        "full cycle: install advances both SessionResultAcceptanceGeneration and "
+                        "SessionPathIntentGeneration (fresh generations)");
+    expectations.expect(afterReopen.pathIntentKind == SessionPathIntentKind::ExistingPath &&
+                            !afterReopen.newestAcceptedPublicationIntent.isValid(),
+                        "full cycle: path authority resets to ExistingPath and the publication "
+                        "frontier clears");
+    expectations.expect(afterReopen.cleanRevision.has_value() &&
+                            afterReopen.currentRevision == afterReopen.cleanRevision &&
+                            afterReopen.dirty == false,
+                        "full cycle: clean at the fresh stack's baseline revision, not dirty");
+    expectations.expect(afterReopen.historySize == 0 && !afterReopen.canUndo &&
+                            !afterReopen.canRedo,
+                        "full cycle: undo history is empty");
+    expectations.expect(afterReopen.displayPath == reopenPath, "full cycle: displayPath is set");
+    expectations.expect(projectName(session) == "First Hop",
+                        "full cycle: the reopened content matches what was actually published "
+                        "(first hop)");
+
+    // Edit + save again -> reopen -> content identical both hops.
+    expectations.expect(session.execute(rename("Second Hop", session)).changed(),
+                        "full cycle: the second edit commits");
+    const auto plainIntent = session.capturePlainSavePathIntent();
+    expectations.expect(plainIntent.isValid() &&
+                            plainIntent.kind() == SessionPathIntentKind::ExistingPath,
+                        "full cycle: a plain-save intent captures existing-path authority after "
+                        "reopen");
+    std::optional<ArtifactTargetObservation> observedFingerprint;
+    {
+        auto peek =
+            artifacts->preflight({.targetPath = targetPath,
+                                  .overwritePolicy = ArtifactOverwritePolicy::ReplaceExisting,
+                                  .expectedTarget = std::nullopt});
+        expectations.expect(peek && peek.target()->observation().exists,
+                            "full cycle: preflight observes the published fingerprint");
+        if (!peek) {
+            return;
+        }
+        observedFingerprint = peek.target()->observation();
+    }
+    const SessionSaveRequest secondSaveRequest{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::ReplaceExisting,
+        .expectedTarget = observedFingerprint,
+        .limits = {},
+        .intent = plainIntent,
+    };
+    auto secondSaved =
+        saveProjectSession(session, *coordinator, *artifacts, secondSaveRequest, makeOperation());
+    expectations.expect(static_cast<bool>(secondSaved),
+                        "full cycle: the second save fully succeeds");
+    if (!secondSaved) {
+        return;
+    }
+    const auto secondPublishedBytes = readFile(targetPath);
+
+    auto secondReopened = openSessionArchive(session, asBytes(secondPublishedBytes), reopenPath,
+                                             SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(secondReopened),
+                        "full cycle: the second reopen also installs");
+    expectations.expect(projectName(session) == "Second Hop",
+                        "full cycle: content is identical both hops -- the second reopen reflects "
+                        "exactly what was published the second time");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Round-tripped newer minor survives session->file->session->file: a spliced {1,1} archive with
+// one unknown root member (built directly, mirroring open_archive_tests.cpp's
+// testOpenRoundTrippedNewerMinorRoundTrip fixture) is opened into a session, saved, reopened
+// again through the SAME pipeline, and saved once more -- the two published files must be
+// byte-identical and both must still carry the unknown member.
+// ---------------------------------------------------------------------------------------------
+
+void testRoundTrippedNewerMinorSurvivesFullCycle(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "round-tripped cycle: fixture is available");
+        return;
+    }
+    const auto firstTarget = directory.path() / "first.bloom";
+    const auto secondTarget = directory.path() / "second.bloom";
+
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    expectations.expect(duration.has_value(), "round-tripped cycle: fixture duration constructs");
+    if (!duration.has_value()) {
+        return;
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document sourceDocument{std::move(newProject.project)};
+    auto sourceSnapshot = sourceDocument.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    const CanonicalDocumentV1 baselineRequest{.snapshot = &sourceSnapshot,
+                                              .colorSettings = &colorSettings,
+                                              .payloadScratch = payloadScratch,
+                                              .sortScratch = sortScratch};
+    const auto size = canonicalDocumentSize(baselineRequest);
+    expectations.expect(static_cast<bool>(size), "round-tripped cycle: baseline document sizes");
+    if (!size) {
+        return;
+    }
+    std::string text(*size.value(), '\0');
+    const auto written =
+        encodeCanonicalDocument(baselineRequest, std::span<char>(text.data(), text.size()));
+    expectations.expect(static_cast<bool>(written),
+                        "round-tripped cycle: baseline document encodes");
+    if (!written) {
+        return;
+    }
+    const std::string anchor = "\"minor\": 0\n  },\n  \"project\"";
+    const auto anchorPos = text.find(anchor);
+    expectations.expect(anchorPos != std::string::npos,
+                        "round-tripped cycle: root schemaVersion anchor is located");
+    if (anchorPos == std::string::npos) {
+        return;
+    }
+    text.replace(anchorPos, std::string_view("\"minor\": 0").size(), "\"minor\": 1");
+    expectations.expect(text.size() >= 2 && text.back() == '\n' && text[text.size() - 2] == '}',
+                        "round-tripped cycle: baseline ends with the root's closing brace");
+    if (text.size() < 2 || text.back() != '\n' || text[text.size() - 2] != '}') {
+        return;
+    }
+    text.resize(text.size() - 2);
+    text += R"(,"zzzFutureField":42})";
+    text += '\n';
+
+    auto parsed = parseStrictJsonDom(asBytes(text), {}, makeOperation());
+    expectations.expect(static_cast<bool>(parsed), "round-tripped cycle: spliced document parses");
+    if (!parsed) {
+        return;
+    }
+    DocumentDecodeResult decoded = decodeDocumentEnvelope(parsed.document()->root());
+    expectations.expect(decoded.outcome() == DocumentDecodeOutcome::Decoded &&
+                            decoded.value() != nullptr && decoded.roundTrip() != nullptr,
+                        "round-tripped cycle: spliced document decodes with round-trip state");
+    if (decoded.value() == nullptr || decoded.roundTrip() == nullptr) {
+        return;
+    }
+    auto reconstructed = bloom::project::reconstructDocument(*decoded.value());
+    expectations.expect(static_cast<bool>(reconstructed),
+                        "round-tripped cycle: spliced document reconstructs");
+    if (!reconstructed) {
+        return;
+    }
+    auto reconstructedSnapshot = reconstructed.value()->document->snapshot();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 1}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &reconstructedSnapshot,
+                                            .colorSettings = &reconstructed.value()->colorSettings,
+                                            .roundTrip = decoded.roundTrip(),
+                                            .schemaMinor = 1};
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built), "round-tripped cycle: fixture archive builds");
+    if (!built) {
+        return;
+    }
+    const auto fixtureBytes = built.archive()->bytes();
+
+    // "session" (via Open) -> "file" hop 1.
+    ProjectSessionIdentitySource sessionIdentitySource;
+    auto session = makeDecodedSession(expectations, sessionIdentitySource, "Round-Trip Host");
+    const auto firstPath = ProjectDisplayPath::create(firstTarget);
+    expectations.expect(firstPath.has_value(), "round-tripped cycle: first target path constructs");
+    if (!firstPath.has_value()) {
+        return;
+    }
+    auto openedFirst =
+        openSessionArchive(session, fixtureBytes, firstPath, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(
+        static_cast<bool>(openedFirst),
+        "round-tripped cycle: openSessionArchive installs the round-tripped fixture");
+    if (!openedFirst) {
+        return;
+    }
+    const SessionSaveRequest firstSaveRequest{
+        .targetPath = firstTarget,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = session.capturePlainSavePathIntent(),
+    };
+    auto firstSaved =
+        saveProjectSession(session, *coordinator, *artifacts, firstSaveRequest, makeOperation());
+    expectations.expect(static_cast<bool>(firstSaved),
+                        "round-tripped cycle: the first save (session->file hop 1) fully succeeds");
+    if (!firstSaved) {
+        return;
+    }
+    const auto firstFileBytes = readFile(firstTarget);
+
+    // "file" -> "session" hop 2 (reopen through the SAME pipeline under test).
+    auto openedSecond = openSessionArchive(session, asBytes(firstFileBytes), firstPath,
+                                           SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(openedSecond),
+                        "round-tripped cycle: the second openSessionArchive reinstalls the "
+                        "just-published round-tripped bytes");
+
+    // "session" -> "file" hop 2.
+    const SessionSaveRequest secondSaveRequest{
+        .targetPath = secondTarget,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = session.capturePlainSavePathIntent(),
+    };
+    auto secondSaved =
+        saveProjectSession(session, *coordinator, *artifacts, secondSaveRequest, makeOperation());
+    expectations.expect(
+        static_cast<bool>(secondSaved),
+        "round-tripped cycle: the second save (session->file hop 2) fully succeeds");
+    if (!secondSaved) {
+        return;
+    }
+    const auto secondFileBytes = readFile(secondTarget);
+
+    expectations.expect(firstFileBytes == secondFileBytes,
+                        "round-tripped cycle: session->file->session->file reproduces "
+                        "byte-identical files");
+
+    // The published archive is a ZIP container, not raw JSON -- reopen it through
+    // openProjectArchive() itself to inspect the round-tripped member the same way
+    // open_archive_tests.cpp does.
+    auto reopenedArchive =
+        openProjectArchive(asBytes(secondFileBytes), SaveArchiveLimits{}, makeOperation());
+    expectations.expect(reopenedArchive.outcome() == OpenArchiveOutcome::Opened,
+                        "round-tripped cycle: the final published file reopens as Opened");
+    if (reopenedArchive.outcome() != OpenArchiveOutcome::Opened) {
+        return;
+    }
+    auto finalValue = std::move(reopenedArchive).takeOpened();
+    expectations.expect(
+        finalValue.schemaMinor == 1,
+        "round-tripped cycle: the final published file still declares schemaMinor 1");
+    expectations.expect(
+        finalValue.roundTrip.has_value(),
+        "round-tripped cycle: the final published file still carries RoundTripState");
+    if (!finalValue.roundTrip.has_value()) {
+        return;
+    }
+    const auto* members = finalValue.roundTrip->find(RoundTripAttachmentPath{});
+    expectations.expect(members != nullptr && members->size() == 1 &&
+                            (*members)[0].key() == "zzzFutureField",
+                        "round-tripped cycle: the unknown root member survives session->file->"
+                        "session->file exactly");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Edit-during-open refusal: admit intent, execute a transaction (and separately: an undo), then
+// attempt install -> RevisionChanged; session state (revision, dirty, history) untouched.
+// ---------------------------------------------------------------------------------------------
+
+void testEditDuringOpenRefusal(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+
+    // A successful edit after admission.
+    {
+        auto session = makeDecodedSession(expectations, identitySource, "Edit During Open");
+        const auto admission = session.admitOpenIntent();
+        expectations.expect(static_cast<bool>(admission), "edit during open: admission succeeds");
+        if (!admission) {
+            return;
+        }
+        const auto intent = admission.capture();
+        expectations.expect(session.execute(rename("Edited While Open", session)).changed(),
+                            "edit during open: the edit commits while Open is pending");
+
+        auto content = takeDecodedContent(expectations, buildMinimalArchiveBytesOrAbort(),
+                                          "edit during open: replacement content builds");
+        if (!content.has_value()) {
+            return;
+        }
+        const auto before = session.stateSnapshot();
+        const auto status = session.installDecodedReplacement(intent, std::move(*content));
+        expectations.expect(
+            status == SessionInstallStatus::RevisionChanged,
+            "edit during open: a successful edit refuses install as RevisionChanged");
+        const auto after = session.stateSnapshot();
+        expectations.expect(
+            after.currentRevision == before.currentRevision &&
+                after.cleanRevision == before.cleanRevision && after.dirty == before.dirty &&
+                after.historySize == before.historySize && after.canUndo == before.canUndo &&
+                after.canRedo == before.canRedo && after.displayPath == before.displayPath &&
+                after.resultAcceptanceGeneration == before.resultAcceptanceGeneration,
+            "edit during open: revision, dirty state, and history are untouched by "
+            "the refused install");
+    }
+
+    // Undo after admission (a newer revision even though content reverts).
+    {
+        auto session = makeDecodedSession(expectations, identitySource, "Undo During Open");
+        expectations.expect(session.execute(rename("Baseline Edit", session)).changed(),
+                            "undo during open: the baseline edit commits");
+        const auto admission = session.admitOpenIntent();
+        expectations.expect(static_cast<bool>(admission), "undo during open: admission succeeds");
+        if (!admission) {
+            return;
+        }
+        const auto intent = admission.capture();
+        const auto undoResult = session.undo();
+        expectations.expect(undoResult.changed(), "undo during open: the undo commits");
+
+        auto content = takeDecodedContent(expectations, buildMinimalArchiveBytesOrAbort(),
+                                          "undo during open: replacement content builds");
+        if (!content.has_value()) {
+            return;
+        }
+        const auto before = session.stateSnapshot();
+        const auto status = session.installDecodedReplacement(intent, std::move(*content));
+        expectations.expect(status == SessionInstallStatus::RevisionChanged,
+                            "undo during open: undo (a newer monotonic revision) also refuses "
+                            "install as RevisionChanged");
+        const auto after = session.stateSnapshot();
+        expectations.expect(after.currentRevision == before.currentRevision &&
+                                after.dirty == before.dirty && after.canRedo == before.canRedo,
+                            "undo during open: session state is untouched by the refused install");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Stale intent: admit twice, install with the first capture -> StaleOpenIntent.
+// Acceptance mismatch: install a capture taken before a successful prior install ->
+// AcceptanceMismatch. Documented gate order (see checkInstallAcceptanceGates() in
+// project_session.cpp): the three acceptance gates are orthogonal (generation+contentKind,
+// resultAcceptance, decoded revision), so this scenario is deterministically AcceptanceMismatch,
+// not StaleOpenIntent, under this implementation's gate order -- pinned here rather than left
+// ambiguous.
+// ---------------------------------------------------------------------------------------------
+
+void testStaleOpenIntent(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = makeDecodedSession(expectations, identitySource, "Stale Open Intent");
+    const auto first = session.admitOpenIntent();
+    const auto second = session.admitOpenIntent();
+    expectations.expect(static_cast<bool>(first) && static_cast<bool>(second),
+                        "stale intent: both admissions succeed");
+    if (!first || !second) {
+        return;
+    }
+    auto content = takeDecodedContent(expectations, buildMinimalArchiveBytesOrAbort(),
+                                      "stale intent: replacement content builds");
+    if (!content.has_value()) {
+        return;
+    }
+    const auto before = session.stateSnapshot();
+    const auto status = session.installDecodedReplacement(first.capture(), std::move(*content));
+    expectations.expect(status == SessionInstallStatus::StaleOpenIntent,
+                        "stale intent: installing with the superseded first capture is refused as "
+                        "StaleOpenIntent");
+    const auto after = session.stateSnapshot();
+    expectations.expect(after.resultAcceptanceGeneration == before.resultAcceptanceGeneration &&
+                            after.pathIntentGeneration == before.pathIntentGeneration &&
+                            after.contentKind == before.contentKind,
+                        "stale intent: the refused install leaves the session's identity/content "
+                        "state untouched");
+}
+
+void testAcceptanceMismatch(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = makeDecodedSession(expectations, identitySource, "Acceptance Mismatch");
+    const auto firstAdmission = session.admitOpenIntent();
+    expectations.expect(static_cast<bool>(firstAdmission),
+                        "acceptance mismatch: admission succeeds");
+    if (!firstAdmission) {
+        return;
+    }
+    const auto firstCapture = firstAdmission.capture();
+
+    auto priorContent = takeDecodedContent(expectations, buildMinimalArchiveBytesOrAbort("Prior"),
+                                           "acceptance mismatch: prior replacement content builds");
+    if (!priorContent.has_value()) {
+        return;
+    }
+    const auto priorStatus =
+        session.installDecodedReplacement(firstCapture, std::move(*priorContent));
+    expectations.expect(priorStatus == SessionInstallStatus::Installed,
+                        "acceptance mismatch: the prior install (using the still-current first "
+                        "capture) succeeds -- installation never advances OpenIntentGeneration");
+
+    auto secondContent =
+        takeDecodedContent(expectations, buildMinimalArchiveBytesOrAbort("Second"),
+                           "acceptance mismatch: second replacement content builds");
+    if (!secondContent.has_value()) {
+        return;
+    }
+    const auto before = session.stateSnapshot();
+    const auto status = session.installDecodedReplacement(firstCapture, std::move(*secondContent));
+    expectations.expect(
+        status == SessionInstallStatus::AcceptanceMismatch,
+        "acceptance mismatch: reusing the same (now result-acceptance-stale) first "
+        "capture after a successful prior install is refused as AcceptanceMismatch, "
+        "not StaleOpenIntent");
+    const auto after = session.stateSnapshot();
+    expectations.expect(
+        after.resultAcceptanceGeneration == before.resultAcceptanceGeneration &&
+            projectName(session) == "Prior",
+        "acceptance mismatch: the refused second install leaves the PRIOR install's "
+        "content in place");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Preserved-read-only install: a {1,1}-container archive -> Installed as preserved-read-only;
+// stateSnapshot shows PreservedReadOnly kind; subsequent captureSaveInput -> ReadOnly; execute ->
+// ReadOnly.
+// ---------------------------------------------------------------------------------------------
+
+void testPreservedReadOnlyInstall(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = makeDecodedSession(expectations, identitySource, "Preserved RO Host");
+    const auto archiveBytes = buildManifestSidePreservedReadOnlyArchiveOrAbort();
+    const auto path = ProjectDisplayPath::create("preserved.bloom");
+    expectations.expect(path.has_value(), "preserved-ro install: fixture path constructs");
+    if (!path.has_value()) {
+        return;
+    }
+
+    auto result =
+        openSessionArchive(session, archiveBytes, path, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(result),
+                        "preserved-ro install: openSessionArchive installs the manifest-side "
+                        "preserved archive");
+    expectations.expect(result.attemptedContentKind() ==
+                            ProjectSessionContentKind::PreservedReadOnly,
+                        "preserved-ro install: the attempted content kind names PreservedReadOnly");
+    const auto* preservation = result.preservedReadOnly();
+    expectations.expect(
+        preservation != nullptr && preservation->side == OpenArchivePreservedReadOnlySide::Manifest,
+        "preserved-ro install: the preservation diagnostics carry the manifest side "
+        "verbatim");
+
+    const auto snapshot = session.stateSnapshot();
+    expectations.expect(snapshot.contentKind == ProjectSessionContentKind::PreservedReadOnly &&
+                            snapshot.displayPath == path,
+                        "preserved-ro install: stateSnapshot shows PreservedReadOnly content kind "
+                        "and the installed path");
+
+    const auto plainIntent = session.capturePlainSavePathIntent();
+    expectations.expect(!plainIntent.isValid(),
+                        "preserved-ro install: no native plain-save intent can be captured");
+    const auto saveInputResult = session.captureSaveInput(plainIntent);
+    expectations.expect(saveInputResult.status() == SessionSaveInputStatus::ReadOnly,
+                        "preserved-ro install: captureSaveInput reports ReadOnly");
+
+    Transaction blocked("Blocked Edit");
+    blocked.emplace<SetProjectName>("Must not apply");
+    expectations.expect(session.execute(std::move(blocked)).status ==
+                            bloom::host::ProjectSessionCommandStatus::ReadOnly,
+                        "preserved-ro install: execute reports ReadOnly");
+}
+
+// A pathless preserved-read-only install is refused as typed InvalidContent
+// (createPreservedReadOnly requires a path too): session untouched, no install*() call is ever
+// made.
+void testPathlessPreservedReadOnlyRefused(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = makeDecodedSession(expectations, identitySource, "Pathless Preserved");
+    const auto before = session.stateSnapshot();
+    const auto archiveBytes = buildManifestSidePreservedReadOnlyArchiveOrAbort();
+
+    auto result = openSessionArchive(session, archiveBytes, std::nullopt, SaveArchiveLimits{},
+                                     makeOperation());
+    expectations.expect(!static_cast<bool>(result) &&
+                            result.stage() == SessionOpenStage::Installation,
+                        "pathless preserved: refused at the Installation stage");
+    const auto* status = installedStatus(result);
+    expectations.expect(status != nullptr && *status == SessionInstallStatus::InvalidContent,
+                        "pathless preserved: the install outcome names InvalidContent");
+    expectations.expect(result.preservedReadOnly() != nullptr,
+                        "pathless preserved: preservation diagnostics are still carried verbatim "
+                        "for the caller");
+
+    const auto after = session.stateSnapshot();
+    expectations.expect(after.contentKind == before.contentKind &&
+                            after.resultAcceptanceGeneration == before.resultAcceptanceGeneration &&
+                            after.displayPath == before.displayPath,
+                        "pathless preserved: the session is untouched (installPreservedReadOnly"
+                        "Replacement() was never called)");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Pending Save As cancelled by install: advance Save As, then install -> path intent back to
+// ExistingPath at a new generation; the old Save As capture is stale for both save and
+// abandonment.
+// ---------------------------------------------------------------------------------------------
+
+void testPendingSaveAsCancelledByInstall(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = makeDecodedSession(expectations, identitySource, "Pending Save As");
+    const auto admission = session.admitOpenIntent();
+    expectations.expect(static_cast<bool>(admission), "pending save as: admission succeeds");
+    if (!admission) {
+        return;
+    }
+    const auto intent = admission.capture();
+
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "pending save as: Save As advances");
+    if (!saveAs) {
+        return;
+    }
+    const auto pathGenerationBefore = session.stateSnapshot().pathIntentGeneration;
+
+    auto content = takeDecodedContent(expectations, buildMinimalArchiveBytesOrAbort(),
+                                      "pending save as: replacement content builds");
+    if (!content.has_value()) {
+        return;
+    }
+    const auto status = session.installDecodedReplacement(intent, std::move(*content));
+    expectations.expect(status == SessionInstallStatus::Installed,
+                        "pending save as: install succeeds despite the pending Save As phase");
+
+    const auto after = session.stateSnapshot();
+    expectations.expect(after.pathIntentKind == SessionPathIntentKind::ExistingPath &&
+                            after.pathIntentGeneration != pathGenerationBefore,
+                        "pending save as: path intent resets to ExistingPath at a new generation");
+
+    const auto saveInputResult = session.captureSaveInput(saveAs.capture());
+    expectations.expect(saveInputResult.status() == SessionSaveInputStatus::StaleIntent,
+                        "pending save as: the old Save As capture is stale for save");
+    expectations.expect(session.abandonSaveAsIntent(saveAs.capture()) ==
+                            SessionPathIntentAbandonStatus::StaleIntent,
+                        "pending save as: the old Save As capture is stale for abandonment too");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Open failure leaves session untouched: corrupt bytes -> Opening-stage failure. Content-bearing
+// stateSnapshot fields are compared before/after; OpenIntentGeneration is compared SEPARATELY and
+// is EXPECTED to advance by exactly one -- admission always consumes a generation for a new
+// desired Open, whether or not that Open goes on to succeed (docs/architecture/project-session.md,
+// "Open Intent": "A newer Open cancels or supersedes every older queued/running Open").
+// ---------------------------------------------------------------------------------------------
+
+void testOpenFailureLeavesSessionUntouched(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = makeDecodedSession(expectations, identitySource, "Corrupt Open");
+    expectations.expect(session.execute(rename("Before Corrupt Open", session)).changed(),
+                        "open failure: a baseline edit commits");
+    const auto before = session.stateSnapshot();
+
+    auto corrupted = buildMinimalArchiveBytesOrAbort();
+    expectations.expect(corrupted.size() > 4, "open failure: fixture archive has bytes to corrupt");
+    for (auto& byte : corrupted) {
+        byte ^= std::byte{0xFF};
+    }
+
+    auto result =
+        openSessionArchive(session, corrupted, std::nullopt, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(!static_cast<bool>(result) && result.stage() == SessionOpenStage::Opening,
+                        "open failure: corrupt bytes fail at the Opening stage");
+    expectations.expect(result.openingFailure() != nullptr,
+                        "open failure: the wrapped SaveArchiveFailure is present");
+
+    const auto after = session.stateSnapshot();
+    expectations.expect(after.openIntentGeneration.value() ==
+                            before.openIntentGeneration.value() + 1,
+                        "open failure: admission still advances OpenIntentGeneration exactly once");
+    expectations.expect(
+        after.resultAcceptanceGeneration == before.resultAcceptanceGeneration &&
+            after.pathIntentGeneration == before.pathIntentGeneration &&
+            after.pathIntentKind == before.pathIntentKind &&
+            after.contentKind == before.contentKind &&
+            after.currentRevision == before.currentRevision &&
+            after.cleanRevision == before.cleanRevision && after.dirty == before.dirty &&
+            after.historySize == before.historySize && after.canUndo == before.canUndo &&
+            after.canRedo == before.canRedo && after.displayPath == before.displayPath &&
+            after.newestAcceptedPublicationIntent == before.newestAcceptedPublicationIntent,
+        "open failure: every content-bearing field of stateSnapshot is untouched (no install*() "
+        "call is ever made on this path)");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Budget exhaustion pass-through: a budget too small for openProjectArchive()'s own chain still
+// fails somewhere in that composed chain, reported verbatim at the Opening stage; the session
+// stays untouched.
+// ---------------------------------------------------------------------------------------------
+
+void testBudgetExhaustionPassThrough(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    auto session = makeDecodedSession(expectations, identitySource, "Budget Exhaustion");
+    const auto archiveBytes = buildMinimalArchiveBytesOrAbort();
+
+    constexpr std::uint64_t kTinyBudget = 512;
+    auto tinyCoordinator = ProjectIoMemoryCoordinator::create(kTinyBudget);
+    expectations.expect(tinyCoordinator.has_value(),
+                        "budget exhaustion: tiny coordinator constructs");
+    if (!tinyCoordinator.has_value()) {
+        return;
+    }
+    auto tinyOperation = tinyCoordinator->createOperation(kTinyBudget, kTinyBudget);
+    expectations.expect(tinyOperation.has_value(), "budget exhaustion: tiny operation constructs");
+    if (!tinyOperation.has_value()) {
+        return;
+    }
+
+    const auto before = session.stateSnapshot();
+    auto result = openSessionArchive(session, archiveBytes, std::nullopt, SaveArchiveLimits{},
+                                     std::move(*tinyOperation));
+    expectations.expect(
+        !static_cast<bool>(result) && result.stage() == SessionOpenStage::Opening,
+        "budget exhaustion: a too-small operation budget still fails at the Opening "
+        "stage, reported verbatim");
+    const auto after = session.stateSnapshot();
+    expectations.expect(after.resultAcceptanceGeneration == before.resultAcceptanceGeneration &&
+                            after.currentRevision == before.currentRevision,
+                        "budget exhaustion: the session is untouched");
+    expectations.expect(tinyCoordinator->snapshot().currentBytes == 0,
+                        "budget exhaustion: the constrained coordinator's charge returns to zero");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Determinism: two independently-built sessions opening the SAME archive bytes install
+// byte-identical content -- proven by re-saving each and comparing the published files.
+// ---------------------------------------------------------------------------------------------
+
+void testDeterminism(Expectations& expectations) {
+    TempDirectory directoryA;
+    TempDirectory directoryB;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directoryA.isValid() || !directoryB.isValid() || !coordinator.has_value() ||
+        !artifacts.has_value()) {
+        expectations.expect(false, "determinism: fixture is available");
+        return;
+    }
+    const auto archiveBytes = buildMinimalArchiveBytesOrAbort("Determinism Source");
+
+    auto sessionA = makeDecodedSession(expectations, identitySource, "Determinism Host A");
+    auto sessionB = makeDecodedSession(expectations, identitySource, "Determinism Host B");
+    auto resultA = openSessionArchive(sessionA, archiveBytes, std::nullopt, SaveArchiveLimits{},
+                                      makeOperation());
+    auto resultB = openSessionArchive(sessionB, archiveBytes, std::nullopt, SaveArchiveLimits{},
+                                      makeOperation());
+    expectations.expect(static_cast<bool>(resultA) && static_cast<bool>(resultB),
+                        "determinism: both independent opens install");
+    expectations.expect(projectName(sessionA) == projectName(sessionB) &&
+                            projectName(sessionA) == "Determinism Source",
+                        "determinism: both installed sessions decode identical content");
+
+    const auto targetA = directoryA.path() / "project.bloom";
+    const auto targetB = directoryB.path() / "project.bloom";
+    const SessionSaveRequest requestA{
+        .targetPath = targetA,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = sessionA.capturePlainSavePathIntent().isValid()
+                      ? sessionA.capturePlainSavePathIntent()
+                      : sessionA.advancePathIntentForSaveAs().capture(),
+    };
+    const SessionSaveRequest requestB{
+        .targetPath = targetB,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = sessionB.capturePlainSavePathIntent().isValid()
+                      ? sessionB.capturePlainSavePathIntent()
+                      : sessionB.advancePathIntentForSaveAs().capture(),
+    };
+    auto savedA = saveProjectSession(sessionA, *coordinator, *artifacts, requestA, makeOperation());
+    auto savedB = saveProjectSession(sessionB, *coordinator, *artifacts, requestB, makeOperation());
+    expectations.expect(static_cast<bool>(savedA) && static_cast<bool>(savedB),
+                        "determinism: both re-saves fully succeed");
+
+    const auto bytesA = readFile(targetA);
+    const auto bytesB = readFile(targetB);
+    expectations.expect(!bytesA.empty() && bytesA == bytesB,
+                        "determinism: two independent openSessionArchive+save cycles of identical "
+                        "archive bytes produce byte-identical published files");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testFullCycleSessionFileSession(expectations);
+        testRoundTrippedNewerMinorSurvivesFullCycle(expectations);
+        testEditDuringOpenRefusal(expectations);
+        testStaleOpenIntent(expectations);
+        testAcceptanceMismatch(expectations);
+        testPreservedReadOnlyInstall(expectations);
+        testPathlessPreservedReadOnlyRefused(expectations);
+        testPendingSaveAsCancelledByInstall(expectations);
+        testOpenFailureLeavesSessionUntouched(expectations);
+        testBudgetExhaustionPassThrough(expectations);
+        testDeterminism(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "FAILED: unexpected fixture exception: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Closes #65.

Session replacement installation — an opened archive (#64) now installs into a live session atomically, completing the Open half of the session lane. The headline test is the full loop: **session → edit → save → open the published bytes into the same session → edit → save → reopen**, content identical both hops, round-trip state surviving every one — newer-minor variant included.

**Three orthogonal gates, all before any mutation**: open-intent identity (stale), result-acceptance match (mismatch), and the exact captured revision — so the contract's edit-during-Open refusal reports `RevisionChanged` with the current project untouched, never silently discarded. The existing bundled intent predicate is deliberately untouched: driving the gates through it would have collapsed the revision refusal into staleness.

**Atomic with the strong exception guarantee**: generation-exhaustion boundaries and the single allocation precede the first state change; then acceptance advances, content and save-side values replace, path authority resets (cancelling any pending Save As per the contract), the clean baseline becomes the fresh stack's revision, and the opened archive's memory reservations transfer into the session — charge follows residency.

**Preserved-read-only** classifications install as read-only sessions carrying the display path; native save and editing refuse afterwards; the caller retains the original bytes for Save Copy.

Testing: eleven functions covering the full cycle, both during-open refusal shapes, distinct gate pins, Save As cancellation, failure state-equality, budget, and determinism — with an early fixture's boundary violation caught by the repository's own architecture check and resolved per precedent. Full ci-linux-native suite 67/67 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).