### PR TITLE
feat: add file menu over real project sessions

### DIFF
--- a/apps/bloom/main.cpp
+++ b/apps/bloom/main.cpp
@@ -1,7 +1,3 @@
-#include <bloom/commands/command_stack.hpp>
-#include <bloom/core/rational_time.hpp>
-#include <bloom/document/document.hpp>
-#include <bloom/document/new_project.hpp>
 #include <bloom/runtime/cpu_composition_evaluator.hpp>
 #include <bloom/runtime/node_definition_registry.hpp>
 #include <bloom/runtime/reference_display_preparation.hpp>
@@ -14,6 +10,7 @@
 #include <bloom/ui/editor_registry.hpp>
 #include <bloom/ui/jobs_editor.hpp>
 #include <bloom/ui/main_window.hpp>
+#include <bloom/ui/project_host.hpp>
 #include <bloom/ui/task_monitor_model.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 
@@ -22,8 +19,6 @@
 #include <QEventLoop>
 #include <QSettings>
 
-#include <utility>
-
 int main(int argc, char* argv[]) {
     QApplication application(argc, argv);
 
@@ -31,12 +26,36 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setApplicationVersion("0.1.0");
     QCoreApplication::setOrganizationName("Kinetik");
 
-    auto newProject = bloom::document::makeNewProject("Untitled", "Composition 1",
-                                                      bloom::core::RationalTime::fromInteger(10));
-    const auto initialCompositionId = newProject.initialCompositionId;
-    bloom::document::Document document(std::move(newProject.project));
-    bloom::commands::CommandStack commandStack(document);
-    bloom::ui::CompositionSession compositionSession(document, commandStack, initialCompositionId);
+    // ProjectHost (task U1, issue #72) replaces the hand-rolled document/command-stack pair: it
+    // owns the application's single live bloom::host::ProjectSession and constructs an initial
+    // createNew() project itself. taskScheduler is shared with CompositionPreviewController below
+    // (both need a TaskExecutor::BlockingIo-capable scheduler; TaskSchedulerConfig::defaults()
+    // already provisions one BlockingIo worker, so a single scheduler instance serves both).
+    bloom::runtime::TaskScheduler taskScheduler;
+    bloom::ui::ProjectHost projectHost(taskScheduler);
+
+    auto [initialDocument, initialCommandStack] = projectHost.liveDocumentAndStack();
+    if (initialDocument == nullptr || initialCommandStack == nullptr) {
+        return 1;
+    }
+    bloom::ui::CompositionSession compositionSession(*initialDocument, *initialCommandStack,
+                                                     projectHost.lowestCompositionId());
+
+    // Projection rebinding (decision 2): every time ProjectHost replaces the live session content
+    // (New or a successful Open install), rebind CompositionSession to whatever document/command-
+    // stack pair is now live. A preserved-read-only install has no document/command-stack at all
+    // (liveDocumentAndStack() returns null); this build has no workspace surface for that content
+    // kind yet, so CompositionSession is deliberately left bound to its previous content rather
+    // than rebinding to nothing -- see the implementor's report for this known limitation.
+    QObject::connect(&projectHost, &bloom::ui::ProjectHost::sessionReplaced, &compositionSession,
+                     [&projectHost, &compositionSession] {
+                         auto [document, commandStack] = projectHost.liveDocumentAndStack();
+                         if (document == nullptr || commandStack == nullptr) {
+                             return;
+                         }
+                         compositionSession.rebind(*document, *commandStack,
+                                                   projectHost.lowestCompositionId());
+                     });
 
     bloom::runtime::NodeDefinitionRegistry nodeDefinitions;
     if (!bloom::runtime::registerBuiltInNodeDefinitions(nodeDefinitions)) {
@@ -46,7 +65,6 @@ int main(int argc, char* argv[]) {
     bloom::runtime::SnapshotCompiler snapshotCompiler(nodeDefinitions);
     bloom::runtime::CpuCompositionEvaluator cpuEvaluator;
     bloom::runtime::CpuReferenceDisplayPreparer referenceDisplayPreparer;
-    bloom::runtime::TaskScheduler taskScheduler;
     bloom::ui::TaskUiBridge taskUiBridge(taskScheduler);
     bloom::ui::CompositionPreviewController previewController(
         compositionSession, taskScheduler, taskUiBridge,
@@ -74,7 +92,7 @@ int main(int argc, char* argv[]) {
 
     application.setQuitOnLastWindowClosed(false);
     QSettings settings;
-    bloom::ui::MainWindow window(editorRegistry, compositionSession);
+    bloom::ui::MainWindow window(editorRegistry, compositionSession, projectHost);
     (void)window.restoreApplicationState(settings);
     QObject::connect(&shutdownCoordinator,
                      &bloom::ui::ApplicationShutdownCoordinator::shutdownStarted, &window,

--- a/src/host/include/bloom/host/project_session.hpp
+++ b/src/host/include/bloom/host/project_session.hpp
@@ -665,6 +665,18 @@ class ProjectSession final {
     [[nodiscard]] bool isValid() const noexcept;
     [[nodiscard]] ProjectSessionStateSnapshot stateSnapshot() const;
     [[nodiscard]] DecodedProjectSnapshotResult decodedSnapshot() const;
+
+    // Design decision 2 (task U1, issue #72): the narrow UI-only "projection binding" seam. A UI
+    // projection (src/ui's CompositionSession::rebind()) needs raw, non-owning access to this
+    // session's CURRENTLY installed live document/command-stack pair so it can atomically rebind
+    // its own internal pointers after New/Open replaces session content -- without owning, copying,
+    // or otherwise duplicating that state. Both pointers are null for preserved-read-only or
+    // otherwise non-decoded content (mirrors decodedSnapshot()'s own NoDecodedDocument case).
+    // Mutation of the document stays exclusively with execute()/undo()/redo(); this accessor exists
+    // only so a UI projection can observe and bind to the CURRENT objects, never to bypass the
+    // command stack.
+    [[nodiscard]] std::pair<document::Document*, commands::CommandStack*>
+    liveDocumentAndStack() noexcept;
     [[nodiscard]] SessionResultAcceptanceCapture captureResultAcceptance() const noexcept;
     [[nodiscard]] SessionPathIntentCapture capturePlainSavePathIntent() const noexcept;
     [[nodiscard]] OpenIntentAdmissionResult admitOpenIntent() noexcept;

--- a/src/host/project_session.cpp
+++ b/src/host/project_session.cpp
@@ -537,6 +537,11 @@ DecodedProjectSnapshotResult ProjectSession::decodedSnapshot() const {
     return DecodedProjectSnapshotResult(document_->snapshot());
 }
 
+std::pair<document::Document*, commands::CommandStack*>
+ProjectSession::liveDocumentAndStack() noexcept {
+    return {document_.get(), commandStack_.get()};
+}
+
 ProjectSessionCommandResult ProjectSession::execute(commands::Transaction transaction) {
     if (!isValid() || contentKind_ != ProjectSessionContentKind::DecodedDocument) {
         return unavailableCommandResult();

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
         jobs_editor.cpp
         main_window.cpp
         node_editor.cpp
+        project_host.cpp
         task_monitor_model.cpp
         task_ui_bridge.cpp
         viewer_editor.cpp
@@ -31,6 +32,7 @@ target_sources(
             include/bloom/ui/jobs_editor.hpp
             include/bloom/ui/main_window.hpp
             include/bloom/ui/node_editor.hpp
+            include/bloom/ui/project_host.hpp
             include/bloom/ui/task_monitor_model.hpp
             include/bloom/ui/task_ui_bridge.hpp
             include/bloom/ui/viewer_editor.hpp
@@ -38,9 +40,25 @@ target_sources(
 )
 
 target_compile_features(bloom_ui PUBLIC cxx_std_20)
+# bloom_host/bloom_platform/bloom_project (task U1, issue #72): ProjectHost (project_host.hpp) is
+# the application's File-menu composition root over bloom::host::ProjectSession -- it directly
+# constructs a bloom::platform::StagedArtifactCoordinator and a
+# bloom::project::ProjectIoMemoryCoordinator/ProjectIoOperationMemory, and its public signatures
+# carry bloom::host types (ProjectSessionStateSnapshot, SessionSaveResult, SessionOpenResult, ...).
+# No repository_checks.cpp kAllowedModuleDependencies edit was needed: src/ui is exempt from that
+# checker's module-dependency scan entirely (see isNonUiSource()/kKnownModules -- "ui" is never a
+# tracked module), matching AGENTS.md's "the UI is the application composition surface".
 target_link_libraries(
     bloom_ui
-    PUBLIC bloom_commands bloom_render bloom_runtime bloom_runtime_evaluator Qt6::Widgets
+    PUBLIC
+        bloom_commands
+        bloom_host
+        bloom_platform
+        bloom_project
+        bloom_render
+        bloom_runtime
+        bloom_runtime_evaluator
+        Qt6::Widgets
 )
 target_link_libraries(bloom_ui PRIVATE bloom_runtime_compiler)
 bloom_enable_warnings(bloom_ui)

--- a/src/ui/composition_session.cpp
+++ b/src/ui/composition_session.cpp
@@ -60,11 +60,31 @@ QString statusMessage(const commands::CommandResult& result) {
 CompositionSession::CompositionSession(document::Document& document,
                                        commands::CommandStack& commandStack,
                                        document::CompositionId compositionId, QObject* parent)
-    : QObject(parent), document_(document), commandStack_(commandStack),
+    : QObject(parent), document_(&document), commandStack_(&commandStack),
       snapshot_(document.snapshot()), compositionId_(compositionId) {
     if (composition() == nullptr && !snapshot_.project().compositions().empty()) {
         compositionId_ = snapshot_.project().compositions().front().id();
     }
+}
+
+void CompositionSession::rebind(document::Document& document, commands::CommandStack& commandStack,
+                                const document::CompositionId compositionId) {
+    Q_ASSERT(QThread::currentThread() == thread());
+    document_ = &document;
+    commandStack_ = &commandStack;
+    snapshot_ = document_->snapshot();
+    compositionId_ = compositionId;
+    currentTime_ = core::RationalTime::fromInteger(0);
+    selection_ = {};
+
+    // One coherent transition (docs/architecture/project-session.md, "Session Publication"):
+    // observers must never see a new document paired with stale selection/time/history, so every
+    // existing changed signal fires here, unconditionally, in this order.
+    emit snapshotChanged();
+    emit compositionChanged();
+    emit currentTimeChanged();
+    emit selectionChanged();
+    emit historyChanged();
 }
 
 const document::Snapshot& CompositionSession::snapshot() const noexcept { return snapshot_; }
@@ -367,7 +387,7 @@ bool CompositionSession::addSolidLayer(const QString& name, const core::Color4d 
     commands::Transaction transaction("Add Solid Layer", snapshot_.revision());
     transaction.emplace<commands::AddSolidLayer>(compositionId_, name.toStdString(), color,
                                                  compositionCenter(*current));
-    const auto result = commandStack_.execute(std::move(transaction));
+    const auto result = commandStack_->execute(std::move(transaction));
     const auto layerId = result.outputId<document::LayerId>(commands::kAddSolidLayerLayerOutput);
     if (!handleResult(result)) {
         return false;
@@ -388,7 +408,7 @@ bool CompositionSession::addTextLayer(const QString& name, const QString& text) 
     commands::Transaction transaction("Add Text Layer", snapshot_.revision());
     transaction.emplace<commands::AddTextLayer>(compositionId_, name.toStdString(),
                                                 text.toStdString(), compositionCenter(*current));
-    const auto result = commandStack_.execute(std::move(transaction));
+    const auto result = commandStack_->execute(std::move(transaction));
     const auto layerId = result.outputId<document::LayerId>(commands::kAddTextLayerLayerOutput);
     if (!handleResult(result)) {
         return false;
@@ -484,19 +504,19 @@ bool CompositionSession::moveLayerBefore(const document::LayerSlotId slotId,
     return execute(std::move(transaction));
 }
 
-bool CompositionSession::canUndo() const noexcept { return commandStack_.canUndo(); }
+bool CompositionSession::canUndo() const noexcept { return commandStack_->canUndo(); }
 
-bool CompositionSession::canRedo() const noexcept { return commandStack_.canRedo(); }
+bool CompositionSession::canRedo() const noexcept { return commandStack_->canRedo(); }
 
 QString CompositionSession::undoLabel() const {
-    const auto label = commandStack_.undoLabel();
+    const auto label = commandStack_->undoLabel();
     return label.has_value()
                ? QString::fromUtf8(label->data(), static_cast<qsizetype>(label->size()))
                : QString{};
 }
 
 QString CompositionSession::redoLabel() const {
-    const auto label = commandStack_.redoLabel();
+    const auto label = commandStack_->redoLabel();
     return label.has_value()
                ? QString::fromUtf8(label->data(), static_cast<qsizetype>(label->size()))
                : QString{};
@@ -504,21 +524,21 @@ QString CompositionSession::redoLabel() const {
 
 bool CompositionSession::undo() {
     Q_ASSERT(QThread::currentThread() == thread());
-    return handleResult(commandStack_.undo());
+    return handleResult(commandStack_->undo());
 }
 
 bool CompositionSession::redo() {
     Q_ASSERT(QThread::currentThread() == thread());
-    return handleResult(commandStack_.redo());
+    return handleResult(commandStack_->redo());
 }
 
 bool CompositionSession::execute(commands::Transaction&& transaction) {
-    return handleResult(commandStack_.execute(std::move(transaction)));
+    return handleResult(commandStack_->execute(std::move(transaction)));
 }
 
 bool CompositionSession::handleResult(const commands::CommandResult& result) {
     const auto previousRevision = snapshot_.revision();
-    snapshot_ = document_.snapshot();
+    snapshot_ = document_->snapshot();
 
     if (!result.succeeded()) {
         const auto message = statusMessage(result);

--- a/src/ui/include/bloom/ui/composition_session.hpp
+++ b/src/ui/include/bloom/ui/composition_session.hpp
@@ -85,6 +85,17 @@ class CompositionSession final : public QObject {
     [[nodiscard]] bool undo();
     [[nodiscard]] bool redo();
 
+    // Projection rebinding (task U1, issue #72): atomically swaps which document/command-stack
+    // this session projects, for use after ProjectHost replaces the live ProjectSession content
+    // (New/Open). Implements the UI-owned half of docs/architecture/project-session.md's "Session
+    // Publication" install list: clears selection/interaction state, resets current time to zero,
+    // selects `compositionId` (the caller's already-computed lowest valid CompositionId, or an
+    // invalid/default id when no composition exists -- see ProjectHost), and emits every existing
+    // changed signal so observers (preview controller, editors) see one coherent transition. The
+    // OLD document/command-stack are left completely untouched by this call.
+    void rebind(document::Document& document, commands::CommandStack& commandStack,
+                document::CompositionId compositionId);
+
   signals:
     void snapshotChanged();
     void compositionChanged();
@@ -106,8 +117,12 @@ class CompositionSession final : public QObject {
     void normalizeSelection();
     void reportUnavailable(const QString& message);
 
-    document::Document& document_;
-    commands::CommandStack& commandStack_;
+    // Pointers, not references (task U1, issue #72): rebind() must be able to atomically retarget
+    // which document/command-stack this session projects after ProjectHost replaces the live
+    // ProjectSession content. A reference member cannot be reseated; both are set at construction
+    // and by rebind(), and are never null while this object is alive.
+    document::Document* document_;
+    commands::CommandStack* commandStack_;
     document::Snapshot snapshot_;
     document::CompositionId compositionId_;
     core::RationalTime currentTime_ = core::RationalTime::fromInteger(0);

--- a/src/ui/include/bloom/ui/main_window.hpp
+++ b/src/ui/include/bloom/ui/main_window.hpp
@@ -11,6 +11,7 @@ namespace bloom::ui {
 
 class CompositionSession;
 class EditorRegistry;
+class ProjectHost;
 class WorkspaceHost;
 enum class WorkspaceLayoutRestoreResult;
 
@@ -19,7 +20,7 @@ class MainWindow final : public QMainWindow {
 
   public:
     MainWindow(const EditorRegistry& editorRegistry, CompositionSession& compositionSession,
-               QWidget* parent = nullptr);
+               ProjectHost& projectHost, QWidget* parent = nullptr);
 
     [[nodiscard]] WorkspaceHost* workspaceHost() const noexcept;
     [[nodiscard]] WorkspaceLayoutRestoreResult restoreApplicationState(QSettings& settings);
@@ -33,17 +34,25 @@ class MainWindow final : public QMainWindow {
 
   private:
     void createMenus();
+    void createFileMenu(QMenu& fileMenu);
     void createWorkspaceSwitcher();
     void createEditorLayout(const EditorRegistry& editorRegistry);
     void createWorkspaceActions();
     void resetCompositingLayout();
     void updateEditActions();
     void updateWorkspaceActions();
+    void updateFileActions();
+    void updateWindowTitle();
     void applyFoundationTheme();
 
     CompositionSession& compositionSession_;
+    ProjectHost& projectHost_;
     QMenu* windowMenu_ = nullptr;
     WorkspaceHost* workspaceHost_ = nullptr;
+    QAction* newProjectAction_ = nullptr;
+    QAction* openProjectAction_ = nullptr;
+    QAction* saveProjectAction_ = nullptr;
+    QAction* saveProjectAsAction_ = nullptr;
     QAction* undoAction_ = nullptr;
     QAction* redoAction_ = nullptr;
     QAction* splitLeftRightAction_ = nullptr;

--- a/src/ui/include/bloom/ui/project_host.hpp
+++ b/src/ui/include/bloom/ui/project_host.hpp
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <bloom/document/document.hpp>
+#include <bloom/document/ids.hpp>
+#include <bloom/host/project_session.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/host/session_async_io.hpp>
+#include <bloom/host/session_open.hpp>
+#include <bloom/host/session_save.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <utility>
+#include <variant>
+
+namespace bloom::commands {
+class CommandStack;
+}
+
+namespace bloom::ui {
+
+// The artist's Save/Discard/Cancel answer to an unsaved-change prompt (docs/architecture/
+// project-session.md, "Unsaved-Change State Machine"). Returned by an injected
+// UnsavedChangeDecisionProvider so offscreen tests can drive all three answers without a real
+// QMessageBox.
+enum class UnsavedChangeDecision : std::uint8_t {
+    Save,
+    Discard,
+    Cancel,
+};
+
+using UnsavedChangeDecisionProvider = std::function<UnsavedChangeDecision()>;
+// Returns a chosen filesystem path, or nullopt for "the artist cancelled the dialog". Used for
+// both Open's and Save As's target-path chooser (decision 4's "same seam pattern for the file
+// dialogs").
+using ProjectPathProvider = std::function<std::optional<std::filesystem::path>()>;
+
+// A typed outcome for saveFinished()/openFinished() -- composed from the host's own typed results
+// (bloom::host::SessionSaveResult/SessionOpenResult) without ever collapsing a non-published or
+// failed outcome into success. `Refused` covers every typed begin-time refusal (busy, read-only,
+// capture/admission/submission failure) that never reached an async worker at all.
+enum class ProjectHostOperationOutcome : std::uint8_t {
+    Published,
+    PublishedWithWarning,
+    Superseded,
+    Cancelled,
+    ExternalConflict,
+    Failed,
+    Oversize,
+    Refused,
+};
+
+// What ProjectHost is currently doing, for the menu's enabled-state and the status bar's
+// "Saving…"/"Opening…" text (decision 3: "a modal-less 'Saving…'/'Opening…' statusBar message +
+// disabled actions until finished").
+enum class ProjectHostActivity : std::uint8_t {
+    Idle,
+    ResolvingUnsavedChanges,
+    Saving,
+    Opening,
+};
+
+// Owns the application's single live bloom::host::ProjectSession plus every service it needs to
+// run New/Open/Save/Save-As over that session (task U1, issue #72). ProjectHost is the ONLY
+// composition root for these services in the application; it owns:
+//   - a bloom::host::ProjectSessionIdentitySource (runtime session identity)
+//   - the live bloom::host::ProjectSession itself
+//   - a bloom::host::PublicationCoordinator
+//   - a bloom::platform::StagedArtifactCoordinator
+//   - a reference to the application's bloom::runtime::TaskScheduler (shared with whatever else
+//     already needs a BlockingIo worker -- see apps/bloom/main.cpp)
+//   - a bloom::project::ProjectIoMemoryCoordinator
+//   - at most ONE in-flight bloom::host::AsyncSessionSave OR bloom::host::AsyncSessionOpen; a
+//     second request while one is in flight is refused with a typed busy outcome (Refused) rather
+//     than queued -- the engine supports more concurrency than this, the UI does not need it yet.
+//
+// A QTimer (task_ui_bridge.cpp's interval precedent) polls the in-flight handle's isReady() and
+// calls tryComplete() once ready, then applies the typed result to the session and emits a typed
+// finished signal.
+//
+// Dialogs are behind small injectable seams (UnsavedChangeDecisionProvider/ProjectPathProvider)
+// defaulting to real QMessageBox/QFileDialog implementations, so offscreen tests can drive New,
+// Open, and Save entirely without a real dialog appearing.
+class ProjectHost final : public QObject {
+    Q_OBJECT
+
+  public:
+    explicit ProjectHost(runtime::TaskScheduler& scheduler, QObject* parent = nullptr);
+    ~ProjectHost() override;
+
+    [[nodiscard]] host::ProjectSessionStateSnapshot stateSnapshot() const;
+    // Editable decoded content, not busy -- matches decision 3 exactly ("Save disabled for
+    // read-only/busy"). Reused for Save As's own enabled-state; this slice does not distinguish
+    // the two.
+    // Not noexcept: each reads bloom::host::ProjectSession::stateSnapshot(), which copies
+    // std::string undo/redo labels and is not itself noexcept.
+    [[nodiscard]] bool canSave() const;
+    [[nodiscard]] bool isDirty() const;
+    [[nodiscard]] bool isBusy() const noexcept;
+    [[nodiscard]] ProjectHostActivity activity() const noexcept;
+    [[nodiscard]] std::optional<std::filesystem::path> displayPath() const;
+
+    // Design decision 2's UI seam, forwarded from the live ProjectSession: raw, non-owning
+    // pointers to the currently installed document/command-stack pair (null for non-decoded
+    // content). The caller hands these to a projection's own rebind() (e.g.
+    // CompositionSession::rebind()) after sessionReplaced() fires.
+    [[nodiscard]] std::pair<document::Document*, commands::CommandStack*>
+    liveDocumentAndStack() noexcept;
+    // The contract's "lowest valid CompositionId" (docs/architecture/project-session.md, "Session
+    // Publication", item 5) for the currently installed decoded content; a default-constructed
+    // (invalid) CompositionId when there is no decoded content or no composition at all.
+    [[nodiscard]] document::CompositionId lowestCompositionId() const;
+
+    // Seam setters (decision 4). Defaults are installed at construction (QMessageBox/QFileDialog);
+    // tests replace them before driving New/Open/Save.
+    void setUnsavedChangeDecisionProvider(UnsavedChangeDecisionProvider provider);
+    void setOpenPathProvider(ProjectPathProvider provider);
+    void setSaveAsPathProvider(ProjectPathProvider provider);
+
+    // Runs the unsaved-change flow (Save/Discard/Cancel) if, and only if, the current content is a
+    // dirty decoded document; otherwise `onProceed` runs immediately. Exposed publicly (beyond
+    // decision 1's newProject()/beginOpen()/beginSave()/beginSaveAs() list) so MainWindow's window
+    // close can share the exact same composed logic per decision 4 ("before New, Open, and window
+    // close ... prompt") instead of duplicating it.
+    void confirmUnsavedChanges(std::function<void()> onProceed);
+
+  public slots:
+    // Composes the unsaved-change flow, then REPLACES the session in-place with a fresh
+    // createNew() session (decision 1). Emits sessionReplaced() on success.
+    void newProject();
+    // The "Open…" menu action's entry point: composes the unsaved-change flow, then the open-path
+    // dialog seam, then beginOpen() with the chosen path.
+    void requestOpen();
+    // The "Save As…" menu action's entry point: the save-path dialog seam, then beginSaveAs() with
+    // the chosen path.
+    void requestSaveAs();
+
+    // The "Save" menu action's entry point (decision 3): a pathless project routes to the Save As
+    // dialog seam internally (session.capturePlainSavePathIntent()'s own PathRequired backs this --
+    // asking the host here instead of duplicating the check in MainWindow).
+    void beginSave();
+    // Lower-level primitives (decision 1's literal list): begin the async op against an
+    // already-known path. Public so tests can drive them directly, bypassing the dialog seams.
+    void beginOpen(const std::filesystem::path& path);
+    void beginSaveAs(std::filesystem::path path);
+
+  signals:
+    // Fires exactly once per successful New replace or successful Open install.
+    void sessionReplaced();
+    void dirtyStateChanged();
+    void activityChanged();
+    // Typed outcome + a display-ready message (never collapses Superseded/failed into success).
+    void saveFinished(bloom::ui::ProjectHostOperationOutcome outcome, QString message);
+    void openFinished(bloom::ui::ProjectHostOperationOutcome outcome, QString message);
+
+  private:
+    void poll();
+    void scheduleNextPoll();
+    void setActivity(ProjectHostActivity activity);
+    void replaceWithNewProject();
+    void promptAndBeginSaveAs();
+    void startSave(std::filesystem::path targetPath, host::SessionPathIntentCapture intent);
+    void handleSaveResult(host::SessionSaveResult result);
+    void handleOpenResult(host::SessionOpenResult result);
+    [[nodiscard]] std::optional<project::ProjectIoOperationMemory> makeOperation() const;
+    [[nodiscard]] bool hasDirtyDecodedContent() const;
+
+    runtime::TaskScheduler& scheduler_;
+    host::ProjectSessionIdentitySource identitySource_;
+    std::optional<host::PublicationCoordinator> publicationCoordinator_;
+    std::optional<platform::StagedArtifactCoordinator> artifactCoordinator_;
+    std::optional<project::ProjectIoMemoryCoordinator> memoryCoordinator_;
+    std::optional<host::ProjectSession> session_;
+
+    std::variant<std::monostate, host::AsyncSessionSave, host::AsyncSessionOpen> inFlight_;
+    QTimer pollTimer_;
+    ProjectHostActivity activity_ = ProjectHostActivity::Idle;
+
+    UnsavedChangeDecisionProvider decisionProvider_;
+    ProjectPathProvider openPathProvider_;
+    ProjectPathProvider saveAsPathProvider_;
+
+    // Set only while the unsaved-change flow's Save choice is running an async save; consumed
+    // exactly once when that save completes (docs/architecture/project-session.md's "If the
+    // document changes while saving, the flow returns to a fresh decision instead of discarding
+    // the newer edit" -- implemented by re-running confirmUnsavedChanges(), which re-reads dirty
+    // state fresh).
+    std::optional<std::function<void()>> pendingUnsavedContinuation_;
+};
+
+} // namespace bloom::ui

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -3,6 +3,7 @@
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_area.hpp>
 #include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/project_host.hpp>
 #include <bloom/ui/workspace_host.hpp>
 
 #include <QAction>
@@ -13,9 +14,13 @@
 #include <QKeySequence>
 #include <QMenu>
 #include <QMenuBar>
+#include <QMessageBox>
 #include <QPalette>
 #include <QSettings>
+#include <QStatusBar>
 #include <QStringList>
+
+#include <filesystem>
 
 namespace {
 
@@ -27,8 +32,8 @@ constexpr auto windowGeometryKey = "window/main/geometry";
 namespace bloom::ui {
 
 MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession& compositionSession,
-                       QWidget* parent)
-    : QMainWindow(parent), compositionSession_(compositionSession) {
+                       ProjectHost& projectHost, QWidget* parent)
+    : QMainWindow(parent), compositionSession_(compositionSession), projectHost_(projectHost) {
     setObjectName("bloomMainWindow");
     setWindowTitle("Bloom");
     resize(1600, 1000);
@@ -39,6 +44,33 @@ MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession&
     createWorkspaceActions();
     updateEditActions();
     applyFoundationTheme();
+
+    connect(&projectHost_, &ProjectHost::dirtyStateChanged, this, &MainWindow::updateWindowTitle);
+    connect(&projectHost_, &ProjectHost::sessionReplaced, this, &MainWindow::updateWindowTitle);
+    connect(&projectHost_, &ProjectHost::activityChanged, this, &MainWindow::updateFileActions);
+    connect(&projectHost_, &ProjectHost::sessionReplaced, this, &MainWindow::updateFileActions);
+    connect(&projectHost_, &ProjectHost::saveFinished, this,
+            [this](const ProjectHostOperationOutcome outcome, const QString& message) {
+                if (outcome == ProjectHostOperationOutcome::Published) {
+                    statusBar()->showMessage(message, 4000);
+                    return;
+                }
+                QMessageBox::warning(this, tr("Save Project"), message);
+            });
+    connect(&projectHost_, &ProjectHost::openFinished, this,
+            [this](const ProjectHostOperationOutcome outcome, const QString& message) {
+                if (outcome == ProjectHostOperationOutcome::Published) {
+                    statusBar()->showMessage(message, 4000);
+                    return;
+                }
+                if (outcome == ProjectHostOperationOutcome::Cancelled) {
+                    statusBar()->clearMessage();
+                    return;
+                }
+                QMessageBox::warning(this, tr("Open Project"), message);
+            });
+    updateFileActions();
+    updateWindowTitle();
 }
 
 WorkspaceHost* MainWindow::workspaceHost() const noexcept { return workspaceHost_; }
@@ -67,12 +99,24 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     if (shutdownRequested_) {
         return;
     }
-    shutdownRequested_ = true;
-    emit shutdownRequested();
+    if (projectHost_.isBusy()) {
+        // v1 simplification (no progress/cancellation UI in scope): a close request while a
+        // project I/O operation or an unsaved-change decision is already in flight is silently
+        // ignored; the artist retries once it finishes.
+        return;
+    }
+    projectHost_.confirmUnsavedChanges([this] {
+        if (shutdownRequested_) {
+            return;
+        }
+        shutdownRequested_ = true;
+        emit shutdownRequested();
+    });
 }
 
 void MainWindow::createMenus() {
-    menuBar()->addMenu("&File");
+    auto* fileMenu = menuBar()->addMenu("&File");
+    createFileMenu(*fileMenu);
     auto* editMenu = menuBar()->addMenu("&Edit");
     undoAction_ = editMenu->addAction("Undo");
     undoAction_->setObjectName("undoAction");
@@ -100,6 +144,70 @@ void MainWindow::updateEditActions() {
     redoAction_->setEnabled(compositionSession_.canRedo());
     undoAction_->setText(undoLabel.isEmpty() ? tr("Undo") : tr("Undo %1").arg(undoLabel));
     redoAction_->setText(redoLabel.isEmpty() ? tr("Redo") : tr("Redo %1").arg(redoLabel));
+}
+
+void MainWindow::createFileMenu(QMenu& fileMenu) {
+    newProjectAction_ = fileMenu.addAction("&New");
+    newProjectAction_->setObjectName("newProjectAction");
+    newProjectAction_->setShortcut(QKeySequence::New);
+    newProjectAction_->setShortcutContext(Qt::WindowShortcut);
+    connect(newProjectAction_, &QAction::triggered, &projectHost_, &ProjectHost::newProject);
+
+    openProjectAction_ = fileMenu.addAction("&Open…");
+    openProjectAction_->setObjectName("openProjectAction");
+    openProjectAction_->setShortcut(QKeySequence::Open);
+    openProjectAction_->setShortcutContext(Qt::WindowShortcut);
+    connect(openProjectAction_, &QAction::triggered, &projectHost_, &ProjectHost::requestOpen);
+
+    saveProjectAction_ = fileMenu.addAction("&Save");
+    saveProjectAction_->setObjectName("saveProjectAction");
+    saveProjectAction_->setShortcut(QKeySequence::Save);
+    saveProjectAction_->setShortcutContext(Qt::WindowShortcut);
+    connect(saveProjectAction_, &QAction::triggered, &projectHost_, &ProjectHost::beginSave);
+
+    saveProjectAsAction_ = fileMenu.addAction("Save &As…");
+    saveProjectAsAction_->setObjectName("saveProjectAsAction");
+    saveProjectAsAction_->setShortcut(QKeySequence::SaveAs);
+    saveProjectAsAction_->setShortcutContext(Qt::WindowShortcut);
+    connect(saveProjectAsAction_, &QAction::triggered, &projectHost_, &ProjectHost::requestSaveAs);
+
+    fileMenu.addSeparator();
+}
+
+void MainWindow::updateFileActions() {
+    const bool busy = projectHost_.isBusy();
+    newProjectAction_->setEnabled(!busy);
+    openProjectAction_->setEnabled(!busy);
+    saveProjectAction_->setEnabled(!busy && projectHost_.canSave());
+    saveProjectAsAction_->setEnabled(!busy && projectHost_.canSave());
+
+    switch (projectHost_.activity()) {
+    case ProjectHostActivity::Saving:
+        statusBar()->showMessage(tr("Saving…"));
+        break;
+    case ProjectHostActivity::Opening:
+        statusBar()->showMessage(tr("Opening…"));
+        break;
+    case ProjectHostActivity::ResolvingUnsavedChanges:
+        statusBar()->showMessage(tr("Waiting for a decision about unsaved changes…"));
+        break;
+    case ProjectHostActivity::Idle:
+        // Never force QMainWindow::statusBar() to lazily create a status bar just to clear a
+        // message that was never shown (e.g. at initial construction, before any project I/O has
+        // ever run): only clear one that already exists.
+        if (auto* bar = findChild<QStatusBar*>()) {
+            bar->clearMessage();
+        }
+        break;
+    }
+}
+
+void MainWindow::updateWindowTitle() {
+    const auto path = projectHost_.displayPath();
+    const QString name =
+        path.has_value() ? QString::fromStdString(path->filename().string()) : tr("Untitled");
+    setWindowTitle(QStringLiteral("%1[*] — Bloom").arg(name));
+    setWindowModified(projectHost_.isDirty());
 }
 
 void MainWindow::createWorkspaceSwitcher() {

--- a/src/ui/project_host.cpp
+++ b/src/ui/project_host.cpp
@@ -1,0 +1,634 @@
+#include <bloom/ui/project_host.hpp>
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/project/save_archive.hpp>
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+#include <cstddef>
+#include <fstream>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace bloom::ui {
+
+namespace {
+
+constexpr int kPollIntervalMs = 100;
+constexpr std::uint64_t kBytesPerMebibyte = 1024ULL * 1024ULL;
+
+} // namespace
+
+ProjectHost::ProjectHost(runtime::TaskScheduler& scheduler, QObject* parent)
+    : QObject(parent), scheduler_(scheduler) {
+    auto publicationResult = host::PublicationCoordinator::create();
+    if (!publicationResult.has_value()) {
+        throw std::runtime_error("Bloom could not create the publication coordinator");
+    }
+    publicationCoordinator_.emplace(std::move(*publicationResult));
+
+    auto artifactResult =
+        platform::StagedArtifactCoordinator::create(platform::StagedArtifactConfig{});
+    if (!artifactResult) {
+        throw std::runtime_error("Bloom could not create the staged-artifact coordinator");
+    }
+    artifactCoordinator_.emplace(std::move(artifactResult).takeCoordinator());
+
+    auto memoryResult = project::ProjectIoMemoryCoordinator::create();
+    if (!memoryResult.has_value()) {
+        throw std::runtime_error("Bloom could not create the project I/O memory coordinator");
+    }
+    memoryCoordinator_.emplace(std::move(*memoryResult));
+
+    decisionProvider_ = [] {
+        QMessageBox box;
+        box.setWindowTitle(tr("Unsaved Changes"));
+        box.setText(tr("This project has unsaved changes."));
+        box.setInformativeText(tr("Do you want to save your changes before continuing?"));
+        box.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+        box.setDefaultButton(QMessageBox::Save);
+        switch (box.exec()) {
+        case QMessageBox::Save:
+            return UnsavedChangeDecision::Save;
+        case QMessageBox::Discard:
+            return UnsavedChangeDecision::Discard;
+        default:
+            return UnsavedChangeDecision::Cancel;
+        }
+    };
+    openPathProvider_ = []() -> std::optional<std::filesystem::path> {
+        const auto chosen = QFileDialog::getOpenFileName(nullptr, tr("Open Project"), {},
+                                                         tr("Bloom Projects (*.bloom)"));
+        if (chosen.isEmpty()) {
+            return std::nullopt;
+        }
+        return std::filesystem::path(chosen.toStdString());
+    };
+    saveAsPathProvider_ = []() -> std::optional<std::filesystem::path> {
+        const auto chosen = QFileDialog::getSaveFileName(nullptr, tr("Save Project As"), {},
+                                                         tr("Bloom Projects (*.bloom)"));
+        if (chosen.isEmpty()) {
+            return std::nullopt;
+        }
+        return std::filesystem::path(chosen.toStdString());
+    };
+
+    pollTimer_.setSingleShot(true);
+    pollTimer_.setTimerType(Qt::PreciseTimer);
+    connect(&pollTimer_, &QTimer::timeout, this, &ProjectHost::poll);
+
+    // Bootstrap the initial session (decision 1/5): the application always starts on a fresh,
+    // untouched new project. No one is connected to sessionReplaced()/dirtyStateChanged() yet, so
+    // this emission is inert.
+    replaceWithNewProject();
+}
+
+ProjectHost::~ProjectHost() {
+    if (auto* save = std::get_if<host::AsyncSessionSave>(&inFlight_)) {
+        save->requestCancellation();
+    } else if (auto* open = std::get_if<host::AsyncSessionOpen>(&inFlight_)) {
+        open->requestCancellation();
+    }
+}
+
+host::ProjectSessionStateSnapshot ProjectHost::stateSnapshot() const {
+    if (!session_.has_value()) {
+        return {};
+    }
+    return session_->stateSnapshot();
+}
+
+bool ProjectHost::canSave() const {
+    if (!session_.has_value() || isBusy()) {
+        return false;
+    }
+    const auto snapshot = session_->stateSnapshot();
+    return snapshot.valid &&
+           snapshot.contentKind == host::ProjectSessionContentKind::DecodedDocument &&
+           snapshot.editability == host::DecodedProjectEditability::Editable;
+}
+
+bool ProjectHost::isDirty() const {
+    if (!session_.has_value()) {
+        return false;
+    }
+    return session_->stateSnapshot().dirty.value_or(false);
+}
+
+bool ProjectHost::isBusy() const noexcept { return activity_ != ProjectHostActivity::Idle; }
+
+ProjectHostActivity ProjectHost::activity() const noexcept { return activity_; }
+
+std::optional<std::filesystem::path> ProjectHost::displayPath() const {
+    if (!session_.has_value()) {
+        return std::nullopt;
+    }
+    const auto snapshot = session_->stateSnapshot();
+    if (!snapshot.displayPath.has_value()) {
+        return std::nullopt;
+    }
+    return snapshot.displayPath->value();
+}
+
+std::pair<document::Document*, commands::CommandStack*>
+ProjectHost::liveDocumentAndStack() noexcept {
+    if (!session_.has_value()) {
+        return {nullptr, nullptr};
+    }
+    return session_->liveDocumentAndStack();
+}
+
+document::CompositionId ProjectHost::lowestCompositionId() const {
+    if (!session_.has_value()) {
+        return {};
+    }
+    const auto snapshot = session_->decodedSnapshot();
+    if (!snapshot) {
+        return {};
+    }
+    const auto compositions = snapshot.snapshot().project().compositions();
+    if (compositions.empty()) {
+        return {};
+    }
+    auto lowest = compositions.front().id();
+    for (const auto& composition : compositions) {
+        if (composition.id().value() < lowest.value()) {
+            lowest = composition.id();
+        }
+    }
+    return lowest;
+}
+
+void ProjectHost::setUnsavedChangeDecisionProvider(UnsavedChangeDecisionProvider provider) {
+    decisionProvider_ = std::move(provider);
+}
+
+void ProjectHost::setOpenPathProvider(ProjectPathProvider provider) {
+    openPathProvider_ = std::move(provider);
+}
+
+void ProjectHost::setSaveAsPathProvider(ProjectPathProvider provider) {
+    saveAsPathProvider_ = std::move(provider);
+}
+
+bool ProjectHost::hasDirtyDecodedContent() const {
+    if (!session_.has_value()) {
+        return false;
+    }
+    const auto snapshot = session_->stateSnapshot();
+    return snapshot.valid &&
+           snapshot.contentKind == host::ProjectSessionContentKind::DecodedDocument &&
+           snapshot.dirty.value_or(false);
+}
+
+void ProjectHost::confirmUnsavedChanges(std::function<void()> onProceed) {
+    if (activity_ == ProjectHostActivity::ResolvingUnsavedChanges) {
+        // "Only one destructive continuation is active. Duplicate close/quit requests are
+        // idempotent." (docs/architecture/project-session.md, "Unsaved-Change State Machine").
+        return;
+    }
+    if (!hasDirtyDecodedContent()) {
+        onProceed();
+        return;
+    }
+    if (!decisionProvider_) {
+        // No provider configured: never silently discard an artist's edit.
+        return;
+    }
+
+    setActivity(ProjectHostActivity::ResolvingUnsavedChanges);
+    const auto decision = decisionProvider_();
+    switch (decision) {
+    case UnsavedChangeDecision::Cancel:
+        setActivity(ProjectHostActivity::Idle);
+        return;
+    case UnsavedChangeDecision::Discard:
+        setActivity(ProjectHostActivity::Idle);
+        onProceed();
+        return;
+    case UnsavedChangeDecision::Save:
+        pendingUnsavedContinuation_ = std::move(onProceed);
+        // Let beginSave() own activity tracking from here; it refuses while busy, and this flow
+        // is itself the only reason activity_ is currently non-Idle.
+        setActivity(ProjectHostActivity::Idle);
+        beginSave();
+        if (activity_ != ProjectHostActivity::Saving) {
+            // beginSave() could not even start an async attempt (pathless with no dialog answer,
+            // no provider configured, or a typed begin refusal). Abandon this continuation rather
+            // than looping automatically: the edit is never discarded, but the artist must retry
+            // from the menu. The project stays dirty.
+            pendingUnsavedContinuation_.reset();
+            setActivity(ProjectHostActivity::Idle);
+        }
+        return;
+    }
+}
+
+void ProjectHost::newProject() {
+    if (isBusy()) {
+        return;
+    }
+    confirmUnsavedChanges([this] { replaceWithNewProject(); });
+}
+
+void ProjectHost::requestOpen() {
+    if (isBusy()) {
+        return;
+    }
+    confirmUnsavedChanges([this] {
+        if (!openPathProvider_) {
+            return;
+        }
+        auto chosen = openPathProvider_();
+        if (!chosen.has_value()) {
+            return;
+        }
+        beginOpen(*chosen);
+    });
+}
+
+void ProjectHost::requestSaveAs() {
+    if (isBusy()) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+    promptAndBeginSaveAs();
+}
+
+void ProjectHost::promptAndBeginSaveAs() {
+    if (!saveAsPathProvider_) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("No Save As dialog is configured."));
+        return;
+    }
+    auto chosen = saveAsPathProvider_();
+    if (!chosen.has_value()) {
+        return; // The artist cancelled the dialog; not an error.
+    }
+    beginSaveAs(std::move(*chosen));
+}
+
+void ProjectHost::beginSave() {
+    if (isBusy() || !session_.has_value()) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+    const auto snapshot = session_->stateSnapshot();
+    if (!snapshot.valid ||
+        snapshot.contentKind != host::ProjectSessionContentKind::DecodedDocument ||
+        snapshot.editability != host::DecodedProjectEditability::Editable) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("This project cannot be saved."));
+        return;
+    }
+    if (!snapshot.displayPath.has_value()) {
+        // Pathless Save routes to Save As (decision 3; captureSaveInput()'s own PathRequired
+        // backs this -- asking the host here instead of duplicating the check in MainWindow).
+        promptAndBeginSaveAs();
+        return;
+    }
+    const auto intent = session_->capturePlainSavePathIntent();
+    if (!intent.isValid()) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused, tr("Save could not start."));
+        return;
+    }
+    startSave(snapshot.displayPath->value(), intent);
+}
+
+void ProjectHost::beginSaveAs(std::filesystem::path path) {
+    if (isBusy() || !session_.has_value()) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+    auto advance = session_->advancePathIntentForSaveAs();
+    if (!advance) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused, tr("Save As could not start."));
+        return;
+    }
+    startSave(std::move(path), advance.capture());
+}
+
+void ProjectHost::startSave(std::filesystem::path targetPath,
+                            const host::SessionPathIntentCapture intent) {
+    // Callers (beginSave()/beginSaveAs()) already checked isBusy()/session_.has_value(); these
+    // guards are repeated defensively so this function is never the one place that assumes a
+    // caller-side check without stating its own.
+    if (!session_.has_value() || !publicationCoordinator_.has_value() ||
+        !artifactCoordinator_.has_value()) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+    auto operation = makeOperation();
+    if (!operation.has_value()) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Not enough memory is available to start this save."));
+        return;
+    }
+    const host::SessionSaveRequest request{
+        .targetPath = std::move(targetPath),
+        .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
+        .expectedTarget = std::nullopt,
+        .limits = {},
+        .intent = intent,
+    };
+    auto begun = host::beginSessionSave(*session_, scheduler_, *publicationCoordinator_,
+                                        *artifactCoordinator_, request, std::move(*operation));
+    if (!begun) {
+        emit saveFinished(ProjectHostOperationOutcome::Refused,
+                          tr("The save could not be started."));
+        return;
+    }
+    inFlight_.emplace<host::AsyncSessionSave>(std::move(begun).takeHandle());
+    setActivity(ProjectHostActivity::Saving);
+    scheduleNextPoll();
+}
+
+void ProjectHost::beginOpen(const std::filesystem::path& path) {
+    if (isBusy() || !session_.has_value()) {
+        emit openFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+
+    std::error_code sizeError;
+    const auto fileBytes = std::filesystem::file_size(path, sizeError);
+    if (sizeError) {
+        emit openFinished(ProjectHostOperationOutcome::Failed,
+                          tr("The project file could not be read: %1")
+                              .arg(QString::fromStdString(sizeError.message())));
+        return;
+    }
+
+    // Bounded by the archive size limit BEFORE reading fully (task U1 spec): checking the file
+    // size against the same physical-archive limit project::openProjectArchive() itself enforces
+    // avoids reading an oversize file into memory just to have it refused afterward.
+    const project::SaveArchiveLimits limits{};
+    if (fileBytes > limits.container.maxArchiveBytes) {
+        emit openFinished(ProjectHostOperationOutcome::Oversize,
+                          tr("This project file is too large to open (%1 MB; the limit is %2 MB).")
+                              .arg(static_cast<qulonglong>(fileBytes / kBytesPerMebibyte))
+                              .arg(static_cast<qulonglong>(limits.container.maxArchiveBytes /
+                                                           kBytesPerMebibyte)));
+        return;
+    }
+
+    auto displayPath = host::ProjectDisplayPath::create(path);
+    if (!displayPath.has_value()) {
+        emit openFinished(ProjectHostOperationOutcome::Refused,
+                          tr("The chosen path is not valid."));
+        return;
+    }
+
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream.is_open()) {
+        emit openFinished(ProjectHostOperationOutcome::Failed,
+                          tr("The project file could not be opened for reading."));
+        return;
+    }
+    std::vector<std::byte> bytes(static_cast<std::size_t>(fileBytes));
+    if (!bytes.empty()) {
+        stream.read(reinterpret_cast<char*>(bytes.data()),
+                    static_cast<std::streamsize>(bytes.size()));
+    }
+    if (!stream) {
+        emit openFinished(ProjectHostOperationOutcome::Failed,
+                          tr("The project file could not be fully read."));
+        return;
+    }
+
+    auto operation = makeOperation();
+    if (!operation.has_value()) {
+        emit openFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Not enough memory is available to start this open."));
+        return;
+    }
+
+    auto begun = host::beginSessionOpen(*session_, scheduler_, std::move(bytes),
+                                        std::move(displayPath), limits, std::move(*operation));
+    if (!begun) {
+        emit openFinished(ProjectHostOperationOutcome::Refused,
+                          tr("The open could not be started."));
+        return;
+    }
+    inFlight_.emplace<host::AsyncSessionOpen>(std::move(begun).takeHandle());
+    setActivity(ProjectHostActivity::Opening);
+    scheduleNextPoll();
+}
+
+void ProjectHost::replaceWithNewProject() {
+    host::NewProjectSessionRequest request{
+        .projectName = "Untitled",
+        .compositionName = "Composition 1",
+        .duration = core::RationalTime::fromInteger(10),
+        .format = {},
+    };
+    auto created = host::ProjectSession::createNew(identitySource_, std::move(request));
+    if (!created) {
+        // RuntimeIdentityExhausted/ResourceUnavailable/InvalidNewProject: unreachable in practice
+        // with a fresh identity source and fixed request fields. The previous session (if any) is
+        // left completely untouched rather than crashing the application.
+        return;
+    }
+    session_.emplace(std::move(created).takeSession());
+    emit sessionReplaced();
+    emit dirtyStateChanged();
+}
+
+void ProjectHost::poll() {
+    if (!session_.has_value()) {
+        // Unreachable in practice: an in-flight handle is never created without a valid session,
+        // and session_ is only ever replaced, never emptied. Guarded explicitly so tryComplete()
+        // below is never called against an absent session; reschedule rather than silently
+        // abandoning any in-flight handle.
+        if (!std::holds_alternative<std::monostate>(inFlight_)) {
+            scheduleNextPoll();
+        }
+        return;
+    }
+    if (auto* save = std::get_if<host::AsyncSessionSave>(&inFlight_)) {
+        if (!save->isReady()) {
+            scheduleNextPoll();
+            return;
+        }
+        auto result = save->tryComplete(*session_);
+        inFlight_.emplace<std::monostate>();
+        setActivity(ProjectHostActivity::Idle);
+        if (result.has_value()) {
+            handleSaveResult(std::move(*result));
+        }
+        return;
+    }
+    if (auto* open = std::get_if<host::AsyncSessionOpen>(&inFlight_)) {
+        if (!open->isReady()) {
+            scheduleNextPoll();
+            return;
+        }
+        auto result = open->tryComplete(*session_);
+        inFlight_.emplace<std::monostate>();
+        setActivity(ProjectHostActivity::Idle);
+        if (result.has_value()) {
+            handleOpenResult(std::move(*result));
+        }
+        return;
+    }
+}
+
+void ProjectHost::scheduleNextPoll() { pollTimer_.start(kPollIntervalMs); }
+
+void ProjectHost::setActivity(const ProjectHostActivity activity) {
+    if (activity_ == activity) {
+        return;
+    }
+    activity_ = activity;
+    emit activityChanged();
+}
+
+void ProjectHost::handleSaveResult(host::SessionSaveResult result) {
+    emit dirtyStateChanged();
+
+    auto outcome = ProjectHostOperationOutcome::Failed;
+    QString message;
+
+    switch (result.stage()) {
+    case host::SessionSaveStage::None:
+        outcome = ProjectHostOperationOutcome::Refused;
+        message = tr("The save did not run.");
+        break;
+    case host::SessionSaveStage::Capture:
+        outcome = ProjectHostOperationOutcome::Refused;
+        message = tr("The save could not capture the current project state.");
+        break;
+    case host::SessionSaveStage::Publication:
+        outcome = ProjectHostOperationOutcome::Failed;
+        message = tr("The save failed before the file could be written.");
+        break;
+    case host::SessionSaveStage::Savepoint: {
+        const auto* publication = result.publication();
+        const auto publicationOutcome =
+            publication != nullptr
+                ? publication->outcome
+                : platform::StagedArtifactPublicationOutcome::FailedBeforePublication;
+        switch (publicationOutcome) {
+        case platform::StagedArtifactPublicationOutcome::Published:
+            outcome = ProjectHostOperationOutcome::Published;
+            message = tr("Project saved.");
+            break;
+        case platform::StagedArtifactPublicationOutcome::PublishedWithDurabilityWarning:
+            outcome = ProjectHostOperationOutcome::PublishedWithWarning;
+            message =
+                tr("Project saved, but a later durability step failed. Consider saving again.");
+            break;
+        case platform::StagedArtifactPublicationOutcome::Superseded:
+            outcome = ProjectHostOperationOutcome::Superseded;
+            message = tr("This save was superseded by a newer save.");
+            break;
+        case platform::StagedArtifactPublicationOutcome::CancelledBeforePublication:
+            outcome = ProjectHostOperationOutcome::Cancelled;
+            message = tr("The save was cancelled.");
+            break;
+        case platform::StagedArtifactPublicationOutcome::ExternalModificationConflict:
+            outcome = ProjectHostOperationOutcome::ExternalConflict;
+            message =
+                tr("The file changed outside Bloom. Reload, Save As, or overwrite explicitly.");
+            break;
+        case platform::StagedArtifactPublicationOutcome::FailedBeforePublication:
+            outcome = ProjectHostOperationOutcome::Failed;
+            message = tr("The save failed before the file could be replaced.");
+            break;
+        }
+        if (publication != nullptr && publication->targetWasPublished() &&
+            result.savepointStatus().has_value() &&
+            *result.savepointStatus() != host::ProjectSessionSavepointStatus::Accepted) {
+            // The file is durably published, but the local session bookkeeping refused the
+            // savepoint (e.g. a stale intent after a later replacement). Never claim success here
+            // even though a real file now exists on disk -- see
+            // docs/architecture/project-session.md, "Save Result Acceptance".
+            outcome = ProjectHostOperationOutcome::Failed;
+            message = tr("The project file was written, but this open project is now out of date "
+                         "with it; reopen the file to continue editing it.");
+        }
+        break;
+    }
+    }
+
+    emit saveFinished(outcome, message);
+
+    if (pendingUnsavedContinuation_.has_value()) {
+        auto continuation = std::move(*pendingUnsavedContinuation_);
+        pendingUnsavedContinuation_.reset();
+        // Re-run the flow fresh (docs/architecture/project-session.md's "If the document changes
+        // while saving, the flow returns to a fresh decision instead of discarding the newer
+        // edit"): confirmUnsavedChanges() re-reads dirty state now, so a clean project proceeds
+        // immediately, a still-dirty one (failure/supersession/an intervening edit) re-prompts.
+        confirmUnsavedChanges(std::move(continuation));
+    }
+}
+
+void ProjectHost::handleOpenResult(host::SessionOpenResult result) {
+    auto outcome = ProjectHostOperationOutcome::Failed;
+    QString message;
+    bool installed = false;
+
+    switch (result.stage()) {
+    case host::SessionOpenStage::Admission:
+        outcome = ProjectHostOperationOutcome::Refused;
+        message = tr("The open could not start.");
+        break;
+    case host::SessionOpenStage::Opening:
+        outcome = ProjectHostOperationOutcome::Failed;
+        message = tr("The project file could not be opened.");
+        break;
+    case host::SessionOpenStage::NotOpened:
+        outcome = ProjectHostOperationOutcome::Cancelled;
+        message = tr("The open was cancelled.");
+        break;
+    case host::SessionOpenStage::Installation: {
+        const auto* outcomeVariant = result.installOutcome();
+        const auto* status = outcomeVariant != nullptr
+                                 ? std::get_if<host::SessionInstallStatus>(outcomeVariant)
+                                 : nullptr;
+        if (status != nullptr && *status == host::SessionInstallStatus::Installed) {
+            installed = true;
+            outcome = ProjectHostOperationOutcome::Published;
+            // A preserved-read-only install has no live document/command-stack at all (see
+            // liveDocumentAndStack()); this build has no workspace surface for that content kind
+            // (KNOWN LIMITATION -- see the implementor's report), so callers must not assume a
+            // Published open outcome always means an editable composition became available.
+            message =
+                result.attemptedContentKind() == host::ProjectSessionContentKind::PreservedReadOnly
+                    ? tr("Opened as preserved read-only content; this build has no editor for it "
+                         "yet.")
+                    : tr("Project opened.");
+        } else {
+            outcome = ProjectHostOperationOutcome::Failed;
+            message = tr("The project could not be installed.");
+        }
+        break;
+    }
+    }
+
+    emit dirtyStateChanged();
+    emit openFinished(outcome, message);
+
+    if (installed) {
+        emit sessionReplaced();
+    }
+}
+
+std::optional<project::ProjectIoOperationMemory> ProjectHost::makeOperation() const {
+    if (!memoryCoordinator_.has_value()) {
+        return std::nullopt;
+    }
+    return memoryCoordinator_->createOperation();
+}
+
+} // namespace bloom::ui

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -7,8 +7,14 @@ add_executable(bloom_composition_preview_controller_test
 add_executable(bloom_composition_session_animation_test
     composition_session_animation_tests.cpp
 )
+add_executable(bloom_composition_session_rebind_test
+    composition_session_rebind_tests.cpp
+)
 add_executable(bloom_application_shutdown_test
     application_shutdown_tests.cpp
+)
+add_executable(bloom_project_host_test
+    project_host_tests.cpp
 )
 add_executable(bloom_task_monitor_test
     task_monitor_test.cpp
@@ -20,13 +26,17 @@ add_executable(bloom_viewer_editor_test
 target_link_libraries(bloom_composition_projection_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_preview_controller_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_session_animation_test PRIVATE bloom_ui)
+target_link_libraries(bloom_composition_session_rebind_test PRIVATE bloom_ui)
 target_link_libraries(bloom_application_shutdown_test PRIVATE bloom_ui)
+target_link_libraries(bloom_project_host_test PRIVATE bloom_ui)
 target_link_libraries(bloom_task_monitor_test PRIVATE bloom_ui)
 target_link_libraries(bloom_viewer_editor_test PRIVATE bloom_ui)
 bloom_enable_warnings(bloom_composition_projection_test)
 bloom_enable_warnings(bloom_composition_preview_controller_test)
 bloom_enable_warnings(bloom_composition_session_animation_test)
+bloom_enable_warnings(bloom_composition_session_rebind_test)
 bloom_enable_warnings(bloom_application_shutdown_test)
+bloom_enable_warnings(bloom_project_host_test)
 bloom_enable_warnings(bloom_task_monitor_test)
 bloom_enable_warnings(bloom_viewer_editor_test)
 
@@ -57,9 +67,25 @@ bloom_add_test(
 )
 
 bloom_add_test(
+    NAME bloom.ui.composition_session_rebind
+    COMMAND bloom_composition_session_rebind_test
+    LABELS ui unit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
     NAME bloom.ui.application_shutdown
     COMMAND bloom_application_shutdown_test
     LABELS ui integration
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.project_host
+    COMMAND bloom_project_host_test
+    LABELS ui integration host
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )

--- a/src/ui/tests/application_shutdown_tests.cpp
+++ b/src/ui/tests/application_shutdown_tests.cpp
@@ -8,6 +8,7 @@
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_registry.hpp>
 #include <bloom/ui/main_window.hpp>
+#include <bloom/ui/project_host.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 
 #include <QApplication>
@@ -124,8 +125,9 @@ void testShutdownAndCloseRouting(Expectations& expectations) {
     auto* application = QCoreApplication::instance();
     application->installEventFilter(&shutdown);
 
+    ui::ProjectHost projectHost(scheduler);
     ui::EditorRegistry registry;
-    ui::MainWindow window(registry, session);
+    ui::MainWindow window(registry, session, projectHost);
     window.resize(913, 577);
     QTemporaryDir settingsDirectory;
     QSettings settings(settingsDirectory.filePath(QStringLiteral("shutdown-state.ini")),

--- a/src/ui/tests/composition_session_rebind_tests.cpp
+++ b/src/ui/tests/composition_session_rebind_tests.cpp
@@ -1,0 +1,125 @@
+#include <bloom/ui/composition_session.hpp>
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+
+#include <QApplication>
+#include <QObject>
+
+#include <iostream>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <utility>
+#include <variant>
+
+// CompositionSession::rebind() unit test (task U1, issue #72, frozen design decision 2): bind ->
+// select things -> rebind to a second document -> selection cleared, time zero, every changed
+// signal emitted exactly once, and the OLD document is left completely untouched.
+
+namespace {
+
+using bloom::core::Color4d;
+using bloom::core::RationalTime;
+using bloom::ui::CompositionSession;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+void testRebindClearsSelectionResetsTimeAndEmitsEverySignalOnce(Expectations& expectations) {
+    auto firstNewProject = bloom::document::makeNewProject("First Project", "Main Composition",
+                                                           RationalTime::fromInteger(10));
+    const auto firstCompositionId = firstNewProject.initialCompositionId;
+    bloom::document::Document firstDocument(std::move(firstNewProject.project));
+    bloom::commands::CommandStack firstCommandStack(firstDocument);
+
+    auto secondNewProject = bloom::document::makeNewProject("Second Project", "Main Composition",
+                                                            RationalTime::fromInteger(10));
+    const auto secondCompositionId = secondNewProject.initialCompositionId;
+    bloom::document::Document secondDocument(std::move(secondNewProject.project));
+    bloom::commands::CommandStack secondCommandStack(secondDocument);
+
+    CompositionSession session(firstDocument, firstCommandStack, firstCompositionId);
+
+    expectations.expect(session.addSolidLayer("Layer One", Color4d{1.0, 0.0, 0.0, 1.0}),
+                        "rebind fixture: adding a solid layer to the first document succeeds");
+    expectations.expect(
+        std::holds_alternative<bloom::document::LayerId>(session.selection().primary),
+        "rebind fixture: adding the layer selects it");
+
+    const auto nonzeroTime = RationalTime::create(3, 2);
+    expectations.expect(nonzeroTime.has_value() && session.setCurrentTime(*nonzeroTime),
+                        "rebind fixture: the session starts at a nonzero time");
+
+    const auto firstDocumentRevisionBeforeRebind = firstDocument.snapshot().revision();
+
+    int snapshotChangedCount = 0;
+    int compositionChangedCount = 0;
+    int currentTimeChangedCount = 0;
+    int selectionChangedCount = 0;
+    int historyChangedCount = 0;
+    QObject::connect(&session, &CompositionSession::snapshotChanged,
+                     [&] { ++snapshotChangedCount; });
+    QObject::connect(&session, &CompositionSession::compositionChanged,
+                     [&] { ++compositionChangedCount; });
+    QObject::connect(&session, &CompositionSession::currentTimeChanged,
+                     [&] { ++currentTimeChangedCount; });
+    QObject::connect(&session, &CompositionSession::selectionChanged,
+                     [&] { ++selectionChangedCount; });
+    QObject::connect(&session, &CompositionSession::historyChanged, [&] { ++historyChangedCount; });
+
+    session.rebind(secondDocument, secondCommandStack, secondCompositionId);
+
+    expectations.expect(snapshotChangedCount == 1 && compositionChangedCount == 1 &&
+                            currentTimeChangedCount == 1 && selectionChangedCount == 1 &&
+                            historyChangedCount == 1,
+                        "rebind: every existing changed signal fires exactly once");
+
+    expectations.expect(session.currentTime() == RationalTime::fromInteger(0),
+                        "rebind: current time resets to zero");
+    expectations.expect(std::holds_alternative<std::monostate>(session.selection().primary),
+                        "rebind: selection is cleared");
+    expectations.expect(session.compositionId() == secondCompositionId,
+                        "rebind: the session now targets the given composition id");
+    expectations.expect(session.snapshot().project().name() == "Second Project",
+                        "rebind: the session now projects the second document");
+
+    // Post-rebind activity targets the SECOND document only.
+    const auto secondNonzeroTime = RationalTime::create(1, 2);
+    expectations.expect(secondNonzeroTime.has_value() && session.setCurrentTime(*secondNonzeroTime),
+                        "rebind: the rebound session accepts further edits against the new "
+                        "document");
+
+    expectations.expect(firstDocument.snapshot().revision() == firstDocumentRevisionBeforeRebind,
+                        "rebind: the OLD document's revision is untouched by post-rebind activity");
+    expectations.expect(firstDocument.snapshot().project().name() == "First Project",
+                        "rebind: the OLD document's content is untouched by post-rebind activity");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testRebindClearsSelectionResetsTimeAndEmitsEverySignalOnce(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/project_host_tests.cpp
+++ b/src/ui/tests/project_host_tests.cpp
@@ -1,0 +1,471 @@
+#include <bloom/ui/project_host.hpp>
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/result.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/host/project_session.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QString>
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+// ProjectHost unit tests (task U1, issue #72): drives bloom::ui::ProjectHost's public surface --
+// New/Open/Save/Save-As over a REAL bloom::runtime::TaskScheduler with the injectable decision/
+// dialog seams standing in for real QMessageBox/QFileDialog prompts, exactly as an offscreen test
+// must. Follows src/host/tests/session_async_io_tests.cpp's fixture idiom (TempDirectory,
+// Expectations) and src/ui/tests/composition_preview_controller_tests.cpp's pumped-event-loop
+// waitUntil() idiom.
+
+namespace {
+
+using bloom::commands::SetProjectName;
+using bloom::commands::Transaction;
+using bloom::host::ProjectSessionContentKind;
+using bloom::ui::ProjectHost;
+using bloom::ui::ProjectHostActivity;
+using bloom::ui::ProjectHostOperationOutcome;
+using bloom::ui::UnsavedChangeDecision;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-project-host-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+template <typename Predicate> [[nodiscard]] bool waitUntil(Predicate predicate) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 4'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (std::invoke(predicate)) {
+            return true;
+        }
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return std::invoke(predicate);
+}
+
+[[nodiscard]] bool waitUntilIdle(const ProjectHost& host) {
+    return waitUntil([&host] { return !host.isBusy(); });
+}
+
+// Executes a rename transaction directly through the host's live command stack (the same path
+// CompositionSession/editors already use -- see this task's command-routing finding: dirty-state
+// tracking works via ProjectSession::stateSnapshot() reading the live document/command-stack
+// directly, regardless of which caller executed the transaction).
+[[nodiscard]] bool executeRename(ProjectHost& host, const std::string& name) {
+    auto [document, commandStack] = host.liveDocumentAndStack();
+    if (document == nullptr || commandStack == nullptr) {
+        return false;
+    }
+    Transaction transaction("Rename", commandStack->trackedRevision());
+    transaction.emplace<SetProjectName>(name);
+    return commandStack->execute(std::move(transaction)).changed();
+}
+
+struct OutcomeCapture final {
+    int count = 0;
+    ProjectHostOperationOutcome outcome = ProjectHostOperationOutcome::Refused;
+    QString message;
+};
+
+void connectSaveCapture(ProjectHost& host, OutcomeCapture& capture) {
+    QObject::connect(&host, &ProjectHost::saveFinished,
+                     [&capture](const ProjectHostOperationOutcome outcome, const QString& message) {
+                         ++capture.count;
+                         capture.outcome = outcome;
+                         capture.message = message;
+                     });
+}
+
+void connectOpenCapture(ProjectHost& host, OutcomeCapture& capture) {
+    QObject::connect(&host, &ProjectHost::openFinished,
+                     [&capture](const ProjectHostOperationOutcome outcome, const QString& message) {
+                         ++capture.count;
+                         capture.outcome = outcome;
+                         capture.message = message;
+                     });
+}
+
+// ---------------------------------------------------------------------------------------------
+// New-project construction: valid session, clean, not dirty.
+// ---------------------------------------------------------------------------------------------
+
+void testNewProjectConstruction(Expectations& expectations) {
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+
+    const auto snapshot = host.stateSnapshot();
+    expectations.expect(snapshot.valid, "new-project construction: the initial session is valid");
+    expectations.expect(snapshot.contentKind == ProjectSessionContentKind::DecodedDocument,
+                        "new-project construction: the initial content is a decoded document");
+    expectations.expect(!snapshot.displayPath.has_value(),
+                        "new-project construction: an untouched new project has no display path");
+    expectations.expect(!host.isDirty(),
+                        "new-project construction: an untouched new project is not dirty");
+    expectations.expect(host.canSave(),
+                        "new-project construction: an editable, non-busy project can save");
+    expectations.expect(!host.isBusy(), "new-project construction: the host starts idle");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Dirty after an executed transaction.
+// ---------------------------------------------------------------------------------------------
+
+void testDirtyAfterExecutedTransaction(Expectations& expectations) {
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+
+    expectations.expect(executeRename(host, "Renamed Project"),
+                        "dirty after edit: the rename transaction commits");
+    expectations.expect(host.isDirty(), "dirty after edit: the host reports dirty after an edit");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Full save -> open cycle to a temp directory through the host's async flows.
+// ---------------------------------------------------------------------------------------------
+
+void testFullSaveThenOpenCycle(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "save/open cycle: temp directory is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+    OutcomeCapture saveCapture;
+    OutcomeCapture openCapture;
+    connectSaveCapture(host, saveCapture);
+    connectOpenCapture(host, openCapture);
+
+    expectations.expect(executeRename(host, "Round Trip Project"),
+                        "save/open cycle: the rename transaction commits");
+    expectations.expect(host.isDirty(), "save/open cycle: the project is dirty before saving");
+
+    host.beginSaveAs(targetPath);
+    expectations.expect(host.isBusy(), "save/open cycle: beginSaveAs starts an async save");
+    expectations.expect(waitUntilIdle(host), "save/open cycle: the save reaches a terminal state");
+    expectations.expect(saveCapture.count == 1 &&
+                            saveCapture.outcome == ProjectHostOperationOutcome::Published,
+                        "save/open cycle: the save publishes");
+    expectations.expect(!host.isDirty(), "save/open cycle: the session is clean after saving");
+    expectations.expect(host.displayPath() == std::optional(targetPath),
+                        "save/open cycle: the display path is the saved target");
+    expectations.expect(std::filesystem::exists(targetPath),
+                        "save/open cycle: the file exists on disk");
+
+    int sessionReplacedCount = 0;
+    QObject::connect(&host, &ProjectHost::sessionReplaced, [&] { ++sessionReplacedCount; });
+
+    host.beginOpen(targetPath);
+    expectations.expect(host.isBusy(), "save/open cycle: beginOpen starts an async open");
+    expectations.expect(waitUntilIdle(host), "save/open cycle: the open reaches a terminal state");
+    expectations.expect(openCapture.count == 1 &&
+                            openCapture.outcome == ProjectHostOperationOutcome::Published,
+                        "save/open cycle: the open installs");
+    expectations.expect(sessionReplacedCount == 1,
+                        "save/open cycle: sessionReplaced fires exactly once for this open");
+    expectations.expect(!host.isDirty(), "save/open cycle: the reopened session is clean");
+    expectations.expect(host.displayPath() == std::optional(targetPath),
+                        "save/open cycle: the reopened display path matches the opened file");
+
+    const auto reopenedSnapshot = host.stateSnapshot();
+    expectations.expect(reopenedSnapshot.contentKind == ProjectSessionContentKind::DecodedDocument,
+                        "save/open cycle: the reopened content is a decoded document");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Busy refusal: a second begin* call while one is already in flight is refused synchronously with
+// a typed Refused outcome, and never disturbs the in-flight operation.
+// ---------------------------------------------------------------------------------------------
+
+void testBusyRefusalWhileInFlight(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "busy refusal: temp directory is available");
+        return;
+    }
+    const auto firstPath = directory.path() / "first.bloom";
+    const auto secondPath = directory.path() / "second.bloom";
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+    OutcomeCapture saveCapture;
+    connectSaveCapture(host, saveCapture);
+
+    host.beginSaveAs(firstPath);
+    expectations.expect(host.isBusy(), "busy refusal: the first save is in flight");
+    expectations.expect(host.activity() == ProjectHostActivity::Saving,
+                        "busy refusal: the host activity names Saving");
+
+    // No event-loop pump between these two calls: the second request is synchronously refused
+    // before the first save can possibly have completed.
+    host.beginSaveAs(secondPath);
+    expectations.expect(saveCapture.count == 1 &&
+                            saveCapture.outcome == ProjectHostOperationOutcome::Refused,
+                        "busy refusal: the second concurrent save is refused with a typed busy "
+                        "outcome");
+    expectations.expect(!std::filesystem::exists(secondPath),
+                        "busy refusal: the refused second save never wrote a file");
+
+    expectations.expect(waitUntilIdle(host), "busy refusal: the first save still completes");
+    expectations.expect(saveCapture.count == 2 &&
+                            saveCapture.outcome == ProjectHostOperationOutcome::Published,
+                        "busy refusal: the first save publishes normally afterward");
+    expectations.expect(std::filesystem::exists(firstPath),
+                        "busy refusal: the first save's file exists");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Typed failure surfaced: saving to an unwritable (missing parent directory) path never reports
+// success.
+// ---------------------------------------------------------------------------------------------
+
+void testTypedFailureSurfacedOnUnwritablePath(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "typed failure: temp directory is available");
+        return;
+    }
+    const auto badPath = directory.path() / "missing-subdirectory" / "project.bloom";
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+    OutcomeCapture saveCapture;
+    connectSaveCapture(host, saveCapture);
+
+    host.beginSaveAs(badPath);
+    expectations.expect(waitUntilIdle(host), "typed failure: the save reaches a terminal state");
+    expectations.expect(saveCapture.count == 1, "typed failure: exactly one outcome is reported");
+    expectations.expect(saveCapture.outcome != ProjectHostOperationOutcome::Published,
+                        "typed failure: an unwritable target is never reported as Published");
+    expectations.expect(!saveCapture.message.isEmpty(),
+                        "typed failure: a display-ready message is provided");
+    expectations.expect(!std::filesystem::exists(badPath),
+                        "typed failure: no file was written to the unwritable target");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Unsaved-change decision seam for New: Cancel keeps the dirty project; Discard replaces it
+// immediately; Save saves first, then replaces it.
+// ---------------------------------------------------------------------------------------------
+
+void testUnsavedChangeDecisionSeamForNew(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "unsaved flow (New): temp directory is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+    int sessionReplacedCount = 0;
+    QObject::connect(&host, &ProjectHost::sessionReplaced, [&] { ++sessionReplacedCount; });
+
+    // Cancel: the dirty project is untouched.
+    expectations.expect(executeRename(host, "Cancel Me"),
+                        "unsaved flow (New): the rename transaction commits");
+    host.setUnsavedChangeDecisionProvider([] { return UnsavedChangeDecision::Cancel; });
+    host.newProject();
+    expectations.expect(sessionReplacedCount == 0,
+                        "unsaved flow (New): Cancel never replaces the session");
+    expectations.expect(host.isDirty(), "unsaved flow (New): Cancel leaves the project dirty");
+
+    // Discard: the session is replaced immediately, synchronously.
+    host.setUnsavedChangeDecisionProvider([] { return UnsavedChangeDecision::Discard; });
+    host.newProject();
+    expectations.expect(sessionReplacedCount == 1,
+                        "unsaved flow (New): Discard replaces the session exactly once");
+    expectations.expect(!host.isDirty(), "unsaved flow (New): the replaced session is clean");
+
+    // Save: dirty again, decision Save routes through the Save As dialog seam (pathless), then
+    // proceeds once the save publishes.
+    expectations.expect(executeRename(host, "Save Me First"),
+                        "unsaved flow (New): the second rename transaction commits");
+    bool saveDialogInvoked = false;
+    host.setSaveAsPathProvider([&] {
+        saveDialogInvoked = true;
+        return std::optional(targetPath);
+    });
+    host.setUnsavedChangeDecisionProvider([] { return UnsavedChangeDecision::Save; });
+    host.newProject();
+    expectations.expect(waitUntil([&] { return sessionReplacedCount == 2; }),
+                        "unsaved flow (New): Save eventually replaces the session");
+    expectations.expect(saveDialogInvoked,
+                        "unsaved flow (New): the pathless Save routed through the Save As seam");
+    expectations.expect(!host.isDirty(), "unsaved flow (New): the final replaced session is clean");
+    expectations.expect(std::filesystem::exists(targetPath),
+                        "unsaved flow (New): the Save choice's file was actually written");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Unsaved-change decision seam for Open: same three answers, gating requestOpen().
+// ---------------------------------------------------------------------------------------------
+
+void testUnsavedChangeDecisionSeamForOpen(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "unsaved flow (Open): temp directory is available");
+        return;
+    }
+    const auto openTargetPath = directory.path() / "to-open.bloom";
+
+    // Build a real file to open by saving a throwaway host's content to it first.
+    {
+        bloom::runtime::TaskScheduler seedScheduler;
+        ProjectHost seedHost(seedScheduler);
+        expectations.expect(executeRename(seedHost, "Openable Project"),
+                            "unsaved flow (Open): the seed rename transaction commits");
+        seedHost.beginSaveAs(openTargetPath);
+        expectations.expect(waitUntilIdle(seedHost),
+                            "unsaved flow (Open): the seed save reaches a terminal state");
+        expectations.expect(std::filesystem::exists(openTargetPath),
+                            "unsaved flow (Open): the seed file was written");
+    }
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+    int sessionReplacedCount = 0;
+    QObject::connect(&host, &ProjectHost::sessionReplaced, [&] { ++sessionReplacedCount; });
+    host.setOpenPathProvider([&] { return std::optional(openTargetPath); });
+
+    // Cancel: nothing happens.
+    expectations.expect(executeRename(host, "Cancel Open"),
+                        "unsaved flow (Open): the rename transaction commits");
+    host.setUnsavedChangeDecisionProvider([] { return UnsavedChangeDecision::Cancel; });
+    host.requestOpen();
+    expectations.expect(sessionReplacedCount == 0,
+                        "unsaved flow (Open): Cancel never opens anything");
+    expectations.expect(host.isDirty(), "unsaved flow (Open): Cancel leaves the project dirty");
+
+    // Discard: the open-path seam is invoked and the open proceeds.
+    host.setUnsavedChangeDecisionProvider([] { return UnsavedChangeDecision::Discard; });
+    host.requestOpen();
+    expectations.expect(waitUntil([&] { return sessionReplacedCount == 1; }),
+                        "unsaved flow (Open): Discard opens the chosen file");
+    expectations.expect(!host.isDirty(), "unsaved flow (Open): the opened session is clean");
+
+    // Save: dirty the reopened project, choose Save, then Open proceeds once the save publishes.
+    expectations.expect(executeRename(host, "Dirty Again"),
+                        "unsaved flow (Open): the re-dirtying transaction commits");
+    host.setUnsavedChangeDecisionProvider([] { return UnsavedChangeDecision::Save; });
+    host.requestOpen();
+    expectations.expect(waitUntil([&] { return sessionReplacedCount == 2; }),
+                        "unsaved flow (Open): Save eventually opens the chosen file");
+    expectations.expect(!host.isDirty(), "unsaved flow (Open): the final opened session is clean");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Pathless Save routes to the Save As decision (the seam observes it).
+// ---------------------------------------------------------------------------------------------
+
+void testPathlessSaveRoutesToSaveAsDecision(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "pathless save: temp directory is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "project.bloom";
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+    OutcomeCapture saveCapture;
+    connectSaveCapture(host, saveCapture);
+
+    bool saveAsSeamInvoked = false;
+    host.setSaveAsPathProvider([&] {
+        saveAsSeamInvoked = true;
+        return std::optional(targetPath);
+    });
+
+    expectations.expect(!host.stateSnapshot().displayPath.has_value(),
+                        "pathless save: the fresh project has no display path");
+    host.beginSave();
+    expectations.expect(waitUntilIdle(host), "pathless save: the routed save completes");
+    expectations.expect(saveAsSeamInvoked,
+                        "pathless save: a pathless Save invokes the Save As dialog seam");
+    expectations.expect(saveCapture.count == 1 &&
+                            saveCapture.outcome == ProjectHostOperationOutcome::Published,
+                        "pathless save: the routed save publishes");
+    expectations.expect(host.displayPath() == std::optional(targetPath),
+                        "pathless save: the display path is now the chosen Save As target");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testNewProjectConstruction(expectations);
+    testDirtyAfterExecutedTransaction(expectations);
+    testFullSaveThenOpenCycle(expectations);
+    testBusyRefusalWhileInFlight(expectations);
+    testTypedFailureSurfacedOnUnwritablePath(expectations);
+    testUnsavedChangeDecisionSeamForNew(expectations);
+    testUnsavedChangeDecisionSeamForOpen(expectations);
+    testPathlessSaveRoutesToSaveAsDecision(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/tests/ui_smoke.cpp
+++ b/tests/ui_smoke.cpp
@@ -2,10 +2,12 @@
 #include <bloom/core/rational_time.hpp>
 #include <bloom/document/document.hpp>
 #include <bloom/document/new_project.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_area.hpp>
 #include <bloom/ui/editor_registry.hpp>
 #include <bloom/ui/main_window.hpp>
+#include <bloom/ui/project_host.hpp>
 #include <bloom/ui/workspace_host.hpp>
 
 #include <QAction>
@@ -413,16 +415,60 @@ int testMaximizeAndPersistence(const EditorRegistry& registry) {
 }
 
 int testMainWindow(const EditorRegistry& registry,
-                   bloom::ui::CompositionSession& compositionSession) {
-    bloom::ui::MainWindow window(registry, compositionSession);
-    if (!require(window.windowTitle() == "Bloom" && window.workspaceHost() != nullptr, 40)) {
+                   bloom::ui::CompositionSession& compositionSession,
+                   bloom::ui::ProjectHost& projectHost) {
+    bloom::ui::MainWindow window(registry, compositionSession, projectHost);
+    if (!require(window.workspaceHost() != nullptr, 40)) {
         return 40;
+    }
+    // Window title (decision 5): "name[*] — Bloom" via Qt's windowModified pattern, wired to the
+    // host's dirty signal and display path; a fresh untouched project shows "Untitled" and is not
+    // modified.
+    if (!require(window.windowTitle().contains("Bloom") &&
+                     window.windowTitle().contains("Untitled") && !window.isWindowModified(),
+                 71)) {
+        return 71;
     }
     if (!require(window.workspaceHost()->areaCount() == 5, 41)) {
         return 41;
     }
     if (!require(window.findChild<QStatusBar*>() == nullptr, 42)) {
         return 42;
+    }
+
+    // File menu actions exist and are wired (task U1, issue #72) -- a light check per this task's
+    // smoke-test scope: "don't force full dialog flows through smoke".
+    auto* newProjectAction = window.findChild<QAction*>("newProjectAction");
+    auto* openProjectAction = window.findChild<QAction*>("openProjectAction");
+    auto* saveProjectAction = window.findChild<QAction*>("saveProjectAction");
+    auto* saveProjectAsAction = window.findChild<QAction*>("saveProjectAsAction");
+    if (!require(newProjectAction != nullptr && openProjectAction != nullptr &&
+                     saveProjectAction != nullptr && saveProjectAsAction != nullptr,
+                 65)) {
+        return 65;
+    }
+    if (!require(!newProjectAction->shortcut().isEmpty() &&
+                     !openProjectAction->shortcut().isEmpty() &&
+                     !saveProjectAction->shortcut().isEmpty() &&
+                     !saveProjectAsAction->shortcut().isEmpty(),
+                 66)) {
+        return 66;
+    }
+    // A fresh, idle, editable project: New/Open/Save/Save As are all enabled (decision 3 only
+    // disables Save for read-only/busy content, and everything else only while busy).
+    if (!require(newProjectAction->isEnabled() && openProjectAction->isEnabled() &&
+                     saveProjectAction->isEnabled() && saveProjectAsAction->isEnabled(),
+                 67)) {
+        return 67;
+    }
+    // Triggering New on an untouched project never prompts and replaces ProjectHost's own session
+    // synchronously -- this exercises the action's wiring without a real dialog.
+    newProjectAction->trigger();
+    if (!require(!projectHost.isDirty() && !projectHost.isBusy(), 68)) {
+        return 68;
+    }
+    if (!require(window.workspaceHost()->areaCount() == 5, 69)) {
+        return 69;
     }
 
     auto* splitAction = window.findChild<QAction*>("splitAreaLeftRightAction");
@@ -514,5 +560,8 @@ int main(int argc, char* argv[]) {
     bloom::document::Document document(std::move(newProject.project));
     bloom::commands::CommandStack commandStack(document);
     bloom::ui::CompositionSession compositionSession(document, commandStack, compositionId);
-    return testMainWindow(registry, compositionSession);
+
+    bloom::runtime::TaskScheduler taskScheduler;
+    bloom::ui::ProjectHost projectHost(taskScheduler);
+    return testMainWindow(registry, compositionSession, projectHost);
 }


### PR DESCRIPTION
Closes #72.

The desktop application now runs on real project sessions: **New, Open, Save, and Save As exist as menu actions driving the completed persistence engine** — the whole stack is reachable from the running application for the first time. New project, edit, Ctrl+S, close, reopen the `.bloom` file: it comes back.

**ProjectHost** owns the session and coordinators, shares the application task scheduler, holds one in-flight async save or open, polls per the task-bridge precedent, and applies completions on the UI thread. Typed outcomes surface with honest copy — a superseded or failed save never claims success, and the published-but-savepoint-refused case tells the artist exactly what happened.

**The unsaved-change flow** follows the session contract behind injectable seams (decision prompt and both file dialogs), so offscreen tests drive every path — including Save-then-continue re-prompting after failure, supersession, or an intervening edit, and never silently discarding an edit.

**Projections rebind**: CompositionSession gains an atomic rebind per the contract's install list; the bootstrap replaces its hand-rolled document with the host's session; one narrow ProjectSession accessor is the projection-binding seam.

Known limitation, documented: preserved-read-only opens install correctly but have no workspace surface yet — a read-only viewer is a follow-up slice, as is the pre-existing insertion-order composition fallback the review noted.

Testing: the ProjectHost suite (offscreen, pumped event loops) covering the full save-then-open cycle, busy refusals, typed failures, and every unsaved-change path; a rebind test; smoke wiring checks. Desktop suite 78/78, native suite 69/69, format green.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).