### PR TITLE
feat: run session saves and opens asynchronously

### DIFF
--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
         project_session.cpp
         publication_coordinator.cpp
         save_publication.cpp
+        session_async_io.cpp
         session_open.cpp
         session_save.cpp
     PUBLIC
@@ -16,6 +17,7 @@ target_sources(
             include/bloom/host/project_session.hpp
             include/bloom/host/publication_coordinator.hpp
             include/bloom/host/save_publication.hpp
+            include/bloom/host/session_async_io.hpp
             include/bloom/host/session_open.hpp
             include/bloom/host/session_save.hpp
 )
@@ -26,8 +28,15 @@ target_compile_features(bloom_host PUBLIC cxx_std_20)
 # CanonicalDocumentV1/SaveArchiveLimits/StagedSaveFailure, ArtifactOverwritePolicy/
 # ArtifactTargetObservation/StagedArtifactCoordinator/StagedArtifactPublicationResult) in its
 # public signatures, so anything including that header needs both modules' headers visible too.
+# bloom_runtime is PUBLIC for the identical reason: include/bloom/host/session_async_io.hpp (task
+# A1, issue #68 -- async session Save/Open over the blocking-I/O lane) declares AsyncSessionSave/
+# AsyncSessionOpen/beginSessionSave()/beginSessionOpen() carrying bloom::runtime::TaskScheduler/
+# TaskHandle/TaskSubmissionStatus in its public signatures. The {"host", "runtime"} module
+# dependency this introduces is already present in
+# tools/quality/repository_checks/repository_checks.cpp's kAllowedModuleDependencies allowlist (no
+# allowlist edit was needed for this task).
 target_link_libraries(bloom_host PUBLIC bloom_commands bloom_core bloom_document bloom_project
-                                        bloom_platform)
+                                        bloom_platform bloom_runtime)
 bloom_enable_warnings(bloom_host)
 
 if(BUILD_TESTING)
@@ -108,6 +117,19 @@ if(BUILD_TESTING)
         bloom_add_test(
             NAME bloom.host.session-open
             COMMAND bloom_host_session_open_test
+            LABELS unit host persistence security
+        )
+
+        # Gated Linux-only exactly as bloom.host.session-save/session-open are gated: drives
+        # beginSessionSave()/beginSessionOpen() (session_async_io.cpp, task A1, issue #68) against
+        # the same real platform::StagedArtifactCoordinator over a real bloom::runtime::TaskScheduler
+        # with a real TaskExecutor::BlockingIo worker.
+        add_executable(bloom_host_session_async_io_test tests/session_async_io_tests.cpp)
+        target_link_libraries(bloom_host_session_async_io_test PRIVATE bloom_host)
+        bloom_enable_warnings(bloom_host_session_async_io_test)
+        bloom_add_test(
+            NAME bloom.host.session-async-io
+            COMMAND bloom_host_session_async_io_test
             LABELS unit host persistence security
         )
     endif()

--- a/src/host/include/bloom/host/project_session.hpp
+++ b/src/host/include/bloom/host/project_session.hpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <filesystem>
 #include <memory>
 #include <mutex>
