### PR TITLE
feat: show preserved projects as read-only

### DIFF
--- a/apps/bloom/main.cpp
+++ b/apps/bloom/main.cpp
@@ -44,9 +44,14 @@ int main(int argc, char* argv[]) {
     // Projection rebinding (decision 2): every time ProjectHost replaces the live session content
     // (New or a successful Open install), rebind CompositionSession to whatever document/command-
     // stack pair is now live. A preserved-read-only install has no document/command-stack at all
-    // (liveDocumentAndStack() returns null); this build has no workspace surface for that content
-    // kind yet, so CompositionSession is deliberately left bound to its previous content rather
-    // than rebinding to nothing -- see the implementor's report for this known limitation.
+    // (liveDocumentAndStack() returns null), so this lambda intentionally skips rebinding and
+    // leaves CompositionSession bound to whatever it projected before. That skip is now
+    // intentional and safe rather than a known limitation (task R1, issue #74): MainWindow hides
+    // the entire editor workspace behind a presentation-level read-only placeholder page whenever
+    // ProjectHost's content kind is PreservedReadOnly (see MainWindow::updateContentSurface()), so
+    // the stale CompositionSession this lambda leaves bound is never shown to the artist. Returning
+    // to decoded content (a New or an editable Open) switches the workspace back into view and this
+    // lambda rebinds normally.
     QObject::connect(&projectHost, &bloom::ui::ProjectHost::sessionReplaced, &compositionSession,
                      [&projectHost, &compositionSession] {
                          auto [document, commandStack] = projectHost.liveDocumentAndStack();

--- a/src/ui/composition_session.cpp
+++ b/src/ui/composition_session.cpp
@@ -55,6 +55,23 @@ QString statusMessage(const commands::CommandResult& result) {
     return {static_cast<double>(format.width()) * 0.5, static_cast<double>(format.height()) * 0.5};
 }
 
+// The contract's "lowest valid CompositionId" (docs/architecture/project-session.md, "Session
+// Publication", item 5), mirroring ProjectHost::lowestCompositionId()'s own min-scan (issue #75:
+// this used to be `compositions().front().id()`, which is insertion order, not id order -- a
+// document whose compositions were inserted out of id order picked the wrong fallback
+// composition). Precondition: `project.compositions()` is non-empty; callers below only invoke
+// this after checking that.
+[[nodiscard]] document::CompositionId lowestCompositionId(const document::Project& project) {
+    const auto compositions = project.compositions();
+    auto lowest = compositions.front().id();
+    for (const auto& candidate : compositions) {
+        if (candidate.id().value() < lowest.value()) {
+            lowest = candidate.id();
+        }
+    }
+    return lowest;
+}
+
 } // namespace
 
 CompositionSession::CompositionSession(document::Document& document,
@@ -63,7 +80,7 @@ CompositionSession::CompositionSession(document::Document& document,
     : QObject(parent), document_(&document), commandStack_(&commandStack),
       snapshot_(document.snapshot()), compositionId_(compositionId) {
     if (composition() == nullptr && !snapshot_.project().compositions().empty()) {
-        compositionId_ = snapshot_.project().compositions().front().id();
+        compositionId_ = lowestCompositionId(snapshot_.project());
     }
 }
 

--- a/src/ui/include/bloom/ui/main_window.hpp
+++ b/src/ui/include/bloom/ui/main_window.hpp
@@ -4,8 +4,10 @@
 
 class QAction;
 class QCloseEvent;
+class QLabel;
 class QMenu;
 class QSettings;
+class QStackedWidget;
 
 namespace bloom::ui {
 
@@ -25,6 +27,12 @@ class MainWindow final : public QMainWindow {
     [[nodiscard]] WorkspaceHost* workspaceHost() const noexcept;
     [[nodiscard]] WorkspaceLayoutRestoreResult restoreApplicationState(QSettings& settings);
     void saveApplicationState(QSettings& settings) const;
+    // Presentation-level read-only surface (task R1, issue #74): true exactly when the central
+    // QStackedWidget's current page is the read-only placeholder instead of the editor workspace
+    // -- i.e. the live ProjectHost content kind is PreservedReadOnly. Exposed so an offscreen test
+    // can assert the switch without depending on QWidget::isVisible(), which only reports
+    // correctly once the top-level window itself has been shown.
+    [[nodiscard]] bool isShowingReadOnlyPlaceholder() const noexcept;
 
   signals:
     void shutdownRequested();
@@ -37,18 +45,25 @@ class MainWindow final : public QMainWindow {
     void createFileMenu(QMenu& fileMenu);
     void createWorkspaceSwitcher();
     void createEditorLayout(const EditorRegistry& editorRegistry);
+    void createCentralStack();
+    QWidget* createReadOnlyPlaceholderPage();
     void createWorkspaceActions();
     void resetCompositingLayout();
     void updateEditActions();
     void updateWorkspaceActions();
     void updateFileActions();
     void updateWindowTitle();
+    void updateContentSurface();
     void applyFoundationTheme();
 
     CompositionSession& compositionSession_;
     ProjectHost& projectHost_;
     QMenu* windowMenu_ = nullptr;
+    QStackedWidget* centralStack_ = nullptr;
     WorkspaceHost* workspaceHost_ = nullptr;
+    QWidget* readOnlyPlaceholderPage_ = nullptr;
+    QLabel* readOnlyPlaceholderFileNameLabel_ = nullptr;
+    QLabel* readOnlyPlaceholderBodyLabel_ = nullptr;
     QAction* newProjectAction_ = nullptr;
     QAction* openProjectAction_ = nullptr;
     QAction* saveProjectAction_ = nullptr;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1,5 +1,6 @@
 #include <bloom/ui/main_window.hpp>
 
+#include <bloom/host/project_session.hpp>
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_area.hpp>
 #include <bloom/ui/editor_registry.hpp>
@@ -12,13 +13,16 @@
 #include <QCloseEvent>
 #include <QColor>
 #include <QKeySequence>
+#include <QLabel>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QPalette>
 #include <QSettings>
+#include <QStackedWidget>
 #include <QStatusBar>
 #include <QStringList>
+#include <QVBoxLayout>
 
 #include <filesystem>
 
@@ -41,6 +45,7 @@ MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession&
     createMenus();
     createWorkspaceSwitcher();
     createEditorLayout(editorRegistry);
+    createCentralStack();
     createWorkspaceActions();
     updateEditActions();
     applyFoundationTheme();
@@ -49,6 +54,11 @@ MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession&
     connect(&projectHost_, &ProjectHost::sessionReplaced, this, &MainWindow::updateWindowTitle);
     connect(&projectHost_, &ProjectHost::activityChanged, this, &MainWindow::updateFileActions);
     connect(&projectHost_, &ProjectHost::sessionReplaced, this, &MainWindow::updateFileActions);
+    // Presentation-level read-only surface (task R1, issue #74): switch which central-stack page
+    // is authoritative every time ProjectHost replaces its installed content. Frozen design
+    // decision 1's wiring point -- "Switching happens on sessionReplaced() by asking the host's
+    // stateSnapshot()".
+    connect(&projectHost_, &ProjectHost::sessionReplaced, this, &MainWindow::updateContentSurface);
     connect(&projectHost_, &ProjectHost::saveFinished, this,
             [this](const ProjectHostOperationOutcome outcome, const QString& message) {
                 if (outcome == ProjectHostOperationOutcome::Published) {
@@ -71,9 +81,14 @@ MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession&
             });
     updateFileActions();
     updateWindowTitle();
+    updateContentSurface();
 }
 
 WorkspaceHost* MainWindow::workspaceHost() const noexcept { return workspaceHost_; }
+
+bool MainWindow::isShowingReadOnlyPlaceholder() const noexcept {
+    return centralStack_ != nullptr && centralStack_->currentWidget() == readOnlyPlaceholderPage_;
+}
 
 WorkspaceLayoutRestoreResult MainWindow::restoreApplicationState(QSettings& settings) {
     const auto geometry = settings.value(windowGeometryKey).toByteArray();
@@ -210,6 +225,31 @@ void MainWindow::updateWindowTitle() {
     setWindowModified(projectHost_.isDirty());
 }
 
+void MainWindow::updateContentSurface() {
+    const auto snapshot = projectHost_.stateSnapshot();
+    const bool readOnly =
+        snapshot.contentKind == host::ProjectSessionContentKind::PreservedReadOnly;
+    if (!readOnly) {
+        centralStack_->setCurrentWidget(workspaceHost_);
+        return;
+    }
+
+    const auto path = projectHost_.displayPath();
+    const QString fileName =
+        path.has_value() ? QString::fromStdString(path->filename().string()) : tr("Untitled");
+    readOnlyPlaceholderFileNameLabel_->setText(fileName);
+    // Honest reason + options (frozen design decision 1): this file needs capabilities this Bloom
+    // cannot edit safely; it is opened read-only; editing and saving are disabled; a byte-exact
+    // Save Copy will be offered in a future update. No apology, no promise beyond what is true
+    // today.
+    readOnlyPlaceholderBodyLabel_->setText(
+        tr("“%1” uses capabilities this version of Bloom cannot edit safely, so it was "
+           "opened read-only. Editing and saving are disabled. A future update will offer Save "
+           "Copy to create a byte-exact copy of this file.")
+            .arg(fileName));
+    centralStack_->setCurrentWidget(readOnlyPlaceholderPage_);
+}
+
 void MainWindow::createWorkspaceSwitcher() {
     menuBar()->addSeparator();
 
@@ -228,9 +268,47 @@ void MainWindow::createWorkspaceSwitcher() {
 
 void MainWindow::createEditorLayout(const EditorRegistry& editorRegistry) {
     workspaceHost_ = new WorkspaceHost(editorRegistry, this);
-    setCentralWidget(workspaceHost_);
-
     resetCompositingLayout();
+}
+
+void MainWindow::createCentralStack() {
+    // The read-only placeholder (task R1, issue #74) is a QStackedWidget wrapping the existing
+    // central widget rather than any CompositionSession/ProjectHost surgery: WorkspaceHost is
+    // already MainWindow's one central widget with no panel-replacement seam of its own at this
+    // level, so a two-page stack is the smallest mechanism that lets MainWindow pick which page is
+    // authoritative for the current ProjectHost content kind while leaving WorkspaceHost, its
+    // layout, and CompositionSession completely untouched.
+    centralStack_ = new QStackedWidget(this);
+    centralStack_->addWidget(workspaceHost_);
+    readOnlyPlaceholderPage_ = createReadOnlyPlaceholderPage();
+    centralStack_->addWidget(readOnlyPlaceholderPage_);
+    centralStack_->setCurrentWidget(workspaceHost_);
+    setCentralWidget(centralStack_);
+}
+
+QWidget* MainWindow::createReadOnlyPlaceholderPage() {
+    auto* page = new QWidget(this);
+    page->setObjectName("readOnlyPlaceholderPage");
+
+    auto* heading = new QLabel(tr("Read-only project"), page);
+    heading->setObjectName("readOnlyPlaceholderHeading");
+
+    readOnlyPlaceholderFileNameLabel_ = new QLabel(page);
+    readOnlyPlaceholderFileNameLabel_->setObjectName("readOnlyPlaceholderFileName");
+
+    readOnlyPlaceholderBodyLabel_ = new QLabel(page);
+    readOnlyPlaceholderBodyLabel_->setObjectName("readOnlyPlaceholderBody");
+    readOnlyPlaceholderBodyLabel_->setWordWrap(true);
+    readOnlyPlaceholderBodyLabel_->setMaximumWidth(520);
+
+    auto* layout = new QVBoxLayout(page);
+    layout->setContentsMargins(48, 48, 48, 48);
+    layout->addStretch(1);
+    layout->addWidget(heading);
+    layout->addWidget(readOnlyPlaceholderFileNameLabel_);
+    layout->addWidget(readOnlyPlaceholderBodyLabel_);
+    layout->addStretch(2);
+    return page;
 }
 
 void MainWindow::resetCompositingLayout() {
@@ -332,6 +410,21 @@ void MainWindow::applyFoundationTheme() {
         }
         QLabel#editorPlaceholder {
             color: #777777;
+        }
+        QWidget#readOnlyPlaceholderPage {
+            background: #111111;
+        }
+        QLabel#readOnlyPlaceholderHeading {
+            color: #d7d7d7;
+            font-size: 20px;
+            font-weight: 600;
+        }
+        QLabel#readOnlyPlaceholderFileName {
+            color: #178ee6;
+            font-weight: 600;
+        }
+        QLabel#readOnlyPlaceholderBody {
+            color: #a0a0a0;
         }
         QComboBox {
             background: #1b1b1b;

--- a/src/ui/project_host.cpp
+++ b/src/ui/project_host.cpp
@@ -600,13 +600,15 @@ void ProjectHost::handleOpenResult(host::SessionOpenResult result) {
             installed = true;
             outcome = ProjectHostOperationOutcome::Published;
             // A preserved-read-only install has no live document/command-stack at all (see
-            // liveDocumentAndStack()); this build has no workspace surface for that content kind
-            // (KNOWN LIMITATION -- see the implementor's report), so callers must not assume a
-            // Published open outcome always means an editable composition became available.
+            // liveDocumentAndStack()); callers must not assume a Published open outcome always
+            // means an editable composition became available. MainWindow (task R1, issue #74)
+            // handles this at the presentation level: it shows a read-only placeholder page
+            // instead of the editor workspace whenever the content kind is PreservedReadOnly (see
+            // MainWindow::updateContentSurface()), so this status-bar message stays short rather
+            // than duplicating the placeholder's own explanation.
             message =
                 result.attemptedContentKind() == host::ProjectSessionContentKind::PreservedReadOnly
-                    ? tr("Opened as preserved read-only content; this build has no editor for it "
-                         "yet.")
+                    ? tr("Opened as preserved read-only content.")
                     : tr("Project opened.");
         } else {
             outcome = ProjectHostOperationOutcome::Failed;

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -23,6 +23,16 @@ add_executable(bloom_viewer_editor_test
     viewer_editor_tests.cpp
 )
 
+# Links ZLIB::ZLIB directly for its own trimmed hand-rolled ZIP-writer fixture (a preserved-
+# read-only archive builder) -- mirroring src/host/CMakeLists.txt's bloom_host_session_open_test,
+# which documents the same src-module tests/-directory boundary this duplicate exists to respect.
+if(NOT TARGET ZLIB::ZLIB)
+    find_package(ZLIB REQUIRED)
+endif()
+add_executable(bloom_main_window_readonly_placeholder_test
+    main_window_readonly_placeholder_tests.cpp
+)
+
 target_link_libraries(bloom_composition_projection_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_preview_controller_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_session_animation_test PRIVATE bloom_ui)
@@ -31,6 +41,7 @@ target_link_libraries(bloom_application_shutdown_test PRIVATE bloom_ui)
 target_link_libraries(bloom_project_host_test PRIVATE bloom_ui)
 target_link_libraries(bloom_task_monitor_test PRIVATE bloom_ui)
 target_link_libraries(bloom_viewer_editor_test PRIVATE bloom_ui)
+target_link_libraries(bloom_main_window_readonly_placeholder_test PRIVATE bloom_ui ZLIB::ZLIB)
 bloom_enable_warnings(bloom_composition_projection_test)
 bloom_enable_warnings(bloom_composition_preview_controller_test)
 bloom_enable_warnings(bloom_composition_session_animation_test)
@@ -39,6 +50,7 @@ bloom_enable_warnings(bloom_application_shutdown_test)
 bloom_enable_warnings(bloom_project_host_test)
 bloom_enable_warnings(bloom_task_monitor_test)
 bloom_enable_warnings(bloom_viewer_editor_test)
+bloom_enable_warnings(bloom_main_window_readonly_placeholder_test)
 
 include(BloomTesting)
 
@@ -102,6 +114,14 @@ bloom_add_test(
     NAME bloom.ui.viewer_editor
     COMMAND bloom_viewer_editor_test
     LABELS ui unit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.main_window_readonly_placeholder
+    COMMAND bloom_main_window_readonly_placeholder_test
+    LABELS ui integration host
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )

--- a/src/ui/tests/composition_session_rebind_tests.cpp
+++ b/src/ui/tests/composition_session_rebind_tests.cpp
@@ -4,12 +4,14 @@
 #include <bloom/core/color.hpp>
 #include <bloom/core/rational_time.hpp>
 #include <bloom/document/document.hpp>
+#include <bloom/document/graph.hpp>
 #include <bloom/document/new_project.hpp>
 #include <bloom/document/project.hpp>
 
 #include <QApplication>
 #include <QObject>
 
+#include <cstdlib>
 #include <iostream>
 #include <optional>
 #include <source_location>
@@ -20,6 +22,11 @@
 // CompositionSession::rebind() unit test (task U1, issue #72, frozen design decision 2): bind ->
 // select things -> rebind to a second document -> selection cleared, time zero, every changed
 // signal emitted exactly once, and the OLD document is left completely untouched.
+//
+// Also carries the R1/issue #75 constructor-fallback pin: CompositionSession's own constructor
+// falls back to a min-scan for the lowest CompositionId (mirroring
+// ProjectHost::lowestCompositionId()) when constructed with an absent id, rather than
+// compositions().front() (insertion order).
 
 namespace {
 
@@ -114,6 +121,79 @@ void testRebindClearsSelectionResetsTimeAndEmitsEverySignalOnce(Expectations& ex
                         "rebind: the OLD document's content is untouched by post-rebind activity");
 }
 
+// ---------------------------------------------------------------------------------------------
+// Issue #75: a hand-built minimal composition (mirrors makeNewProject()'s own layer-stack ->
+// composition-output topology so Document's constructor validation passes) at a given
+// CompositionId, node/edge ids offset per-composition so project-wide uniqueness holds when two
+// of these share one Project.
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] bloom::document::Composition makeMinimalComposition(bloom::document::CompositionId id,
+                                                                  std::string name,
+                                                                  const std::uint64_t nodeIdBase) {
+    using bloom::document::EdgeId;
+    using bloom::document::NodeId;
+
+    const auto layerStackNodeId = NodeId::fromRaw(nodeIdBase);
+    const auto outputNodeId = NodeId::fromRaw(nodeIdBase + 1);
+    const auto edgeId = EdgeId::fromRaw(nodeIdBase);
+
+    bloom::document::CanonicalGraph graph(layerStackNodeId);
+    const bool topologyCreated =
+        graph.addNode({layerStackNodeId,
+                       std::string(bloom::document::kLayerStackNodeType),
+                       {},
+                       bloom::document::kLayerStackNodeSchemaVersion}) &&
+        graph.addNode({outputNodeId,
+                       std::string(bloom::document::kCompositionOutputNodeType),
+                       {},
+                       bloom::document::kCompositionOutputNodeSchemaVersion}) &&
+        graph.addEdge(
+            {edgeId,
+             {layerStackNodeId, std::string(bloom::document::kLayerStackOutputPort)},
+             bloom::document::NodeInputRef{
+                 outputNodeId, std::string(bloom::document::kCompositionOutputInputPort)}});
+    if (!topologyCreated) {
+        std::abort();
+    }
+    graph.setCompositionOutput(
+        {outputNodeId, std::string(bloom::document::kCompositionOutputOutputPort)});
+
+    return bloom::document::Composition(id, std::move(name), RationalTime::fromInteger(10),
+                                        std::move(graph));
+}
+
+void testConstructorFallbackPicksLowestCompositionIdNotInsertionOrder(Expectations& expectations) {
+    bloom::document::Project project(bloom::document::ProjectId::fromRaw(1),
+                                     "Fallback Fixture Project");
+
+    // Insertion order is [id 10, id 2] -- the OLD behavior (compositions().front()) would pick id
+    // 10; the fixed min-scan must pick id 2, the numerically lowest valid CompositionId.
+    const auto highId = bloom::document::CompositionId::fromRaw(10);
+    const auto lowId = bloom::document::CompositionId::fromRaw(2);
+    expectations.expect(
+        project.addComposition(makeMinimalComposition(highId, "High Id Composition", 1)),
+        "fallback fixture: the higher-id composition (inserted first) is added");
+    expectations.expect(
+        project.addComposition(makeMinimalComposition(lowId, "Low Id Composition", 10)),
+        "fallback fixture: the lower-id composition (inserted second) is added");
+    expectations.expect(project.compositions().size() == 2 &&
+                            project.compositions().front().id() == highId,
+                        "fallback fixture: insertion order really does differ from id order");
+
+    bloom::document::Document document(std::move(project));
+    bloom::commands::CommandStack commandStack(document);
+
+    // A bogus/absent CompositionId: composition() finds nullptr for it, so the constructor's
+    // fallback runs.
+    const auto bogusId = bloom::document::CompositionId::fromRaw(999);
+    CompositionSession session(document, commandStack, bogusId);
+
+    expectations.expect(session.compositionId() == lowId,
+                        "constructor fallback (#75): the lowest CompositionId wins over insertion "
+                        "order, not compositions().front()");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -121,5 +201,6 @@ int main(int argc, char** argv) {
     QApplication application(argc, argv);
     Expectations expectations;
     testRebindClearsSelectionResetsTimeAndEmitsEverySignalOnce(expectations);
+    testConstructorFallbackPicksLowestCompositionIdNotInsertionOrder(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/tests/main_window_readonly_placeholder_tests.cpp
+++ b/src/ui/tests/main_window_readonly_placeholder_tests.cpp
@@ -1,0 +1,521 @@
+#include <bloom/ui/main_window.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/host/project_session.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/project_host.hpp>
+#include <bloom/ui/workspace_host.hpp>
+
+#include <zlib.h>
+
+#include <QAction>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QLabel>
+#include <QString>
+#include <QWidget>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// MainWindow's read-only placeholder surface (task R1, issue #74): drives a REAL ProjectHost
+// through a real preserved-read-only Open (a hand-assembled {1,1}-container archive -- the fixture
+// technique is a trimmed duplicate of src/host/tests/session_open_tests.cpp's
+// buildManifestSidePreservedReadOnlyArchiveOrAbort()/ArchiveWriter, since src modules may not reach
+// across a sibling module's tests/ directory, exactly as that file's own comment documents for its
+// own duplicate of src/project/tests/zip_container_test_support.hpp) inside a full, offscreen
+// MainWindow, and asserts the placeholder mechanism switches presentation state without any
+// CompositionSession/ProjectHost surgery.
+
+namespace {
+
+using bloom::host::ProjectSessionContentKind;
+using bloom::ui::EditorRegistry;
+using bloom::ui::MainWindow;
+using bloom::ui::ProjectHost;
+using bloom::ui::WorkspaceHost;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-mainwindow-placeholder-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+template <typename Predicate> [[nodiscard]] bool waitUntil(Predicate predicate) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 4'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (std::invoke(predicate)) {
+            return true;
+        }
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return std::invoke(predicate);
+}
+
+[[nodiscard]] bool waitUntilIdle(const ProjectHost& host) {
+    return waitUntil([&host] { return !host.isBusy(); });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Archive fixture plumbing (trimmed duplicate of src/host/tests/session_open_tests.cpp -- see the
+// file comment above).
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U;
+
+[[nodiscard]] bloom::project::ProjectIoOperationMemory makeOperation() {
+    auto coordinator = bloom::project::ProjectIoMemoryCoordinator::create(kGenerousOperationBudget);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation =
+        coordinator->createOperation(kGenerousOperationBudget, kGenerousOperationBudget);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::uint32_t crc32Of(const std::span<const std::byte> payload) noexcept {
+    const auto value = crc32_z(0L, reinterpret_cast<const Bytef*>(payload.data()), payload.size());
+    return static_cast<std::uint32_t>(value);
+}
+
+struct EntrySpec final {
+    std::string localName;
+    std::string centralName;
+    std::uint16_t localFlags = 0x0800;
+    std::uint16_t centralFlags = 0x0800;
+    std::uint16_t localMethod = 0;
+    std::uint16_t centralMethod = 0;
+    std::vector<std::byte> data;
+    std::uint32_t localCompressedSize = 0;
+    std::uint32_t centralCompressedSize = 0;
+    std::uint32_t localUncompressedSize = 0;
+    std::uint32_t centralUncompressedSize = 0;
+    std::uint32_t localCrc = 0;
+    std::uint32_t centralCrc = 0;
+    std::vector<std::byte> localExtra;
+    std::vector<std::byte> centralExtra;
+    std::string centralComment;
+    std::uint16_t versionMadeBy = 0x0314;
+    std::uint32_t externalAttrs = 0100644U << 16U;
+    std::uint16_t diskNumberStart = 0;
+};
+
+[[nodiscard]] EntrySpec makeStoredEntry(const std::string& name,
+                                        const std::span<const std::byte> payload) {
+    EntrySpec spec;
+    spec.localName = name;
+    spec.centralName = name;
+    spec.data.assign(payload.begin(), payload.end());
+    spec.localCompressedSize = spec.centralCompressedSize =
+        static_cast<std::uint32_t>(payload.size());
+    spec.localUncompressedSize = spec.centralUncompressedSize =
+        static_cast<std::uint32_t>(payload.size());
+    spec.localCrc = spec.centralCrc = crc32Of(payload);
+    return spec;
+}
+
+class ArchiveWriter final {
+  public:
+    std::uint64_t appendLocal(const EntrySpec& entry) {
+        const auto offset = bytes_.size();
+        appendU32(0x04034b50U);
+        appendU16(20);
+        appendU16(entry.localFlags);
+        appendU16(entry.localMethod);
+        appendU16(0);
+        appendU16(0);
+        appendU32(entry.localCrc);
+        appendU32(entry.localCompressedSize);
+        appendU32(entry.localUncompressedSize);
+        appendU16(static_cast<std::uint16_t>(entry.localName.size()));
+        appendU16(static_cast<std::uint16_t>(entry.localExtra.size()));
+        appendText(entry.localName);
+        appendRaw(entry.localExtra);
+        appendRaw(entry.data);
+        return offset;
+    }
+
+    void appendCentral(const EntrySpec& entry, const std::uint32_t localHeaderOffset) {
+        appendU32(0x02014b50U);
+        appendU16(entry.versionMadeBy);
+        appendU16(20);
+        appendU16(entry.centralFlags);
+        appendU16(entry.centralMethod);
+        appendU16(0);
+        appendU16(0);
+        appendU32(entry.centralCrc);
+        appendU32(entry.centralCompressedSize);
+        appendU32(entry.centralUncompressedSize);
+        appendU16(static_cast<std::uint16_t>(entry.centralName.size()));
+        appendU16(static_cast<std::uint16_t>(entry.centralExtra.size()));
+        appendU16(static_cast<std::uint16_t>(entry.centralComment.size()));
+        appendU16(entry.diskNumberStart);
+        appendU16(0);
+        appendU32(entry.externalAttrs);
+        appendU32(localHeaderOffset);
+        appendText(entry.centralName);
+        appendRaw(entry.centralExtra);
+        appendText(entry.centralComment);
+    }
+
+    void appendEocd(const std::uint16_t diskNumber, const std::uint16_t diskWithCd,
+                    const std::uint16_t entriesThisDisk, const std::uint16_t entriesTotal,
+                    const std::uint32_t cdSize, const std::uint32_t cdOffset) {
+        appendU32(0x06054b50U);
+        appendU16(diskNumber);
+        appendU16(diskWithCd);
+        appendU16(entriesThisDisk);
+        appendU16(entriesTotal);
+        appendU32(cdSize);
+        appendU32(cdOffset);
+        appendU16(0);
+    }
+
+    [[nodiscard]] std::uint64_t size() const { return bytes_.size(); }
+    [[nodiscard]] const std::vector<std::byte>& bytes() const { return bytes_; }
+
+  private:
+    void appendU16(const std::uint16_t value) {
+        bytes_.push_back(static_cast<std::byte>(value & 0xFFU));
+        bytes_.push_back(static_cast<std::byte>((value >> 8U) & 0xFFU));
+    }
+    void appendU32(const std::uint32_t value) {
+        for (unsigned shift = 0; shift < 32U; shift += 8U) {
+            bytes_.push_back(static_cast<std::byte>((value >> shift) & 0xFFU));
+        }
+    }
+    void appendText(const std::string_view text) {
+        for (const char character : text) {
+            bytes_.push_back(static_cast<std::byte>(static_cast<unsigned char>(character)));
+        }
+    }
+    void appendRaw(const std::span<const std::byte> raw) {
+        bytes_.insert(bytes_.end(), raw.begin(), raw.end());
+    }
+
+    std::vector<std::byte> bytes_;
+};
+
+[[nodiscard]] std::vector<std::byte> buildConformingArchive(const EntrySpec& manifest,
+                                                            const EntrySpec& document) {
+    ArchiveWriter writer;
+    const auto manifestOffset = writer.appendLocal(manifest);
+    const auto documentOffset = writer.appendLocal(document);
+    const auto centralStart = writer.size();
+    writer.appendCentral(manifest, static_cast<std::uint32_t>(manifestOffset));
+    writer.appendCentral(document, static_cast<std::uint32_t>(documentOffset));
+    const auto centralSize = writer.size() - centralStart;
+    writer.appendEocd(0, 0, 2, 2, static_cast<std::uint32_t>(centralSize),
+                      static_cast<std::uint32_t>(centralStart));
+    return writer.bytes();
+}
+
+[[nodiscard]] std::vector<std::byte> minimalCanonicalDocumentBytesOrAbort() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Untitled Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    std::vector<char> payloadScratch(64, '\0');
+    std::vector<std::size_t> sortScratch(64, 0);
+    const bloom::project::CanonicalDocumentV1 request{.snapshot = &snapshot,
+                                                      .colorSettings = &colorSettings,
+                                                      .payloadScratch = payloadScratch,
+                                                      .sortScratch = sortScratch};
+    const auto documentSize = bloom::project::canonicalDocumentSize(request);
+    if (!documentSize) {
+        std::abort();
+    }
+    std::vector<char> documentText(*documentSize.value());
+    if (!bloom::project::encodeCanonicalDocument(request, documentText)) {
+        std::abort();
+    }
+    std::vector<std::byte> documentBytes(documentText.size());
+    std::memcpy(documentBytes.data(), documentText.data(), documentText.size());
+    return documentBytes;
+}
+
+// A {1,1}-container archive (mirrors session_open_tests.cpp's
+// testManifestSidePreservedReadOnly/buildManifestSidePreservedReadOnlyArchiveOrAbort exactly): a
+// manifest declaring containerVersion {1,1} over an otherwise valid {1,0} document classifies
+// PreservedReadOnlyRequired on the manifest side.
+[[nodiscard]] std::vector<std::byte> buildManifestSidePreservedReadOnlyArchiveOrAbort() {
+    const std::string manifestText =
+        R"({"format":"org.kinetik.bloom.project","containerVersion":{"major":1,"minor":1},)"
+        R"("document":{"path":"document.json","schemaVersion":{"major":1,"minor":0}},)"
+        R"("requirements":[]})";
+    std::vector<std::byte> manifestBytes(manifestText.size());
+    std::memcpy(manifestBytes.data(), manifestText.data(), manifestText.size());
+    const auto documentBytes = minimalCanonicalDocumentBytesOrAbort();
+
+    auto manifestEntry = makeStoredEntry("manifest.json", manifestBytes);
+    auto documentEntry = makeStoredEntry("document.json", documentBytes);
+    return buildConformingArchive(manifestEntry, documentEntry);
+}
+
+// A minimal, valid, unverified two-entry archive that classifies Opened -- built through
+// bloom::project's own real archive writer (no hand-rolled ZIP entries needed, since this one
+// declares the container version this build actually supports).
+[[nodiscard]] std::vector<std::byte> buildEditableArchiveBytesOrAbort() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Editable Reopened Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+
+    const bloom::project::CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0},
+                                                       .requirements = {}};
+    const bloom::project::CanonicalDocumentV1 documentInput{.snapshot = &snapshot,
+                                                            .colorSettings = &colorSettings};
+    auto built = bloom::project::buildVerifiedSaveArchive(
+        manifest, documentInput, bloom::project::SaveArchiveLimits{}, makeOperation());
+    if (!built) {
+        std::abort();
+    }
+    const auto bytes = built.archive()->bytes();
+    return {bytes.begin(), bytes.end()};
+}
+
+void writeFileOrAbort(const std::filesystem::path& path, const std::span<const std::byte> bytes) {
+    std::ofstream stream(path, std::ios::binary);
+    if (!bytes.empty()) {
+        stream.write(reinterpret_cast<const char*>(bytes.data()),
+                     static_cast<std::streamsize>(bytes.size()));
+    }
+    if (!stream) {
+        std::abort();
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// A small stand-in EditorRegistry matching MainWindow::resetCompositingLayout()'s five fixed
+// editor ids (mirrors tests/ui_smoke.cpp's testRegistry()) -- this test drives the placeholder
+// switch, not the real editors, so plain QLabel stand-ins are enough.
+// ---------------------------------------------------------------------------------------------
+
+[[nodiscard]] bool registerStandInEditors(EditorRegistry& registry) {
+    const auto addTestEditor = [&registry](std::string id, QString name) {
+        return registry.registerEditor(
+            {.id = std::move(id), .displayName = std::move(name), .create = [](QWidget* parent) {
+                 return new QLabel("Workspace test editor", parent);
+             }});
+    };
+    return addTestEditor("bloom.viewer", "Compositor") && addTestEditor("bloom.nodes", "Nodes") &&
+           addTestEditor("bloom.timeline", "Timeline") && addTestEditor("bloom.media", "Media") &&
+           addTestEditor("bloom.properties", "Properties");
+}
+
+// ---------------------------------------------------------------------------------------------
+// The placeholder switch itself: preserved-read-only Open -> placeholder shown, workspace hidden,
+// Save/Save As disabled; editable Open on top of that -> workspace returns, actions re-enable.
+// ---------------------------------------------------------------------------------------------
+
+void testPlaceholderSwitchesOnPreservedReadOnlyOpenAndBack(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "placeholder switch: temp directory is available");
+        return;
+    }
+    const auto preservedPath = directory.path() / "preserved.bloom";
+    const auto editablePath = directory.path() / "editable.bloom";
+    writeFileOrAbort(preservedPath, buildManifestSidePreservedReadOnlyArchiveOrAbort());
+    writeFileOrAbort(editablePath, buildEditableArchiveBytesOrAbort());
+
+    EditorRegistry registry;
+    expectations.expect(registerStandInEditors(registry),
+                        "placeholder switch: the stand-in editors register");
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost projectHost(scheduler);
+    auto [initialDocument, initialCommandStack] = projectHost.liveDocumentAndStack();
+    expectations.expect(initialDocument != nullptr && initialCommandStack != nullptr,
+                        "placeholder switch: the fresh ProjectHost exposes a live document/stack");
+    if (initialDocument == nullptr || initialCommandStack == nullptr) {
+        return;
+    }
+    bloom::ui::CompositionSession compositionSession(*initialDocument, *initialCommandStack,
+                                                     projectHost.lowestCompositionId());
+
+    MainWindow window(registry, compositionSession, projectHost);
+    window.show();
+    QApplication::processEvents();
+
+    auto* newProjectAction = window.findChild<QAction*>("newProjectAction");
+    auto* openProjectAction = window.findChild<QAction*>("openProjectAction");
+    auto* saveProjectAction = window.findChild<QAction*>("saveProjectAction");
+    auto* saveProjectAsAction = window.findChild<QAction*>("saveProjectAsAction");
+    expectations.expect(newProjectAction != nullptr && openProjectAction != nullptr &&
+                            saveProjectAction != nullptr && saveProjectAsAction != nullptr,
+                        "placeholder switch: the file menu actions exist");
+    if (newProjectAction == nullptr || openProjectAction == nullptr ||
+        saveProjectAction == nullptr || saveProjectAsAction == nullptr) {
+        return;
+    }
+
+    // Baseline: a fresh, editable, decoded project shows the workspace.
+    expectations.expect(!window.isShowingReadOnlyPlaceholder(),
+                        "placeholder switch: a fresh editable project shows the workspace, not "
+                        "the placeholder");
+    expectations.expect(window.workspaceHost()->isVisible(),
+                        "placeholder switch: the workspace is visible at baseline");
+    expectations.expect(saveProjectAction->isEnabled() && saveProjectAsAction->isEnabled(),
+                        "placeholder switch: Save/Save As are enabled at baseline");
+
+    // A real preserved-read-only Open (task R1, issue #74's target scenario).
+    projectHost.beginOpen(preservedPath);
+    expectations.expect(waitUntilIdle(projectHost),
+                        "placeholder switch: the preserved-read-only open reaches a terminal "
+                        "state");
+    expectations.expect(projectHost.stateSnapshot().contentKind ==
+                            ProjectSessionContentKind::PreservedReadOnly,
+                        "placeholder switch: the installed content kind is PreservedReadOnly");
+
+    expectations.expect(window.isShowingReadOnlyPlaceholder(),
+                        "placeholder switch: the placeholder is shown for preserved-read-only "
+                        "content");
+    expectations.expect(!window.workspaceHost()->isVisible(),
+                        "placeholder switch: the workspace is hidden behind the placeholder");
+    expectations.expect(!saveProjectAction->isEnabled() && !saveProjectAsAction->isEnabled(),
+                        "placeholder switch: Save/Save As are disabled for read-only content");
+    expectations.expect(newProjectAction->isEnabled() && openProjectAction->isEnabled(),
+                        "placeholder switch: New/Open remain enabled (only busy disables them)");
+
+    auto* fileNameLabel = window.findChild<QLabel*>("readOnlyPlaceholderFileName");
+    auto* bodyLabel = window.findChild<QLabel*>("readOnlyPlaceholderBody");
+    auto* headingLabel = window.findChild<QLabel*>("readOnlyPlaceholderHeading");
+    expectations.expect(fileNameLabel != nullptr && bodyLabel != nullptr && headingLabel != nullptr,
+                        "placeholder switch: the placeholder's labels exist");
+    if (fileNameLabel != nullptr) {
+        expectations.expect(fileNameLabel->text() ==
+                                QString::fromStdString(preservedPath.filename().string()),
+                            "placeholder switch: the placeholder names the opened file");
+    }
+    if (bodyLabel != nullptr) {
+        expectations.expect(
+            bodyLabel->text().contains(QString::fromStdString(preservedPath.filename().string())),
+            "placeholder switch: the placeholder body also names the file");
+    }
+    if (headingLabel != nullptr) {
+        expectations.expect(!headingLabel->text().isEmpty(),
+                            "placeholder switch: the placeholder has a heading");
+    }
+
+    // Opening an editable archive on top of the preserved-read-only content returns the workspace.
+    projectHost.beginOpen(editablePath);
+    expectations.expect(waitUntilIdle(projectHost),
+                        "placeholder switch: the editable reopen reaches a terminal state");
+    expectations.expect(projectHost.stateSnapshot().contentKind ==
+                            ProjectSessionContentKind::DecodedDocument,
+                        "placeholder switch: the reopened content kind is DecodedDocument");
+
+    expectations.expect(!window.isShowingReadOnlyPlaceholder(),
+                        "placeholder switch: the workspace returns for decoded content");
+    expectations.expect(window.workspaceHost()->isVisible(),
+                        "placeholder switch: the workspace is visible again");
+    expectations.expect(saveProjectAction->isEnabled() && saveProjectAsAction->isEnabled(),
+                        "placeholder switch: Save/Save As re-enable for editable content");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testPlaceholderSwitchesOnPreservedReadOnlyOpenAndBack(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Closes #74. Closes #75.

Preserved-read-only projects now have an honest workspace surface. The main window's central widget becomes a two-page stack: the existing workspace, and a read-only placeholder shown whenever the installed content is preserved-read-only — naming the file and stating plainly why it cannot be edited, that saving is disabled, and that a byte-exact Save Copy will come in a future update. Switching keys off the session-replacement signal reading the host's content kind; no projection or session surgery, and the stale-document hazard documented in #73 is fully masked at the presentation level.

Save/Save As were **verified** already disabled for read-only content through the host's existing content-kind gate — nothing was missing there.

Also fixes the composition constructor fallback (#75): a min-scan for the lowest composition id replaces the insertion-order pick, pinned by a fixture whose insertion order deliberately differs from id order.

Testing: an offscreen full-main-window test drives a real preserved-read-only open from a hand-assembled newer-minor archive and back to an editable one, asserting the surface, labels, and action states both ways. Desktop suite 79/79, native suite 69/69, format green.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).