### PR TITLE
ci: build and test the desktop UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
 
       - name: Install Qt 6.8
         if: steps.cache-qt.outputs.cache-hit != 'true'
+        # Runs from the runner temp directory: aqt writes aqtinstall.log into its working
+        # directory, and a stray log in the workspace fails the repository hygiene check.
+        working-directory: ${{ runner.temp }}
         run: |
           python3 -m pip install --user aqtinstall==3.2.1
           python3 -m aqt install-qt linux desktop 6.8.3 linux_gcc_64 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,75 @@ jobs:
             -DBLOOM_DEPENDENCY_PREFIX="$GITHUB_WORKSPACE/build/dependency-prefix"
           cmake --build "${{ runner.temp }}/bloom-consume"
           "${{ runner.temp }}/bloom-consume/bloom_consume_smoke"
+
+  linux-desktop:
+    name: Linux Qt desktop
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      CC: clang-22
+      CXX: clang++-22
+      # Widgets tests run without a display server; the offscreen platform keeps them headless.
+      QT_QPA_PLATFORM: offscreen
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Install LLVM 22 quality tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ca-certificates cmake curl gnupg ninja-build \
+            libgl-dev libegl-dev libfontconfig1-dev libxkbcommon-dev
+          llvm_key=$(mktemp)
+          trap 'rm -f "$llvm_key"' EXIT
+          curl --fail --silent --show-error --location \
+            https://apt.llvm.org/llvm-snapshot.gpg.key \
+            --output "$llvm_key"
+          primary_fingerprint=$(gpg --show-keys --with-colons "$llvm_key" | awk -F: '$1 == "fpr" {print $10; exit}')
+          test "$primary_fingerprint" = 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421
+          gpg --dearmor < "$llvm_key" | \
+            sudo tee /usr/share/keyrings/llvm-snapshot.gpg >/dev/null
+          printf '%s\n' \
+            'deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-22 main' | \
+            sudo tee /etc/apt/sources.list.d/llvm-22.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install --yes clang-22 clang-format-22 clang-tidy-22
+
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/qt
+          key: bloom-qt-6.8.3-linux-gcc-64
+
+      - name: Install Qt 6.8
+        if: steps.cache-qt.outputs.cache-hit != 'true'
+        run: |
+          python3 -m pip install --user aqtinstall==3.2.1
+          python3 -m aqt install-qt linux desktop 6.8.3 linux_gcc_64 \
+            --outputdir "${{ runner.temp }}/qt"
+
+      - name: Cache dependency archives
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/bloom-dependency-downloads
+          key: bloom-dependency-archives-b16246f617b2a136c78d73e5e2647c6f1de1313e46678062985bdcf1f40bb75d
+
+      - name: Build dependency superbuild prefix
+        run: |
+          cmake -S dependencies/superbuild -B "${{ runner.temp }}/bloom-superbuild" -G Ninja \
+            -DBLOOM_DEPENDENCY_DOWNLOAD_DIR="${{ runner.temp }}/bloom-dependency-downloads" \
+            -DBLOOM_DEPENDENCY_PREFIX="$GITHUB_WORKSPACE/build/dependency-prefix"
+          cmake --build "${{ runner.temp }}/bloom-superbuild"
+
+      - name: Configure desktop build
+        run: |
+          cmake --preset ci-linux-desktop \
+            -DCMAKE_PREFIX_PATH="${{ runner.temp }}/qt/6.8.3/gcc_64"
+
+      - name: Build desktop with clang-tidy
+        run: cmake --build --preset ci-linux-desktop --parallel
+
+      - name: Test desktop build
+        run: ctest --preset ci-linux-desktop --output-on-failure

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,6 +31,15 @@
         "BLOOM_DEPENDENCY_MODE": "qualified",
         "BLOOM_DEPENDENCY_PREFIX": "${sourceDir}/build/dependency-prefix"
       }