@@ -24,6 +25,19 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+// Design decision 1 (task A1, issue #68): ProjectSession's round-trip state is an owning
+// std::shared_ptr<const project::RoundTripState> (nullable), not a std::optional<RoundTripState>.
+// A replacement install (installDecodedReplacement()) swaps the session's shared_ptr; any capture
+// already handed out by captureSaveInput() (SessionSaveInput::roundTripView()) holds its own
+// std::shared_ptr copy, so it keeps the OLD state alive independently of the session even across a
+// session-thread replacement -- this is what makes an async worker's captured view safe against a
+// concurrent Save As/Open install on the authoring thread (see session_async_io.hpp's "replacement
+// survives capture" contract). Public request/content types (DecodedProjectSessionRequest::
+// roundTrip, DecodedReplacementContent::roundTrip_) deliberately keep their existing
+// std::optional<project::RoundTripState> by-value shape -- ProjectSession itself wraps the value
+// into the shared owning pointer on install/create, so no other module needs to know about the
+// shared_ptr.
 
 namespace bloom::host {
 
@@ -425,13 +439,14 @@ enum class SessionSaveInputStatus : std::uint8_t {
 };
 
 // One immutable capture of everything a synchronous Save needs from a ProjectSession, per
-// docs/architecture/project-session.md's "Save Inputs And Intent". `roundTrip()` is a non-owning
-// view into the session's own installed project::RoundTripState (null when the session has none):
-// valid only while the originating ProjectSession stays alive and is not replaced with new
-// installed content, exactly as project::CanonicalDocumentV1::roundTrip documents for its own
-// pointee. The synchronous save flow in this slice satisfies that trivially (the session is a
-// caller-owned reference for the whole call); an asynchronous slice revisits this as the
-// contract's "immutable round-trip view" (project-session.md, "Save Inputs And Intent").
+// docs/architecture/project-session.md's "Save Inputs And Intent". Every member here is a self-
+// contained OWNING copy (snapshot/colorSettings/schemaMinor/retainedRequirements are by-value;
+// roundTripView() is a std::shared_ptr<const project::RoundTripState> copy -- see
+// project_session.hpp's design-decision-1 comment above): a SessionSaveInput is safe to move off
+// the authoring thread and outlive the ProjectSession it was captured from, including across a
+// later replacement install on that session. This IS the contract's "immutable round-trip view"
+// (project-session.md, "Save Inputs And Intent"), reused verbatim by both the synchronous save flow
+// (session_save.cpp) and the async save worker (session_async_io.cpp).
 class SessionSaveInput final {
   public:
     [[nodiscard]] const document::Snapshot& snapshot() const& noexcept { return snapshot_; }
@@ -441,8 +456,19 @@ class SessionSaveInput final {
         return colorSettings_;
     }
     const document::ColorSettings& colorSettings() const&& = delete;
-    // Non-owning; see the class comment above for the exact lifetime contract.
-    [[nodiscard]] const project::RoundTripState* roundTrip() const noexcept { return roundTrip_; }
+    // The owning shared view itself (nullable); copying it keeps the pointee alive independently
+    // of this SessionSaveInput and of the originating ProjectSession.
+    [[nodiscard]] const std::shared_ptr<const project::RoundTripState>&
+    roundTripView() const& noexcept {
+        return roundTrip_;
+    }
+    const std::shared_ptr<const project::RoundTripState>& roundTripView() const&& = delete;
+    // Derived raw pointer for project::CanonicalDocumentV1::roundTrip; valid for as long as this
+    // SessionSaveInput (or a roundTripView() copy taken from it) stays alive -- no longer tied to
+    // the originating ProjectSession's own lifetime.
+    [[nodiscard]] const project::RoundTripState* roundTrip() const noexcept {
+        return roundTrip_.get();
+    }
     [[nodiscard]] std::uint32_t schemaMinor() const noexcept { return schemaMinor_; }
     [[nodiscard]] const std::vector<project::ManifestRequirement>&
     retainedRequirements() const& noexcept {
@@ -463,20 +489,21 @@ class SessionSaveInput final {
 
   private:
     SessionSaveInput(document::Snapshot snapshot, document::ColorSettings colorSettings,
-                     const project::RoundTripState* roundTrip, std::uint32_t schemaMinor,
+                     std::shared_ptr<const project::RoundTripState> roundTrip,
+                     std::uint32_t schemaMinor,
                      std::vector<project::ManifestRequirement> retainedRequirements,
                      std::optional<ProjectDisplayPath> displayPath,
                      SessionPathIntentCapture pathIntent,
                      SessionResultAcceptanceCapture resultAcceptance) noexcept
         : snapshot_(std::move(snapshot)), colorSettings_(std::move(colorSettings)),
-          roundTrip_(roundTrip), schemaMinor_(schemaMinor),
+          roundTrip_(std::move(roundTrip)), schemaMinor_(schemaMinor),
           retainedRequirements_(std::move(retainedRequirements)),
           displayPath_(std::move(displayPath)), pathIntent_(pathIntent),
           resultAcceptance_(resultAcceptance) {}
 
     document::Snapshot snapshot_;
     document::ColorSettings colorSettings_;
-    const project::RoundTripState* roundTrip_ = nullptr;
+    std::shared_ptr<const project::RoundTripState> roundTrip_;
     std::uint32_t schemaMinor_ = 0;
     std::vector<project::ManifestRequirement> retainedRequirements_;
     std::optional<ProjectDisplayPath> displayPath_;
@@ -500,6 +527,19 @@ class [[nodiscard]] SessionSaveInputResult final {
         return input_.has_value() ? &*input_ : nullptr;
     }
     [[nodiscard]] const SessionSaveInput* value() const&& = delete;
+
+    // Moves the captured input out; valid only when status() == Captured (terminates otherwise,
+    // mirroring ProjectSessionCreateResult::takeSession()'s established pattern). Additive: the
+    // synchronous save flow never needed this (it kept `*this` alive for the call's duration and
+    // used value() alone), but the async save path (session_async_io.cpp) builds a self-contained
+    // owning capture that must outlive this result and the whole begin() call stack -- see this
+    // task's frozen design decision 2.
+    [[nodiscard]] SessionSaveInput takeValue() && noexcept {
+        if (!input_.has_value()) {
+            std::terminate();
+        }
+        return std::move(*input_);
+    }
 
   private:
     friend class ProjectSession;
@@ -673,13 +713,17 @@ class ProjectSession final {
     friend class ProjectSessionCreateResult;
     friend class ProjectSessionTestAccess;
 
+    // Not noexcept: wrapping a present `roundTrip` into the session's owning
+    // std::shared_ptr<const project::RoundTripState> (design decision 1) allocates a control block,
+    // which may throw std::bad_alloc. Both callers (createNew()/createDecoded()) already wrap their
+    // entire construction in a try/catch for exactly this reason.
     ProjectSession(ProjectSessionId projectSessionId, std::unique_ptr<document::Document> document,
                    std::unique_ptr<commands::CommandStack> commandStack,
                    DecodedProjectEditability editability, document::Revision cleanRevision,
                    std::optional<ProjectDisplayPath> displayPath,
                    std::optional<document::ColorSettings> colorSettings,
                    std::optional<project::RoundTripState> roundTrip, std::uint32_t schemaMinor,
-                   std::vector<project::ManifestRequirement> retainedRequirements) noexcept;
+                   std::vector<project::ManifestRequirement> retainedRequirements);
     ProjectSession(ProjectSessionId projectSessionId,
                    ProjectDisplayPath preservedDisplayPath) noexcept;
 
@@ -715,7 +759,11 @@ class ProjectSession final {
     // captureSaveInput() must still refuse cleanly rather than save an absent value if some
     // future construction path is added that does not supply one.
     std::optional<document::ColorSettings> colorSettings_;
-    std::optional<project::RoundTripState> roundTrip_;
+    // Owning, nullable, shared (design decision 1 -- see the file-level comment above): swapped
+    // wholesale on a replacement install; a shared_ptr copy already handed out by
+    // captureSaveInput() (SessionSaveInput::roundTripView()) keeps the OLD pointee alive
+    // independently of this member's own later reassignment.
+    std::shared_ptr<const project::RoundTripState> roundTrip_;
     std::uint32_t schemaMinor_ = 0;
     std::vector<project::ManifestRequirement> retainedRequirements_;
     // Present only for content installed via installDecodedReplacement() from a real opened

--- a/src/host/include/bloom/host/session_async_io.hpp
+++ b/src/host/include/bloom/host/session_async_io.hpp
@@ -1,0 +1,349 @@
+#pragma once
+
+#include <bloom/host/project_session.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/host/save_publication.hpp>
+#include <bloom/host/session_open.hpp>
+#include <bloom/host/session_save.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/open_archive.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <vector>
+
+// Asynchronous session Save/Open over the blocking-I/O lane (task A1, issue #68). Both handles run
+// the SAME code the synchronous session_save.cpp/session_open.cpp entry points run -- the
+// session-free "middles" (executeSessionSaveMiddle() / project::openProjectArchive()) plus, on
+// completion, the exact shared "accept"/"install" tails (acceptSessionSavePublication() /
+// installOpenedArchiveResult()) -- as a bloom::runtime::TaskScheduler TaskExecutor::BlockingIo
+// task.
+//
+// ---------------------------------------------------------------------------------------------
+// Threading rules (both AsyncSessionSave and AsyncSessionOpen)
+// ---------------------------------------------------------------------------------------------
+// - begin*(): authoring thread only. Runs admission (captureSaveInput()/admitOpenIntent()) on the
+//   calling thread synchronously; a refusal is a typed begin-failure and no task is submitted.
+// - isReady() / tryComplete() / handle destruction: authoring thread only. tryComplete() applies
+//   its session-dependent tail (acceptSavepoint() / installDecodedReplacement()) against whatever
+//   ProjectSession& is passed in AT THAT CALL -- which may legitimately differ in state from
+//   begin-time; the existing intent/generation checks inside acceptSavepoint()/install*() decide,
+//   not this module.
+// - requestCancellation(): may be called from ANY thread at any time (including from a destructor
+//   racing with an authoring-thread caller, as long as the handle itself is not used concurrently
+//   from two threads -- it is not internally synchronized beyond the scheduler's own submission
+//   state, exactly as bloom::runtime::TaskHandle documents for itself).
+// - `session`, `coordinator`, `artifacts` (Save) and `session` (Open) are caller-owned references
+//   captured by the worker closure; they must outlive the whole asynchronous operation (until
+//   tryComplete() returns a result or the handle is destroyed and the scheduler reaches
+//   quiescence for that task), not merely the begin*() call -- unlike the synchronous entry points,
+//   whose composed calls all run and return before begin*() returns.
+// - `request.preAdmitted` (Save only) is the one exception to "caller keeps ownership": when
+//   non-null, beginSessionSave() MOVES *request.preAdmitted into the handle's own owned storage
+//   before it returns (PublicationAdmission is move-only RAII; owning it in the closure means an
+//   unstarted or rejected task abandons it correctly on destruction, exactly like a caller-side
+//   admission that never registers). After beginSessionSave() returns, `*request.preAdmitted` is
+//   moved-from and the caller has no further lifetime obligation toward it -- unlike the
+//   synchronous saveProjectSession(), whose `SessionSaveRequest::preAdmitted` pointer must merely
+//   outlive that one same-frame call, an async worker consumes the pointee at an unbounded later
+//   time on another thread, so a borrowed pointer would dangle against the caller's natural
+//   "admit, then let the admission go out of scope" pattern.
+//
+// ---------------------------------------------------------------------------------------------
+// Cancellation bridge
+// ---------------------------------------------------------------------------------------------
+// Each handle owns one std::atomic_bool (inside a small heap-allocated shared state also reachable
+// from the worker closure) that IS the `const std::atomic_bool* cancellationFlag` the synchronous
+// executor primitives already accept (SavePublicationRequest::cancellationFlag).
+// requestCancellation() writes that atomic directly (release order), so a cancellation requested
+// WHILE executeSessionSaveMiddle()/executeSavePublication() is already running on the worker thread
+// is observed at its very next between-stage check -- no different in kind from the synchronous
+// flow handing it the same kind of flag. In addition, at worker entry (before doing any real work)
+// the worker checks bloom::runtime::TaskContext::isCancellationRequested() (the scheduler's own
+// CancellationToken, which handle.cancel() -- also invoked by requestCancellation() -- and any
+// other scheduler-level cancellation source such as owner cancellation or beginShutdown() all set)
+// and, if set, also writes it into the same atomic before proceeding. This entry check is the ONLY
+// point where a cancellation source other than this handle's own requestCancellation() can reach
+// the executor flag: once the worker is running, only requestCancellation()'s direct write is
+// observed (the worker does not re-poll the scheduler token mid-flight).
+// project::openProjectArchive() (the Open middle) has no internal checkpoints of its own at all --
+// it is a single non-cancellable call
+// -- so AsyncSessionOpen's bridge only ever has an effect at that one entry checkpoint:
+// cancellation requested before the worker starts skips calling openProjectArchive() entirely
+// (SessionOpenStage::NotOpened / CancelledBeforeOpening); cancellation requested after the worker
+// has already begun that call is not observed until it returns (openProjectArchive() takes no
+// cancellation parameter and this task's non-goals forbid changing it or the scheduler/runtime
+// modules).
+//
+// ---------------------------------------------------------------------------------------------
+// Readiness
+// ---------------------------------------------------------------------------------------------
+// isReady() calls bloom::runtime::TaskScheduler::snapshot(handle.id()) and checks
+// bloom::runtime::isTerminal(snapshot->state) -- the same non-blocking, non-consuming observability
+// the scheduler already publishes to any consumer (its own tests read task lifecycle the identical
+// way). This avoids a second, module-owned readiness channel and any polling loop internal to this
+// module; the caller is the one who polls (in a bounded spin), exactly as the task's test plan
+// requires.
+namespace bloom::host {
+
+namespace detail {
+
+struct AsyncSessionSaveSharedState final {
+    // The executor-side cancellation flag bridged from the scheduler's own CancellationToken (see
+    // the cancellation-bridge documentation above).
+    std::atomic_bool cancellationFlag{false};
+    // Populated exactly once by the worker before it returns (TaskResult<void>::succeeded() is
+    // always what the worker itself reports at the scheduler level; the REAL outcome lives here).
+    // The worker's write happens-before the scheduler ever reports the task terminal (the same
+    // internal synchronization TaskHandle::tryTakeResult()/TaskScheduler::snapshot() rely on for
+    // every other typed task result), so reading this after isReady() observes a terminal state, or
+    // after tryTakeResult() itself returns a value, is safe without additional synchronization
+    // here.
+    std::optional<SavePublicationResult> publication;
+    // The caller's SessionSaveRequest::preAdmitted, MOVED here on the authoring thread by
+    // beginSessionSave() before task submission (see the file-level threading-rules "preAdmitted"
+    // note). Held in the shared state -- rather than captured by value directly in the worker
+    // closure -- because PublicationAdmission is move-only and std::function (which
+    // bloom::runtime::TaskFunction is built on) requires its target to stay copy-constructible;
+    // std::shared_ptr<AsyncSessionSaveSharedState> itself is trivially copyable regardless of what
+    // it points to. Written once, before submission (so before the worker thread could ever
+    // observe `shared`); read/consumed at most once, by the worker.
+    std::optional<PublicationAdmission> preAdmitted;
+};
+
+struct AsyncSessionOpenSharedState final {
+    std::atomic_bool cancellationFlag{false};
+    // Set by the worker instead of `opened` when cancellation was observed at entry (see the
+    // cancellation-bridge documentation above): the worker never called
+    // project::openProjectArchive().
+    bool cancelledBeforeOpening = false;
+    std::optional<project::OpenArchiveResult> opened;
+};
+
+} // namespace detail
+
+// ================================================================================================
+// Save
+// ================================================================================================
+
+enum class AsyncSessionSaveBeginStage : std::uint8_t { Capture, Submission };
+
+class AsyncSessionSaveResult;
+
+class AsyncSessionSave final {
+  public:
+    AsyncSessionSave(AsyncSessionSave&&) noexcept = default;
+    AsyncSessionSave& operator=(AsyncSessionSave&&) noexcept = default;
+    AsyncSessionSave(const AsyncSessionSave&) = delete;
+    AsyncSessionSave& operator=(const AsyncSessionSave&) = delete;
+    // Typed abandonment (see docs/architecture/project-session.md's late-completion staleness
+    // rules, extended here to an in-flight worker): requests cancellation, then drops the handle
+    // (and, once the scheduler reclaims it, the worker's result) without touching any session. A
+    // save whose executeSavePublication() had ALREADY entered its non-cancellable platform
+    // publication lease before this destructor runs may still have durably published remotely --
+    // that publication is real and stays real, but the caller who abandons the handle here forfeits
+    // ever recording the resulting savepoint against a session (nothing calls acceptSavepoint() for
+    // it), exactly as a late/stale completion the caller never observes would be under the
+    // synchronous contract.
+    ~AsyncSessionSave();
+
+    // Non-blocking, non-consuming poll; see the file-level "Readiness" documentation.
+    [[nodiscard]] bool isReady() const noexcept;
+    // May be called from any thread, at any time, including after tryComplete() has already
+    // returned a result (a no-op then). See the file-level cancellation-bridge documentation.
+    void requestCancellation() noexcept;
+    // Returns nullopt while the worker has not yet reached a scheduler-terminal state. Once it has,
+    // returns the full result exactly once (subsequent calls return nullopt) -- applying
+    // acceptSessionSavePublication() (the same tail saveProjectSession() itself runs) against
+    // `session`, which may legitimately differ in state from begin-time (see the file-level
+    // threading-rules documentation).
+    [[nodiscard]] std::optional<SessionSaveResult> tryComplete(ProjectSession& session);
+
+  private:
+    friend class AsyncSessionSaveResult;
+    friend AsyncSessionSaveResult beginSessionSave(ProjectSession&, runtime::TaskScheduler&,
+                                                   PublicationCoordinator&,
+                                                   platform::StagedArtifactCoordinator&,
+                                                   const SessionSaveRequest&,
+                                                   project::ProjectIoOperationMemory);
+
+    AsyncSessionSave(runtime::TaskScheduler& scheduler, runtime::TaskHandle<void> handle,
+                     std::shared_ptr<detail::AsyncSessionSaveSharedState> shared,
+                     SessionPathIntentCapture intent, document::Revision revision,
+                     std::filesystem::path targetPath) noexcept;
+
+    runtime::TaskScheduler* scheduler_ = nullptr;
+    runtime::TaskHandle<void> handle_;
+    std::shared_ptr<detail::AsyncSessionSaveSharedState> shared_;
+    SessionPathIntentCapture intent_;
+    document::Revision revision_;
+    std::filesystem::path targetPath_;
+    bool completed_ = false;
+};
+
+// [[nodiscard]] begin-outcome: either a live handle (Submission stage, operator bool() true) or a
+// typed begin-failure at Capture stage (session.captureSaveInput()'s own refusal, or a wrapped
+// exception from building the owning input -- see SessionSaveResourceExhausted/
+// SessionSaveUnexpectedFailure in session_save.hpp) or Submission stage (the scheduler's own typed
+// submission refusal). Capture refusals surface HERE, on the authoring thread, exactly as the
+// synchronous saveProjectSession()'s Capture stage does -- no task is ever submitted for them.
+class [[nodiscard]] AsyncSessionSaveResult final {
+  public:
+    AsyncSessionSaveResult(AsyncSessionSaveResult&&) noexcept = default;
+    AsyncSessionSaveResult& operator=(AsyncSessionSaveResult&&) noexcept = default;
+    AsyncSessionSaveResult(const AsyncSessionSaveResult&) = delete;
+    AsyncSessionSaveResult& operator=(const AsyncSessionSaveResult&) = delete;
+    ~AsyncSessionSaveResult() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return handle_.has_value(); }
+    [[nodiscard]] AsyncSessionSaveBeginStage stage() const noexcept { return stage_; }
+    // Valid only when stage() == Capture and !*this.
+    [[nodiscard]] const SessionSaveCaptureOutcome* captureFailure() const& noexcept {
+        return stage_ == AsyncSessionSaveBeginStage::Capture ? &captureFailure_ : nullptr;
+    }
+    [[nodiscard]] const SessionSaveCaptureOutcome* captureFailure() const&& = delete;
+    // Valid only when stage() == Submission and !*this.
+    [[nodiscard]] std::optional<runtime::TaskSubmissionStatus> submissionFailure() const noexcept {
+        return submissionFailure_;
+    }
+    // Moves the handle out; valid only when *this is true (terminates otherwise, mirroring
+    // ProjectSessionCreateResult::takeSession()'s established pattern).
+    [[nodiscard]] AsyncSessionSave takeHandle() && noexcept;
+
+  private:
+    friend AsyncSessionSaveResult beginSessionSave(ProjectSession&, runtime::TaskScheduler&,
+                                                   PublicationCoordinator&,
+                                                   platform::StagedArtifactCoordinator&,
+                                                   const SessionSaveRequest&,
+                                                   project::ProjectIoOperationMemory);
+
+    explicit AsyncSessionSaveResult(SessionSaveCaptureOutcome outcome) noexcept;
+    explicit AsyncSessionSaveResult(runtime::TaskSubmissionStatus status) noexcept;
+    explicit AsyncSessionSaveResult(AsyncSessionSave handle) noexcept;
+
+    AsyncSessionSaveBeginStage stage_ = AsyncSessionSaveBeginStage::Capture;
+    SessionSaveCaptureOutcome captureFailure_;
+    std::optional<runtime::TaskSubmissionStatus> submissionFailure_;
+    std::optional<AsyncSessionSave> handle_;
+};
+
+// begin*(): runs session.captureSaveInput(request.intent) on the calling (authoring) thread; a
+// refusal is a typed begin-failure, no task submitted. On success it builds a
+// SessionSaveOwningInput (design decision 2) and submits the save middle
+// (executeSessionSaveMiddle()) as a TaskExecutor::BlockingIo task, bridging cancellation as
+// documented above. `session`, `coordinator`, and `artifacts` must outlive the whole asynchronous
+// operation -- see the file-level threading-rules documentation. `request.preAdmitted`, when
+// non-null, is CONSUMED here (moved into the handle's own owned storage) before this function
+// returns; the caller has no lifetime obligation toward `*request.preAdmitted` afterward -- see the
+// threading-rules documentation's `preAdmitted` note.
+[[nodiscard]] AsyncSessionSaveResult
+beginSessionSave(ProjectSession& session, runtime::TaskScheduler& scheduler,
+                 PublicationCoordinator& coordinator,
+                 platform::StagedArtifactCoordinator& artifacts, const SessionSaveRequest& request,
+                 project::ProjectIoOperationMemory operation);
+
+// ================================================================================================
+// Open
+// ================================================================================================
+
+enum class AsyncSessionOpenBeginStage : std::uint8_t { Admission, Submission };
+
+class AsyncSessionOpenResult;
+
+class AsyncSessionOpen final {
+  public:
+    AsyncSessionOpen(AsyncSessionOpen&&) noexcept = default;
+    AsyncSessionOpen& operator=(AsyncSessionOpen&&) noexcept = default;
+    AsyncSessionOpen(const AsyncSessionOpen&) = delete;
+    AsyncSessionOpen& operator=(const AsyncSessionOpen&) = delete;
+    // Same typed-abandonment contract as ~AsyncSessionSave() above: requests cancellation, then
+    // drops the handle without touching any session. Open never publishes anything remotely, so
+    // there is no "forfeited savepoint" analogue here -- an abandoned Open simply never installs.
+    ~AsyncSessionOpen();
+
+    [[nodiscard]] bool isReady() const noexcept;
+    void requestCancellation() noexcept;
+    // Returns nullopt while running. Once the worker has reached a scheduler-terminal state,
+    // returns the full result exactly once, applying installOpenedArchiveResult() (the O2 install
+    // gates, which already refuse edit-during-open as RevisionChanged) against `session`.
+    [[nodiscard]] std::optional<SessionOpenResult> tryComplete(ProjectSession& session);
+
+  private:
+    friend class AsyncSessionOpenResult;
+    friend AsyncSessionOpenResult beginSessionOpen(ProjectSession&, runtime::TaskScheduler&,
+                                                   std::vector<std::byte>,
+                                                   std::optional<ProjectDisplayPath>,
+                                                   const project::SaveArchiveLimits&,
+                                                   project::ProjectIoOperationMemory);
+
+    AsyncSessionOpen(runtime::TaskScheduler& scheduler, runtime::TaskHandle<void> handle,
+                     std::shared_ptr<detail::AsyncSessionOpenSharedState> shared,
+                     OpenIntentCapture intent,
+                     std::optional<ProjectDisplayPath> displayPath) noexcept;
+
+    runtime::TaskScheduler* scheduler_ = nullptr;
+    runtime::TaskHandle<void> handle_;
+    std::shared_ptr<detail::AsyncSessionOpenSharedState> shared_;
+    OpenIntentCapture intent_;
+    std::optional<ProjectDisplayPath> displayPath_;
+    bool completed_ = false;
+};
+
+class [[nodiscard]] AsyncSessionOpenResult final {
+  public:
+    AsyncSessionOpenResult(AsyncSessionOpenResult&&) noexcept = default;
+    AsyncSessionOpenResult& operator=(AsyncSessionOpenResult&&) noexcept = default;
+    AsyncSessionOpenResult(const AsyncSessionOpenResult&) = delete;
+    AsyncSessionOpenResult& operator=(const AsyncSessionOpenResult&) = delete;
+    ~AsyncSessionOpenResult() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return handle_.has_value(); }
+    [[nodiscard]] AsyncSessionOpenBeginStage stage() const noexcept { return stage_; }
+    // Valid only when stage() == Admission and !*this: session.admitOpenIntent()'s own refusal.
+    [[nodiscard]] std::optional<OpenIntentAdmissionStatus> admissionFailure() const noexcept {
+        return admissionFailure_;
+    }
+    // Valid only when stage() == Submission and !*this: the scheduler's own typed submission
+    // refusal.
+    [[nodiscard]] std::optional<runtime::TaskSubmissionStatus> submissionFailure() const noexcept {
+        return submissionFailure_;
+    }
+    [[nodiscard]] AsyncSessionOpen takeHandle() && noexcept;
+
+  private:
+    friend AsyncSessionOpenResult beginSessionOpen(ProjectSession&, runtime::TaskScheduler&,
+                                                   std::vector<std::byte>,
+                                                   std::optional<ProjectDisplayPath>,
+                                                   const project::SaveArchiveLimits&,
+                                                   project::ProjectIoOperationMemory);
+
+    explicit AsyncSessionOpenResult(OpenIntentAdmissionStatus status) noexcept;
+    explicit AsyncSessionOpenResult(runtime::TaskSubmissionStatus status) noexcept;
+    explicit AsyncSessionOpenResult(AsyncSessionOpen handle) noexcept;
+
+    AsyncSessionOpenBeginStage stage_ = AsyncSessionOpenBeginStage::Admission;
+    std::optional<OpenIntentAdmissionStatus> admissionFailure_;
+    std::optional<runtime::TaskSubmissionStatus> submissionFailure_;
+    std::optional<AsyncSessionOpen> handle_;
+};
+
+// begin*(): runs session.admitOpenIntent() on the calling (authoring) thread; a refusal is a typed
+// begin-failure, no task submitted. The handle takes ownership of `bytes` (moved in, by value --
+// the caller hands over the archive buffer; nothing else may mutate it afterward). On success,
+// submits the open middle (project::openProjectArchive() over the owned bytes) as a
+// TaskExecutor::BlockingIo task. `session` must outlive the whole asynchronous operation -- see the
+// file-level threading-rules documentation.
+[[nodiscard]] AsyncSessionOpenResult beginSessionOpen(ProjectSession& session,
+                                                      runtime::TaskScheduler& scheduler,
+                                                      std::vector<std::byte> bytes,
+                                                      std::optional<ProjectDisplayPath> displayPath,
+                                                      const project::SaveArchiveLimits& limits,
+                                                      project::ProjectIoOperationMemory operation);
+
+} // namespace bloom::host

--- a/src/host/include/bloom/host/session_open.hpp
+++ b/src/host/include/bloom/host/session_open.hpp
@@ -28,10 +28,29 @@ namespace bloom::host {
 // either Opened or PreservedReadOnlyRequired, and this module attempted (or, for a pathless
 // PreservedReadOnlyRequired result, deliberately declined to attempt) an install*() call (see
 // SessionOpenResult::installOutcome()).
+// NotOpened (task A1, issue #68): the async open worker never produced a project::OpenArchiveResult
+// at all -- see SessionOpenResult::notOpened() and SessionOpenNotOpenedReason below. Unreachable
+// from the synchronous openSessionArchive() (which always calls project::openProjectArchive()
+// unconditionally once admission succeeds); reachable only from AsyncSessionOpen::tryComplete()
+// (session_async_io.cpp).
 enum class SessionOpenStage : std::uint8_t {
     Admission,
     Opening,
     Installation,
+    NotOpened,
+};
+
+// Why the async open worker never called project::openProjectArchive() at all (see
+// SessionOpenStage::NotOpened above). CancelledBeforeOpening: requestCancellation() (or an
+// entry-time scheduler cancellation) was observed before the worker began -- see
+// session_async_io.hpp's cancellation-bridge documentation for exactly what this covers.
+// WorkerUnexpectedFailure: the scheduler-level task itself never ran to completion (an exception
+// the runtime's own TypedTaskWork wrapper caught, or a scheduler state
+// AsyncSessionOpen::tryComplete cannot otherwise interpret) -- session untouched either way,
+// matching openingFailure()'s own "session untouched, no install*() call is ever made" contract.
+enum class SessionOpenNotOpenedReason : std::uint8_t {
+    CancelledBeforeOpening,
+    WorkerUnexpectedFailure,
 };
 
 // Wraps a thrown exception from ProjectSession::installDecodedReplacement()/
@@ -71,6 +90,8 @@ class [[nodiscard]] SessionOpenResult final {
     [[nodiscard]] static SessionOpenResult
     installation(SessionOpenInstallOutcome outcome, ProjectSessionContentKind attemptedContentKind,
                  std::optional<project::OpenArchivePreservedReadOnly> preservedReadOnly) noexcept;
+    // See SessionOpenStage::NotOpened/SessionOpenNotOpenedReason above; async-only.
+    [[nodiscard]] static SessionOpenResult notOpened(SessionOpenNotOpenedReason reason) noexcept;
 
     // True only for the single fully-succeeded path: Installation stage with a real
     // SessionInstallStatus::Installed outcome. Every other case -- including a wrapped install
@@ -122,6 +143,11 @@ class [[nodiscard]] SessionOpenResult final {
     }
     [[nodiscard]] const project::OpenArchivePreservedReadOnly* preservedReadOnly() const&& = delete;
 
+    // Valid only when stage() == NotOpened (async-only; see notOpened() above).
+    [[nodiscard]] std::optional<SessionOpenNotOpenedReason> notOpenedReason() const noexcept {
+        return notOpenedReason_;
+    }
+
   private:
     SessionOpenResult() = default;
 
@@ -131,7 +157,23 @@ class [[nodiscard]] SessionOpenResult final {
     SessionOpenInstallOutcome installOutcome_ = SessionInstallStatus::InvalidSession;
     std::optional<ProjectSessionContentKind> attemptedContentKind_;
     std::optional<project::OpenArchivePreservedReadOnly> preservedReadOnly_;
+    std::optional<SessionOpenNotOpenedReason> notOpenedReason_;
 };
+
+// Session-dependent installation step shared by the synchronous openSessionArchive() below and the
+// async open worker's completion (AsyncSessionOpen::tryComplete(), session_async_io.cpp) -- task A1
+// (issue #68), frozen design decision 2. Open's session-free "middle" is simply
+// project::openProjectArchive() itself (already session-free; no extraction needed there); this
+// function is the remaining session-dependent tail both callers share verbatim: classify `opened`'s
+// outcome (Opened / PreservedReadOnlyRequired / Failed) and compose it with
+// ProjectSession::installDecodedReplacement()/installPreservedReadOnlyReplacement() exactly as
+// openSessionArchive()'s own declaration documents. `displayPath` moves in unconditionally; a
+// PreservedReadOnlyRequired outcome without one is refused as typed InvalidContent without an
+// install*() call.
+[[nodiscard]] SessionOpenResult
+installOpenedArchiveResult(ProjectSession& session, OpenIntentCapture intent,
+                           project::OpenArchiveResult opened,
+                           std::optional<ProjectDisplayPath> displayPath) noexcept;
 
 // Pipeline: session.admitOpenIntent() -> project::openProjectArchive(archive, limits, operation) ->
 //   - Opened: build a DecodedReplacementContent from the OpenedArchive (editability is always

--- a/src/host/include/bloom/host/session_save.hpp
+++ b/src/host/include/bloom/host/session_save.hpp
@@ -187,11 +187,53 @@ class [[nodiscard]] SessionSaveResult final {
     std::optional<SessionSaveSavepointBookkeepingFailure> savepointBookkeepingFailure_;
 };
 
-// Pipeline: session.captureSaveInput(request.intent) -> assemble one CanonicalManifestV1 (format/
-// containerVersion constants, documentSchemaVersion {1, schemaMinor}, the captured retained
-// requirements) and one CanonicalDocumentV1 (the captured snapshot, colorSettings, roundTrip,
-// schemaMinor) -> executeSavePublication() -> outcome handling exactly as documented on
-// SessionSaveResult's factory functions above.
+// ------------------------------------------------------------------------------------------------
+// Task A1 (issue #68), frozen design decision 2: "session-free middles" so the synchronous
+// saveProjectSession() below and the async save worker (session_async_io.cpp) drive the SAME code.
+// A SessionSaveOwningInput is a fully self-contained snapshot -- everything captureSaveInput() and
+// SessionSaveRequest's own by-value fields provide, with no remaining reference back to
+// ProjectSession or to the caller's request object -- so it can cross a thread boundary and outlive
+// the call that built it. `capturedInput` alone already owns the round-trip view (see
+// SessionSaveInput's class comment): a copy of the session's std::shared_ptr<const
+// project::RoundTripState>, kept alive independently of the session (design decision 1).
+// ------------------------------------------------------------------------------------------------
+struct SessionSaveOwningInput final {
+    SessionSaveInput capturedInput;
+    std::filesystem::path targetPath;
+    platform::ArtifactOverwritePolicy overwritePolicy =
+        platform::ArtifactOverwritePolicy::CreateOrReplace;
+    std::optional<platform::ArtifactTargetObservation> expectedTarget;
+    project::SaveArchiveLimits limits;
+};
+
+// The session-free save middle: manifest/document assembly (from `input.capturedInput`) ->
+// executeSavePublication(). Owns no session reference at all. `preAdmitted`/`cancellationFlag` are
+// forwarded verbatim to executeSavePublication(), exactly as SessionSaveRequest documents them --
+// for the async save worker, `cancellationFlag` is the executor-side atomic the scheduler's
+// CancellationToken is bridged onto (see session_async_io.hpp's cancellation-bridge documentation).
+// noexcept: mirrors executeSavePublication() itself; nothing this function does beyond that call
+// can throw (CanonicalManifestV1::requirements is a non-owning std::span over `input`'s own
+// already- owned vector).
+[[nodiscard]] SavePublicationResult executeSessionSaveMiddle(
+    PublicationCoordinator& coordinator, platform::StagedArtifactCoordinator& artifacts,
+    const SessionSaveOwningInput& input, PublicationAdmission* preAdmitted,
+    const std::atomic_bool* cancellationFlag, project::ProjectIoOperationMemory operation) noexcept;
+
+// The shared "accept" step: given a real SavePublicationResult reached via executeSessionSaveMiddle
+// (synchronously below, or from a completed async worker in session_async_io.cpp's
+// AsyncSessionSave::tryComplete()), decides the outcome and, on a published target, calls
+// session.acceptSavepoint() -- exactly saveProjectSession()'s own tail, factored out so the
+// synchronous entry point and the async completion drive identical logic. noexcept: mirrors
+// saveProjectSession()'s own top-level noexcept guarantee (acceptSavepoint() is wrapped
+// internally).
+[[nodiscard]] SessionSaveResult
+acceptSessionSavePublication(ProjectSession& session, SavePublicationResult publicationResult,
+                             SessionPathIntentCapture intent, document::Revision capturedRevision,
+                             const std::filesystem::path& targetPath) noexcept;
+
+// Pipeline: session.captureSaveInput(request.intent) -> build a SessionSaveOwningInput ->
+// executeSessionSaveMiddle() -> acceptSessionSavePublication() -- outcome handling exactly as
+// documented on SessionSaveResult's factory functions above.
 //
 // On Published/PublishedWithDurabilityWarning, acceptSavepoint() is called with `request.intent`,
 // the winning PublicationIntentId, the captured revision, and -- per the frozen design -- the
@@ -199,10 +241,10 @@ class [[nodiscard]] SessionSaveResult final {
 // acceptSavepoint()'s own path-authority contract). Save As abandonment on a non-published outcome
 // is deliberately left to the caller (session.abandonSaveAsIntent()); this function never calls it.
 //
-// noexcept top level: neither captureSaveInput() nor acceptSavepoint() is itself noexcept (both
-// can allocate -- copying document::ColorSettings/retained requirements, or a
+// noexcept top level: neither captureSaveInput() nor building the owning input is itself noexcept
+// (both can allocate -- copying document::ColorSettings/retained requirements/a
 // std::filesystem::path -- and are wrapped accordingly; see SessionSaveResourceExhausted above).
-// executeSavePublication() is already noexcept.
+// executeSessionSaveMiddle() and acceptSessionSavePublication() are already noexcept.
 [[nodiscard]] SessionSaveResult
 saveProjectSession(ProjectSession& session, PublicationCoordinator& coordinator,
                    platform::StagedArtifactCoordinator& artifacts,

--- a/src/host/project_session.cpp
+++ b/src/host/project_session.cpp
@@ -79,20 +79,25 @@ const document::Snapshot& DecodedProjectSnapshotResult::snapshot() const& {
     return *snapshot_;
 }
 
-ProjectSession::ProjectSession(
-    const ProjectSessionId projectSessionId, std::unique_ptr<document::Document> document,
-    std::unique_ptr<commands::CommandStack> commandStack,
-    const DecodedProjectEditability editability, const document::Revision cleanRevision,
-    std::optional<ProjectDisplayPath> displayPath,
-    std::optional<document::ColorSettings> colorSettings,
-    std::optional<project::RoundTripState> roundTrip, const std::uint32_t schemaMinor,
-    std::vector<project::ManifestRequirement> retainedRequirements) noexcept
+ProjectSession::ProjectSession(const ProjectSessionId projectSessionId,
+                               std::unique_ptr<document::Document> document,
+                               std::unique_ptr<commands::CommandStack> commandStack,
+                               const DecodedProjectEditability editability,
+                               const document::Revision cleanRevision,
+                               std::optional<ProjectDisplayPath> displayPath,
+                               std::optional<document::ColorSettings> colorSettings,
+                               std::optional<project::RoundTripState> roundTrip,
+                               const std::uint32_t schemaMinor,
+                               std::vector<project::ManifestRequirement> retainedRequirements)
     : projectSessionId_(projectSessionId), contentKind_(ProjectSessionContentKind::DecodedDocument),
       editability_(editability), displayPath_(std::move(displayPath)),
       cleanRevision_(cleanRevision), colorSettings_(std::move(colorSettings)),
-      roundTrip_(std::move(roundTrip)), schemaMinor_(schemaMinor),
-      retainedRequirements_(std::move(retainedRequirements)), document_(std::move(document)),
-      commandStack_(std::move(commandStack)), valid_(true) {}
+      // Design decision 1: wrap the by-value optional into the session's owning shared view.
+      roundTrip_(roundTrip.has_value()
+                     ? std::make_shared<const project::RoundTripState>(std::move(*roundTrip))
+                     : nullptr),
+      schemaMinor_(schemaMinor), retainedRequirements_(std::move(retainedRequirements)),
+      document_(std::move(document)), commandStack_(std::move(commandStack)), valid_(true) {}
 
 ProjectSession::ProjectSession(const ProjectSessionId projectSessionId,
                                ProjectDisplayPath preservedDisplayPath) noexcept
@@ -424,10 +429,16 @@ SessionInstallStatus ProjectSession::installDecodedReplacement(const OpenIntentC
         return SessionInstallStatus::RuntimeIdentityExhausted;
     }
 
-    // The one allocation this method performs: a fresh CommandStack bound to the new document.
-    // Constructed before any session-state mutation below, so a thrown std::bad_alloc here leaves
-    // the session completely untouched (strong exception guarantee).
+    // The allocations this method performs: a fresh CommandStack bound to the new document, and
+    // (design decision 1) wrapping a present content.roundTrip_ into the session's owning
+    // std::shared_ptr<const project::RoundTripState>. Both happen before any session-state mutation
+    // below, so a thrown std::bad_alloc here leaves the session completely untouched (strong
+    // exception guarantee).
     auto freshStack = std::make_unique<commands::CommandStack>(*content.document_);
+    auto sharedRoundTrip =
+        content.roundTrip_.has_value()
+            ? std::make_shared<const project::RoundTripState>(std::move(*content.roundTrip_))
+            : nullptr;
 
     // Atomic installation (docs/architecture/project-session.md, "Session Publication").
     const auto advanceStatus = advanceResultAcceptanceForInstalledReplacement();
@@ -450,7 +461,7 @@ SessionInstallStatus ProjectSession::installDecodedReplacement(const OpenIntentC
     document_ = std::move(content.document_);
     commandStack_ = std::move(freshStack);
     colorSettings_ = std::move(content.colorSettings_);
-    roundTrip_ = std::move(content.roundTrip_);
+    roundTrip_ = std::move(sharedRoundTrip);
     schemaMinor_ = content.schemaMinor_;
     retainedRequirements_ = std::move(content.requirements_);
     contentKind_ = ProjectSessionContentKind::DecodedDocument;
@@ -612,9 +623,12 @@ ProjectSession::captureSaveInput(const SessionPathIntentCapture intent) const {
     if (!matchesPathIntent(intent)) {
         return SessionSaveInputResult(SessionSaveInputStatus::StaleIntent);
     }
-    return SessionSaveInputResult(SessionSaveInput(
-        document_->snapshot(), *colorSettings_, roundTrip_.has_value() ? &*roundTrip_ : nullptr,
-        schemaMinor_, retainedRequirements_, displayPath_, intent, captureResultAcceptance()));
+    // roundTrip_ is copied (shared_ptr copy, not the pointee) into the returned SessionSaveInput --
+    // see design decision 1: the capture keeps the CURRENT round-trip state alive independently of
+    // this session, even across a later replacement install on this same session.
+    return SessionSaveInputResult(
+        SessionSaveInput(document_->snapshot(), *colorSettings_, roundTrip_, schemaMinor_,
+                         retainedRequirements_, displayPath_, intent, captureResultAcceptance()));
 }
 
 ProjectSessionCommandResult ProjectSession::unavailableCommandResult() const noexcept {

--- a/src/host/session_async_io.cpp
+++ b/src/host/session_async_io.cpp
@@ -1,0 +1,296 @@
+#include <bloom/host/session_async_io.hpp>
+
+#include <exception>
+#include <new>
+#include <span>
+#include <utility>
+
+namespace bloom::host {
+
+namespace {
+
+// Neither ProjectSession nor bloom::runtime::TaskScheduler exposes a per-session TaskOwnerId today
+// (docs/architecture/project-session.md: "The runtime Project task owner uses a fresh TaskOwnerId
+// for each installed session" -- that identity does not yet exist on ProjectSession's public
+// surface). This task's non-goals forbid jobs/task-bridge changes, so both async workers below
+// submit under this fixed placeholder Application-kind owner rather than inventing new
+// session-owned identity plumbing. A future slice that wires ProjectSession to a real per-session
+// TaskOwnerId should replace this with that identity so scheduler-level owner cancellation
+// (TaskScheduler::cancelOwner()) can target one session's async I/O specifically.
+[[nodiscard]] runtime::TaskOwner asyncSessionIoOwner() noexcept {
+    return {.kind = runtime::TaskOwnerKind::Application, .id = runtime::TaskOwnerId::fromRaw(1)};
+}
+
+} // namespace
+
+// ================================================================================================
+// Save
+// ================================================================================================
+
+AsyncSessionSave::AsyncSessionSave(runtime::TaskScheduler& scheduler,
+                                   runtime::TaskHandle<void> handle,
+                                   std::shared_ptr<detail::AsyncSessionSaveSharedState> shared,
+                                   const SessionPathIntentCapture intent,
+                                   const document::Revision revision,
+                                   std::filesystem::path targetPath) noexcept
+    : scheduler_(&scheduler), handle_(std::move(handle)), shared_(std::move(shared)),
+      intent_(intent), revision_(revision), targetPath_(std::move(targetPath)) {}
+
+AsyncSessionSave::~AsyncSessionSave() {
+    if (shared_ && !completed_) {
+        requestCancellation();
+    }
+}
+
+bool AsyncSessionSave::isReady() const noexcept {
+    if (!shared_ || completed_ || scheduler_ == nullptr) {
+        return false;
+    }
+    const auto snapshot = scheduler_->snapshot(handle_.id());
+    return snapshot.has_value() && runtime::isTerminal(snapshot->state);
+}
+
+void AsyncSessionSave::requestCancellation() noexcept {
+    if (shared_) {
+        shared_->cancellationFlag.store(true, std::memory_order_release);
+    }
+    if (handle_.isValid()) {
+        handle_.cancel();
+    }
+}
+
+std::optional<SessionSaveResult> AsyncSessionSave::tryComplete(ProjectSession& session) {
+    if (!shared_ || completed_) {
+        return std::nullopt;
+    }
+    const auto taken = handle_.tryTakeResult();
+    if (!taken.has_value()) {
+        return std::nullopt;
+    }
+    completed_ = true;
+    if (!shared_->publication.has_value()) {
+        // The scheduler-level task never populated its shared result (an exception the runtime's
+        // own TypedTaskWork wrapper caught before our worker body ran to completion, or a
+        // scheduler-level Cancelled state for a task that never started) -- no middle ever ran, so
+        // the session is untouched. Reported the same typed way the synchronous flow reports an
+        // unexpected pipeline failure before publish() ever runs.
+        return SessionSaveResult::publicationFailure(
+            SavePublicationFailure(SavePublicationStage::None, SavePublicationUnexpectedFailure{}),
+            std::nullopt);
+    }
+    return acceptSessionSavePublication(session, std::move(*shared_->publication), intent_,
+                                        revision_, targetPath_);
+}
+
+AsyncSessionSaveResult::AsyncSessionSaveResult(SessionSaveCaptureOutcome outcome) noexcept
+    : stage_(AsyncSessionSaveBeginStage::Capture), captureFailure_(outcome) {}
+
+AsyncSessionSaveResult::AsyncSessionSaveResult(const runtime::TaskSubmissionStatus status) noexcept
+    : stage_(AsyncSessionSaveBeginStage::Submission), submissionFailure_(status) {}
+
+AsyncSessionSaveResult::AsyncSessionSaveResult(AsyncSessionSave handle) noexcept
+    : stage_(AsyncSessionSaveBeginStage::Submission), handle_(std::move(handle)) {}
+
+AsyncSessionSave AsyncSessionSaveResult::takeHandle() && noexcept {
+    if (!handle_.has_value()) {
+        std::terminate();
+    }
+    return std::move(*handle_);
+}
+
+AsyncSessionSaveResult beginSessionSave(ProjectSession& session, runtime::TaskScheduler& scheduler,
+                                        PublicationCoordinator& coordinator,
+                                        platform::StagedArtifactCoordinator& artifacts,
+                                        const SessionSaveRequest& request,
+                                        project::ProjectIoOperationMemory operation) {
+    std::optional<SessionSaveOwningInput> owning;
+    try {
+        SessionSaveInputResult captured = session.captureSaveInput(request.intent);
+        if (!captured) {
+            return AsyncSessionSaveResult(SessionSaveCaptureOutcome{captured.status()});
+        }
+        owning.emplace(SessionSaveOwningInput{
+            .capturedInput = std::move(captured).takeValue(),
+            .targetPath = request.targetPath,
+            .overwritePolicy = request.overwritePolicy,
+            .expectedTarget = request.expectedTarget,
+            .limits = request.limits,
+        });
+    } catch (const std::bad_alloc&) {
+        return AsyncSessionSaveResult(SessionSaveCaptureOutcome{SessionSaveResourceExhausted{}});
+    } catch (...) {
+        return AsyncSessionSaveResult(SessionSaveCaptureOutcome{SessionSaveUnexpectedFailure{}});
+    }
+
+    const auto intent = owning->capturedInput.pathIntent();
+    const auto revision = owning->capturedInput.revision();
+    auto targetPath = owning->targetPath;
+    auto shared = std::make_shared<detail::AsyncSessionSaveSharedState>();
+
+    // Ownership transfer, not a borrow (see session_async_io.hpp's threading-rules "preAdmitted"
+    // note): the synchronous flow's `preAdmitted` pointer is same-frame-safe
+    // (executeSavePublication() runs and returns before saveProjectSession() does), but the async
+    // worker consumes it at an unbounded later time on another thread -- a borrowed pointer would
+    // dangle against the caller's natural "admit, then let the admission go out of scope" pattern.
+    // Move the admission out of the caller's object HERE, on the authoring thread, into `shared`
+    // (see AsyncSessionSaveSharedState::preAdmitted's own comment for why it lives there rather
+    // than in the worker closure's captures directly). PublicationAdmission is move-only RAII that
+    // abandons itself on destruction, which is exactly correct if the task is never started
+    // (submission rejected) or never reaches registration.
+    if (request.preAdmitted != nullptr) {
+        shared->preAdmitted.emplace(std::move(*request.preAdmitted));
+    }
+
+    runtime::TaskRequest taskRequest("Save project (async)", asyncSessionIoOwner(),
+                                     runtime::TaskPriority::Foreground,
+                                     runtime::TaskExecutor::BlockingIo);
+
+    auto submission = scheduler.submit<void>(
+        std::move(taskRequest),
+        [&coordinator, &artifacts, ownedInput = std::move(*owning),
+         operation = std::move(operation),
+         shared](runtime::TaskContext& context) -> runtime::TaskResult<void> {
+            // Entry-time cancellation bridge -- see session_async_io.hpp's cancellation-bridge
+            // documentation for exactly what this covers.
+            if (context.isCancellationRequested()) {
+                shared->cancellationFlag.store(true, std::memory_order_release);
+            }
+            // `shared` is captured by value (a copy of the shared_ptr), but its pointee is not
+            // const-qualified by that -- mutating *shared through it (here, and via
+            // shared->publication.emplace() below) needs no `mutable` on this lambda.
+            auto* const preAdmitted =
+                shared->preAdmitted.has_value() ? &*shared->preAdmitted : nullptr;
+            auto publication =
+                executeSessionSaveMiddle(coordinator, artifacts, ownedInput, preAdmitted,
+                                         &shared->cancellationFlag, operation);
+            shared->publication.emplace(std::move(publication));
+            return runtime::TaskResult<void>::succeeded();
+        });
+
+    if (!submission.accepted()) {
+        return AsyncSessionSaveResult(submission.status);
+    }
+
+    return AsyncSessionSaveResult(AsyncSessionSave(scheduler, std::move(submission.handle),
+                                                   std::move(shared), intent, revision,
+                                                   std::move(targetPath)));
+}
+
+// ================================================================================================
+// Open
+// ================================================================================================
+
+AsyncSessionOpen::AsyncSessionOpen(runtime::TaskScheduler& scheduler,
+                                   runtime::TaskHandle<void> handle,
+                                   std::shared_ptr<detail::AsyncSessionOpenSharedState> shared,
+                                   const OpenIntentCapture intent,
+                                   std::optional<ProjectDisplayPath> displayPath) noexcept
+    : scheduler_(&scheduler), handle_(std::move(handle)), shared_(std::move(shared)),
+      intent_(intent), displayPath_(std::move(displayPath)) {}
+
+AsyncSessionOpen::~AsyncSessionOpen() {
+    if (shared_ && !completed_) {
+        requestCancellation();
+    }
+}
+
+bool AsyncSessionOpen::isReady() const noexcept {
+    if (!shared_ || completed_ || scheduler_ == nullptr) {
+        return false;
+    }
+    const auto snapshot = scheduler_->snapshot(handle_.id());
+    return snapshot.has_value() && runtime::isTerminal(snapshot->state);
+}
+
+void AsyncSessionOpen::requestCancellation() noexcept {
+    if (shared_) {
+        shared_->cancellationFlag.store(true, std::memory_order_release);
+    }
+    if (handle_.isValid()) {
+        handle_.cancel();
+    }
+}
+
+std::optional<SessionOpenResult> AsyncSessionOpen::tryComplete(ProjectSession& session) {
+    if (!shared_ || completed_) {
+        return std::nullopt;
+    }
+    const auto taken = handle_.tryTakeResult();
+    if (!taken.has_value()) {
+        return std::nullopt;
+    }
+    completed_ = true;
+    if (shared_->cancelledBeforeOpening) {
+        return SessionOpenResult::notOpened(SessionOpenNotOpenedReason::CancelledBeforeOpening);
+    }
+    if (!shared_->opened.has_value()) {
+        // Same scheduler-level "never populated" edge as AsyncSessionSave::tryComplete() -- no
+        // install*() call is ever made, session untouched.
+        return SessionOpenResult::notOpened(SessionOpenNotOpenedReason::WorkerUnexpectedFailure);
+    }
+    return installOpenedArchiveResult(session, intent_, std::move(*shared_->opened),
+                                      std::move(displayPath_));
+}
+
+AsyncSessionOpenResult::AsyncSessionOpenResult(const OpenIntentAdmissionStatus status) noexcept
+    : stage_(AsyncSessionOpenBeginStage::Admission), admissionFailure_(status) {}
+
+AsyncSessionOpenResult::AsyncSessionOpenResult(const runtime::TaskSubmissionStatus status) noexcept
+    : stage_(AsyncSessionOpenBeginStage::Submission), submissionFailure_(status) {}
+
+AsyncSessionOpenResult::AsyncSessionOpenResult(AsyncSessionOpen handle) noexcept
+    : stage_(AsyncSessionOpenBeginStage::Submission), handle_(std::move(handle)) {}
+
+AsyncSessionOpen AsyncSessionOpenResult::takeHandle() && noexcept {
+    if (!handle_.has_value()) {
+        std::terminate();
+    }
+    return std::move(*handle_);
+}
+
+AsyncSessionOpenResult beginSessionOpen(ProjectSession& session, runtime::TaskScheduler& scheduler,
+                                        std::vector<std::byte> bytes,
+                                        std::optional<ProjectDisplayPath> displayPath,
+                                        const project::SaveArchiveLimits& limits,
+                                        project::ProjectIoOperationMemory operation) {
+    const auto admission = session.admitOpenIntent();
+    if (!admission) {
+        return AsyncSessionOpenResult(admission.status());
+    }
+    const auto intent = admission.capture();
+    const auto limitsCopy = limits;
+    auto shared = std::make_shared<detail::AsyncSessionOpenSharedState>();
+
+    runtime::TaskRequest taskRequest("Open project (async)", asyncSessionIoOwner(),
+                                     runtime::TaskPriority::Foreground,
+                                     runtime::TaskExecutor::BlockingIo);
+
+    auto submission = scheduler.submit<void>(
+        std::move(taskRequest),
+        [bytesOwned = std::move(bytes), limitsCopy, operation = std::move(operation),
+         shared](runtime::TaskContext& context) -> runtime::TaskResult<void> {
+            // Entry-time-only cancellation bridge -- project::openProjectArchive() has no internal
+            // checkpoints of its own to observe a mid-flight cancellation; see
+            // session_async_io.hpp's cancellation-bridge documentation.
+            if (context.isCancellationRequested() ||
+                shared->cancellationFlag.load(std::memory_order_acquire)) {
+                shared->cancellationFlag.store(true, std::memory_order_release);
+                shared->cancelledBeforeOpening = true;
+                return runtime::TaskResult<void>::succeeded();
+            }
+            auto opened = project::openProjectArchive(std::span<const std::byte>(bytesOwned),
+                                                      limitsCopy, operation);
+            shared->opened.emplace(std::move(opened));
+            return runtime::TaskResult<void>::succeeded();
+        });
+
+    if (!submission.accepted()) {
+        return AsyncSessionOpenResult(submission.status);
+    }
+
+    return AsyncSessionOpenResult(AsyncSessionOpen(scheduler, std::move(submission.handle),
+                                                   std::move(shared), intent,
+                                                   std::move(displayPath)));
+}
+
+} // namespace bloom::host

--- a/src/host/session_open.cpp
+++ b/src/host/session_open.cpp
@@ -31,6 +31,13 @@ SessionOpenResult SessionOpenResult::installation(
     return result;
 }
 
+SessionOpenResult SessionOpenResult::notOpened(const SessionOpenNotOpenedReason reason) noexcept {
+    SessionOpenResult result;
+    result.stage_ = SessionOpenStage::NotOpened;
+    result.notOpenedReason_ = reason;
+    return result;
+}
+
 namespace {
 
 // Both install*() calls below are the only non-noexcept composed surfaces in this pipeline (each
@@ -80,17 +87,10 @@ installPreservedReadOnlyAndReport(ProjectSession& session, const OpenIntentCaptu
 
 } // namespace
 
-SessionOpenResult openSessionArchive(ProjectSession& session, std::span<const std::byte> archive,
-                                     std::optional<ProjectDisplayPath> displayPath,
-                                     const project::SaveArchiveLimits& limits,
-                                     project::ProjectIoOperationMemory operation) noexcept {
-    const auto admission = session.admitOpenIntent();
-    if (!admission) {
-        return SessionOpenResult::admissionFailure(admission.status());
-    }
-    const auto intent = admission.capture();
-
-    auto opened = project::openProjectArchive(archive, limits, std::move(operation));
+SessionOpenResult
+installOpenedArchiveResult(ProjectSession& session, const OpenIntentCapture intent,
+                           project::OpenArchiveResult opened,
+                           std::optional<ProjectDisplayPath> displayPath) noexcept {
     if (opened.outcome() == project::OpenArchiveOutcome::Failed) {
         // Session untouched: no install*() call is ever made on this path.
         return SessionOpenResult::openingFailure(std::move(opened).takeFailure());
@@ -106,8 +106,8 @@ SessionOpenResult openSessionArchive(ProjectSession& session, std::span<const st
             // createPreservedReadOnly() requires a path too: a pathless preserved-read-only
             // install is refused here, without ever calling installPreservedReadOnlyReplacement()
             // (which requires a real ProjectDisplayPath by contract) -- session untouched. The
-            // caller still gets the preservation diagnostics verbatim (it retains `archive` for
-            // Save Copy per this module's file comment).
+            // caller still gets the preservation diagnostics verbatim (it retains the archive
+            // bytes for Save Copy per this module's file comment).
             return SessionOpenResult::installation(SessionInstallStatus::InvalidContent,
                                                    ProjectSessionContentKind::PreservedReadOnly,
                                                    diagnostics);
@@ -131,6 +131,19 @@ SessionOpenResult openSessionArchive(ProjectSession& session, std::span<const st
         // decision 2) -- every opened archive installs as fully Editable here.
         DecodedProjectEditability::Editable, std::move(displayPath), std::move(reservations));
     return installDecodedAndReport(session, intent, std::move(content));
+}
+
+SessionOpenResult openSessionArchive(ProjectSession& session, std::span<const std::byte> archive,
+                                     std::optional<ProjectDisplayPath> displayPath,
+                                     const project::SaveArchiveLimits& limits,
+                                     project::ProjectIoOperationMemory operation) noexcept {
+    const auto admission = session.admitOpenIntent();
+    if (!admission) {
+        return SessionOpenResult::admissionFailure(admission.status());
+    }
+    auto opened = project::openProjectArchive(archive, limits, std::move(operation));
+    return installOpenedArchiveResult(session, admission.capture(), std::move(opened),
+                                      std::move(displayPath));
 }
 
 } // namespace bloom::host

--- a/src/host/session_save.cpp
+++ b/src/host/session_save.cpp
@@ -56,76 +56,39 @@ SessionSaveResult SessionSaveResult::publishedSavepointBookkeepingFailed(
     return result;
 }
 
-namespace {
-
-// The one allocation this module performs itself, ahead of executeSavePublication() (which is
-// already noexcept and reports its own allocation failures as a typed SavePublicationFailure): a
-// copy of the captured retained-requirements vector, kept alive for CanonicalManifestV1's span for
-// the duration of the executeSavePublication() call. A failure here is attributed to the
-// Publication stage at SavePublicationStage::None -- honestly "failed before the publication
-// pipeline was ever entered, while assembling its input" -- reusing SavePublicationFailure's own
-// resource-exhausted payload rather than inventing a fourth stage for one allocation.
-[[nodiscard]] SessionSaveResult assemblyResourceExhausted() noexcept {
-    return SessionSaveResult::publicationFailure(
-        SavePublicationFailure(SavePublicationStage::None, SavePublicationResourceExhausted{}),
-        std::nullopt);
-}
-
-} // namespace
-
-SessionSaveResult saveProjectSession(ProjectSession& session, PublicationCoordinator& coordinator,
-                                     platform::StagedArtifactCoordinator& artifacts,
-                                     const SessionSaveRequest& request,
-                                     project::ProjectIoOperationMemory operation) noexcept {
-    std::optional<SessionSaveInputResult> captured;
-    try {
-        captured.emplace(session.captureSaveInput(request.intent));
-    } catch (const std::bad_alloc&) {
-        return SessionSaveResult::captureFailure(SessionSaveResourceExhausted{});
-    } catch (...) {
-        return SessionSaveResult::captureFailure(SessionSaveUnexpectedFailure{});
-    }
-    if (!*captured) {
-        return SessionSaveResult::captureFailure(captured->status());
-    }
-    const auto* input = captured->value();
-    if (input == nullptr) {
-        // Unreachable: `*captured` above already proved status() == Captured, which guarantees
-        // value() is non-null (see SessionSaveInputResult::operator bool()). Handled anyway so
-        // this function's control flow stays provably total.
-        return SessionSaveResult::captureFailure(SessionSaveUnexpectedFailure{});
-    }
-
-    std::vector<project::ManifestRequirement> requirements;
-    try {
-        requirements = input->retainedRequirements();
-    } catch (const std::bad_alloc&) {
-        return assemblyResourceExhausted();
-    }
-
+SavePublicationResult executeSessionSaveMiddle(
+    PublicationCoordinator& coordinator, platform::StagedArtifactCoordinator& artifacts,
+    const SessionSaveOwningInput& input, PublicationAdmission* const preAdmitted,
+    const std::atomic_bool* const cancellationFlag,
+    project::ProjectIoOperationMemory operation) noexcept {
     const project::CanonicalManifestV1 manifest{
-        .documentSchemaVersion = {1, input->schemaMinor()},
-        .requirements = requirements,
+        .documentSchemaVersion = {1, input.capturedInput.schemaMinor()},
+        .requirements = input.capturedInput.retainedRequirements(),
     };
     const project::CanonicalDocumentV1 documentInput{
-        .snapshot = &input->snapshot(),
-        .colorSettings = &input->colorSettings(),
-        .roundTrip = input->roundTrip(),
-        .schemaMinor = input->schemaMinor(),
+        .snapshot = &input.capturedInput.snapshot(),
+        .colorSettings = &input.capturedInput.colorSettings(),
+        .roundTrip = input.capturedInput.roundTrip(),
+        .schemaMinor = input.capturedInput.schemaMinor(),
     };
     const SavePublicationRequest publicationRequest{
-        .targetPath = request.targetPath,
-        .overwritePolicy = request.overwritePolicy,
-        .expectedTarget = request.expectedTarget,
+        .targetPath = input.targetPath,
+        .overwritePolicy = input.overwritePolicy,
+        .expectedTarget = input.expectedTarget,
         .manifest = &manifest,
         .document = &documentInput,
-        .limits = request.limits,
-        .preAdmitted = request.preAdmitted,
-        .cancellationFlag = request.cancellationFlag,
+        .limits = input.limits,
+        .preAdmitted = preAdmitted,
+        .cancellationFlag = cancellationFlag,
     };
+    return executeSavePublication(coordinator, artifacts, publicationRequest, std::move(operation));
+}
 
-    auto publicationResult =
-        executeSavePublication(coordinator, artifacts, publicationRequest, std::move(operation));
+SessionSaveResult acceptSessionSavePublication(ProjectSession& session,
+                                               SavePublicationResult publicationResult,
+                                               const SessionPathIntentCapture intent,
+                                               const document::Revision capturedRevision,
+                                               const std::filesystem::path& targetPath) noexcept {
     if (!publicationResult) {
         return SessionSaveResult::publicationFailure(*publicationResult.failure(),
                                                      publicationResult.rejectDiagnostic());
@@ -144,11 +107,11 @@ SessionSaveResult saveProjectSession(ProjectSession& session, PublicationCoordin
 
     try {
         std::optional<ProjectDisplayPath> publishedPath;
-        if (request.intent.kind() == SessionPathIntentKind::ReplacementPath) {
-            publishedPath = ProjectDisplayPath::create(request.targetPath);
+        if (intent.kind() == SessionPathIntentKind::ReplacementPath) {
+            publishedPath = ProjectDisplayPath::create(targetPath);
         }
         const auto savepointStatus =
-            session.acceptSavepoint(request.intent, intentId, input->revision(), publishedPath);
+            session.acceptSavepoint(intent, intentId, capturedRevision, publishedPath);
         return SessionSaveResult::published(*publication, intentId, savepointStatus);
     } catch (const std::bad_alloc&) {
         // The file was already durably published (`*publication`/`intentId` are both still in
@@ -162,6 +125,38 @@ SessionSaveResult saveProjectSession(ProjectSession& session, PublicationCoordin
         return SessionSaveResult::publishedSavepointBookkeepingFailed(
             *publication, intentId, SessionSaveSavepointBookkeepingFailure::UnexpectedFailure);
     }
+}
+
+SessionSaveResult saveProjectSession(ProjectSession& session, PublicationCoordinator& coordinator,
+                                     platform::StagedArtifactCoordinator& artifacts,
+                                     const SessionSaveRequest& request,
+                                     project::ProjectIoOperationMemory operation) noexcept {
+    std::optional<SessionSaveOwningInput> owning;
+    try {
+        SessionSaveInputResult captured = session.captureSaveInput(request.intent);
+        if (!captured) {
+            return SessionSaveResult::captureFailure(captured.status());
+        }
+        owning.emplace(SessionSaveOwningInput{
+            .capturedInput = std::move(captured).takeValue(),
+            .targetPath = request.targetPath,
+            .overwritePolicy = request.overwritePolicy,
+            .expectedTarget = request.expectedTarget,
+            .limits = request.limits,
+        });
+    } catch (const std::bad_alloc&) {
+        return SessionSaveResult::captureFailure(SessionSaveResourceExhausted{});
+    } catch (...) {
+        return SessionSaveResult::captureFailure(SessionSaveUnexpectedFailure{});
+    }
+
+    const auto intent = owning->capturedInput.pathIntent();
+    const auto capturedRevision = owning->capturedInput.revision();
+    auto publicationResult =
+        executeSessionSaveMiddle(coordinator, artifacts, *owning, request.preAdmitted,
+                                 request.cancellationFlag, std::move(operation));
+    return acceptSessionSavePublication(session, std::move(publicationResult), intent,
+                                        capturedRevision, owning->targetPath);
 }
 
 } // namespace bloom::host

--- a/src/host/tests/session_async_io_tests.cpp
+++ b/src/host/tests/session_async_io_tests.cpp
@@ -1,0 +1,1098 @@
+#include <bloom/host/session_async_io.hpp>
+
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/host/project_session.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/host/session_open.hpp>
+#include <bloom/host/session_save.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/manifest_requirements.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+// Drives beginSessionSave()/beginSessionOpen() (session_async_io.cpp, task A1, issue #68) against a
+// REAL bloom::runtime::TaskScheduler with a real TaskExecutor::BlockingIo worker and REAL
+// PublicationCoordinator/platform::StagedArtifactCoordinator instances -- following
+// session_save_tests.cpp's/session_open_tests.cpp's fixture pattern one layer up, plus
+// src/runtime/tests/task_scheduler_tests.cpp's Gate/awaitQuiescence patterns for driving the
+// scheduler deterministically.
+
+namespace {
+
+using namespace std::chrono_literals;
+
+using bloom::commands::SetProjectName;
+using bloom::commands::Transaction;
+
+using bloom::host::ArtifactTargetKey;
+using bloom::host::AsyncSessionOpen;
+using bloom::host::AsyncSessionOpenBeginStage;
+using bloom::host::AsyncSessionSave;
+using bloom::host::AsyncSessionSaveBeginStage;
+using bloom::host::beginSessionOpen;
+using bloom::host::beginSessionSave;
+using bloom::host::DecodedProjectEditability;
+using bloom::host::DecodedProjectSessionRequest;
+using bloom::host::OpenIntentAdmissionStatus;
+using bloom::host::openSessionArchive;
+using bloom::host::ProjectDisplayPath;
+using bloom::host::ProjectSession;
+using bloom::host::ProjectSessionContentKind;
+using bloom::host::ProjectSessionIdentitySource;
+using bloom::host::ProjectSessionSavepointStatus;
+using bloom::host::PublicationAdmission;
+using bloom::host::PublicationCoordinator;
+using bloom::host::PublicationCoordinatorConfig;
+using bloom::host::saveProjectSession;
+using bloom::host::SessionInstallStatus;
+using bloom::host::SessionOpenInstallOutcome;
+using bloom::host::SessionOpenNotOpenedReason;
+using bloom::host::SessionOpenResult;
+using bloom::host::SessionOpenStage;
+using bloom::host::SessionPathIntentKind;
+using bloom::host::SessionSaveCaptureOutcome;
+using bloom::host::SessionSaveInputStatus;
+using bloom::host::SessionSaveRequest;
+using bloom::host::SessionSaveResult;
+using bloom::host::SessionSaveStage;
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::ArtifactTargetObservation;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+using bloom::platform::StagedArtifactPublicationOutcome;
+
+using bloom::project::buildVerifiedSaveArchive;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::SaveArchiveLimits;
+
+using bloom::runtime::TaskContext;
+using bloom::runtime::TaskExecutor;
+using bloom::runtime::TaskOwner;
+using bloom::runtime::TaskOwnerId;
+using bloom::runtime::TaskOwnerKind;
+using bloom::runtime::TaskPriority;
+using bloom::runtime::TaskRequest;
+using bloom::runtime::TaskResult;
+using bloom::runtime::TaskScheduler;
+using bloom::runtime::TaskSchedulerConfig;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-session-async-io-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Shared plumbing (mirrors session_save_tests.cpp/session_open_tests.cpp)
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U;
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    auto coordinator = ProjectIoMemoryCoordinator::create(kGenerousOperationBudget);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation =
+        coordinator->createOperation(kGenerousOperationBudget, kGenerousOperationBudget);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::span<const char> bytes) noexcept {
+    return {reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::optional<PublicationCoordinator>
+makePublicationCoordinator(Expectations& expectations,
+                           const PublicationCoordinatorConfig config = {}) {
+    auto result = PublicationCoordinator::create(config);
+    expectations.expect(result.has_value(), "the publication coordinator is created");
+    return result;
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeArtifactsCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-artifact coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+[[nodiscard]] std::optional<PublicationAdmission> admitIntent(PublicationCoordinator& coordinator,
+                                                              Expectations& expectations,
+                                                              const std::string_view context) {
+    auto result = coordinator.admit();
+    expectations.expect(static_cast<bool>(result), context);
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeAdmission();
+}
+
+[[nodiscard]] bloom::document::Revision currentRevision(const ProjectSession& session) {
+    const auto state = session.stateSnapshot();
+    if (!state.currentRevision.has_value()) {
+        throw std::logic_error("Expected a decoded revision");
+    }
+    return *state.currentRevision;
+}
+
+[[nodiscard]] Transaction rename(std::string value, const ProjectSession& session,
+                                 std::string label = "Rename") {
+    Transaction transaction(std::move(label), currentRevision(session));
+    transaction.emplace<SetProjectName>(std::move(value));
+    return transaction;
+}
+
+[[nodiscard]] std::optional<std::string> projectName(const ProjectSession& session) {
+    const auto snapshot = session.decodedSnapshot();
+    if (!snapshot) {
+        return std::nullopt;
+    }
+    return std::string(snapshot.snapshot().project().name());
+}
+
+[[nodiscard]] ProjectSession
+makeDecodedSession(Expectations& expectations, ProjectSessionIdentitySource& identitySource,
+                   const std::string& projectName,
+                   const std::optional<std::filesystem::path>& displayPath = std::nullopt) {
+    auto created = bloom::document::makeNewProject(projectName, "Main Composition",
+                                                   bloom::core::RationalTime::fromInteger(10));
+    std::optional<ProjectDisplayPath> path;
+    if (displayPath.has_value()) {
+        path = ProjectDisplayPath::create(*displayPath);
+        expectations.expect(path.has_value(), "the display-path fixture is valid");
+    }
+    auto result = ProjectSession::createDecoded(identitySource,
+                                                {.project = std::move(created.project),
+                                                 .colorSettings = neutralColorSettings(),
+                                                 .editability = DecodedProjectEditability::Editable,
+                                                 .displayPath = std::move(path),
+                                                 .persistedAllocatorHighWater = std::nullopt});
+    expectations.expect(static_cast<bool>(result), "the decoded session fixture must be valid");
+    if (!result) {
+        throw std::logic_error("Could not create decoded project-session fixture");
+    }
+    return std::move(result).takeSession();
+}
+
+// A minimal, valid, unverified two-entry archive that always classifies Opened -- mirrors
+// session_open_tests.cpp's buildMinimalArchiveBytesOrAbort() (per-test-file fixture duplication is
+// this codebase's established precedent; see that file's own comment).
+[[nodiscard]] std::vector<std::byte>
+buildMinimalArchiveBytesOrAbort(const std::string& projectName = "Untitled Project") {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject = bloom::document::makeNewProject(projectName, "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    if (!built) {
+        std::abort();
+    }
+    const auto bytes = built.archive()->bytes();
+    return {bytes.begin(), bytes.end()};
+}
+
+// A blocking gate task fixture (mirrors src/runtime/tests/task_scheduler_tests.cpp's Gate): used to
+// saturate the scheduler's single BlockingIo worker so a subsequently-submitted async save/open
+// task provably has not started running yet -- the deterministic way to test
+// cancellation-before-the- worker-starts and destruction-while-still-queued (abandonment).
+class BlockingIoGate final {
+  public:
+    void enterAndWait(TaskContext& context) {
+        std::unique_lock lock(mutex_);
+        entered_ = true;
+        condition_.notify_all();
+        condition_.wait(lock, [&] { return released_ || context.isCancellationRequested(); });
+    }
+
+    [[nodiscard]] bool waitUntilEntered() {
+        std::unique_lock lock(mutex_);
+        return condition_.wait_for(lock, 2s, [&] { return entered_; });
+    }
+
+    void release() {
+        std::lock_guard lock(mutex_);
+        released_ = true;
+        condition_.notify_all();
+    }
+
+  private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    bool entered_ = false;
+    bool released_ = false;
+};
+
+// Submits a task that occupies the scheduler's single BlockingIo worker until `gate.release()` is
+// called. `scheduler.submit<void>` keeps `gate` alive by reference for the fixture's own scope.
+void occupyBlockingIoWorker(Expectations& expectations, TaskScheduler& scheduler,
+                            BlockingIoGate& gate) {
+    auto submission = scheduler.submit<void>(
+        TaskRequest("Blocking IO gate",
+                    TaskOwner{.kind = TaskOwnerKind::Application, .id = TaskOwnerId::fromRaw(999)},
+                    TaskPriority::Foreground, TaskExecutor::BlockingIo),
+        [&gate](TaskContext& context) {
+            gate.enterAndWait(context);
+            return TaskResult<void>::succeeded();
+        });
+    expectations.expect(submission.accepted() && gate.waitUntilEntered(),
+                        "the blocking-I/O gate fixture occupies the single worker");
+}
+
+bool awaitQuiescence(const TaskScheduler& scheduler) {
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (scheduler.isQuiescent()) {
+            return true;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return false;
+}
+
+template <typename Handle> [[nodiscard]] bool pollUntilReady(const Handle& handle) {
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (handle.isReady()) {
+            return true;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Async save end-to-end: begin -> poll until ready -> tryComplete -> Published + Accepted, session
+// clean at the published revision.
+// ---------------------------------------------------------------------------------------------
+
+void testAsyncSaveEndToEnd(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "async save end to end: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    TaskScheduler scheduler;
+
+    auto session = makeDecodedSession(expectations, identitySource, "Async Save End To End");
+    expectations.expect(session.execute(rename("Renamed", session)).changed(),
+                        "async save end to end: the edit commits");
+    const auto editedRevision = currentRevision(session);
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "async save end to end: Save As advances");
+    if (!saveAs) {
+        return;
+    }
+
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto begun =
+        beginSessionSave(session, scheduler, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(begun),
+                        "async save end to end: beginSessionSave submits a handle");
+    if (!begun) {
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+    expectations.expect(pollUntilReady(handle),
+                        "async save end to end: isReady() becomes true without a blocking wait");
+
+    auto result = handle.tryComplete(session);
+    expectations.expect(result.has_value(), "async save end to end: tryComplete yields a result "
+                                            "once ready");
+    if (!result.has_value()) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*result),
+                        "async save end to end: the result names Published + Accepted");
+    expectations.expect(
+        result->stage() == SessionSaveStage::Savepoint && result->publication() != nullptr &&
+            result->publication()->outcome == StagedArtifactPublicationOutcome::Published &&
+            result->savepointStatus() == ProjectSessionSavepointStatus::Accepted,
+        "async save end to end: the result shape matches the synchronous flow's own contract");
+
+    const auto state = session.stateSnapshot();
+    expectations.expect(state.cleanRevision == editedRevision && state.dirty == false,
+                        "async save end to end: session is clean at the published revision");
+
+    // A second tryComplete() call returns nullopt (at-most-once contract).
+    auto again = handle.tryComplete(session);
+    expectations.expect(!again.has_value(),
+                        "async save end to end: tryComplete is idempotent-absent after the first "
+                        "real result");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Async open end-to-end: begin -> poll -> tryComplete -> Installed.
+// ---------------------------------------------------------------------------------------------
+
+void testAsyncOpenEndToEnd(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    TaskScheduler scheduler;
+    auto session = makeDecodedSession(expectations, identitySource, "Async Open Host");
+    auto bytes = buildMinimalArchiveBytesOrAbort("Async Opened Content");
+    auto displayPath = ProjectDisplayPath::create("/tmp/async-opened.bloom");
+    expectations.expect(displayPath.has_value(), "async open end to end: display path constructs");
+    if (!displayPath.has_value()) {
+        return;
+    }
+
+    auto begun = beginSessionOpen(session, scheduler, std::move(bytes), displayPath,
+                                  SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(begun),
+                        "async open end to end: beginSessionOpen submits a handle");
+    if (!begun) {
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+    expectations.expect(pollUntilReady(handle), "async open end to end: isReady() becomes true");
+
+    auto result = handle.tryComplete(session);
+    expectations.expect(result.has_value(), "async open end to end: tryComplete yields a result");
+    if (!result.has_value()) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*result) &&
+                            result->stage() == SessionOpenStage::Installation,
+                        "async open end to end: installation succeeds");
+    const auto* outcome = result->installOutcome();
+    const auto* status = outcome != nullptr ? std::get_if<SessionInstallStatus>(outcome) : nullptr;
+    expectations.expect(status != nullptr && *status == SessionInstallStatus::Installed,
+                        "async open end to end: the install outcome names Installed verbatim");
+
+    const auto state = session.stateSnapshot();
+    expectations.expect(state.displayPath == displayPath && state.dirty == false,
+                        "async open end to end: the session installs the opened content cleanly");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Async open, round-tripped newer minor: a schema {1,1} fixture with an unknown root member opens
+// through the async path exactly as the synchronous flow's
+// testNewProjectFullCycleInstallsBloomNeutralColor / testRoundTrippedNewerMinorSurvivesFullCycle
+// counterparts do.
+// ---------------------------------------------------------------------------------------------
+
+void testAsyncOpenRoundTrippedNewerMinor(Expectations& expectations) {
+    using bloom::project::canonicalDocumentSize;
+    using bloom::project::decodeDocumentEnvelope;
+    using bloom::project::DocumentClassification;
+    using bloom::project::DocumentDecodeOutcome;
+    using bloom::project::DocumentDecodeResult;
+    using bloom::project::encodeCanonicalDocument;
+    using bloom::project::parseStrictJsonDom;
+    using bloom::project::reconstructDocument;
+
+    ProjectSessionIdentitySource identitySource;
+    TaskScheduler scheduler;
+    auto session = makeDecodedSession(expectations, identitySource, "Async Round-Trip Host");
+
+    auto newProject = bloom::document::makeNewProject("Untitled Project", "Main Composition",
+                                                      bloom::core::RationalTime::fromInteger(10));
+    bloom::document::Document sourceDocument{std::move(newProject.project)};
+    auto sourceSnapshot = sourceDocument.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    const CanonicalDocumentV1 baselineRequest{.snapshot = &sourceSnapshot,
+                                              .colorSettings = &colorSettings,
+                                              .payloadScratch = payloadScratch,
+                                              .sortScratch = sortScratch};
+    const auto size = canonicalDocumentSize(baselineRequest);
+    expectations.expect(static_cast<bool>(size), "async round trip: baseline document sizes");
+    if (!size) {
+        return;
+    }
+    std::string text(*size.value(), '\0');
+    const auto written =
+        encodeCanonicalDocument(baselineRequest, std::span<char>(text.data(), text.size()));
+    expectations.expect(static_cast<bool>(written), "async round trip: baseline document encodes");
+    if (!written) {
+        return;
+    }
+    const std::string anchor = "\"minor\": 0\n  },\n  \"project\"";
+    const auto anchorPos = text.find(anchor);
+    expectations.expect(anchorPos != std::string::npos, "async round trip: anchor is located");
+    if (anchorPos == std::string::npos) {
+        return;
+    }
+    text.replace(anchorPos, std::string_view("\"minor\": 0").size(), "\"minor\": 1");
+    if (text.size() < 2 || text.back() != '\n' || text[text.size() - 2] != '}') {
+        expectations.expect(false, "async round trip: baseline ends with the root's closing brace");
+        return;
+    }
+    text.resize(text.size() - 2);
+    text += R"(,"zzzFutureField":42})";
+    text += '\n';
+
+    auto parsed = parseStrictJsonDom(asBytes(text), {}, makeOperation());
+    expectations.expect(static_cast<bool>(parsed), "async round trip: spliced document parses");
+    if (!parsed) {
+        return;
+    }
+    DocumentDecodeResult decoded = decodeDocumentEnvelope(parsed.document()->root());
+    expectations.expect(decoded.outcome() == DocumentDecodeOutcome::Decoded &&
+                            decoded.value() != nullptr && decoded.roundTrip() != nullptr,
+                        "async round trip: spliced document decodes with round-trip state");
+    if (decoded.value() == nullptr || decoded.roundTrip() == nullptr) {
+        return;
+    }
+    auto reconstructed = reconstructDocument(*decoded.value());
+    expectations.expect(static_cast<bool>(reconstructed),
+                        "async round trip: document reconstructs");
+    if (!reconstructed) {
+        return;
+    }
+    auto reconstructedSnapshot = reconstructed.value()->document->snapshot();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 1}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &reconstructedSnapshot,
+                                            .colorSettings = &reconstructed.value()->colorSettings,
+                                            .roundTrip = decoded.roundTrip(),
+                                            .schemaMinor = 1};
+    auto built =
+        buildVerifiedSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(built), "async round trip: fixture archive builds");
+    if (!built) {
+        return;
+    }
+    const auto fixtureBytes = built.archive()->bytes();
+    std::vector<std::byte> ownedBytes(fixtureBytes.begin(), fixtureBytes.end());
+
+    auto displayPath = ProjectDisplayPath::create("/tmp/async-round-trip.bloom");
+    expectations.expect(displayPath.has_value(), "async round trip: display path constructs");
+    if (!displayPath.has_value()) {
+        return;
+    }
+    auto begun = beginSessionOpen(session, scheduler, std::move(ownedBytes), displayPath,
+                                  SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(begun), "async round trip: beginSessionOpen submits");
+    if (!begun) {
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+    expectations.expect(pollUntilReady(handle), "async round trip: isReady() becomes true");
+    auto result = handle.tryComplete(session);
+    expectations.expect(result.has_value() && static_cast<bool>(*result),
+                        "async round trip: the round-tripped newer-minor fixture installs "
+                        "asynchronously exactly as it does synchronously");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Sync/async equivalence: identical content saved once synchronously and once asynchronously
+// produces byte-identical published files.
+// ---------------------------------------------------------------------------------------------
+
+void testSyncAsyncEquivalence(Expectations& expectations) {
+    TempDirectory directoryA;
+    TempDirectory directoryB;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directoryA.isValid() || !directoryB.isValid() || !coordinator.has_value() ||
+        !artifacts.has_value()) {
+        expectations.expect(false, "sync/async equivalence: fixture is available");
+        return;
+    }
+    const auto targetPathSync = directoryA.path() / "project.bloom";
+    const auto targetPathAsync = directoryB.path() / "project.bloom";
+    TaskScheduler scheduler;
+
+    auto sessionSync = makeDecodedSession(expectations, identitySource, "Equivalence Project");
+    const auto saveAsSync = sessionSync.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAsSync),
+                        "sync/async equivalence: sync Save As advances");
+    if (saveAsSync) {
+        const SessionSaveRequest requestSync{
+            .targetPath = targetPathSync,
+            .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+            .expectedTarget = std::nullopt,
+            .limits = {},
+            .intent = saveAsSync.capture(),
+        };
+        auto resultSync =
+            saveProjectSession(sessionSync, *coordinator, *artifacts, requestSync, makeOperation());
+        expectations.expect(static_cast<bool>(resultSync),
+                            "sync/async equivalence: the synchronous save fully succeeds");
+    }
+
+    auto sessionAsync = makeDecodedSession(expectations, identitySource, "Equivalence Project");
+    const auto saveAsAsync = sessionAsync.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAsAsync),
+                        "sync/async equivalence: async Save As advances");
+    if (saveAsAsync) {
+        const SessionSaveRequest requestAsync{
+            .targetPath = targetPathAsync,
+            .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+            .expectedTarget = std::nullopt,
+            .limits = {},
+            .intent = saveAsAsync.capture(),
+        };
+        auto begun = beginSessionSave(sessionAsync, scheduler, *coordinator, *artifacts,
+                                      requestAsync, makeOperation());
+        expectations.expect(static_cast<bool>(begun),
+                            "sync/async equivalence: beginSessionSave submits a handle");
+        if (begun) {
+            auto handle = std::move(begun).takeHandle();
+            expectations.expect(pollUntilReady(handle),
+                                "sync/async equivalence: the async handle becomes ready");
+            auto resultAsync = handle.tryComplete(sessionAsync);
+            expectations.expect(resultAsync.has_value() && static_cast<bool>(*resultAsync),
+                                "sync/async equivalence: the asynchronous save fully succeeds");
+        }
+    }
+
+    const auto bytesSync = readFile(targetPathSync);
+    const auto bytesAsync = readFile(targetPathAsync);
+    expectations.expect(!bytesSync.empty() && bytesSync == bytesAsync,
+                        "sync/async equivalence: saveProjectSession() and begin/tryComplete "
+                        "produce byte-identical published files for identical input");
+}
+
+// ---------------------------------------------------------------------------------------------
+// beginSessionSave() consumes request.preAdmitted at begin (authoring-thread ownership transfer,
+// not a caller-kept-alive borrow): mirrors session_save_tests.cpp's
+// testSupersededLeavesSessionUntouchedThenAbandons, but drives the SAME supersession scenario
+// through the async path with the caller's admission object going out of scope immediately after
+// beginSessionSave() returns -- exactly the natural "admit, then let it go out of scope" caller
+// pattern the fix targets. A higher-intent competitor registers for the same target first, so the
+// worker's own (lower, pre-admitted) intent is Superseded; session untouched.
+// ---------------------------------------------------------------------------------------------
+
+void testAsyncPreAdmittedOwnershipSupersession(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "async preAdmitted ownership: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    TaskScheduler scheduler;
+
+    auto session = makeDecodedSession(expectations, identitySource, "Async Supersession Project");
+    expectations.expect(session.execute(rename("Edited", session)).changed(),
+                        "async preAdmitted ownership: the edit commits");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "async preAdmitted ownership: Save As advances");
+    if (!saveAs) {
+        return;
+    }
+    const auto beforeState = session.stateSnapshot();
+
+    ArtifactTargetKey targetKey;
+    {
+        auto peek = artifacts->preflight({.targetPath = targetPath,
+                                          .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                          .expectedTarget = std::nullopt});
+        expectations.expect(static_cast<bool>(peek),
+                            "async preAdmitted ownership: the peek preflight succeeds");
+        if (!peek) {
+            return;
+        }
+        targetKey = peek.target()->targetKey();
+    }
+
+    auto lowerAdmission =
+        admitIntent(*coordinator, expectations,
+                    "async preAdmitted ownership: the executor's own (lower) intent is admitted "
+                    "first");
+    auto competitorAdmission =
+        admitIntent(*coordinator, expectations,
+                    "async preAdmitted ownership: the competing (higher) intent is admitted "
+                    "second");
+    if (!lowerAdmission.has_value() || !competitorAdmission.has_value()) {
+        return;
+    }
+    auto competitorRegistration =
+        coordinator->registerTarget(std::move(*competitorAdmission), targetKey);
+    expectations.expect(static_cast<bool>(competitorRegistration),
+                        "async preAdmitted ownership: the competitor registers for the identical "
+                        "target key");
+    if (!competitorRegistration) {
+        return;
+    }
+    std::move(competitorRegistration).takeClaim().reset();
+
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+        .preAdmitted = &(*lowerAdmission),
+    };
+    auto begun =
+        beginSessionSave(session, scheduler, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(begun),
+                        "async preAdmitted ownership: beginSessionSave submits a handle");
+    // The fix under test: beginSessionSave() already moved *lowerAdmission's state out by the time
+    // it returns, on the authoring thread -- the caller's admission object is left valid-but-empty
+    // (isValid() false) here, exactly as documented, and may now safely go out of scope (it does,
+    // at the end of this function) without the worker (which may not even have started yet) ever
+    // touching a dangling PublicationAdmission.
+    expectations.expect(lowerAdmission.has_value() && !lowerAdmission->isValid(),
+                        "async preAdmitted ownership: the caller's admission is moved-from "
+                        "immediately when beginSessionSave() returns, not borrowed for the "
+                        "worker's lifetime");
+    if (!begun) {
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+
+    expectations.expect(pollUntilReady(handle),
+                        "async preAdmitted ownership: the worker still reaches a terminal state "
+                        "using its OWN owned admission");
+    auto result = handle.tryComplete(session);
+    expectations.expect(result.has_value(),
+                        "async preAdmitted ownership: tryComplete yields a result");
+    if (!result.has_value()) {
+        return;
+    }
+    expectations.expect(
+        !static_cast<bool>(*result) && result->stage() == SessionSaveStage::Savepoint &&
+            result->publication() != nullptr &&
+            result->publication()->outcome == StagedArtifactPublicationOutcome::Superseded &&
+            !result->savepointStatus().has_value(),
+        "async preAdmitted ownership: Superseded triggers no acceptSavepoint attempt -- the "
+        "worker's owned admission carried the same losing intent the caller's would have");
+
+    const auto afterState = session.stateSnapshot();
+    expectations.expect(afterState.dirty == true &&
+                            afterState.cleanRevision == beforeState.cleanRevision &&
+                            afterState.newestAcceptedPublicationIntent ==
+                                beforeState.newestAcceptedPublicationIntent,
+                        "async preAdmitted ownership: session state is untouched by the "
+                        "non-published outcome");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Cancellation: requestCancellation() before the scheduler starts the task (the single BlockingIo
+// worker is saturated by a blocker task first, for determinism) -> a cancelled-before-publication
+// outcome, session untouched.
+// ---------------------------------------------------------------------------------------------
+
+void testCancellationBeforeWorkerStarts(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "cancellation: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    TaskScheduler scheduler;
+    BlockingIoGate gate;
+    occupyBlockingIoWorker(expectations, scheduler, gate);
+
+    auto session = makeDecodedSession(expectations, identitySource, "Cancellation Project");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "cancellation: Save As advances");
+    if (!saveAs) {
+        gate.release();
+        return;
+    }
+    const auto beforeState = session.stateSnapshot();
+
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto begun =
+        beginSessionSave(session, scheduler, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(begun), "cancellation: beginSessionSave submits a handle "
+                                                  "(still queued behind the blocker)");
+    if (!begun) {
+        gate.release();
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+    handle.requestCancellation();
+    gate.release();
+
+    expectations.expect(pollUntilReady(handle), "cancellation: the cancelled task still reaches a "
+                                                "terminal state");
+    auto result = handle.tryComplete(session);
+    expectations.expect(result.has_value(), "cancellation: tryComplete yields a result");
+    if (result.has_value()) {
+        expectations.expect(
+            !static_cast<bool>(*result),
+            "cancellation: a cancellation requested before the worker starts never publishes");
+        const auto* publicationFailure = result->publicationFailure();
+        const auto* publication = result->publication();
+        const bool cancelledBeforePublication =
+            (publicationFailure != nullptr) ||
+            (publication != nullptr &&
+             publication->outcome == StagedArtifactPublicationOutcome::CancelledBeforePublication);
+        expectations.expect(
+            cancelledBeforePublication,
+            "cancellation: the result names a cancelled-before-publication outcome "
+            "(a typed pipeline failure at the Cancelled stage, or the platform's own "
+            "CancelledBeforePublication outcome)");
+    }
+
+    const auto afterState = session.stateSnapshot();
+    expectations.expect(afterState.dirty == beforeState.dirty &&
+                            afterState.cleanRevision == beforeState.cleanRevision &&
+                            afterState.displayPath == beforeState.displayPath,
+                        "cancellation: session state is untouched");
+    expectations.expect(awaitQuiescence(scheduler), "cancellation: the scheduler reaches "
+                                                    "quiescence");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Edit during async open: begin open, edit the current project while the worker runs, tryComplete
+// -> RevisionChanged, current project intact.
+// ---------------------------------------------------------------------------------------------
+
+void testEditDuringAsyncOpen(Expectations& expectations) {
+    ProjectSessionIdentitySource identitySource;
+    TaskScheduler scheduler;
+    auto session = makeDecodedSession(expectations, identitySource, "Edit During Async Open");
+    auto bytes = buildMinimalArchiveBytesOrAbort("Should Not Install");
+    auto displayPath = ProjectDisplayPath::create("/tmp/edit-during-open.bloom");
+    expectations.expect(displayPath.has_value(), "edit during async open: display path constructs");
+    if (!displayPath.has_value()) {
+        return;
+    }
+
+    auto begun = beginSessionOpen(session, scheduler, std::move(bytes), displayPath,
+                                  SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(begun), "edit during async open: beginSessionOpen "
+                                                  "submits a handle");
+    if (!begun) {
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+
+    // The edit lands deterministically before tryComplete(): whether the worker has already
+    // finished by this point does not matter for RevisionChanged -- the gate is the session's
+    // tracked revision at INSTALL time, not at worker-completion time.
+    expectations.expect(session.execute(rename("Edited While Opening", session)).changed(),
+                        "edit during async open: the edit commits");
+    const auto editedRevision = currentRevision(session);
+    const auto editedName = projectName(session);
+
+    expectations.expect(pollUntilReady(handle), "edit during async open: isReady() becomes true");
+    auto result = handle.tryComplete(session);
+    expectations.expect(result.has_value(), "edit during async open: tryComplete yields a result");
+    if (!result.has_value()) {
+        return;
+    }
+    expectations.expect(!static_cast<bool>(*result) &&
+                            result->stage() == SessionOpenStage::Installation,
+                        "edit during async open: installation is refused");
+    const auto* outcome = result->installOutcome();
+    const auto* status = outcome != nullptr ? std::get_if<SessionInstallStatus>(outcome) : nullptr;
+    expectations.expect(status != nullptr && *status == SessionInstallStatus::RevisionChanged,
+                        "edit during async open: the refusal names RevisionChanged");
+
+    const auto afterState = session.stateSnapshot();
+    expectations.expect(afterState.currentRevision == editedRevision,
+                        "edit during async open: the current project (including the edit) is "
+                        "intact");
+    if (afterState.contentKind == ProjectSessionContentKind::DecodedDocument) {
+        expectations.expect(projectName(session) == editedName,
+                            "edit during async open: the edited content was never replaced");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Replacement-survives-capture (the dangling-view regression test): begin a save, then (before
+// tryComplete) install replacement content into the SAME session via the O2 path. The worker's
+// captured view stays valid -- the save completes with its ORIGINAL content -- and its tryComplete
+// savepoint is then refused by acceptSavepoint()'s own checks (StaleIntent, since installation
+// advanced SessionResultAcceptanceGeneration/SessionPathIntentGeneration out from under the
+// outstanding Save As capture). The session's NEW (replacement) content is untouched by the stale
+// savepoint attempt.
+// ---------------------------------------------------------------------------------------------
+
+void testReplacementSurvivesCapture(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "replacement survives capture: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    TaskScheduler scheduler;
+
+    auto session = makeDecodedSession(expectations, identitySource, "Original Content");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs),
+                        "replacement survives capture: Save As advances");
+    if (!saveAs) {
+        return;
+    }
+
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    auto begun =
+        beginSessionSave(session, scheduler, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(begun),
+                        "replacement survives capture: beginSessionSave submits a handle");
+    if (!begun) {
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+
+    // Before tryComplete(): install replacement content into the SAME session via the O2 Open
+    // path. This advances SessionResultAcceptanceGeneration/SessionPathIntentGeneration,
+    // invalidating the outstanding Save As capture the worker already snapshotted at begin() time.
+    auto replacementBytes = buildMinimalArchiveBytesOrAbort("Replacement Content");
+    auto replacementPath = ProjectDisplayPath::create("/tmp/replacement.bloom");
+    expectations.expect(replacementPath.has_value(),
+                        "replacement survives capture: replacement display path constructs");
+    if (!replacementPath.has_value()) {
+        return;
+    }
+    auto installed = openSessionArchive(session, replacementBytes, replacementPath,
+                                        SaveArchiveLimits{}, makeOperation());
+    expectations.expect(static_cast<bool>(installed),
+                        "replacement survives capture: the O2 replacement installs");
+
+    expectations.expect(pollUntilReady(handle),
+                        "replacement survives capture: the save worker still reaches a terminal "
+                        "state, unaffected by the session replacement");
+    auto result = handle.tryComplete(session);
+    expectations.expect(result.has_value(),
+                        "replacement survives capture: tryComplete yields a result");
+    if (!result.has_value()) {
+        return;
+    }
+    expectations.expect(
+        !static_cast<bool>(*result) && result->stage() == SessionSaveStage::Savepoint &&
+            result->publication() != nullptr && result->publication()->targetWasPublished(),
+        "replacement survives capture: the worker's captured (original) view still published a "
+        "real file -- unaffected by the later replacement -- but the savepoint is refused");
+    expectations.expect(result->savepointStatus() == ProjectSessionSavepointStatus::StaleIntent,
+                        "replacement survives capture: the refusal is typed as StaleIntent");
+
+    // The published file on disk names the ORIGINAL content, proving the worker's captured view
+    // (SessionSaveOwningInput) stayed valid and was never affected by the replacement install.
+    // Decoded (not a raw byte search): the archive is a ZIP container and its entries may be
+    // compressed.
+    const auto published = readFile(targetPath);
+    auto reopened = bloom::project::openProjectArchive(asBytes(published), SaveArchiveLimits{},
+                                                       makeOperation());
+    expectations.expect(reopened.outcome() == bloom::project::OpenArchiveOutcome::Opened,
+                        "replacement survives capture: the published file reopens");
+    if (reopened.outcome() == bloom::project::OpenArchiveOutcome::Opened) {
+        auto openedValue = std::move(reopened).takeOpened();
+        expectations.expect(
+            std::string(openedValue.document->snapshot().project().name()) == "Original Content",
+            "replacement survives capture: the published bytes reflect the ORIGINAL captured "
+            "content, not the replacement");
+    }
+
+    // The session's NEW (replacement) content is untouched by the stale savepoint attempt.
+    const auto state = session.stateSnapshot();
+    expectations.expect(state.displayPath == replacementPath,
+                        "replacement survives capture: the session's replacement content (display "
+                        "path) is untouched by the refused stale savepoint");
+    expectations.expect(projectName(session) == std::optional<std::string>{"Replacement Content"},
+                        "replacement survives capture: the session's replacement content (project "
+                        "name) is untouched by the refused stale savepoint");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Abandonment: destroy a handle mid-flight (still queued behind a saturated worker); no crash, no
+// session mutation, scheduler drains cleanly.
+// ---------------------------------------------------------------------------------------------
+
+void testAbandonmentMidFlight(Expectations& expectations) {
+    TempDirectory directory;
+    ProjectSessionIdentitySource identitySource;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "abandonment: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+    TaskScheduler scheduler;
+    BlockingIoGate gate;
+    occupyBlockingIoWorker(expectations, scheduler, gate);
+
+    auto session = makeDecodedSession(expectations, identitySource, "Abandonment Project");
+    const auto saveAs = session.advancePathIntentForSaveAs();
+    expectations.expect(static_cast<bool>(saveAs), "abandonment: Save As advances");
+    if (!saveAs) {
+        gate.release();
+        return;
+    }
+    const auto beforeState = session.stateSnapshot();
+
+    const SessionSaveRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = saveAs.capture(),
+    };
+    {
+        auto begun = beginSessionSave(session, scheduler, *coordinator, *artifacts, request,
+                                      makeOperation());
+        expectations.expect(static_cast<bool>(begun),
+                            "abandonment: beginSessionSave submits a handle (still queued)");
+        if (begun) {
+            auto handle = std::move(begun).takeHandle();
+            // Handle destroyed here, mid-flight, without ever calling tryComplete().
+        }
+    }
+    gate.release();
+
+    expectations.expect(awaitQuiescence(scheduler), "abandonment: the scheduler drains cleanly "
+                                                    "(quiescence per its own API)");
+    const auto afterState = session.stateSnapshot();
+    expectations.expect(afterState.dirty == beforeState.dirty &&
+                            afterState.cleanRevision == beforeState.cleanRevision &&
+                            afterState.displayPath == beforeState.displayPath &&
+                            afterState.newestAcceptedPublicationIntent ==
+                                beforeState.newestAcceptedPublicationIntent,
+                        "abandonment: no crash, no session mutation");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testAsyncSaveEndToEnd(expectations);
+        testAsyncOpenEndToEnd(expectations);
+        testAsyncOpenRoundTrippedNewerMinor(expectations);
+        testSyncAsyncEquivalence(expectations);
+        testAsyncPreAdmittedOwnershipSupersession(expectations);
+        testCancellationBeforeWorkerStarts(expectations);
+        testEditDuringAsyncOpen(expectations);
+        testReplacementSurvivesCapture(expectations);
+        testAbandonmentMidFlight(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "FAILED: unexpected fixture exception: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Closes #68.

Session save and open now run as blocking-I/O tasks that never freeze the authoring thread — the last engine step before iterative UI work. The shape is the contract's: capture on the authoring thread, session-free work on the scheduler's blocking-I/O lane, result acceptance back on the authoring thread through poll-able handles that match the UI task bridge's existing polling model.

**The immutable round-trip view, made literal**: the session stores its round-trip state behind shared ownership and captures share it, so an in-flight save survives a concurrent replacement installation — pinned by a dedicated regression test where the save completes with its original content and its late savepoint is refused by the acceptance seam's own checks, never applied against the new content.

**No behavior fork**: sync and async drive the same extracted session-free middles; the synchronous entry points keep their exact signatures with their suites passing unchanged.

**Handles that can't be misused**: refusals surface as typed begin failures before any task exists; readiness reuses the scheduler's non-consuming terminal snapshot; completion applies acceptance exactly once (an edit during an async open is refused at completion per the contract); abandonment cancels and never mutates a session; and a pre-admitted publication admission is consumed at begin into handle-owned state — no caller-side lifetime requirement across the thread boundary.

Testing: nine functions against a real scheduler and worker, including sync/async byte-identical equivalence, deterministic pre-start cancellation, both during-flight interference shapes, and repeated standalone runs for flake resistance. Full ci-linux-native suite 69/69 and format check green, independently re-verified.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (one review round on cross-thread admission ownership).