### PR TITLE
feat: give new projects Bloom Neutral color

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # the intake contract binds their exact bytes to SHA-256 records.
 dependencies/unicode/** -text
 dependencies/licenses/** -text
+assets/ocio/** -text

--- a/assets/ocio/neutral-v1/config.ocio
+++ b/assets/ocio/neutral-v1/config.ocio
@@ -1,0 +1,26 @@
+ocio_profile_version: 2
+
+roles:
+  scene_linear: lin_rec709_scene
+  default: lin_rec709_scene
+
+displays:
+  srgb_rec709_display:
+    - !<View> {name: srgb_rec709_display, colorspace: srgb_rec709_display}
+
+active_displays: [srgb_rec709_display]
+active_views: [srgb_rec709_display]
+
+colorspaces:
+  - !<ColorSpace>
+    name: lin_rec709_scene
+    interop_id: lin_rec709_scene
+    bitdepth: 32f
+    isdata: false
+
+  - !<ColorSpace>
+    name: srgb_rec709_display
+    interop_id: srgb_rec709_display
+    bitdepth: 32f
+    isdata: false
+    from_scene_reference: !<ExponentWithLinearTransform> {gamma: 2.4, offset: 0.055, direction: inverse}

--- a/assets/ocio/neutral-v1/provenance.md
+++ b/assets/ocio/neutral-v1/provenance.md
@@ -1,0 +1,94 @@
+# Bloom Neutral v1 OCIO Configuration Provenance
+
+Reviewed: 2026-08-29
+
+## Origin
+
+`config.ocio` in this directory is authored directly against
+`docs/architecture/color-management.md`'s Bloom Neutral v1 paragraph and Version 1 Decisions --
+it is not derived from, or a copy of, any third-party OCIO configuration. It is a minimal
+OpenColorIO v2 configuration written and validated against OpenColorIO 2.5.2 (the version this
+repository's documentation cites in its Primary References), using OCIO's native `interop_id`
+color-space field (introduced in the OpenColorIO 2.x line this repository targets) so that the
+two required Color Interop Forum identifiers are exact, unambiguous, machine-checkable mappings
+rather than a name, role, alias, or approximate-chromaticities substitute.
+
+## Exposed Color Interop IDs
+
+| Color-space name | `interop_id` | Role |
+| --- | --- | --- |
+| `lin_rec709_scene` | `lin_rec709_scene` | Scene-referred process reference space (`scene_linear` role); linear-light Rec.709 primaries, D65 white point |
+| `srgb_rec709_display` | `srgb_rec709_display` | Display/output space; sRGB (IEC 61966-2-1 EOTF) over Rec.709 primaries |
+
+Both interop IDs were confirmed round-trip-readable via `OCIO::Config::getColorSpace(name)
+.getInteropID()` against the exact checked-in bytes. Because the process reference space and the
+display space share identical Rec.709/D65 primaries, the display space's `from_scene_reference`
+transform is exactly the sRGB piecewise transfer function (`ExponentWithLinearTransform`, gamma
+2.4, offset 0.055, `direction: inverse`) with no primaries matrix -- an exact transform, not an
+approximate-chromaticities shortcut. Numerically verified against the closed-form sRGB OETF
+(`v = 12.92*l` at or below the 0.0031308 breakpoint, `v = 1.055*l^(1/2.4) - 0.055` above it) and
+its EOTF inverse: maximum observed float32 discrepancy 6.7e-6 across a 0..1 sample sweep on both
+`lin_rec709_scene -> srgb_rec709_display` and the reverse direction, consistent with float32
+rounding, not formula error.
+
+The config also validates cleanly under `OCIO::Config::validate()` on OpenColorIO 2.5.2: it
+declares exactly one display (`srgb_rec709_display`) with exactly one view
+(`srgb_rec709_display`), and the `scene_linear`/`default` roles both resolve to
+`lin_rec709_scene`.
+
+## Immutability
+
+Per `docs/architecture/color-management.md`: "Any content change requires a new built-in URI."
+The bytes of `config.ocio` in this directory are the durable identity bound to
+`bloom://ocio/neutral-v1/config.ocio` forever. A future revision to Bloom Neutral's transform,
+roles, or structure -- for any reason, including a defect found later -- MUST land at a new URI
+(e.g. `bloom://ocio/neutral-v2/config.ocio`) with its own directory and its own digest; this file
+is never edited in place once merged.
+
+## Digest
+
+Two SHA-256 values are recorded for this payload. Only the second is a durable value; the first
+is a reference identity of the raw bytes, useful for `sha256sum`-style spot checks, but it is NOT
+what `kBloomNeutralV1ConfigDigest` carries.
+
+**Plain payload SHA-256** (reference identity only, not a project-persisted value):
+
+```
+SHA-256(config.ocio bytes) = 6cb2d1460218958ffede3fb747f3a7d46d355ac0d3d5e6452eb9a5a47d63373f
+```
+
+Computed directly with `sha256sum assets/ocio/neutral-v1/config.ocio` over the exact checked-in
+632-byte payload (26 lines, ASCII-only, LF line endings, single trailing LF, no timestamps or
+environment references).
+
+**Doc-normative OCIO Content Revision Version 1 envelope digest** -- this is the value
+`kBloomNeutralV1ConfigDigest` (`src/host/include/bloom/host/bloom_neutral_profile.hpp`) actually
+carries, and the value `makeBloomNeutralColorSettingsV1()` installs into
+`OcioConfigReference.expectedRevision.digest`:
+
+```
+SHA-256("BloomOcioRevision\0" || u16(1) || u8(1) || u64(632) || config.ocio bytes)
+  = a6fc07c95cea14897b725992a179d35055cccce2ffaf719ca73b4a289c89eacf
+```
+
+Per `docs/architecture/color-management.md`'s "OCIO Content Revision Version 1": for a built-in
+payload, `expectedRevision.digest = SHA-256("BloomOcioRevision\0" || u16(1) || u8(locatorKind) ||
+u64(payloadByteCount) || exactPayloadBytes)`, with all integers unsigned big-endian. Here
+`u16(1)` is the revision format version, `u8(1)` is `locatorKind` 1 (immutable Bloom built-in, per
+the doc: "`locatorKind` is `1` for an immutable built-in"), and `u64(632)` is the exact byte count
+of `assets/ocio/neutral-v1/config.ocio`. This constant conforms to that formula exactly --
+`bloom.host.bloom-neutral-profile` (`src/host/tests/bloom_neutral_profile_tests.cpp`) rebuilds the
+envelope byte-for-byte from the checked-in asset and asserts equality with
+`kBloomNeutralV1ConfigDigest`, so a regression in the asset bytes, the envelope formula, or the
+constant is caught, not just a regression in the asset bytes alone.
+
+The repository `.gitattributes` marks `assets/ocio/**` `-text` so these digest-bound bytes are
+never line-ending normalized.
+
+## Status
+
+Authored and reviewed bytes for the version 1 durable Bloom Neutral profile, with a digest
+constant conforming to `docs/architecture/color-management.md`'s OCIO Content Revision Version 1
+formula. OCIO parsing, processor construction, transform execution, the built-in registry, and
+cross-platform qualification remain pending Batch 7 implementation per the color-management doc;
+this asset supplies only the frozen, checked-in payload and its doc-normative digest.

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
         FILE_SET HEADERS
         BASE_DIRS include
         FILES
+            include/bloom/host/bloom_neutral_profile.hpp
             include/bloom/host/project_session.hpp
             include/bloom/host/publication_coordinator.hpp
             include/bloom/host/save_publication.hpp
@@ -50,6 +51,19 @@ if(BUILD_TESTING)
         NAME bloom.host.project-session
         COMMAND bloom_host_project_session_test
         LABELS unit host project commands
+    )
+
+    # Offline drift guard for the immutable Bloom Neutral v1 built-in OCIO asset (issue #60):
+    # locates the repository root via --root exactly as tools/quality/dependency_artifact_checks'
+    # own bloom.quality.dependency_artifacts test does, rather than relying on an ambient working
+    # directory.
+    add_executable(bloom_host_bloom_neutral_profile_test tests/bloom_neutral_profile_tests.cpp)
+    target_link_libraries(bloom_host_bloom_neutral_profile_test PRIVATE bloom_host)
+    bloom_enable_warnings(bloom_host_bloom_neutral_profile_test)
+    bloom_add_test(
+        NAME bloom.host.bloom-neutral-profile
+        COMMAND bloom_host_bloom_neutral_profile_test --root "${PROJECT_SOURCE_DIR}"
+        LABELS unit host color quality
     )
 
     # Gated Linux-only exactly as bloom.project.staged_save is gated: this exercises a real

--- a/src/host/include/bloom/host/bloom_neutral_profile.hpp
+++ b/src/host/include/bloom/host/bloom_neutral_profile.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <bloom/core/sha256.hpp>
+
+namespace bloom::host {
+
+// The reviewed, checked-in content revision digest for the immutable Bloom Neutral v1 built-in
+// OCIO payload at assets/ocio/neutral-v1/config.ocio (durable locator
+// bloom::document::kBloomNeutralConfigUriV1, exactly "bloom://ocio/neutral-v1/config.ocio" --
+// see color_settings.hpp, which already owns that URI constant; it is not duplicated here).
+//
+// This is the doc-normative digest from docs/architecture/color-management.md's "OCIO Content
+// Revision Version 1" for a built-in payload -- an envelope hash, not a plain payload hash:
+//
+//   SHA-256("BloomOcioRevision\0" || u16(1) || u8(1) || u64(632) || exactPayloadBytes)
+//
+// where u16/u8/u64 are unsigned big-endian, `u8(1)` is locatorKind 1 (immutable built-in), and
+// `u64(632)` is the exact byte count of assets/ocio/neutral-v1/config.ocio. See
+// assets/ocio/neutral-v1/provenance.md for the full origin record, including the reference plain
+// payload SHA-256 and the derivation of this envelope value.
+//
+// The asset's bytes are immutable forever once merged: any future content change requires a new
+// built-in URI (a new assets/ocio/<name>/config.ocio directory) with its own digest constant,
+// never an edit of this value or the payload it names.
+//
+// bloom.host.bloom-neutral-profile (see tests/bloom_neutral_profile_tests.cpp) re-derives this
+// exact envelope from the checked-in payload through core::Sha256Hasher at test time -- verifying
+// the FORMULA, not just the payload bytes -- so the asset and this constant can never silently
+// drift apart.
+inline constexpr core::Sha256Digest kBloomNeutralV1ConfigDigest = core::Sha256Digest::fromBytes({{
+    0xa6, 0xfc, 0x07, 0xc9, 0x5c, 0xea, 0x14, 0x89, //
+    0x7b, 0x72, 0x59, 0x92, 0xa1, 0x79, 0xd3, 0x50, //
+    0x55, 0xcc, 0xcc, 0xe2, 0xff, 0xaf, 0x71, 0x9c, //
+    0xa7, 0x3b, 0x4a, 0x28, 0x9c, 0x89, 0xea, 0xcf, //
+}});
+
+} // namespace bloom::host

--- a/src/host/include/bloom/host/project_session.hpp
+++ b/src/host/include/bloom/host/project_session.hpp
@@ -296,8 +296,10 @@ struct DecodedProjectSessionRequest final {
     document::Project project;
     // REQUIRED for a decoded session: the canonical writer (project::CanonicalDocumentV1) takes
     // color settings as explicit caller input by contract -- bloom::document::Project does not
-    // itself own color settings. Unlike a brand-new project (see createNew()), a decoded project
-    // always has a real opened value to carry forward, so no synthesized default is needed here.
+    // itself own color settings. A decoded project always has a real opened value to carry
+    // forward here, unlike a brand-new project (see createNew()), which always synthesizes the
+    // immutable Bloom Neutral v1 built-in default (color_settings.hpp's
+    // makeBloomNeutralColorSettingsV1()) rather than accepting caller input.
     document::ColorSettings colorSettings;
     DecodedProjectEditability editability = DecodedProjectEditability::Editable;
     std::optional<ProjectDisplayPath> displayPath;
@@ -404,12 +406,15 @@ class [[nodiscard]] DecodedProjectSnapshotResult final {
 };
 
 // Typed statuses for ProjectSession::captureSaveInput(). ColorSettingsUnavailable is not part of
-// docs/architecture/project-session.md's normative text; it exists because a session installed
-// through createNew() has no color settings and no qualified build-profile default currently
-// exists to synthesize one (see color_settings.hpp's makeBloomNeutralColorSettingsV1(), which
-// requires a real caller-supplied content-revision digest). Rather than inventing a default, a
-// createNew() session is gated unsaveable-pending-color until a decoded/installed session
-// supplies real color settings -- see the implementor's report for the full reasoning.
+// docs/architecture/project-session.md's normative text. Historically it existed because a
+// session installed through createNew() had no color settings and no qualified build-profile
+// default to synthesize one; createNew() now always installs the immutable Bloom Neutral v1
+// built-in color settings (see color_settings.hpp's makeBloomNeutralColorSettingsV1() and
+// bloom_neutral_profile.hpp's kBloomNeutralV1ConfigDigest, issue #60), so a createNew() session
+// no longer reaches this status in practice. The enumerator and its captureSaveInput() gate stay
+// in place -- colorSettings_ remains std::optional on ProjectSession, and any future construction
+// path that installs decoded content without color settings would still be refused here rather
+// than silently saved with an absent/invalid value.
 enum class SessionSaveInputStatus : std::uint8_t {
     Captured,
     ReadOnly,
@@ -703,8 +708,12 @@ class ProjectSession final {
     std::optional<DecodedProjectEditability> editability_;
     std::optional<ProjectDisplayPath> displayPath_;
     std::optional<document::Revision> cleanRevision_;
-    // Absent for a createNew() session: see SessionSaveInputStatus::ColorSettingsUnavailable's
-    // comment above. Always present for a createDecoded() session (required by that request).
+    // Present for a createNew() session (the immutable Bloom Neutral v1 built-in, installed
+    // unconditionally -- see project_session.cpp's createNew()) and always present for a
+    // createDecoded() session (required by that request). Stays std::optional -- see
+    // SessionSaveInputStatus::ColorSettingsUnavailable's comment above -- because
+    // captureSaveInput() must still refuse cleanly rather than save an absent value if some
+    // future construction path is added that does not supply one.
     std::optional<document::ColorSettings> colorSettings_;
     std::optional<project::RoundTripState> roundTrip_;
     std::uint32_t schemaMinor_ = 0;

--- a/src/host/project_session.cpp
+++ b/src/host/project_session.cpp
@@ -1,6 +1,7 @@
 #include <bloom/host/project_session.hpp>
 
 #include <bloom/document/new_project.hpp>
+#include <bloom/host/bloom_neutral_profile.hpp>
 
 #include <exception>
 #include <limits>
@@ -131,16 +132,17 @@ ProjectSessionCreateResult ProjectSession::createNew(ProjectSessionIdentitySourc
         if (!projectSessionId.has_value()) {
             return ProjectSessionCreateResult(ProjectSessionCreateStatus::RuntimeIdentityExhausted);
         }
-        // No colorSettings/roundTrip/schemaMinor/retainedRequirements: a brand-new project has no
-        // qualified color-settings default to synthesize (see color_settings.hpp's
-        // makeBloomNeutralColorSettingsV1(), which requires a real caller-supplied content-
-        // revision digest that no build profile currently wires up here). The resulting session
-        // is gated unsaveable-pending-color -- see
-        // SessionSaveInputStatus::ColorSettingsUnavailable.
+        // A brand-new project installs the immutable Bloom Neutral v1 built-in color settings
+        // (docs/architecture/color-management.md: "New version 1 projects use the immutable
+        // built-in configuration Bloom Neutral v1"), keyed by the reviewed, checked-in
+        // kBloomNeutralV1ConfigDigest constant (bloom_neutral_profile.hpp) -- no roundTrip,
+        // schemaMinor stays 0, and retainedRequirements stays empty, exactly as for any other
+        // freshly authored (not reopened) document.
         return ProjectSessionCreateResult(
             ProjectSession(*projectSessionId, std::move(document), std::move(commandStack),
                            DecodedProjectEditability::Editable, cleanRevision, std::nullopt,
-                           std::nullopt, std::nullopt, 0, {}));
+                           document::makeBloomNeutralColorSettingsV1(kBloomNeutralV1ConfigDigest),
+                           std::nullopt, 0, {}));
     } catch (const std::bad_alloc&) {
         return ProjectSessionCreateResult(ProjectSessionCreateStatus::ResourceUnavailable);
     } catch (const std::logic_error&) {

--- a/src/host/tests/bloom_neutral_profile_tests.cpp
+++ b/src/host/tests/bloom_neutral_profile_tests.cpp
@@ -1,0 +1,165 @@
+#include <bloom/host/bloom_neutral_profile.hpp>
+
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Offline drift guard for the immutable Bloom Neutral v1 built-in OCIO asset (design decision 3
+// of the task package for issue #60, corrected per supervisor review to verify the doc-normative
+// formula rather than a plain payload hash): reads assets/ocio/neutral-v1/config.ocio from the
+// repository source tree, builds the exact "OCIO Content Revision Version 1" built-in envelope
+// from docs/architecture/color-management.md --
+//   SHA-256("BloomOcioRevision\0" || u16(1) || u8(locatorKind) || u64(payloadByteCount) ||
+//           exactPayloadBytes)
+// with locatorKind 1 (immutable built-in) and payloadByteCount the asset's exact size -- hashes
+// that envelope through the repository's own core::Sha256 surface, and asserts equality with the
+// frozen bloom::host::kBloomNeutralV1ConfigDigest constant. This verifies the FORMULA (domain
+// string, big-endian integer packing, locatorKind, byte count, payload), not just that the raw
+// asset bytes hash to something: a formula regression (wrong locatorKind, wrong endianness, a
+// dropped domain byte) would be caught even if the asset bytes themselves never changed.
+// Also pins the two exact Color Interop Forum colorspace names as a cheap textual check; full
+// OCIO parsing/validation is the runtime epic's job, not this package's (see
+// docs/architecture/color-management.md and assets/ocio/neutral-v1/provenance.md).
+//
+// Locates the repository root the same way tools/quality/repository_checks and
+// tools/quality/dependency_artifact_checks locate repository files: an explicit --root argument
+// supplied by CMake as ${PROJECT_SOURCE_DIR} (see src/host/CMakeLists.txt), not an ambient
+// working directory or environment variable.
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] std::optional<std::vector<std::byte>> readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream) {
+        return std::nullopt;
+    }
+    std::vector<char> chars((std::istreambuf_iterator<char>(stream)),
+                            std::istreambuf_iterator<char>());
+    std::vector<std::byte> bytes(chars.size());
+    for (std::size_t index = 0; index < chars.size(); ++index) {
+        bytes[index] = static_cast<std::byte>(chars[index]);
+    }
+    return bytes;
+}
+
+[[nodiscard]] std::string_view asStringView(const std::span<const std::byte> bytes) noexcept {
+    return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+void appendBytes(std::vector<std::byte>& out, const std::string_view text) {
+    for (const char character : text) {
+        out.push_back(static_cast<std::byte>(character));
+    }
+}
+
+void appendByte(std::vector<std::byte>& out, const std::uint8_t value) {
+    out.push_back(static_cast<std::byte>(value));
+}
+
+void appendU16BigEndian(std::vector<std::byte>& out, const std::uint16_t value) {
+    out.push_back(static_cast<std::byte>((value >> 8U) & 0xFFU));
+    out.push_back(static_cast<std::byte>(value & 0xFFU));
+}
+
+void appendU64BigEndian(std::vector<std::byte>& out, const std::uint64_t value) {
+    for (int shift = 56; shift >= 0; shift -= 8) {
+        out.push_back(static_cast<std::byte>((value >> static_cast<unsigned>(shift)) & 0xFFU));
+    }
+}
+
+// Builds docs/architecture/color-management.md's "OCIO Content Revision Version 1" built-in
+// envelope verbatim:
+//   "BloomOcioRevision\0" || u16(1) || u8(locatorKind) || u64(payloadByteCount) ||
+//   exactPayloadBytes
+// with locatorKind 1 (immutable built-in), per that section's exact byte layout.
+[[nodiscard]] std::vector<std::byte>
+buildBuiltInOcioRevisionEnvelope(const std::span<const std::byte> payload) {
+    std::vector<std::byte> envelope;
+    envelope.reserve(18 + 2 + 1 + 8 + payload.size());
+    appendBytes(envelope, "BloomOcioRevision");
+    appendByte(envelope, 0x00); // the domain string's explicit NUL terminator byte
+    appendU16BigEndian(envelope, 1);
+    constexpr std::uint8_t kBuiltInLocatorKind = 1;
+    appendByte(envelope, kBuiltInLocatorKind);
+    appendU64BigEndian(envelope, payload.size());
+    envelope.insert(envelope.end(), payload.begin(), payload.end());
+    return envelope;
+}
+
+void testBloomNeutralAssetDigestMatchesFrozenConstant(Expectations& expectations,
+                                                      const std::filesystem::path& repositoryRoot) {
+    const auto assetPath = repositoryRoot / "assets" / "ocio" / "neutral-v1" / "config.ocio";
+    const auto bytes = readFile(assetPath);
+    expectations.expect(bytes.has_value(), "the Bloom Neutral v1 asset file is readable");
+    if (!bytes.has_value()) {
+        return;
+    }
+
+    const auto envelope = buildBuiltInOcioRevisionEnvelope(*bytes);
+    const auto computed = bloom::core::Sha256Hasher::hash(envelope);
+    expectations.expect(computed.has_value(), "the envelope hashes within SHA-256's message limit");
+    if (!computed.has_value()) {
+        return;
+    }
+
+    expectations.expect(
+        *computed == bloom::host::kBloomNeutralV1ConfigDigest,
+        "the doc-normative BloomOcioRevision envelope built from the checked-in asset bytes "
+        "(domain string, u16(1), locatorKind 1, u64 payload length, exact payload) hashes to "
+        "exactly kBloomNeutralV1ConfigDigest -- asset, formula, and constant have not drifted "
+        "apart");
+
+    const auto text = asStringView(*bytes);
+    expectations.expect(
+        text.find(bloom::document::kProcessColorSpaceIdV1) != std::string_view::npos,
+        "the asset text contains the exact process Color Interop ID colorspace name "
+        "(lin_rec709_scene)");
+    expectations.expect(text.find("srgb_rec709_display") != std::string_view::npos,
+                        "the asset text contains the exact display/output Color Interop ID "
+                        "colorspace name (srgb_rec709_display)");
+}
+
+} // namespace
+
+int main(int argumentCount, char** arguments) {
+    std::filesystem::path repositoryRoot = std::filesystem::current_path();
+    for (int index = 1; index < argumentCount; ++index) {
+        const std::string_view argument{arguments[index]};
+        if (argument == "--root" && index + 1 < argumentCount) {
+            repositoryRoot = arguments[++index];
+        }
+    }
+
+    Expectations expectations;
+    testBloomNeutralAssetDigestMatchesFrozenConstant(expectations, repositoryRoot);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/host/tests/project_session_tests.cpp
+++ b/src/host/tests/project_session_tests.cpp
@@ -4,6 +4,7 @@
 #include <bloom/core/sha256.hpp>
 #include <bloom/document/color_settings.hpp>
 #include <bloom/document/new_project.hpp>
+#include <bloom/host/bloom_neutral_profile.hpp>
 #include <bloom/project/round_trip_state.hpp>
 
 #include <array>
@@ -1037,15 +1038,29 @@ void testInvalidConstruction(Expectations& expectations,
 
 void testColorSettingsGatingAndRoundTripValidation(Expectations& expectations,
                                                    ProjectSessionIdentitySource& identitySource) {
-    // createNew() has no color settings to synthesize (see color_settings.hpp's
-    // makeBloomNeutralColorSettingsV1(), which requires a real caller-supplied content-revision
-    // digest); such a session is gated unsaveable-pending-color.
+    // createNew() installs the immutable Bloom Neutral v1 built-in color settings
+    // unconditionally (issue #60), so a createNew() session's captureSaveInput() never reaches
+    // ColorSettingsUnavailable. A pathless session still needs Save-As path authority to
+    // otherwise succeed (PathRequired is an orthogonal gate), so advancePathIntentForSaveAs()
+    // supplies that authority here to observe an actual Captured result end to end.
     auto session = newSession(expectations, identitySource);
-    const auto plainSave = session.capturePlainSavePathIntent();
-    expectations.expect(session.captureSaveInput(plainSave).status() ==
-                            SessionSaveInputStatus::ColorSettingsUnavailable,
-                        "a createNew session has no color settings and is gated "
-                        "unsaveable-pending-color");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs),
+                        "a createNew session can advance Save-As path authority");
+    const auto captured = session.captureSaveInput(saveAs.capture());
+    expectations.expect(captured.status() == SessionSaveInputStatus::Captured &&
+                            static_cast<bool>(captured) && captured.value() != nullptr,
+                        "a createNew session's captureSaveInput succeeds -- never "
+                        "ColorSettingsUnavailable");
+    if (captured.value() != nullptr) {
+        const auto expectedColorSettings = bloom::document::makeBloomNeutralColorSettingsV1(
+            bloom::host::kBloomNeutralV1ConfigDigest);
+        expectations.expect(captured.value()->colorSettings() == expectedColorSettings,
+                            "a createNew session installs exactly "
+                            "makeBloomNeutralColorSettingsV1(kBloomNeutralV1ConfigDigest)");
+        expectations.expect(captured.value()->colorSettings().validate().ok(),
+                            "a createNew session's installed ColorSettings passes validate()");
+    }
 
     // A decoded session's captureSaveInput carries the exact captured fields.
     auto decoded = decodedSessionWithPath(expectations, identitySource, "capture.bloom");

--- a/src/host/tests/session_open_tests.cpp
+++ b/src/host/tests/session_open_tests.cpp
@@ -8,6 +8,7 @@
 #include <bloom/document/document.hpp>
 #include <bloom/document/new_project.hpp>
 #include <bloom/document/project.hpp>
+#include <bloom/host/bloom_neutral_profile.hpp>
 #include <bloom/host/project_session.hpp>
 #include <bloom/host/publication_coordinator.hpp>
 #include <bloom/host/session_save.hpp>
@@ -643,6 +644,112 @@ void testFullCycleSessionFileSession(Expectations& expectations) {
 }
 
 // ---------------------------------------------------------------------------------------------
+// New-project color default full cycle (issue #60, the gap it exists to close): createNew() ->
+// edit -> Save As -> saveProjectSession() -> reopen the just-published bytes via
+// openSessionArchive() -> Installed. The decoded colorSettings must equal the Bloom Neutral v1
+// value exactly, proving the locator URI and expected-revision digest survive the full
+// save/decode/reconstruct/install cycle, not just in-memory construction.
+// ---------------------------------------------------------------------------------------------
+
+void testNewProjectFullCycleInstallsBloomNeutralColor(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "new-project color cycle: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "new-project-color.bloom";
+    const auto expectedColorSettings =
+        bloom::document::makeBloomNeutralColorSettingsV1(bloom::host::kBloomNeutralV1ConfigDigest);
+    expectations.expect(expectedColorSettings.validate().ok(),
+                        "new-project color cycle: the expected Bloom Neutral value itself "
+                        "passes validate()");
+
+    auto createResult = ProjectSession::createNew(
+        identitySource, {.projectName = "New Project Color",
+                         .compositionName = "Main",
+                         .duration = bloom::core::RationalTime::fromInteger(10),
+                         .format = {}});
+    expectations.expect(static_cast<bool>(createResult),
+                        "new-project color cycle: createNew() succeeds");
+    if (!createResult) {
+        return;
+    }
+    auto session = std::move(createResult).takeSession();
+    // createNew() installs the Bloom Neutral v1 color settings unconditionally -- never
+    // ColorSettingsUnavailable -- and captureSaveInput() carries it from the moment the session
+    // exists; see bloom.host.project-session's testColorSettingsGatingAndRoundTripValidation for
+    // that pre-save assertion. This test's own job is proving the value survives the full
+    // save/decode/reconstruct/install cycle below, not re-proving the in-memory default.
+
+    expectations.expect(session.execute(rename("Renamed New Project", session)).changed(),
+                        "new-project color cycle: the edit commits");
+
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs),
+                        "new-project color cycle: Save As advances path authority");
+    if (!saveAs) {
+        return;
+    }
+    const SessionSaveRequest saveRequest{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto saved =
+        saveProjectSession(session, *coordinator, *artifacts, saveRequest, makeOperation());
+    expectations.expect(static_cast<bool>(saved), "new-project color cycle: the save succeeds");
+    if (!saved) {
+        return;
+    }
+
+    const auto publishedBytes = readFile(targetPath);
+    expectations.expect(!publishedBytes.empty(),
+                        "new-project color cycle: the published file has bytes");
+
+    const auto reopenPath = ProjectDisplayPath::create(targetPath);
+    expectations.expect(reopenPath.has_value(),
+                        "new-project color cycle: the reopen display path constructs");
+    if (!reopenPath.has_value()) {
+        return;
+    }
+
+    auto reopened = openSessionArchive(session, asBytes(publishedBytes), reopenPath,
+                                       SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(reopened) &&
+                            reopened.stage() == SessionOpenStage::Installation,
+                        "new-project color cycle: openSessionArchive installs the just-published "
+                        "bytes into the SAME session");
+    const auto* status = installedStatus(reopened);
+    expectations.expect(status != nullptr && *status == SessionInstallStatus::Installed,
+                        "new-project color cycle: the install outcome names Installed verbatim");
+
+    expectations.expect(projectName(session) == "Renamed New Project",
+                        "new-project color cycle: the reopened content matches what was "
+                        "actually published");
+
+    const auto plainIntent = session.capturePlainSavePathIntent();
+    const auto reopenedCaptured = session.captureSaveInput(plainIntent);
+    expectations.expect(
+        reopenedCaptured.status() == SessionSaveInputStatus::Captured &&
+            static_cast<bool>(reopenedCaptured) && reopenedCaptured.value() != nullptr,
+        "new-project color cycle: captureSaveInput succeeds on the reopened session");
+    if (reopenedCaptured.value() != nullptr) {
+        expectations.expect(
+            reopenedCaptured.value()->colorSettings() == expectedColorSettings,
+            "new-project color cycle: the reopened colorSettings equal "
+            "makeBloomNeutralColorSettingsV1(kBloomNeutralV1ConfigDigest) exactly -- locator URI "
+            "and expected digest survived the full save/decode/reconstruct/install cycle");
+        expectations.expect(reopenedCaptured.value()->colorSettings().validate().ok(),
+                            "new-project color cycle: the reopened colorSettings pass validate()");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
 // Round-tripped newer minor survives session->file->session->file: a spliced {1,1} archive with
 // one unknown root member (built directly, mirroring open_archive_tests.cpp's
 // testOpenRoundTrippedNewerMinorRoundTrip fixture) is opened into a session, saved, reopened
@@ -1258,6 +1365,7 @@ int main() {
     Expectations expectations;
     try {
         testFullCycleSessionFileSession(expectations);
+        testNewProjectFullCycleInstallsBloomNeutralColor(expectations);
         testRoundTrippedNewerMinorSurvivesFullCycle(expectations);
         testEditDuringOpenRefusal(expectations);
         testStaleOpenIntent(expectations);


### PR DESCRIPTION
Closes #60.

New projects can now save. The Bloom Neutral v1 built-in configuration exists as a canonical repository asset with a qualified digest identity, and `createNew` installs it as the session's color settings — closing the typed `ColorSettingsUnavailable` gap with the product moment this issue existed for: **new project → edit → Save As → publish → reopen**, the Bloom Neutral locator and digest surviving the complete cycle.

**The asset is contract**: a minimal, immutable OCIO v2 config whose colorspace names are exactly the required Color Interop Forum identifiers — `lin_rec709_scene` as the scene-linear reference, `srgb_rec709_display` defined by the exact IEC 61966-2-1 transfer transform (never approximate chromaticities) — authored and numerically validated against OpenColorIO 2.5.2 before freezing, with no OCIO dependency entering the build. Content changes require a new URI, so the bytes carry the same line-ending guard as every digest-bound range in the repository.

**The digest is the normative one**: the frozen constant is the color contract's OCIO Content Revision v1 *envelope* digest (domain-prefixed, big-endian framed over the exact payload bytes), derived independently twice with matching results. A drift-guard test rebuilds the envelope from the checked-in bytes through the repository's own hashing surface on every run, so asset, formula, and constant can never drift apart silently.

Runtime resolution (registry, helper, OCIO execution) remains the color epic's scope — this package owns the durable identity persistence needs.

Testing: the drift-guard suite, createNew capture/validate assertions, and the full end-to-end cycle. Full ci-linux-native suite 68/68 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (one review round on the digest formula).