+    },
+    {
+      "name": "ci-linux-desktop",
+      "displayName": "Bloom Linux desktop CI",
+      "inherits": "ci-linux-native",
+      "binaryDir": "${sourceDir}/build/ci-linux-desktop",
+      "cacheVariables": {
+        "BLOOM_BUILD_DESKTOP": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -41,6 +50,10 @@
     {
       "name": "ci-linux-native",
       "configurePreset": "ci-linux-native"
+    },
+    {
+      "name": "ci-linux-desktop",
+      "configurePreset": "ci-linux-desktop"
     }
   ],
   "testPresets": [
@@ -54,6 +67,13 @@
     {
       "name": "ci-linux-native",
       "configurePreset": "ci-linux-native",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "ci-linux-desktop",
+      "configurePreset": "ci-linux-desktop",
       "output": {
         "outputOnFailure": true
       }

--- a/src/ui/tests/composition_preview_controller_tests.cpp
+++ b/src/ui/tests/composition_preview_controller_tests.cpp
@@ -236,8 +236,9 @@ void testRevisionAndPanelSuppression(Expectations& expectations) {
     firstRequest.release();
     expectations.expect(waitUntil([&] { return isReady(controller); }),
                         "current revision becomes ready after the replaced Viewer is destroyed");
-    expectations.expect(controller.state().desiredIdentity->sourceRevision ==
-                            session.snapshot().revision(),
+    expectations.expect(controller.state().desiredIdentity.has_value() &&
+                            controller.state().desiredIdentity->sourceRevision ==
+                                session.snapshot().revision(),
                         "published frame identifies the active document revision");
     expectations.expect(!publishedReadyGenerations.empty() &&
                             std::ranges::all_of(publishedReadyGenerations,
@@ -302,6 +303,7 @@ void testNewestPendingRequestGate(Expectations& expectations) {
 
     expectations.expect(
         controller.state().activity == ui::PreviewActivity::Rendering &&
+            controller.state().desiredIdentity.has_value() &&
             controller.state().desiredIdentity->requestGeneration == newestGeneration &&
             !controller.state().taskId.has_value(),
         "the desired identity advances immediately while the newest request remains pending");
@@ -369,6 +371,7 @@ void testSameRevisionGenerationAndSelection(Expectations& expectations) {
     const auto generationBeforeTime = generation(controller.state());
     expectations.expect(session.setCurrentTime(*halfway) &&
                             generation(controller.state()) > generationBeforeTime &&
+                            controller.state().desiredIdentity.has_value() &&
                             controller.state().desiredIdentity->time == *halfway &&
                             session.snapshot().revision() == revisionBeforeTime,
                         "session time advances preview intent without dirtying the document");
@@ -384,11 +387,17 @@ void testSameRevisionGenerationAndSelection(Expectations& expectations) {
                         "an unchanged session time creates no preview churn");
 
     const auto firstFrame = controller.state().frame;
+    if (!controller.state().desiredIdentity.has_value()) {
+        expectations.expect(false, "desired identity is populated once the preview is ready");
+        reachQuiescence(controller, bridge, scheduler, expectations);
+        return;
+    }
     const auto revision = controller.state().desiredIdentity->sourceRevision;
     const auto firstGeneration = generation(controller.state());
     controller.requestRefresh();
     const auto secondGeneration = generation(controller.state());
-    expectations.expect(controller.state().desiredIdentity->sourceRevision == revision &&
+    expectations.expect(controller.state().desiredIdentity.has_value() &&
+                            controller.state().desiredIdentity->sourceRevision == revision &&
                             secondGeneration > firstGeneration &&
                             controller.state().activity == ui::PreviewActivity::Rendering &&
                             controller.state().freshness == ui::FrameFreshness::Stale &&
@@ -573,6 +582,7 @@ void testCompositionSwitchClearsPixels(Expectations& expectations) {
                             controller.state().freshness == ui::FrameFreshness::None &&
                             controller.state().frame == nullptr &&
                             session.currentTime() == core::RationalTime::fromInteger(0) &&
+                            controller.state().desiredIdentity.has_value() &&
                             controller.state().desiredIdentity->time ==
                                 core::RationalTime::fromInteger(0),
                         "composition switch resets time and clears pixels in one preview intent");

--- a/src/ui/tests/composition_projection_test.cpp
+++ b/src/ui/tests/composition_projection_test.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <iostream>
 #include <optional>
 #include <string>
@@ -91,7 +92,7 @@ parameterForRole(const bloom::document::Composition& composition,
     }
 
     addSolidAction->trigger();
-    const auto firstLayer = std::get_if<document::LayerId>(&session.selection().primary);
+    const auto* firstLayer = std::get_if<document::LayerId>(&session.selection().primary);
     const auto firstSource =
         firstLayer == nullptr ? std::nullopt : session.directSourceNodeForLayer(*firstLayer);
     const auto* firstParameter = firstSource.has_value()
@@ -102,7 +103,7 @@ parameterForRole(const bloom::document::Composition& composition,
         firstParameter == nullptr ? std::nullopt : session.constantColorValue(firstParameter->id);
 
     addSolidAction->trigger();
-    const auto secondLayer = std::get_if<document::LayerId>(&session.selection().primary);
+    const auto* secondLayer = std::get_if<document::LayerId>(&session.selection().primary);
     const auto secondSource =
         secondLayer == nullptr ? std::nullopt : session.directSourceNodeForLayer(*secondLayer);
     const auto* secondParameter = secondSource.has_value()
@@ -123,7 +124,8 @@ parameterForRole(const bloom::document::Composition& composition,
 [[nodiscard]] bool runProjectionTest() {
     using namespace bloom;
     const auto format = document::CompositionFormat::create(64, 36);
-    if (!require(format.has_value(), "small projection format is valid")) {
+    if (!format.has_value()) {
+        (void)require(false, "small projection format is valid");
         return false;
     }
     auto newProject = document::makeNewProject("Projection Test", "Main",
@@ -208,18 +210,23 @@ parameterForRole(const bloom::document::Composition& composition,
     const auto* composition = session.composition();
     if (!require(composition != nullptr, "active composition remains available") ||
         !require(composition->graph().layerStack().entries().size() == 1,
-                 "text command inserts one layer stack entry") ||
-        !require(std::holds_alternative<document::LayerId>(session.selection().primary),
-                 "new layer becomes the stable shared selection")) {
+                 "text command inserts one layer stack entry")) {
         return false;
     }
 
-    const auto layerId = std::get<document::LayerId>(session.selection().primary);
+    const auto* layerIdPtr = std::get_if<document::LayerId>(&session.selection().primary);
+    if (!require(layerIdPtr != nullptr, "new layer becomes the stable shared selection")) {
+        return false;
+    }
+    const auto layerId = *layerIdPtr;
     const auto boundaryNode = session.boundaryNodeForLayer(layerId);
     const auto directTextSource = session.directSourceNodeForLayer(layerId);
     auto* layerRow = timeline.findChild<QTreeWidget*>("layerStackView")->topLevelItem(0);
-    if (!require(boundaryNode.has_value(), "layer resolves to its graph boundary") ||
-        !require(directTextSource.has_value() && *directTextSource != *boundaryNode,
+    if (!boundaryNode.has_value()) {
+        (void)require(false, "layer resolves to its graph boundary");
+        return false;
+    }
+    if (!require(directTextSource.has_value() && *directTextSource != *boundaryNode,
                  "layer resolves only its direct content source") ||
         !require(layerRow != nullptr && layerRow->text(0) == QStringLiteral("Text 1") &&
                      layerRow->text(1) == QStringLiteral("Text"),
@@ -267,6 +274,10 @@ parameterForRole(const bloom::document::Composition& composition,
     }
 
     composition = session.composition();
+    if (!boundaryNode.has_value()) {
+        (void)require(false, "boundary node ID remains available for parameter lookup");
+        return false;
+    }
     const auto* positionParameter =
         parameterForRole(*composition, *boundaryNode, document::kPositionParameterRole);
     const auto* opacityParameter =
@@ -304,17 +315,22 @@ parameterForRole(const bloom::document::Composition& composition,
     addSolidAction->trigger();
     composition = session.composition();
     if (!require(composition != nullptr && composition->graph().layerStack().entries().size() == 2,
-                 "Solid menu action adds one structured layer") ||
-        !require(std::holds_alternative<document::LayerId>(session.selection().primary),
-                 "new solid becomes the primary layer selection")) {
+                 "Solid menu action adds one structured layer")) {
         return false;
     }
 
-    const auto solidLayerId = std::get<document::LayerId>(session.selection().primary);
+    const auto* solidLayerIdPtr = std::get_if<document::LayerId>(&session.selection().primary);
+    if (!require(solidLayerIdPtr != nullptr, "new solid becomes the primary layer selection")) {
+        return false;
+    }
+    const auto solidLayerId = *solidLayerIdPtr;
     const auto solidSourceNodeId = session.directSourceNodeForLayer(solidLayerId);
     auto* solidRow = timeline.findChild<QTreeWidget*>("layerStackView")->topLevelItem(1);
-    if (!require(solidSourceNodeId.has_value(), "solid layer has one exact direct source node") ||
-        !require(solidRow != nullptr && solidRow->text(0) == QStringLiteral("Solid 1") &&
+    if (!solidSourceNodeId.has_value()) {
+        (void)require(false, "solid layer has one exact direct source node");
+        return false;
+    }
+    if (!require(solidRow != nullptr && solidRow->text(0) == QStringLiteral("Solid 1") &&
                      solidRow->text(1) == QStringLiteral("Solid"),
                  "timeline derives Solid kind and default numbered name from project truth")) {
         return false;
@@ -367,10 +383,18 @@ parameterForRole(const bloom::document::Composition& composition,
                  "session can add an explicit HDR solid")) {
         return false;
     }
-    const auto hdrLayerId = std::get<document::LayerId>(session.selection().primary);
+    const auto* hdrLayerIdPtr = std::get_if<document::LayerId>(&session.selection().primary);
+    if (!require(hdrLayerIdPtr != nullptr,
+                 "explicit HDR solid becomes the primary layer selection")) {
+        return false;
+    }
+    const auto hdrLayerId = *hdrLayerIdPtr;
     const auto hdrSourceNodeId = session.directSourceNodeForLayer(hdrLayerId);
-    if (!require(hdrSourceNodeId.has_value() &&
-                     solidColorValue->text() == QStringLiteral("R -0.25  G 1.5  B 0.125  A 0.8"),
+    if (!hdrSourceNodeId.has_value()) {
+        (void)require(false, "HDR solid layer has one exact direct source node");
+        return false;
+    }
+    if (!require(solidColorValue->text() == QStringLiteral("R -0.25  G 1.5  B 0.125  A 0.8"),
                  "Properties preserves negative and HDR RGB without clipping") ||
         !require(session.undo(), "adding the HDR solid is undoable") ||
         !require(session.composition()->graph().layerStack().entries().size() == 2 &&
@@ -413,5 +437,11 @@ parameterForRole(const bloom::document::Composition& composition,
 int main(int argc, char** argv) {
     qputenv("QT_QPA_PLATFORM", "offscreen");
     QApplication application(argc, argv);
-    return runSolidPaletteTest() && runProjectionTest() ? 0 : 1;
+    try {
+        return runSolidPaletteTest() && runProjectionTest() ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "composition projection test failed with an exception: " << error.what()
+                  << '\n';
+        return 1;
+    }
 }

--- a/src/ui/tests/composition_session_animation_tests.cpp
+++ b/src/ui/tests/composition_session_animation_tests.cpp
@@ -35,7 +35,9 @@ void require(const bool condition, const std::string_view message) {
 [[nodiscard]] core::RationalTime time(const std::int64_t numerator,
                                       const std::int64_t denominator = 1) {
     const auto result = core::RationalTime::create(numerator, denominator);
-    require(result.has_value(), "test time must be valid");
+    if (!result.has_value()) {
+        fail("test time must be valid");
+    }
     return *result;
 }
 
@@ -56,8 +58,9 @@ struct LayerIds final {
         result.outputId<document::ParameterId>(commands::kAddSolidLayerPositionParameterOutput);
     const auto opacity =
         result.outputId<document::ParameterId>(commands::kAddSolidLayerOpacityParameterOutput);
-    require(result.changed() && layer.has_value() && position.has_value() && opacity.has_value(),
-            "solid layer command must expose its stable IDs");
+    if (!(result.changed() && layer.has_value() && position.has_value() && opacity.has_value())) {
+        fail("solid layer command must expose its stable IDs");
+    }
     return {*layer, *position, *opacity};
 }
 
@@ -69,7 +72,9 @@ animateParameter(document::Document& document, commands::CommandStack& stack,
     transaction.emplace<commands::CreateAnimationForParameter>(compositionId, parameterId, time(0));
     const auto result = stack.execute(std::move(transaction));
     const auto curve = result.outputId<document::AnimationCurveId>(commands::kAnimationCurveOutput);
-    require(result.changed() && curve.has_value(), "animation command must expose its curve ID");
+    if (!(result.changed() && curve.has_value())) {
+        fail("animation command must expose its curve ID");
+    }
     return *curve;
 }
 

--- a/tests/ui_smoke.cpp
+++ b/tests/ui_smoke.cpp
@@ -163,7 +163,10 @@ int testSplitCloseAndActivation(const EditorRegistry& registry) {
     dynamicComposite->setParent(liveEditor);
     QFocusEvent dynamicFocusEvent(QEvent::FocusIn, Qt::OtherFocusReason);
     QApplication::sendEvent(dynamicChild, &dynamicFocusEvent);
-    if (!require(host.activeArea() == viewer, 59)) {
+    const bool activeAreaAfterDynamicFocus = host.activeArea() == viewer;
+    delete dynamicChild;
+    delete dynamicComposite;
+    if (!require(activeAreaAfterDynamicFocus, 59)) {
         return 59;
     }
 


### PR DESCRIPTION
Closes #70.

The merge gate never compiled `src/ui` or `apps/bloom` — the single CI job runs the native preset with the desktop off, so a UI regression could not fail a required check. With UI work about to iterate against the completed persistence engine, that gap closes now:

- **`ci-linux-desktop` preset**: the native preset with `BLOOM_BUILD_DESKTOP=ON` (same clang-tidy, same qualified dependency prefix), own binary dir.
- **`Linux Qt desktop` job**: pinned Qt 6.8.3 via cached `aqtinstall` (Ubuntu 24.04 ships only Qt 6.4, below the required 6.8), the same LLVM 22 toolchain install as the native job, the same superbuild prefix, and UI tests running headless on the offscreen platform.

Whether the new job becomes a required check is decided after it proves stable across a few runs. This PR's own run is the end-to-end proof of the CI-side Qt provisioning; the preset also configures and builds against a host Qt locally.