### PR TITLE
feat: publish byte-exact copies of preserved projects

### DIFF
--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(bloom_host STATIC)
 target_sources(
     bloom_host
     PRIVATE
+        copy_async_io.cpp
+        copy_publication.cpp
         project_session.cpp
         publication_coordinator.cpp
         save_publication.cpp
@@ -14,6 +16,8 @@ target_sources(
         BASE_DIRS include
         FILES
             include/bloom/host/bloom_neutral_profile.hpp
+            include/bloom/host/copy_async_io.hpp
+            include/bloom/host/copy_publication.hpp
             include/bloom/host/project_session.hpp
             include/bloom/host/publication_coordinator.hpp
             include/bloom/host/save_publication.hpp
@@ -130,6 +134,29 @@ if(BUILD_TESTING)
         bloom_add_test(
             NAME bloom.host.session-async-io
             COMMAND bloom_host_session_async_io_test
+            LABELS unit host persistence security
+        )
+
+        # Gated Linux-only exactly as bloom.host.save-publication is gated: executeCopyPublication()
+        # drives the same real platform::StagedArtifactCoordinator.
+        add_executable(bloom_host_copy_publication_test tests/copy_publication_tests.cpp)
+        target_link_libraries(bloom_host_copy_publication_test PRIVATE bloom_host)
+        bloom_enable_warnings(bloom_host_copy_publication_test)
+        bloom_add_test(
+            NAME bloom.host.copy-publication
+            COMMAND bloom_host_copy_publication_test
+            LABELS unit host persistence security
+        )
+
+        # Gated Linux-only exactly as bloom.host.session-async-io is gated: drives
+        # beginCopyPublication() against the same real platform::StagedArtifactCoordinator over a
+        # real bloom::runtime::TaskScheduler with a real TaskExecutor::BlockingIo worker.
+        add_executable(bloom_host_copy_async_io_test tests/copy_async_io_tests.cpp)
+        target_link_libraries(bloom_host_copy_async_io_test PRIVATE bloom_host)
+        bloom_enable_warnings(bloom_host_copy_async_io_test)
+        bloom_add_test(
+            NAME bloom.host.copy-async-io
+            COMMAND bloom_host_copy_async_io_test
             LABELS unit host persistence security
         )
     endif()

--- a/src/host/copy_async_io.cpp
+++ b/src/host/copy_async_io.cpp
@@ -1,0 +1,141 @@
+#include <bloom/host/copy_async_io.hpp>
+
+#include <exception>
+#include <new>
+#include <span>
+#include <utility>
+
+namespace bloom::host {
+
+namespace {
+
+// A distinct placeholder TaskOwner from session_async_io.cpp's asyncSessionIoOwner() (id 1):
+// Save Copy has no ProjectSession tie at all, so it deliberately does not share an owner identity
+// with session-scoped Save/Open async work -- a future scheduler-level cancelOwner() targeting one
+// session's async I/O should not also reach an unrelated in-flight Save Copy, and vice versa. Both
+// remain fixed Application-kind placeholders for the same reason session_async_io.cpp's own comment
+// documents: neither ProjectSession nor TaskScheduler exposes a per-session TaskOwnerId today, and
+// this task's non-goals forbid jobs/task-bridge changes.
+[[nodiscard]] runtime::TaskOwner asyncCopyPublicationOwner() noexcept {
+    return {.kind = runtime::TaskOwnerKind::Application, .id = runtime::TaskOwnerId::fromRaw(2)};
+}
+
+} // namespace
+
+AsyncCopyPublication::AsyncCopyPublication(
+    runtime::TaskScheduler& scheduler, runtime::TaskHandle<void> handle,
+    std::shared_ptr<detail::AsyncCopyPublicationSharedState> shared) noexcept
+    : scheduler_(&scheduler), handle_(std::move(handle)), shared_(std::move(shared)) {}
+
+AsyncCopyPublication::~AsyncCopyPublication() {
+    if (shared_ && !completed_) {
+        requestCancellation();
+    }
+}
+
+bool AsyncCopyPublication::isReady() const noexcept {
+    if (!shared_ || completed_ || scheduler_ == nullptr) {
+        return false;
+    }
+    const auto snapshot = scheduler_->snapshot(handle_.id());
+    return snapshot.has_value() && runtime::isTerminal(snapshot->state);
+}
+
+void AsyncCopyPublication::requestCancellation() noexcept {
+    if (shared_) {
+        shared_->cancellationFlag.store(true, std::memory_order_release);
+    }
+    if (handle_.isValid()) {
+        handle_.cancel();
+    }
+}
+
+std::optional<CopyPublicationResult> AsyncCopyPublication::tryComplete() {
+    if (!shared_ || completed_) {
+        return std::nullopt;
+    }
+    const auto taken = handle_.tryTakeResult();
+    if (!taken.has_value()) {
+        return std::nullopt;
+    }
+    completed_ = true;
+    if (!shared_->publication.has_value()) {
+        // Same scheduler-level "never populated" edge session_async_io.cpp's
+        // AsyncSessionSave::tryComplete() documents: no CopyPublicationResult was ever produced, so
+        // this is reported the same typed way an unexpected pipeline failure before publish() would
+        // be.
+        return CopyPublicationResult::failure(
+            CopyPublicationFailure(CopyPublicationStage::None, CopyPublicationUnexpectedFailure{}));
+    }
+    return std::move(shared_->publication);
+}
+
+AsyncCopyPublicationResult::AsyncCopyPublicationResult(
+    const runtime::TaskSubmissionStatus status) noexcept
+    : submissionFailure_(status) {}
+
+AsyncCopyPublicationResult::AsyncCopyPublicationResult(AsyncCopyPublication handle) noexcept
+    : handle_(std::move(handle)) {}
+
+AsyncCopyPublication AsyncCopyPublicationResult::takeHandle() && noexcept {
+    if (!handle_.has_value()) {
+        std::terminate();
+    }
+    return std::move(*handle_);
+}
+
+AsyncCopyPublicationResult beginCopyPublication(runtime::TaskScheduler& scheduler,
+                                                PublicationCoordinator& coordinator,
+                                                platform::StagedArtifactCoordinator& artifacts,
+                                                AsyncCopyPublicationRequest request,
+                                                project::ProjectIoOperationMemory operation) {
+    auto shared = std::make_shared<detail::AsyncCopyPublicationSharedState>();
+
+    // Ownership transfer, not a borrow -- see this file's own "preAdmitted" threading-rules note
+    // for why (identical to beginSessionSave()'s treatment of SessionSaveRequest::preAdmitted).
+    if (request.preAdmitted != nullptr) {
+        shared->preAdmitted.emplace(std::move(*request.preAdmitted));
+    }
+
+    runtime::TaskRequest taskRequest("Save a copy (async)", asyncCopyPublicationOwner(),
+                                     runtime::TaskPriority::Foreground,
+                                     runtime::TaskExecutor::BlockingIo);
+
+    auto submission = scheduler.submit<void>(
+        std::move(taskRequest),
+        [&coordinator, &artifacts, bytesOwned = std::move(request.bytes),
+         targetPath = request.targetPath, overwritePolicy = request.overwritePolicy,
+         expectedTarget = request.expectedTarget, limits = request.limits,
+         operation = std::move(operation),
+         shared](runtime::TaskContext& context) -> runtime::TaskResult<void> {
+            // Entry-time cancellation bridge -- see this file's own cancellation-bridge
+            // documentation (identical to session_async_io.hpp's) for exactly what this covers.
+            if (context.isCancellationRequested()) {
+                shared->cancellationFlag.store(true, std::memory_order_release);
+            }
+            auto* const preAdmitted =
+                shared->preAdmitted.has_value() ? &*shared->preAdmitted : nullptr;
+            const CopyPublicationRequest executorRequest{
+                .targetPath = targetPath,
+                .overwritePolicy = overwritePolicy,
+                .expectedTarget = expectedTarget,
+                .sourceBytes = std::span<const std::byte>(bytesOwned),
+                .limits = limits,
+                .preAdmitted = preAdmitted,
+                .cancellationFlag = &shared->cancellationFlag,
+            };
+            auto publication =
+                executeCopyPublication(coordinator, artifacts, executorRequest, operation);
+            shared->publication.emplace(std::move(publication));
+            return runtime::TaskResult<void>::succeeded();
+        });
+
+    if (!submission.accepted()) {
+        return AsyncCopyPublicationResult(submission.status);
+    }
+
+    return AsyncCopyPublicationResult(
+        AsyncCopyPublication(scheduler, std::move(submission.handle), std::move(shared)));
+}
+
+} // namespace bloom::host

--- a/src/host/copy_publication.cpp
+++ b/src/host/copy_publication.cpp
@@ -1,0 +1,153 @@
+#include <bloom/host/copy_publication.hpp>
+
+#include <new>
+#include <optional>
+#include <utility>
+
+namespace bloom::host {
+
+CopyPublicationResult
+CopyPublicationResult::published(platform::StagedArtifactPublicationResult publication,
+                                 const PublicationIntentId intentId) noexcept {
+    CopyPublicationResult result;
+    result.publication_ = publication;
+    result.intentId_ = intentId;
+    return result;
+}
+
+CopyPublicationResult CopyPublicationResult::failure(
+    CopyPublicationFailure failureValue,
+    const std::optional<platform::StagedArtifactError> rejectDiagnostic) noexcept {
+    CopyPublicationResult result;
+    // CopyPublicationFailurePayload's alternatives are all trivial types
+    // (project::StagedCopyFailure included -- see staged_copy.cpp's identical comment), so
+    // CopyPublicationFailure ends up trivially copyable; std::move() would be a no-op clang-tidy
+    // flags (performance-move-const-arg), so this is a plain copy.
+    result.failure_.emplace(failureValue);
+    result.rejectDiagnostic_ = rejectDiagnostic;
+    return result;
+}
+
+namespace {
+
+[[nodiscard]] bool cancelled(const std::atomic_bool* flag) noexcept {
+    return flag != nullptr && flag->load(std::memory_order_relaxed);
+}
+
+[[nodiscard]] CopyPublicationResult cancelledResult() noexcept {
+    return CopyPublicationResult::failure(
+        CopyPublicationFailure(CopyPublicationStage::Cancelled, std::monostate{}));
+}
+
+} // namespace
+
+CopyPublicationResult executeCopyPublication(PublicationCoordinator& coordinator,
+                                             platform::StagedArtifactCoordinator& artifacts,
+                                             const CopyPublicationRequest& request,
+                                             project::ProjectIoOperationMemory operation) noexcept {
+    auto stage = CopyPublicationStage::Admission;
+    try {
+        // Step 1: take ownership of a caller-supplied admission, or admit here -- identical to
+        // executeSavePublication()'s own step 1 (see its comment for the full rationale).
+        std::optional<PublicationAdmission> admission;
+        if (request.preAdmitted != nullptr) {
+            admission.emplace(std::move(*request.preAdmitted));
+        } else {
+            auto admissionResult = coordinator.admit();
+            if (!admissionResult) {
+                return CopyPublicationResult::failure(CopyPublicationFailure(
+                    CopyPublicationStage::Admission, admissionResult.status()));
+            }
+            admission.emplace(std::move(admissionResult).takeAdmission());
+        }
+
+        if (cancelled(request.cancellationFlag)) {
+            return cancelledResult();
+        }
+
+        // Step 2: platform preflight.
+        stage = CopyPublicationStage::Preflight;
+        auto preflightResult = artifacts.preflight({.targetPath = request.targetPath,
+                                                    .overwritePolicy = request.overwritePolicy,
+                                                    .expectedTarget = request.expectedTarget});
+        if (!preflightResult) {
+            return CopyPublicationResult::failure(
+                CopyPublicationFailure(CopyPublicationStage::Preflight, preflightResult.error()));
+        }
+        auto target = std::move(preflightResult).takeTarget();
+        const auto targetKey = target.targetKey();
+
+        if (cancelled(request.cancellationFlag)) {
+            return cancelledResult();
+        }
+
+        // Step 3: register the admission for this target, consuming it into a target claim -- the
+        // same application coordinator sequence Save and frame export share (project-session.md's
+        // "Per-Target Ordering And Publication").
+        stage = CopyPublicationStage::Registration;
+        auto registrationResult = coordinator.registerTarget(std::move(*admission), targetKey);
+        if (!registrationResult) {
+            return CopyPublicationResult::failure(CopyPublicationFailure(
+                CopyPublicationStage::Registration, registrationResult.status()));
+        }
+        auto claim = std::move(registrationResult).takeClaim();
+        const auto intentId = claim.intentId();
+
+        // Step 4: stage the artifact, exchanging the preflight target for a writable lease.
+        stage = CopyPublicationStage::Staging;
+        auto stageResult = artifacts.stage(std::move(target));
+        if (!stageResult) {
+            return CopyPublicationResult::failure(
+                CopyPublicationFailure(CopyPublicationStage::Staging, stageResult.error()));
+        }
+        auto lease = std::move(stageResult).takeLease();
+
+        if (cancelled(request.cancellationFlag)) {
+            return cancelledResult();
+        }
+
+        // Step 5: write/read-back/verify the byte copy over the staged lease (project::
+        // stageCopyArchive() -- the byte-copy sibling of project::stageSaveArchive()).
+        stage = CopyPublicationStage::StagedCopy;
+        auto stagedCopyResult = project::stageCopyArchive(
+            lease, request.sourceBytes, request.limits.container, std::move(operation));
+        if (!stagedCopyResult) {
+            return CopyPublicationResult::failure(
+                CopyPublicationFailure(CopyPublicationStage::StagedCopy,
+                                       *stagedCopyResult.failure()),
+                stagedCopyResult.rejectDiagnostic());
+        }
+
+        // Step 6: attempt to enter the non-cancellable publication lease at the winning intent --
+        // identical to executeSavePublication()'s own step 6 (see its comment for the full guard
+        // contract, including why InvalidClaim/TargetBusy/AlreadyEntered are unreachable from this
+        // single-executor composition but still handled).
+        stage = CopyPublicationStage::Guard;
+        auto guardResult = claim.tryEnterPublication();
+        switch (guardResult.status()) {
+        case PublicationGuardStatus::Entered: {
+            auto guard = std::move(guardResult).takeGuard();
+            auto publication = lease.publish(platform::PublicationDisposition::Proceed);
+            return CopyPublicationResult::published(publication, intentId);
+        }
+        case PublicationGuardStatus::Superseded:
+            return CopyPublicationResult::published(
+                lease.publish(platform::PublicationDisposition::Superseded), intentId);
+        case PublicationGuardStatus::InvalidClaim:
+        case PublicationGuardStatus::TargetBusy:
+        case PublicationGuardStatus::AlreadyEntered:
+            return CopyPublicationResult::failure(
+                CopyPublicationFailure(CopyPublicationStage::Guard, guardResult.status()));
+        }
+        return CopyPublicationResult::failure(
+            CopyPublicationFailure(CopyPublicationStage::Guard, guardResult.status()));
+    } catch (const std::bad_alloc&) {
+        return CopyPublicationResult::failure(
+            CopyPublicationFailure(stage, CopyPublicationResourceExhausted{}));
+    } catch (...) {
+        return CopyPublicationResult::failure(
+            CopyPublicationFailure(stage, CopyPublicationUnexpectedFailure{}));
+    }
+}
+
+} // namespace bloom::host

--- a/src/host/include/bloom/host/copy_async_io.hpp
+++ b/src/host/include/bloom/host/copy_async_io.hpp
@@ -1,0 +1,182 @@
+#pragma once
+
+#include <bloom/host/copy_publication.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <vector>
+
+// Asynchronous Save Copy over the blocking-I/O lane -- the sessionless sibling of
+// bloom/host/session_async_io.hpp's AsyncSessionSave, over the SAME bloom::runtime::TaskScheduler
+// TaskExecutor::BlockingIo lane, wrapping bloom::host::executeCopyPublication()
+// (copy_publication.hpp) exactly as AsyncSessionSave wraps
+// executeSessionSaveMiddle()/executeSavePublication().
+//
+// A deliberate sibling file rather than an addition to session_async_io.{hpp,cpp}: Save Copy has
+// no ProjectSession dependency at all (docs/architecture/project-session.md: "Save Copy ... never
+// [proposes] ProjectSession path/dirty changes"), so keeping it out of the session-titled module
+// avoids implying a session tie that does not exist, and leaves session_async_io.{hpp,cpp} and its
+// existing tests completely untouched (this task's scope guard: "defects in merged modules get
+// documented, not fixed").
+//
+// ---------------------------------------------------------------------------------------------
+// Threading rules
+// ---------------------------------------------------------------------------------------------
+// - beginCopyPublication(): authoring thread only. There is no session-level capture or admission
+//   step to run synchronously here (unlike beginSessionSave()'s captureSaveInput() or
+//   beginSessionOpen()'s admitOpenIntent()) -- Save Copy's only "capture" is the caller already
+//   handing over the bytes to publish by value. Submission can still be refused by the scheduler
+//   itself (a typed runtime::TaskSubmissionStatus), which is this wrapper's only begin-time failure
+//   mode.
+// - isReady() / tryComplete() / handle destruction: authoring thread only. tryComplete() takes NO
+//   session and simply returns the typed CopyPublicationResult -- Save Copy never changes
+//   clean/path/dirty state, so there is no acceptance tail to apply against anything (contrast
+//   AsyncSessionSave::tryComplete(ProjectSession&), which applies acceptSessionSavePublication()).
+// - requestCancellation(): may be called from ANY thread at any time -- identical contract to
+//   AsyncSessionSave::requestCancellation(); see session_async_io.hpp's cancellation-bridge
+//   documentation, which applies here unchanged (this wrapper bridges the identical
+//   scheduler-CancellationToken-plus-owned-atomic pattern to executeCopyPublication()'s own
+//   `cancellationFlag` seam).
+// - `coordinator`, `artifacts` are caller-owned references captured by the worker closure; they
+//   must outlive the whole asynchronous operation, exactly as session_async_io.hpp documents for
+//   AsyncSessionSave's identical captures.
+// - `request.preAdmitted`, when non-null, is CONSUMED here (moved into the handle's own owned
+//   storage) before beginCopyPublication() returns -- the identical cross-thread ownership-transfer
+//   lesson beginSessionSave() applies to SessionSaveRequest::preAdmitted (see
+//   session_async_io.hpp's own "preAdmitted" threading-rules note for the full rationale: an async
+//   worker consumes the pointee at an unbounded later time on another thread, so a borrowed pointer
+//   would dangle against the caller's natural "admit, then let the admission go out of scope"
+//   pattern).
+namespace bloom::host {
+
+namespace detail {
+
+struct AsyncCopyPublicationSharedState final {
+    std::atomic_bool cancellationFlag{false};
+    // Populated exactly once by the worker before it returns; see
+    // session_async_io.hpp's AsyncSessionSaveSharedState::publication for the identical
+    // happens-before argument (the worker's write happens-before the scheduler ever reports the
+    // task terminal).
+    std::optional<CopyPublicationResult> publication;
+    // The caller's AsyncCopyPublicationRequest::preAdmitted, MOVED here on the authoring thread by
+    // beginCopyPublication() before task submission -- see the file-level "preAdmitted" threading
+    // note above.
+    std::optional<PublicationAdmission> preAdmitted;
+};
+
+} // namespace detail
+
+// The async-level request: bytes-by-value (the handle takes ownership -- mirrors
+// AsyncSessionOpen's own owned-bytes parameter), rather than CopyPublicationRequest's non-owning
+// span (which is only ever safe for a same-frame synchronous call). `preAdmitted`, when non-null,
+// follows the ownership-transfer contract documented at the top of this file.
+struct AsyncCopyPublicationRequest final {
+    std::filesystem::path targetPath;
+    platform::ArtifactOverwritePolicy overwritePolicy =
+        platform::ArtifactOverwritePolicy::CreateOrReplace;
+    std::optional<platform::ArtifactTargetObservation> expectedTarget;
+    std::vector<std::byte> bytes;
+    project::SaveArchiveLimits limits;
+    PublicationAdmission* preAdmitted = nullptr;
+};
+
+class AsyncCopyPublicationResult;
+
+class AsyncCopyPublication final {
+  public:
+    AsyncCopyPublication(AsyncCopyPublication&&) noexcept = default;
+    AsyncCopyPublication& operator=(AsyncCopyPublication&&) noexcept = default;
+    AsyncCopyPublication(const AsyncCopyPublication&) = delete;
+    AsyncCopyPublication& operator=(const AsyncCopyPublication&) = delete;
+    // Typed abandonment, identical in spirit to ~AsyncSessionSave(): requests cancellation, then
+    // drops the handle without touching anything. A copy whose executeCopyPublication() had
+    // ALREADY entered its non-cancellable platform publication lease before this destructor runs
+    // may still have durably published remotely -- that publication is real and stays real, but
+    // the caller who abandons the handle here simply never observes the result (there is no
+    // session bookkeeping to forfeit, since Save Copy never had any to begin with).
+    ~AsyncCopyPublication();
+
+    // Non-blocking, non-consuming poll; identical contract to AsyncSessionSave::isReady().
+    [[nodiscard]] bool isReady() const noexcept;
+    // May be called from any thread, at any time; identical contract to
+    // AsyncSessionSave::requestCancellation().
+    void requestCancellation() noexcept;
+    // Returns nullopt while the worker has not yet reached a scheduler-terminal state. Once it has,
+    // returns the full result exactly once (subsequent calls return nullopt). Takes NO session --
+    // see the file-level threading-rules documentation above.
+    [[nodiscard]] std::optional<CopyPublicationResult> tryComplete();
+
+  private:
+    friend class AsyncCopyPublicationResult;
+    friend AsyncCopyPublicationResult beginCopyPublication(runtime::TaskScheduler&,
+                                                           PublicationCoordinator&,
+                                                           platform::StagedArtifactCoordinator&,
+                                                           AsyncCopyPublicationRequest,
+                                                           project::ProjectIoOperationMemory);
+
+    AsyncCopyPublication(runtime::TaskScheduler& scheduler, runtime::TaskHandle<void> handle,
+                         std::shared_ptr<detail::AsyncCopyPublicationSharedState> shared) noexcept;
+
+    runtime::TaskScheduler* scheduler_ = nullptr;
+    runtime::TaskHandle<void> handle_;
+    std::shared_ptr<detail::AsyncCopyPublicationSharedState> shared_;
+    bool completed_ = false;
+};
+
+// [[nodiscard]] begin-outcome: either a live handle (operator bool() true) or the scheduler's own
+// typed submission refusal. Unlike AsyncSessionSaveResult/AsyncSessionOpenResult, there is no
+// separate Capture/Admission begin-stage: Save Copy has no session-level step to run synchronously
+// before submission (see the file-level threading-rules documentation above), so submission is the
+// only way begin can fail.
+class [[nodiscard]] AsyncCopyPublicationResult final {
+  public:
+    AsyncCopyPublicationResult(AsyncCopyPublicationResult&&) noexcept = default;
+    AsyncCopyPublicationResult& operator=(AsyncCopyPublicationResult&&) noexcept = default;
+    AsyncCopyPublicationResult(const AsyncCopyPublicationResult&) = delete;
+    AsyncCopyPublicationResult& operator=(const AsyncCopyPublicationResult&) = delete;
+    ~AsyncCopyPublicationResult() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return handle_.has_value(); }
+    // Valid only when !*this: the scheduler's own typed submission refusal.
+    [[nodiscard]] std::optional<runtime::TaskSubmissionStatus> submissionFailure() const noexcept {
+        return submissionFailure_;
+    }
+    // Moves the handle out; valid only when *this is true (terminates otherwise, mirroring
+    // AsyncSessionSaveResult::takeHandle()'s established pattern).
+    [[nodiscard]] AsyncCopyPublication takeHandle() && noexcept;
+
+  private:
+    friend AsyncCopyPublicationResult beginCopyPublication(runtime::TaskScheduler&,
+                                                           PublicationCoordinator&,
+                                                           platform::StagedArtifactCoordinator&,
+                                                           AsyncCopyPublicationRequest,
+                                                           project::ProjectIoOperationMemory);
+
+    explicit AsyncCopyPublicationResult(runtime::TaskSubmissionStatus status) noexcept;
+    explicit AsyncCopyPublicationResult(AsyncCopyPublication handle) noexcept;
+
+    std::optional<runtime::TaskSubmissionStatus> submissionFailure_;
+    std::optional<AsyncCopyPublication> handle_;
+};
+
+// Submits executeCopyPublication() over the owned `request.bytes` as a TaskExecutor::BlockingIo
+// task, bridging cancellation exactly as beginSessionSave() does (see session_async_io.hpp's
+// cancellation-bridge documentation, which applies unchanged here). `coordinator` and `artifacts`
+// must outlive the whole asynchronous operation -- see the file-level threading-rules
+// documentation. `request.preAdmitted`, when non-null, is CONSUMED here (moved into the handle's
+// own owned storage) before this function returns.
+[[nodiscard]] AsyncCopyPublicationResult
+beginCopyPublication(runtime::TaskScheduler& scheduler, PublicationCoordinator& coordinator,
+                     platform::StagedArtifactCoordinator& artifacts,
+                     AsyncCopyPublicationRequest request,
+                     project::ProjectIoOperationMemory operation);
+
+} // namespace bloom::host

--- a/src/host/include/bloom/host/copy_publication.hpp
+++ b/src/host/include/bloom/host/copy_publication.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/staged_copy.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <variant>
+
+// The application-host composition of docs/architecture/project-format.md's "Staging And Atomic
+// Publication" nine-step sequence with docs/architecture/project-session.md's "Per-Target Ordering
+// And Publication" for Save Copy -- the byte-copy sibling of save_publication.hpp's identical
+// composition for Save. This module owns steps 1-2 (admission and preflight) and 6-8 (publication
+// ordering against the application-wide PublicationCoordinator, then the platform publication
+// lease), composing project::stageCopyArchive() (steps 3-5) and
+// platform::StagedArtifactLease::publish() (the rest of 6-8) in between -- the SAME
+// PublicationCoordinator and PublicationIntentId sequence Save and frame export share (project-
+// session.md: "This one sequence covers project saves, byte-preserving Save Copy, and frame
+// exports"). It is the synchronous, caller-threaded executor primitive only; session/executor
+// threading is a later slice (see bloom/host/copy_async_io.hpp).
+//
+// Save Copy has no manifest/document to build -- the caller already holds the exact bytes to
+// publish (a preserved-read-only project's retained original archive) -- so, unlike
+// SavePublicationRequest, this request carries `sourceBytes` directly instead of manifest/document
+// pointers, and composes project::stageCopyArchive() instead of project::stageSaveArchive() at the
+// StagedCopy step. Every other stage of the pipeline is identical in shape to save_publication.hpp;
+// see the implementor's report for why this module is parallel construction rather than a shared
+// refactor with executeSavePublication().
+namespace bloom::host {
+
+enum class CopyPublicationStage : std::uint8_t {
+    None,
+    Admission,
+    Preflight,
+    Registration,
+    Staging,
+    StagedCopy,
+    Guard,
+    Cancelled,
+};
+
+// Mirrors SavePublicationResourceExhausted/SavePublicationUnexpectedFailure exactly (see
+// save_publication.hpp's identical comment on why a resource-exhausted or unexpected-exception
+// failure is reported at whichever stage was current rather than getting its own per-stage
+// enumerator).
+struct CopyPublicationResourceExhausted final {};
+struct CopyPublicationUnexpectedFailure final {};
+
+// Mirrors SavePublicationFailurePayload exactly, substituting project::StagedCopyFailure for
+// project::StagedSaveFailure at the StagedCopy step. See save_publication.hpp's identical comment
+// on why the PublicationGuardStatus enumerators other than Entered/Superseded are still handled
+// (typed, no publish() call) despite being unreachable from this single-executor composition.
+using CopyPublicationFailurePayload =
+    std::variant<std::monostate, PublicationAdmissionStatus, platform::StagedArtifactError,
+                 PublicationRegistrationStatus, project::StagedCopyFailure, PublicationGuardStatus,
+                 CopyPublicationResourceExhausted, CopyPublicationUnexpectedFailure>;
+
+class CopyPublicationFailure final {
+  public:
+    CopyPublicationFailure() = default;
+
+    template <typename Payload>
+    CopyPublicationFailure(const CopyPublicationStage stage, Payload payload)
+        : stage_(stage), payload_(std::move(payload)) {}
+
+    [[nodiscard]] CopyPublicationStage stage() const noexcept { return stage_; }
+    [[nodiscard]] const CopyPublicationFailurePayload& payload() const noexcept { return payload_; }
+
+    template <typename Payload> [[nodiscard]] const Payload* payloadAs() const noexcept {
+        return std::get_if<Payload>(&payload_);
+    }
+
+  private:
+    CopyPublicationStage stage_ = CopyPublicationStage::None;
+    CopyPublicationFailurePayload payload_;
+};
+
+// Mirrors SavePublicationResult exactly (see its own declaration comment for the full contract):
+// exactly one of `failure()`/`publication()` is non-null, `publication()` set only for the two
+// guard outcomes that actually call platform::StagedArtifactLease::publish().
+class [[nodiscard]] CopyPublicationResult final {
+  public:
+    CopyPublicationResult(CopyPublicationResult&&) noexcept = default;
+    CopyPublicationResult& operator=(CopyPublicationResult&&) noexcept = default;
+    CopyPublicationResult(const CopyPublicationResult&) = delete;
+    CopyPublicationResult& operator=(const CopyPublicationResult&) = delete;
+    ~CopyPublicationResult() = default;
+
+    [[nodiscard]] static CopyPublicationResult
+    published(platform::StagedArtifactPublicationResult publication,
+              PublicationIntentId intentId) noexcept;
+
+    [[nodiscard]] static CopyPublicationResult
+    failure(CopyPublicationFailure failure,
+            std::optional<platform::StagedArtifactError> rejectDiagnostic = std::nullopt) noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return !failure_.has_value(); }
+
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const& noexcept {
+        return publication_.has_value() ? &*publication_ : nullptr;
+    }
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const&& = delete;
+    [[nodiscard]] std::optional<PublicationIntentId> intentId() const noexcept { return intentId_; }
+    [[nodiscard]] const CopyPublicationFailure* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const CopyPublicationFailure* failure() const&& = delete;
+    [[nodiscard]] std::optional<platform::StagedArtifactError> rejectDiagnostic() const noexcept {
+        return rejectDiagnostic_;
+    }
+
+  private:
+    CopyPublicationResult() = default;
+
+    std::optional<platform::StagedArtifactPublicationResult> publication_;
+    std::optional<PublicationIntentId> intentId_;
+    std::optional<CopyPublicationFailure> failure_;
+    std::optional<platform::StagedArtifactError> rejectDiagnostic_;
+};
+
+struct CopyPublicationRequest final {
+    std::filesystem::path targetPath;
+    platform::ArtifactOverwritePolicy overwritePolicy =
+        platform::ArtifactOverwritePolicy::CreateOrReplace;
+    std::optional<platform::ArtifactTargetObservation> expectedTarget;
+    // Non-owning, caller-kept-alive -- mirrors SavePublicationRequest::manifest/document. The
+    // retained original archive bytes to publish verbatim.
+    std::span<const std::byte> sourceBytes;
+    // Only `.container` is consulted (project::stageCopyArchive() takes a bare
+    // project::ZipContainerLimits); the full project::SaveArchiveLimits shape is reused here so
+    // callers that already carry one typed limits value (e.g. bloom::ui::ProjectHost, which uses
+    // the same value for Open) do not need a second, copy-only limits type.
+    project::SaveArchiveLimits limits;
+    // Same seam as SavePublicationRequest::preAdmitted, including its own ownership contract.
+    PublicationAdmission* preAdmitted = nullptr;
+    // Same seam as SavePublicationRequest::cancellationFlag.
+    const std::atomic_bool* cancellationFlag = nullptr;
+};
+
+// See the namespace-level comment above for the composition this performs. noexcept top level,
+// with the identical RAII/exception-safety contract as executeSavePublication() (see its own
+// declaration comment).
+[[nodiscard]] CopyPublicationResult executeCopyPublication(
+    PublicationCoordinator& coordinator, platform::StagedArtifactCoordinator& artifacts,
+    const CopyPublicationRequest& request, project::ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::host

--- a/src/host/tests/copy_async_io_tests.cpp
+++ b/src/host/tests/copy_async_io_tests.cpp
@@ -1,0 +1,450 @@
+#include <bloom/host/copy_async_io.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <mutex>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+// Drives beginCopyPublication() (copy_async_io.cpp) against a REAL bloom::runtime::TaskScheduler
+// with a real TaskExecutor::BlockingIo worker and REAL PublicationCoordinator/
+// platform::StagedArtifactCoordinator instances -- following
+// src/host/tests/session_async_io_tests.cpp's fixture idiom (TempDirectory, Expectations,
+// BlockingIoGate/awaitQuiescence/pollUntilReady) one sibling module over. Per the task package's
+// test plan: end-to-end with a real scheduler, cancellation before start, and abandonment.
+
+namespace {
+
+using namespace std::chrono_literals;
+
+using bloom::host::AsyncCopyPublication;
+using bloom::host::AsyncCopyPublicationRequest;
+using bloom::host::beginCopyPublication;
+using bloom::host::PublicationCoordinator;
+using bloom::host::PublicationCoordinatorConfig;
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+using bloom::platform::StagedArtifactPublicationOutcome;
+
+using bloom::project::buildSaveArchive;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::SaveArchiveLimits;
+
+using bloom::runtime::TaskContext;
+using bloom::runtime::TaskExecutor;
+using bloom::runtime::TaskOwner;
+using bloom::runtime::TaskOwnerId;
+using bloom::runtime::TaskOwnerKind;
+using bloom::runtime::TaskPriority;
+using bloom::runtime::TaskRequest;
+using bloom::runtime::TaskResult;
+using bloom::runtime::TaskScheduler;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-copy-async-io-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U;
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    auto coordinator = ProjectIoMemoryCoordinator::create(kGenerousOperationBudget);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation =
+        coordinator->createOperation(kGenerousOperationBudget, kGenerousOperationBudget);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::vector<std::byte> buildSourceArchiveBytesOrAbort() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Async Copy Source", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    auto built = buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    if (!built) {
+        std::abort();
+    }
+    const auto bytes = built.archive()->bytes();
+    return {bytes.begin(), bytes.end()};
+}
+
+[[nodiscard]] std::optional<PublicationCoordinator>
+makePublicationCoordinator(Expectations& expectations,
+                           const PublicationCoordinatorConfig config = {}) {
+    auto result = PublicationCoordinator::create(config);
+    expectations.expect(result.has_value(), "the publication coordinator is created");
+    return result;
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeArtifactsCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-artifact coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+// Mirrors session_async_io_tests.cpp's BlockingIoGate/occupyBlockingIoWorker exactly: saturates the
+// scheduler's single BlockingIo worker so a subsequently-submitted async copy task provably has not
+// started running yet.
+class BlockingIoGate final {
+  public:
+    void enterAndWait(TaskContext& context) {
+        std::unique_lock lock(mutex_);
+        entered_ = true;
+        condition_.notify_all();
+        condition_.wait(lock, [&] { return released_ || context.isCancellationRequested(); });
+    }
+
+    [[nodiscard]] bool waitUntilEntered() {
+        std::unique_lock lock(mutex_);
+        return condition_.wait_for(lock, 2s, [&] { return entered_; });
+    }
+
+    void release() {
+        std::lock_guard lock(mutex_);
+        released_ = true;
+        condition_.notify_all();
+    }
+
+  private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    bool entered_ = false;
+    bool released_ = false;
+};
+
+void occupyBlockingIoWorker(Expectations& expectations, TaskScheduler& scheduler,
+                            BlockingIoGate& gate) {
+    auto submission = scheduler.submit<void>(
+        TaskRequest("Blocking IO gate",
+                    TaskOwner{.kind = TaskOwnerKind::Application, .id = TaskOwnerId::fromRaw(999)},
+                    TaskPriority::Foreground, TaskExecutor::BlockingIo),
+        [&gate](TaskContext& context) {
+            gate.enterAndWait(context);
+            return TaskResult<void>::succeeded();
+        });
+    expectations.expect(submission.accepted() && gate.waitUntilEntered(),
+                        "the blocking-I/O gate fixture occupies the single worker");
+}
+
+bool awaitQuiescence(const TaskScheduler& scheduler) {
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (scheduler.isQuiescent()) {
+            return true;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return false;
+}
+
+template <typename Handle> [[nodiscard]] bool pollUntilReady(const Handle& handle) {
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (handle.isReady()) {
+            return true;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------------------------
+// End-to-end: begin -> poll until ready -> tryComplete -> Published, byte-identical to the source.
+// ---------------------------------------------------------------------------------------------
+
+void testAsyncCopyEndToEnd(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "async copy end to end: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+    TaskScheduler scheduler;
+
+    AsyncCopyPublicationRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .bytes = sourceBytes,
+        .limits = {},
+    };
+    auto begun =
+        beginCopyPublication(scheduler, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(begun),
+                        "async copy end to end: beginCopyPublication submits a handle");
+    if (!begun) {
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+    expectations.expect(pollUntilReady(handle),
+                        "async copy end to end: isReady() becomes true without a blocking wait");
+
+    auto result = handle.tryComplete();
+    expectations.expect(result.has_value(),
+                        "async copy end to end: tryComplete yields a result once ready");
+    if (!result.has_value()) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*result),
+                        "async copy end to end: the executor reaches publish");
+    const auto* publication = result->publication();
+    expectations.expect(publication != nullptr &&
+                            publication->outcome == StagedArtifactPublicationOutcome::Published,
+                        "async copy end to end: publish reaches Published");
+
+    const auto published = readFile(targetPath);
+    const std::string sourceText(reinterpret_cast<const char*>(sourceBytes.data()),
+                                 sourceBytes.size());
+    expectations.expect(published == sourceText,
+                        "async copy end to end: the published file is byte-for-byte identical to "
+                        "the source bytes");
+
+    // A second tryComplete() call returns nullopt (at-most-once contract).
+    auto again = handle.tryComplete();
+    expectations.expect(!again.has_value(),
+                        "async copy end to end: tryComplete is idempotent-absent after the first "
+                        "real result");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Cancellation before the worker starts: the single BlockingIo worker is saturated by a blocker
+// task first, for determinism.
+// ---------------------------------------------------------------------------------------------
+
+void testCancellationBeforeWorkerStarts(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "cancellation: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+    TaskScheduler scheduler;
+    BlockingIoGate gate;
+    occupyBlockingIoWorker(expectations, scheduler, gate);
+
+    AsyncCopyPublicationRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .bytes = sourceBytes,
+        .limits = {},
+    };
+    auto begun =
+        beginCopyPublication(scheduler, *coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(begun),
+                        "cancellation: beginCopyPublication submits a handle (still queued behind "
+                        "the blocker)");
+    if (!begun) {
+        gate.release();
+        return;
+    }
+    auto handle = std::move(begun).takeHandle();
+    handle.requestCancellation();
+    gate.release();
+
+    expectations.expect(pollUntilReady(handle),
+                        "cancellation: the cancelled task still reaches a terminal state");
+    auto result = handle.tryComplete();
+    expectations.expect(result.has_value(), "cancellation: tryComplete yields a result");
+    if (result.has_value()) {
+        expectations.expect(!static_cast<bool>(*result),
+                            "cancellation: a cancellation requested before the worker starts never "
+                            "publishes");
+        const auto* failure = result->failure();
+        const auto* publication = result->publication();
+        const bool cancelledBeforePublication =
+            (failure != nullptr) ||
+            (publication != nullptr &&
+             publication->outcome == StagedArtifactPublicationOutcome::CancelledBeforePublication);
+        expectations.expect(
+            cancelledBeforePublication,
+            "cancellation: the result names a cancelled-before-publication outcome (a typed "
+            "pipeline failure at the Cancelled stage, or the platform's own "
+            "CancelledBeforePublication outcome)");
+    }
+    expectations.expect(!std::filesystem::exists(targetPath),
+                        "cancellation: no target was ever created");
+    expectations.expect(awaitQuiescence(scheduler),
+                        "cancellation: the scheduler reaches quiescence");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Abandonment: destroy a handle mid-flight (still queued behind a saturated worker); no crash, no
+// leaked coordinator state, scheduler drains cleanly.
+// ---------------------------------------------------------------------------------------------
+
+void testAbandonmentMidFlight(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "abandonment: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+    TaskScheduler scheduler;
+    BlockingIoGate gate;
+    occupyBlockingIoWorker(expectations, scheduler, gate);
+
+    AsyncCopyPublicationRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+        .expectedTarget = std::nullopt,
+        .bytes = sourceBytes,
+        .limits = {},
+    };
+    {
+        auto begun =
+            beginCopyPublication(scheduler, *coordinator, *artifacts, request, makeOperation());
+        expectations.expect(static_cast<bool>(begun),
+                            "abandonment: beginCopyPublication submits a handle (still queued)");
+        if (begun) {
+            auto handle = std::move(begun).takeHandle();
+            // Handle destroyed here, mid-flight, without ever calling tryComplete().
+        }
+    }
+    gate.release();
+
+    expectations.expect(awaitQuiescence(scheduler),
+                        "abandonment: the scheduler drains cleanly (quiescence per its own API)");
+    expectations.expect(!std::filesystem::exists(targetPath),
+                        "abandonment: no target was ever created");
+
+    const auto coordinatorSnapshot = coordinator->snapshot();
+    expectations.expect(coordinatorSnapshot.unresolvedAdmissionCount == 0 &&
+                            coordinatorSnapshot.activeTargetClaimCount == 0 &&
+                            coordinatorSnapshot.activePublicationGuardCount == 0,
+                        "abandonment: the publication coordinator has no leaked bookkeeping");
+    const auto artifactSnapshot = artifacts->snapshot();
+    expectations.expect(artifactSnapshot.activeTargetCount == 0,
+                        "abandonment: the platform artifact coordinator has no active targets");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testAsyncCopyEndToEnd(expectations);
+        testCancellationBeforeWorkerStarts(expectations);
+        testAbandonmentMidFlight(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "FAILED: unexpected fixture exception: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/host/tests/copy_publication_tests.cpp
+++ b/src/host/tests/copy_publication_tests.cpp
@@ -1,0 +1,459 @@
+#include <bloom/host/copy_publication.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Drives executeCopyPublication() -- the host-side composition of the application
+// PublicationCoordinator with the platform StagedArtifactCoordinator over
+// project::stageCopyArchive() -- against REAL coordinators on per-test temporary directories,
+// following src/host/tests/save_publication_tests.cpp's identical pattern one operation over
+// (TempDirectory RAII helper, a thin coordinator/request-building layer). Per the task package's
+// test plan, this file covers: green publish, supersession via preAdmitted, external-modification
+// stale-observation refusal, and leak-free snapshots after failures -- the same shape as
+// save_publication_tests.cpp's own coverage, trimmed to what Save Copy's own contract adds nothing
+// new to (fault injection and budget exhaustion are already covered at the project layer in
+// staged_copy_tests.cpp, mirroring how save_publication_tests.cpp itself does not re-test every
+// staged_save_tests.cpp fault case either -- only the ones this composition layer's own wiring
+// could get wrong).
+
+namespace {
+
+using bloom::host::CopyPublicationFailure;
+using bloom::host::CopyPublicationRequest;
+using bloom::host::CopyPublicationStage;
+using bloom::host::executeCopyPublication;
+using bloom::host::PublicationAdmission;
+using bloom::host::PublicationCoordinator;
+using bloom::host::PublicationCoordinatorConfig;
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::ArtifactTargetObservation;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+using bloom::platform::StagedArtifactError;
+using bloom::platform::StagedArtifactPublicationOutcome;
+
+using bloom::project::buildSaveArchive;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::SaveArchiveLimits;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-copy-publication-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U;
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    auto coordinator = ProjectIoMemoryCoordinator::create(kGenerousOperationBudget);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation =
+        coordinator->createOperation(kGenerousOperationBudget, kGenerousOperationBudget);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::vector<std::byte> buildSourceArchiveBytesOrAbort() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Copy Publication Source", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    auto built = buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    if (!built) {
+        std::abort();
+    }
+    const auto bytes = built.archive()->bytes();
+    return {bytes.begin(), bytes.end()};
+}
+
+[[nodiscard]] std::optional<PublicationCoordinator>
+makePublicationCoordinator(Expectations& expectations,
+                           const PublicationCoordinatorConfig config = {}) {
+    auto result = PublicationCoordinator::create(config);
+    expectations.expect(result.has_value(), "the publication coordinator is created");
+    return result;
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeArtifactsCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-artifact coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+[[nodiscard]] std::optional<PublicationAdmission> admitIntent(PublicationCoordinator& coordinator,
+                                                              Expectations& expectations,
+                                                              const std::string_view context) {
+    auto result = coordinator.admit();
+    expectations.expect(static_cast<bool>(result), context);
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeAdmission();
+}
+
+[[nodiscard]] CopyPublicationRequest
+makeRequest(const std::filesystem::path& targetPath, const ArtifactOverwritePolicy policy,
+            const std::optional<ArtifactTargetObservation>& expectedTarget,
+            const std::span<const std::byte> sourceBytes,
+            PublicationAdmission* preAdmitted = nullptr) {
+    return CopyPublicationRequest{.targetPath = targetPath,
+                                  .overwritePolicy = policy,
+                                  .expectedTarget = expectedTarget,
+                                  .sourceBytes = sourceBytes,
+                                  .limits = {},
+                                  .preAdmitted = preAdmitted,
+                                  .cancellationFlag = nullptr};
+}
+
+void expectIdleSnapshots(Expectations& expectations, const PublicationCoordinator& coordinator,
+                         const StagedArtifactCoordinator& artifacts,
+                         const std::string_view context) {
+    const auto coordinatorSnapshot = coordinator.snapshot();
+    expectations.expect(coordinatorSnapshot.unresolvedAdmissionCount == 0 &&
+                            coordinatorSnapshot.targetRecordCount == 0 &&
+                            coordinatorSnapshot.activeTargetClaimCount == 0 &&
+                            coordinatorSnapshot.activePublicationGuardCount == 0,
+                        std::string(context) + ": the publication coordinator snapshot is idle");
+    const auto artifactSnapshot = artifacts.snapshot();
+    expectations.expect(artifactSnapshot.activeTargetCount == 0,
+                        std::string(context) +
+                            ": the platform artifact coordinator snapshot has no active targets");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Green path: absent target, CreateOnly -> Published, byte-identical to the source.
+// ---------------------------------------------------------------------------------------------
+
+void testGreenPath(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "green path: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+
+    auto request =
+        makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly, std::nullopt, sourceBytes);
+    auto result = executeCopyPublication(*coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(result),
+                        "green path: the executor reaches publish without a protocol failure");
+    const auto* publication = result.publication();
+    expectations.expect(publication != nullptr &&
+                            publication->outcome == StagedArtifactPublicationOutcome::Published,
+                        "green path: publish reaches Published");
+    expectations.expect(result.intentId().has_value() && result.intentId()->value() == 1,
+                        "green path: the winning intent is reported");
+    if (publication == nullptr ||
+        publication->outcome != StagedArtifactPublicationOutcome::Published) {
+        return;
+    }
+
+    const auto published = readFile(targetPath);
+    const std::string sourceText(reinterpret_cast<const char*>(sourceBytes.data()),
+                                 sourceBytes.size());
+    expectations.expect(published == sourceText,
+                        "green path: the published file is byte-for-byte identical to the source");
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "green path");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Supersession: mirrors save_publication_tests.cpp's testSupersession exactly, one composition
+// layer over -- a competing higher intent registers for the same target key between this
+// executor's own (lower) pre-admission and its guard attempt.
+// ---------------------------------------------------------------------------------------------
+
+void testSupersession(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "supersession: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+
+    bloom::host::ArtifactTargetKey targetKey;
+    {
+        auto peek = artifacts->preflight({.targetPath = targetPath,
+                                          .overwritePolicy = ArtifactOverwritePolicy::CreateOnly,
+                                          .expectedTarget = std::nullopt});
+        expectations.expect(static_cast<bool>(peek), "supersession: the peek preflight succeeds");
+        if (!peek) {
+            return;
+        }
+        targetKey = peek.target()->targetKey();
+    }
+
+    auto lowerAdmission = admitIntent(*coordinator, expectations,
+                                      "supersession: the executor's own (lower) intent is "
+                                      "admitted first");
+    auto competitorAdmission = admitIntent(*coordinator, expectations,
+                                           "supersession: the competing (higher) intent is "
+                                           "admitted second");
+    if (!lowerAdmission.has_value() || !competitorAdmission.has_value()) {
+        return;
+    }
+    expectations.expect(lowerAdmission->intentId().value() <
+                            competitorAdmission->intentId().value(),
+                        "supersession: the competitor's intent is strictly higher");
+
+    auto competitorRegistration =
+        coordinator->registerTarget(std::move(*competitorAdmission), targetKey);
+    expectations.expect(static_cast<bool>(competitorRegistration),
+                        "supersession: the competitor registers the higher intent for the "
+                        "identical target key");
+    if (!competitorRegistration) {
+        return;
+    }
+    std::move(competitorRegistration).takeClaim().reset();
+
+    const auto lowerIntentId = lowerAdmission->intentId();
+
+    auto request = makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly, std::nullopt,
+                               sourceBytes, &(*lowerAdmission));
+    auto result = executeCopyPublication(*coordinator, *artifacts, request, makeOperation());
+    expectations.expect(static_cast<bool>(result),
+                        "supersession: the executor still reaches publish (Superseded is a "
+                        "publish outcome, not a pipeline failure)");
+    const auto* publication = result.publication();
+    expectations.expect(publication != nullptr &&
+                            publication->outcome == StagedArtifactPublicationOutcome::Superseded,
+                        "supersession: the outcome is Superseded");
+    expectations.expect(result.intentId().has_value() &&
+                            result.intentId()->value() == lowerIntentId.value(),
+                        "supersession: the reported intent is the executor's own (lower, losing) "
+                        "intent");
+    expectations.expect(!std::filesystem::exists(targetPath),
+                        "supersession: the original (absent) target remains untouched");
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "supersession");
+}
+
+// ---------------------------------------------------------------------------------------------
+// External modification: publish once, capture the fingerprint, modify the target externally, then
+// run again with that now-stale expected observation -- the same typed Preflight-stage refusal
+// save_publication_tests.cpp's testExternalModification exercises.
+// ---------------------------------------------------------------------------------------------
+
+void testExternalModification(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "external modification: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+
+    auto request1 =
+        makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly, std::nullopt, sourceBytes);
+    auto result1 = executeCopyPublication(*coordinator, *artifacts, request1, makeOperation());
+    expectations.expect(static_cast<bool>(result1) && result1.publication() != nullptr &&
+                            result1.publication()->outcome ==
+                                StagedArtifactPublicationOutcome::Published,
+                        "external modification: first publish reaches Published");
+    if (!result1 || result1.publication() == nullptr ||
+        result1.publication()->outcome != StagedArtifactPublicationOutcome::Published) {
+        return;
+    }
+
+    std::optional<ArtifactTargetObservation> staleFingerprint;
+    {
+        auto peek =
+            artifacts->preflight({.targetPath = targetPath,
+                                  .overwritePolicy = ArtifactOverwritePolicy::ReplaceExisting,
+                                  .expectedTarget = std::nullopt});
+        expectations.expect(peek && peek.target()->observation().exists,
+                            "external modification: the fingerprint is observed before the "
+                            "external change");
+        if (!peek) {
+            return;
+        }
+        staleFingerprint = peek.target()->observation();
+    }
+
+    {
+        std::ofstream mutate(targetPath, std::ios::binary | std::ios::app);
+        expectations.expect(static_cast<bool>(mutate),
+                            "external modification: the target opens for an external append");
+        mutate << "external-modification-marker";
+    }
+    const auto tamperedBytes = readFile(targetPath);
+
+    auto request2 = makeRequest(targetPath, ArtifactOverwritePolicy::ReplaceExisting,
+                                staleFingerprint, sourceBytes);
+    auto result2 = executeCopyPublication(*coordinator, *artifacts, request2, makeOperation());
+    expectations.expect(!static_cast<bool>(result2),
+                        "external modification: the executor reports a typed pipeline failure, "
+                        "never reaching publish");
+    const auto* failure = result2.failure();
+    expectations.expect(failure != nullptr && failure->stage() == CopyPublicationStage::Preflight,
+                        "external modification: reported at the Preflight stage");
+    const auto* platformError =
+        failure != nullptr ? failure->payloadAs<StagedArtifactError>() : nullptr;
+    expectations.expect(platformError != nullptr &&
+                            *platformError == StagedArtifactError::ExternalModificationConflict,
+                        "external modification: the payload names ExternalModificationConflict");
+
+    expectations.expect(readFile(targetPath) == tamperedBytes,
+                        "external modification: the externally modified target is left untouched");
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "external modification");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Leak-free snapshots after a failure that never reaches publish(): an invalid target path is
+// refused at Preflight, mirroring save_publication_tests.cpp's testInvalidTargetPath.
+// ---------------------------------------------------------------------------------------------
+
+void testLeakFreeSnapshotsAfterFailure(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makePublicationCoordinator(expectations);
+    auto artifacts = makeArtifactsCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value() || !artifacts.has_value()) {
+        expectations.expect(false, "leak-free snapshots: fixture is available");
+        return;
+    }
+    // A trailing separator makes filename() empty, which platform preflight rejects as
+    // StagedArtifactError::InvalidTargetPath before any parent resolution or admission bookkeeping.
+    const auto invalidTargetPath = std::filesystem::path(directory.path().string() + "/");
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+
+    auto request = makeRequest(invalidTargetPath, ArtifactOverwritePolicy::CreateOnly, std::nullopt,
+                               sourceBytes);
+    auto result = executeCopyPublication(*coordinator, *artifacts, request, makeOperation());
+    expectations.expect(!static_cast<bool>(result),
+                        "leak-free snapshots: the executor reports a typed pipeline failure");
+    const auto* failure = result.failure();
+    expectations.expect(failure != nullptr && failure->stage() == CopyPublicationStage::Preflight,
+                        "leak-free snapshots: reported at the Preflight stage");
+    const auto* platformError =
+        failure != nullptr ? failure->payloadAs<StagedArtifactError>() : nullptr;
+    expectations.expect(platformError != nullptr &&
+                            *platformError == StagedArtifactError::InvalidTargetPath,
+                        "leak-free snapshots: the payload names InvalidTargetPath");
+
+    expectIdleSnapshots(expectations, *coordinator, *artifacts, "leak-free snapshots");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testGreenPath(expectations);
+    testSupersession(expectations);
+    testExternalModification(expectations);
+    testLeakFreeSnapshotsAfterFailure(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(
         round_trip_state.cpp
         save_archive.cpp
         save_archive_internal.hpp
+        staged_copy.cpp
         staged_save.cpp
         strict_json_dom.cpp
         strict_json_preflight.cpp
@@ -54,6 +55,7 @@ target_sources(
             include/bloom/project/project_io_memory_resource.hpp
             include/bloom/project/round_trip_state.hpp
             include/bloom/project/save_archive.hpp
+            include/bloom/project/staged_copy.hpp
             include/bloom/project/staged_save.hpp
             include/bloom/project/strict_json_dom.hpp
             include/bloom/project/unknown_json_number.hpp
@@ -326,6 +328,17 @@ if(BUILD_TESTING)
         bloom_add_test(
             NAME bloom.project.staged_save
             COMMAND bloom_project_staged_save_test
+            LABELS unit project persistence security
+        )
+
+        # Gated Linux-only exactly as bloom.project.staged_save is gated: this exercises a real
+        # platform::StagedArtifactCoordinator over per-test temporary directories.
+        add_executable(bloom_project_staged_copy_test tests/staged_copy_tests.cpp)
+        target_link_libraries(bloom_project_staged_copy_test PRIVATE bloom_project)
+        bloom_enable_warnings(bloom_project_staged_copy_test)
+        bloom_add_test(
+            NAME bloom.project.staged_copy
+            COMMAND bloom_project_staged_copy_test
             LABELS unit project persistence security
         )
     endif()

--- a/src/project/include/bloom/project/staged_copy.hpp
+++ b/src/project/include/bloom/project/staged_copy.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/staged_save.hpp>
+#include <bloom/project/zip_container.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <variant>
+
+// Staged execution of the Save Copy chain over a platform::StagedArtifactLease -- the byte-copy
+// sibling of staged_save.hpp's save/reopen chain (docs/architecture/project-session.md: "Save
+// Copy stages, validates, and atomically publishes an asynchronous byte-for-byte copy and never
+// claims to rewrite or migrate the document"). Unlike stageSaveArchive(), there is no build step:
+// the caller already holds the exact bytes to publish (an already-opened preserved-read-only
+// project's bounded original archive), so this module writes them to the stage verbatim, reads
+// them back, and verifies the round trip two ways: (a) the read-back bytes are byte-identical to
+// the source (the contract's literal claim), and (b) the read-back bytes still preflight as a
+// conforming Constrained ZIP Profile container -- a cheap, allocation-free structural sanity check
+// that catches disk-level corruption of the staged copy distinctly from a byte inequality, exactly
+// as this module's own implementor's report explains. As with stageSaveArchive(), this function
+// NEVER calls publish() -- publication ordering belongs to the application-layer executor
+// (bloom::host::executeCopyPublication).
+namespace bloom::project {
+
+enum class StagedCopyStage : std::uint8_t {
+    None,
+    // lease.write(sourceBytes) failed. Payload: StagedSavePlatformFailure (reused verbatim from
+    // staged_save.hpp -- see that header's own StagedSavePlatformFailure/StagedSaveLeaseCall for
+    // why this shape is generic enough to import unchanged rather than duplicate).
+    StageWrite,
+    // lease.finishWriting() failed. Payload: StagedSavePlatformFailure.
+    StageFinish,
+    // lease.stageBytes() disagreed with sourceBytes.size(), or sourceBytes.size() exceeded
+    // limits.maxArchiveBytes, before any read-back allocation was attempted. Payload:
+    // StagedCopySizeDisagreement.
+    StagedSizeDisagreement,
+    // The PMR-charged read-back buffer (sized to sourceBytes) could not be allocated within
+    // `operation`'s budget. Payload: StagedCopyResourceExhausted.
+    ReadBackAllocation,
+    // lease.readForVerification() failed, or returned a short/zero/over-sized read inconsistent
+    // with the requested bound. Payload: StagedSavePlatformFailure.
+    StageRead,
+    // The round-trip verification over the staged/read-back bytes failed: either (a) the read-back
+    // bytes are not byte-identical to `sourceBytes` (payload StagedCopyByteMismatch), or (b) they
+    // no longer preflight as a conforming Constrained ZIP Profile container (payload
+    // StagedCopyContainerSanityFailure). lease.rejectVerification() was already called
+    // (best-effort; see StagedCopyResult::rejectDiagnostic()).
+    Verification,
+    // lease.acceptVerification() failed. Payload: StagedSavePlatformFailure.
+    Accept,
+};
+
+struct StagedCopySizeDisagreement final {
+    std::uint64_t sourceBytes = 0;
+    std::uint64_t stageBytes = 0;
+};
+
+// The first byte offset (within `sourceBytes`/the read-back buffer) at which the two disagree.
+// Reachability note: with a real platform::StagedArtifactCoordinator, lease.write(sourceBytes)
+// followed by lease.readForVerification() reading back exactly what was written cannot itself
+// disagree without genuine disk-level corruption between finishWriting() and the read-back loop --
+// there is no public seam (and the task package forbids adding a test-only one) to desynchronize
+// the two in-process. See the implementor's report for the full unreachability argument; this type
+// exists for the real (if practically unobserved) disk-corruption case the design calls for.
+struct StagedCopyByteMismatch final {
+    std::uint64_t byteOffset = 0;
+};
+
+// `error` is bloom::project::ZipContainerError (zip_container.hpp's public enum, already reachable
+// from this header transitively) rather than the private allocation-free scanner's own
+// zip_container_preflight.hpp-local enum, so this stays a public-only contract; staged_copy.cpp
+// translates the scanner's result before returning it here.
+struct StagedCopyContainerSanityFailure final {
+    ZipContainerError error = ZipContainerError::None;
+    std::size_t byteOffset = 0;
+};
+
+struct StagedCopyResourceExhausted final {};
+struct StagedCopyUnexpectedFailure final {};
+
+// Verification-stage payload is exactly one of StagedCopyByteMismatch (check (a)) or
+// StagedCopyContainerSanityFailure (check (b)) -- flat alternatives of the same variant every other
+// stage's payload lives in, matching bloom/project/save_archive.hpp's SaveArchiveFailurePayload
+// precedent of one flat variant across every stage rather than nesting a per-stage sub-variant.
+using StagedCopyFailurePayload =
+    std::variant<std::monostate, StagedSavePlatformFailure, StagedCopySizeDisagreement,
+                 StagedCopyByteMismatch, StagedCopyContainerSanityFailure,
+                 StagedCopyResourceExhausted, StagedCopyUnexpectedFailure>;
+
+class StagedCopyFailure final {
+  public:
+    StagedCopyFailure() = default;
+
+    template <typename Payload>
+    StagedCopyFailure(const StagedCopyStage stage, Payload payload)
+        : stage_(stage), payload_(std::move(payload)) {}
+
+    [[nodiscard]] StagedCopyStage stage() const noexcept { return stage_; }
+    [[nodiscard]] const StagedCopyFailurePayload& payload() const noexcept { return payload_; }
+
+    template <typename Payload> [[nodiscard]] const Payload* payloadAs() const noexcept {
+        return std::get_if<Payload>(&payload_);
+    }
+
+  private:
+    StagedCopyStage stage_ = StagedCopyStage::None;
+    StagedCopyFailurePayload payload_;
+};
+
+class [[nodiscard]] StagedCopyResult final {
+  public:
+    StagedCopyResult(StagedCopyResult&&) noexcept = default;
+    StagedCopyResult& operator=(StagedCopyResult&&) noexcept = default;
+    StagedCopyResult(const StagedCopyResult&) = delete;
+    StagedCopyResult& operator=(const StagedCopyResult&) = delete;
+    ~StagedCopyResult() = default;
+
+    [[nodiscard]] static StagedCopyResult success() noexcept;
+    // `rejectDiagnostic`, when set, names a StagedArtifactError from a lease.rejectVerification()
+    // call that itself failed while reacting to this failure (StagedCopyStage::Verification only).
+    // Always secondary to `failure`, mirroring StagedSaveResult::rejectDiagnostic() exactly.
+    [[nodiscard]] static StagedCopyResult
+    failure(StagedCopyFailure failure,
+            std::optional<platform::StagedArtifactError> rejectDiagnostic = std::nullopt);
+
+    [[nodiscard]] explicit operator bool() const noexcept { return !failure_.has_value(); }
+    [[nodiscard]] const StagedCopyFailure* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const StagedCopyFailure* failure() const&& = delete;
+    [[nodiscard]] std::optional<platform::StagedArtifactError> rejectDiagnostic() const noexcept {
+        return rejectDiagnostic_;
+    }
+
+  private:
+    StagedCopyResult() = default;
+
+    std::optional<StagedCopyFailure> failure_;
+    std::optional<platform::StagedArtifactError> rejectDiagnostic_;
+};
+
+// Drives the write/read-back/verify chain over an already-staged platform::StagedArtifactLease
+// (the caller has already run the coordinator's preflight() and stage()): writes `sourceBytes`
+// verbatim, reads the staged bytes back, and verifies the round trip as documented above. On
+// success the lease has accepted verification and is exactly one lease.publish() away from durable
+// publication; this function NEVER calls publish() itself. `sourceBytes` must remain valid for the
+// duration of the call; no reference to it survives the call. Top-level noexcept: an internal
+// std::bad_alloc or budget rejection is reported as a typed StagedCopyResourceExhausted failure at
+// whichever stage was current; any other unexpected exception is reported as
+// StagedCopyUnexpectedFailure.
+[[nodiscard]] StagedCopyResult stageCopyArchive(platform::StagedArtifactLease& lease,
+                                                std::span<const std::byte> sourceBytes,
+                                                const ZipContainerLimits& limits,
+                                                ProjectIoOperationMemory operation) noexcept;
+
+} // namespace bloom::project

--- a/src/project/staged_copy.cpp
+++ b/src/project/staged_copy.cpp
@@ -1,0 +1,227 @@
+#include <bloom/project/staged_copy.hpp>
+
+#include "zip_container_preflight.hpp"
+
+#include <bloom/project/project_io_memory_resource.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <memory_resource>
+#include <new>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace bloom::project {
+
+namespace {
+
+// A strict subset translation, mirroring zip_container.cpp's own private translatePreflightError()
+// exactly (that function is anonymous-namespace-local to zip_container.cpp, not exported -- see
+// zip_container_preflight.hpp's own header comment: "every value here has an exact translation" in
+// the public ZipContainerError enum). Duplicated here rather than exported, matching this
+// codebase's existing precedent for small private per-translation-unit mappings.
+[[nodiscard]] ZipContainerError
+translatePreflightError(const detail::ZipContainerPreflightError error) noexcept {
+    switch (error) {
+    case detail::ZipContainerPreflightError::None:
+        return ZipContainerError::None;
+    case detail::ZipContainerPreflightError::InvalidLimits:
+        return ZipContainerError::InvalidLimits;
+    case detail::ZipContainerPreflightError::ArchiveTooLarge:
+        return ZipContainerError::ArchiveTooLarge;
+    case detail::ZipContainerPreflightError::ArchiveTruncated:
+        return ZipContainerError::ArchiveTruncated;
+    case detail::ZipContainerPreflightError::MissingOrMalformedEocd:
+        return ZipContainerError::MissingOrMalformedEocd;
+    case detail::ZipContainerPreflightError::ArchiveCommentForbidden:
+        return ZipContainerError::ArchiveCommentForbidden;
+    case detail::ZipContainerPreflightError::MultiDiskForbidden:
+        return ZipContainerError::MultiDiskForbidden;
+    case detail::ZipContainerPreflightError::WrongEntryCount:
+        return ZipContainerError::WrongEntryCount;
+    case detail::ZipContainerPreflightError::WrongEntryName:
+        return ZipContainerError::WrongEntryName;
+    case detail::ZipContainerPreflightError::WrongEntryOrder:
+        return ZipContainerError::WrongEntryOrder;
+    case detail::ZipContainerPreflightError::Utf8FlagMissing:
+        return ZipContainerError::Utf8FlagMissing;
+    case detail::ZipContainerPreflightError::ForbiddenGeneralPurposeFlag:
+        return ZipContainerError::ForbiddenGeneralPurposeFlag;
+    case detail::ZipContainerPreflightError::UnsupportedCompressionMethod:
+        return ZipContainerError::UnsupportedCompressionMethod;
+    case detail::ZipContainerPreflightError::ExtraFieldForbidden:
+        return ZipContainerError::ExtraFieldForbidden;
+    case detail::ZipContainerPreflightError::EntryCommentForbidden:
+        return ZipContainerError::EntryCommentForbidden;
+    case detail::ZipContainerPreflightError::Zip64Forbidden:
+        return ZipContainerError::Zip64Forbidden;
+    case detail::ZipContainerPreflightError::LocalCentralHeaderDisagreement:
+        return ZipContainerError::LocalCentralHeaderDisagreement;
+    case detail::ZipContainerPreflightError::OverlappingOrUnaccountedByteRange:
+        return ZipContainerError::OverlappingOrUnaccountedByteRange;
+    case detail::ZipContainerPreflightError::NonRegularEntry:
+        return ZipContainerError::NonRegularEntry;
+    case detail::ZipContainerPreflightError::ExecutableEntry:
+        return ZipContainerError::ExecutableEntry;
+    case detail::ZipContainerPreflightError::ExpandedSizeLimitExceeded:
+        return ZipContainerError::ExpandedSizeLimitExceeded;
+    case detail::ZipContainerPreflightError::ExpansionRatioExceeded:
+        return ZipContainerError::ExpansionRatioExceeded;
+    case detail::ZipContainerPreflightError::StoredSizeMismatch:
+        return ZipContainerError::StoredSizeMismatch;
+    case detail::ZipContainerPreflightError::SizeOverflow:
+        return ZipContainerError::SizeOverflow;
+    }
+    // Unreachable: every enumerator is handled above. Fails closed rather than falling through to
+    // an unrelated default.
+    return ZipContainerError::QualifiedReaderDisagreement;
+}
+
+} // namespace
+
+StagedCopyResult StagedCopyResult::success() noexcept {
+    StagedCopyResult result;
+    return result;
+}
+
+StagedCopyResult
+StagedCopyResult::failure(StagedCopyFailure failureValue,
+                          const std::optional<platform::StagedArtifactError> rejectDiagnostic) {
+    StagedCopyResult result;
+    // StagedCopyFailurePayload's alternatives are all trivial types (unlike staged_save.hpp's
+    // StagedSaveFailurePayload, which carries SaveArchiveErrorPath-bearing alternatives), so
+    // StagedCopyFailure itself ends up trivially copyable; std::move() would be a no-op clang-tidy
+    // flags (performance-move-const-arg), so this is a plain copy.
+    result.failure_.emplace(failureValue);
+    result.rejectDiagnostic_ = rejectDiagnostic;
+    return result;
+}
+
+StagedCopyResult stageCopyArchive(platform::StagedArtifactLease& lease,
+                                  const std::span<const std::byte> sourceBytes,
+                                  const ZipContainerLimits& limits,
+                                  ProjectIoOperationMemory operation) noexcept {
+    auto stage = StagedCopyStage::StageWrite;
+    try {
+        // Step 1: write the source bytes to the stage verbatim and close/reopen for verification.
+        const auto writeResult = lease.write(sourceBytes);
+        if (!writeResult) {
+            return StagedCopyResult::failure(StagedCopyFailure(
+                StagedCopyStage::StageWrite,
+                StagedSavePlatformFailure{writeResult.error, StagedSaveLeaseCall::Write}));
+        }
+
+        stage = StagedCopyStage::StageFinish;
+        const auto finishResult = lease.finishWriting();
+        if (!finishResult) {
+            return StagedCopyResult::failure(StagedCopyFailure(
+                StagedCopyStage::StageFinish,
+                StagedSavePlatformFailure{finishResult.error, StagedSaveLeaseCall::FinishWriting}));
+        }
+
+        // Step 2: validate the platform's own accounting of what got staged against the bytes this
+        // call wrote, before allocating a read-back buffer sized from a value that disagrees with
+        // what was written (defense in depth; see staged_save.cpp's identical
+        // StagedSizeDisagreement comment -- the same unreachability argument applies here).
+        stage = StagedCopyStage::StagedSizeDisagreement;
+        const auto stagedBytes = lease.stageBytes();
+        if (stagedBytes != sourceBytes.size() || sourceBytes.size() > limits.maxArchiveBytes) {
+            return StagedCopyResult::failure(
+                StagedCopyFailure(StagedCopyStage::StagedSizeDisagreement,
+                                  StagedCopySizeDisagreement{sourceBytes.size(), stagedBytes}));
+        }
+
+        stage = StagedCopyStage::ReadBackAllocation;
+        // Unlike staged_save.cpp's readBackResource (which passes `operation` by copy because it
+        // is used again afterward), this function has no further use of `operation`: move it in.
+        ProjectIoMemoryResource readBackResource(std::move(operation));
+        std::pmr::vector<std::byte> readBack(&readBackResource);
+        // ProjectIoMemoryResource::do_allocate() throws on budget rejection; the catch clauses
+        // below translate that into a typed StagedCopyResourceExhausted failure at this stage.
+        readBack.resize(static_cast<std::size_t>(stagedBytes));
+
+        stage = StagedCopyStage::StageRead;
+        std::uint64_t offset = 0;
+        const std::uint64_t total = readBack.size();
+        while (offset < total) {
+            const auto remaining = total - offset;
+            const auto destination = std::span<std::byte>(readBack).subspan(offset, remaining);
+            const auto readResult = lease.readForVerification(offset, destination);
+            if (!readResult) {
+                return StagedCopyResult::failure(StagedCopyFailure(
+                    StagedCopyStage::StageRead,
+                    StagedSavePlatformFailure{readResult.error,
+                                              StagedSaveLeaseCall::ReadForVerification}));
+            }
+            if (readResult.bytesRead == 0 || readResult.bytesRead > remaining) {
+                return StagedCopyResult::failure(StagedCopyFailure(
+                    StagedCopyStage::StageRead,
+                    StagedSavePlatformFailure{
+                        platform::StagedArtifactError::StageVerificationReadFailed,
+                        StagedSaveLeaseCall::ReadForVerification}));
+            }
+            offset += readResult.bytesRead;
+        }
+
+        // Step 3a: verify (a) -- the read-back bytes are byte-identical to the source. Sizes are
+        // already known equal (the StagedSizeDisagreement check above), so a mismatch can only be a
+        // content difference.
+        stage = StagedCopyStage::Verification;
+        const auto readBackBytes = std::span<const std::byte>(readBack);
+        const auto mismatch = std::ranges::mismatch(sourceBytes, readBackBytes);
+        if (mismatch.in1 != sourceBytes.end()) {
+            const auto byteOffset =
+                static_cast<std::uint64_t>(std::distance(sourceBytes.begin(), mismatch.in1));
+            const auto rejectResult = lease.rejectVerification();
+            const std::optional<platform::StagedArtifactError> rejectDiagnostic =
+                rejectResult ? std::nullopt : std::optional(rejectResult.error);
+            return StagedCopyResult::failure(StagedCopyFailure(StagedCopyStage::Verification,
+                                                               StagedCopyByteMismatch{byteOffset}),
+                                             rejectDiagnostic);
+        }
+
+        // Step 3b: verify (b) -- the read-back bytes still preflight as a conforming Constrained
+        // ZIP Profile container. Allocation-free and cheap: no decompression, no dependency call.
+        const detail::ZipContainerPreflightLimits preflightLimits{
+            .maxArchiveBytes = limits.maxArchiveBytes,
+            .maxManifestBytes = limits.maxManifestBytes,
+            .maxDocumentBytes = limits.maxDocumentBytes,
+            .maxTotalExpandedBytes = limits.maxTotalExpandedBytes,
+            .maxExpansionRatio = limits.maxExpansionRatio,
+        };
+        const auto preflight = detail::preflightZipContainer(readBackBytes, preflightLimits);
+        if (!preflight.succeeded()) {
+            const auto rejectResult = lease.rejectVerification();
+            const std::optional<platform::StagedArtifactError> rejectDiagnostic =
+                rejectResult ? std::nullopt : std::optional(rejectResult.error);
+            return StagedCopyResult::failure(
+                StagedCopyFailure(
+                    StagedCopyStage::Verification,
+                    StagedCopyContainerSanityFailure{translatePreflightError(preflight.error),
+                                                     preflight.byteOffset}),
+                rejectDiagnostic);
+        }
+
+        // Step 4: accept. The lease is now exactly one publish() away; that call belongs to the
+        // application-layer publication executor, never to this module.
+        stage = StagedCopyStage::Accept;
+        const auto acceptResult = lease.acceptVerification();
+        if (!acceptResult) {
+            return StagedCopyResult::failure(StagedCopyFailure(
+                StagedCopyStage::Accept,
+                StagedSavePlatformFailure{acceptResult.error,
+                                          StagedSaveLeaseCall::AcceptVerification}));
+        }
+        return StagedCopyResult::success();
+    } catch (const std::bad_alloc&) {
+        return StagedCopyResult::failure(StagedCopyFailure(stage, StagedCopyResourceExhausted{}));
+    } catch (...) {
+        return StagedCopyResult::failure(StagedCopyFailure(stage, StagedCopyUnexpectedFailure{}));
+    }
+}
+
+} // namespace bloom::project

--- a/src/project/tests/staged_copy_tests.cpp
+++ b/src/project/tests/staged_copy_tests.cpp
@@ -1,0 +1,486 @@
+#include <bloom/project/staged_copy.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/color_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/project/canonical_document.hpp>
+#include <bloom/project/canonical_manifest.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/save_archive.hpp>
+#include <bloom/project/zip_container.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Drives a REAL bloom::platform::StagedArtifactCoordinator over a per-test temporary directory,
+// following src/project/tests/staged_save_tests.cpp's own pattern one sibling module over: a
+// TempDirectory RAII helper and a thin coordinator/request-building layer, reused here because
+// stageCopyArchive() only makes sense exercised against the real platform lease state machine and
+// its fault-injection hooks.
+
+namespace {
+
+using bloom::platform::ArtifactOverwritePolicy;
+using bloom::platform::PublicationDisposition;
+using bloom::platform::StagedArtifactConfig;
+using bloom::platform::StagedArtifactCoordinator;
+using bloom::platform::StagedArtifactError;
+using bloom::platform::StagedArtifactFaultPoint;
+using bloom::platform::StagedArtifactLease;
+using bloom::platform::StagedArtifactPreflightRequest;
+using bloom::platform::StagedArtifactPublicationOutcome;
+
+using bloom::project::buildSaveArchive;
+using bloom::project::CanonicalDocumentV1;
+using bloom::project::CanonicalManifestV1;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::SaveArchiveLimits;
+using bloom::project::stageCopyArchive;
+using bloom::project::StagedCopyByteMismatch;
+using bloom::project::StagedCopyContainerSanityFailure;
+using bloom::project::StagedCopyResourceExhausted;
+using bloom::project::StagedCopyResult;
+using bloom::project::StagedCopyStage;
+using bloom::project::StagedSaveLeaseCall;
+using bloom::project::StagedSavePlatformFailure;
+using bloom::project::ZipContainerError;
+using bloom::project::ZipContainerLimits;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-staged-copy-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (path_.empty()) {
+            return;
+        }
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// ---------------------------------------------------------------------------------------------
+// Shared plumbing
+// ---------------------------------------------------------------------------------------------
+
+constexpr std::uint64_t kGenerousOperationBudget = 32ULL << 20U; // 32 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    return makeOperation(kGenerousOperationBudget);
+}
+
+[[nodiscard]] std::array<std::uint8_t, 32> ascendingDigestBytes() noexcept {
+    std::array<std::uint8_t, 32> bytes{};
+    std::iota(bytes.begin(), bytes.end(), std::uint8_t{0});
+    return bytes;
+}
+
+[[nodiscard]] bloom::document::ColorSettings neutralColorSettings() {
+    return bloom::document::makeBloomNeutralColorSettingsV1(
+        bloom::core::Sha256Digest::fromBytes(ascendingDigestBytes()));
+}
+
+[[nodiscard]] std::string readFile(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+[[nodiscard]] std::optional<StagedArtifactCoordinator>
+makeCoordinator(Expectations& expectations, const StagedArtifactConfig config = {}) {
+    auto result = StagedArtifactCoordinator::create(config);
+    expectations.expect(result.succeeded(), "the staged-copy coordinator is created");
+    if (!result) {
+        return std::nullopt;
+    }
+    return std::move(result).takeCoordinator();
+}
+
+[[nodiscard]] StagedArtifactPreflightRequest makeRequest(
+    std::filesystem::path targetPath,
+    const ArtifactOverwritePolicy overwritePolicy = ArtifactOverwritePolicy::CreateOrReplace) {
+    return {.targetPath = std::move(targetPath),
+            .overwritePolicy = overwritePolicy,
+            .expectedTarget = std::nullopt};
+}
+
+// A real, valid, two-entry Constrained ZIP Profile archive -- the exact shape a preserved-read-only
+// project's retained original archive bytes would take (docs/architecture/project-format.md's
+// "Versions, Migrations, And Preservation": "Open returns a preserved-read-only result containing
+// the bounded original archive"). stageCopyArchive() has no build step of its own; it copies
+// whatever bytes it is given verbatim, so this fixture builds real archive bytes purely to serve as
+// realistic, preflight-passing source content.
+[[nodiscard]] std::vector<std::byte> buildSourceArchiveBytesOrAbort() {
+    const auto duration = bloom::core::RationalTime::create(240, 24);
+    if (!duration.has_value()) {
+        std::abort();
+    }
+    auto newProject =
+        bloom::document::makeNewProject("Copy Source Project", "Main Composition", *duration);
+    bloom::document::Document document{std::move(newProject.project)};
+    const auto snapshot = document.snapshot();
+    const auto colorSettings = neutralColorSettings();
+    const CanonicalManifestV1 manifest{.documentSchemaVersion = {1, 0}, .requirements = {}};
+    const CanonicalDocumentV1 documentInput{.snapshot = &snapshot, .colorSettings = &colorSettings};
+    auto built = buildSaveArchive(manifest, documentInput, SaveArchiveLimits{}, makeOperation());
+    if (!built) {
+        std::abort();
+    }
+    const auto bytes = built.archive()->bytes();
+    return {bytes.begin(), bytes.end()};
+}
+
+struct StageAttempt final {
+    std::optional<StagedArtifactLease> lease;
+    std::optional<StagedCopyResult> result;
+};
+
+[[nodiscard]] StageAttempt
+attemptStage(Expectations& expectations, StagedArtifactCoordinator& coordinator,
+             const std::filesystem::path& targetPath, const ArtifactOverwritePolicy policy,
+             const std::span<const std::byte> sourceBytes, const ZipContainerLimits& limits,
+             ProjectIoOperationMemory operation) {
+    StageAttempt attempt;
+    auto preflight = coordinator.preflight(makeRequest(targetPath, policy));
+    if (!preflight) {
+        expectations.expect(false, "attemptStage: preflight succeeds");
+        return attempt;
+    }
+    auto stageResult = coordinator.stage(std::move(preflight).takeTarget());
+    if (!stageResult) {
+        expectations.expect(false, "attemptStage: stage succeeds");
+        return attempt;
+    }
+    attempt.lease = std::move(stageResult).takeLease();
+    attempt.result = stageCopyArchive(*attempt.lease, sourceBytes, limits, std::move(operation));
+    return attempt;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Green path: preflight -> stage -> stageCopyArchive -> success -> caller-side publish(Proceed) ->
+// Published. The published file is byte-compared against the source bytes directly -- Save Copy's
+// literal contract.
+// ---------------------------------------------------------------------------------------------
+
+void testGreenPathEndToEnd(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "green path: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+
+    auto attempt =
+        attemptStage(expectations, *coordinator, targetPath, ArtifactOverwritePolicy::CreateOnly,
+                     sourceBytes, ZipContainerLimits{}, makeOperation());
+    expectations.expect(attempt.lease.has_value() && attempt.result.has_value() &&
+                            static_cast<bool>(*attempt.result),
+                        "green path: stageCopyArchive succeeds");
+    if (!attempt.lease.has_value() || !attempt.result.has_value() || !*attempt.result) {
+        return;
+    }
+    const auto publication = attempt.lease->publish(PublicationDisposition::Proceed);
+    expectations.expect(publication.outcome == StagedArtifactPublicationOutcome::Published,
+                        "green path: publish reaches Published");
+    if (publication.outcome != StagedArtifactPublicationOutcome::Published) {
+        return;
+    }
+
+    const auto published = readFile(targetPath);
+    expectations.expect(
+        published.size() == sourceBytes.size() &&
+            std::memcmp(published.data(), sourceBytes.data(), published.size()) == 0,
+        "green path: the published file is byte-for-byte identical to the source bytes");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Fault injection at StageWrite, StageWriterClose (finishWriting), StageVerificationRead, and
+// StageVerificationAccept: each surfaces the platform's typed FaultInjected error at the right
+// stage/lease-call of stageCopyArchive()'s result, mirroring staged_save_tests.cpp's identical
+// coverage, and every lease releases its active-target admission on drop.
+// ---------------------------------------------------------------------------------------------
+
+void testFaultInjection(Expectations& expectations) {
+    struct FaultCase final {
+        StagedArtifactFaultPoint point;
+        StagedCopyStage expectedStage;
+        StagedSaveLeaseCall expectedCall;
+    };
+    const std::array<FaultCase, 4> cases{{
+        {StagedArtifactFaultPoint::StageWrite, StagedCopyStage::StageWrite,
+         StagedSaveLeaseCall::Write},
+        {StagedArtifactFaultPoint::StageWriterClose, StagedCopyStage::StageFinish,
+         StagedSaveLeaseCall::FinishWriting},
+        {StagedArtifactFaultPoint::StageVerificationRead, StagedCopyStage::StageRead,
+         StagedSaveLeaseCall::ReadForVerification},
+        {StagedArtifactFaultPoint::StageVerificationAccept, StagedCopyStage::Accept,
+         StagedSaveLeaseCall::AcceptVerification},
+    }};
+
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+
+    for (const auto& testCase : cases) {
+        TempDirectory directory;
+        if (!directory.isValid()) {
+            expectations.expect(false, "fault injection: temp directory is available");
+            continue;
+        }
+        StagedArtifactConfig config;
+        config.faults = {.point = testCase.point, .occurrence = 1};
+        auto coordinator = makeCoordinator(expectations, config);
+        if (!coordinator.has_value()) {
+            continue;
+        }
+        const auto targetPath = directory.path() / "copy.bloom";
+
+        auto attempt = attemptStage(expectations, *coordinator, targetPath,
+                                    ArtifactOverwritePolicy::CreateOnly, sourceBytes,
+                                    ZipContainerLimits{}, makeOperation());
+        expectations.expect(attempt.lease.has_value(),
+                            "fault injection: a lease is obtained before the injected failure");
+        expectations.expect(attempt.result.has_value() && !*attempt.result,
+                            "fault injection: stageCopyArchive reports failure");
+        if (!attempt.result.has_value()) {
+            continue;
+        }
+        const auto* failure = attempt.result->failure();
+        expectations.expect(failure != nullptr && failure->stage() == testCase.expectedStage,
+                            "fault injection: the failure stage matches the injected fault point");
+        const auto* platformFailure =
+            failure != nullptr ? failure->payloadAs<StagedSavePlatformFailure>() : nullptr;
+        expectations.expect(platformFailure != nullptr &&
+                                platformFailure->error == StagedArtifactError::FaultInjected &&
+                                platformFailure->call == testCase.expectedCall,
+                            "fault injection: the platform failure payload names FaultInjected and "
+                            "the exact lease call");
+
+        attempt.lease.reset();
+        const auto snapshot = coordinator->snapshot();
+        expectations.expect(snapshot.activeTargetCount == 0,
+                            "fault injection: dropping the lease releases the active target "
+                            "admission");
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Container sanity-check failure (check (b)): source bytes that are not a conforming Constrained
+// ZIP Profile container round-trip byte-for-byte (there is no disk corruption -- write, read back,
+// and compare all agree), but detail::preflightZipContainer() over the read-back bytes still
+// legitimately fails. This is reachable through ordinary public parameters -- stageCopyArchive()
+// itself never requires its caller's `sourceBytes` to already be a conforming container, only the
+// application-layer contract that Save Copy's caller opened the source successfully does -- unlike
+// a genuine byte-content MISMATCH (check (a)), which is NOT reachable this way: see the comment
+// block below.
+// ---------------------------------------------------------------------------------------------
+
+void testContainerSanityCheckFailure(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "container sanity check: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = asBytes("this is not a zip container at all");
+
+    auto preflight =
+        coordinator->preflight(makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly));
+    expectations.expect(static_cast<bool>(preflight), "container sanity check: preflight succeeds");
+    if (!preflight) {
+        return;
+    }
+    auto stageResult = coordinator->stage(std::move(preflight).takeTarget());
+    expectations.expect(static_cast<bool>(stageResult), "container sanity check: stage succeeds");
+    if (!stageResult) {
+        return;
+    }
+    auto lease = std::move(stageResult).takeLease();
+
+    auto result = stageCopyArchive(lease, sourceBytes, ZipContainerLimits{}, makeOperation());
+    expectations.expect(!result, "container sanity check: stageCopyArchive reports failure");
+    const auto* failure = result.failure();
+    expectations.expect(failure != nullptr && failure->stage() == StagedCopyStage::Verification,
+                        "container sanity check: reported at the Verification stage");
+    const auto* sanityFailure =
+        failure != nullptr ? failure->payloadAs<StagedCopyContainerSanityFailure>() : nullptr;
+    expectations.expect(sanityFailure != nullptr && sanityFailure->error != ZipContainerError::None,
+                        "container sanity check: the payload names a real ZipContainerError, typed "
+                        "distinctly from a byte mismatch");
+    expectations.expect(!result.rejectDiagnostic().has_value(),
+                        "container sanity check: lease.rejectVerification() itself succeeded (no "
+                        "secondary diagnostic)");
+
+    const auto publication = lease.publish(PublicationDisposition::Proceed);
+    expectations.expect(
+        publication.outcome == StagedArtifactPublicationOutcome::FailedBeforePublication &&
+            publication.error == StagedArtifactError::StageVerificationRejected,
+        "container sanity check: the lease replays its rejected terminal state on publish");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Byte mismatch (check (a)) and staged-size disagreement are NOT covered by an automated test here,
+// documented honestly rather than faked: stageCopyArchive() issues exactly one
+// lease.write(sourceBytes) call with the complete source buffer, reads back exactly what
+// lease.stageBytes() reports was staged, and compares that read-back to the SAME `sourceBytes`
+// value the caller passed in -- there is only one source of truth throughout the call, no second
+// independently-derived "expected" value to legitimately disagree with it (unlike staged_save.cpp's
+// Verification-stage content mismatch, which compares staged bytes against an independently-derived
+// expected value built from the manifest/document that can be made self-inconsistent through
+// ordinary public parameters; Save Copy's write and its own read-back verification of the identical
+// bytes have no such second lever). A genuine disagreement between what was written and what reads
+// back can only come from real platform-level corruption between finishWriting() and the read-back
+// loop, which the public StagedArtifactLease API and its shipped StagedArtifactFaultPoint values
+// (all of which report a typed FaultInjected error rather than silently corrupting bytes -- see
+// testFaultInjection above) cannot produce, and this task package forbids adding a production test
+// seam solely to make it reachable. Reaching the platform's staged bytes from outside
+// stageCopyArchive() for direct tamper is therefore not possible without a forbidden seam, exactly
+// as staged_save_tests.cpp documents for its own StagedSizeDisagreement case.
+// ---------------------------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------------------------
+// Budget exhaustion, zeroed snapshot. Unlike staged_save's build-then-verify chain,
+// stageCopyArchive() has no build step: the only allocation charged through `operation` is the PMR
+// read-back buffer, sized to exactly `sourceBytes.size()`. A budget smaller than that size is
+// therefore guaranteed to exhaust at ReadBackAllocation specifically -- no two-pass probing needed.
+// ---------------------------------------------------------------------------------------------
+
+void testBudgetExhaustion(Expectations& expectations) {
+    TempDirectory directory;
+    auto coordinator = makeCoordinator(expectations);
+    if (!directory.isValid() || !coordinator.has_value()) {
+        expectations.expect(false, "budget exhaustion: fixture is available");
+        return;
+    }
+    const auto targetPath = directory.path() / "copy.bloom";
+    const auto sourceBytes = buildSourceArchiveBytesOrAbort();
+    expectations.expect(sourceBytes.size() > 1,
+                        "budget exhaustion: the fixture archive is non-trivial");
+
+    const std::uint64_t budget = static_cast<std::uint64_t>(sourceBytes.size()) - 1;
+    auto memory = ProjectIoMemoryCoordinator::create(kGenerousOperationBudget);
+    expectations.expect(memory.has_value(), "budget exhaustion: coordinator constructs");
+    if (!memory.has_value()) {
+        return;
+    }
+    auto operation = memory->createOperation(budget, budget);
+    expectations.expect(operation.has_value(),
+                        "budget exhaustion: constrained operation constructs");
+    if (!operation.has_value()) {
+        return;
+    }
+
+    auto preflight =
+        coordinator->preflight(makeRequest(targetPath, ArtifactOverwritePolicy::CreateOnly));
+    expectations.expect(static_cast<bool>(preflight), "budget exhaustion: preflight succeeds");
+    if (!preflight) {
+        return;
+    }
+    auto stageResult = coordinator->stage(std::move(preflight).takeTarget());
+    expectations.expect(static_cast<bool>(stageResult), "budget exhaustion: stage succeeds");
+    if (!stageResult) {
+        return;
+    }
+    {
+        auto lease = std::move(stageResult).takeLease();
+        auto result =
+            stageCopyArchive(lease, sourceBytes, ZipContainerLimits{}, std::move(*operation));
+        expectations.expect(!result, "budget exhaustion: a budget below the source size fails");
+        const auto* failure = result.failure();
+        expectations.expect(failure != nullptr &&
+                                failure->stage() == StagedCopyStage::ReadBackAllocation,
+                            "budget exhaustion: reported at the ReadBackAllocation stage");
+        const auto* resourceExhausted =
+            failure != nullptr ? failure->payloadAs<StagedCopyResourceExhausted>() : nullptr;
+        expectations.expect(resourceExhausted != nullptr,
+                            "budget exhaustion: the payload names StagedCopyResourceExhausted");
+    } // The lease is destroyed here; its stage cleanup is exercised by this scope exit.
+    const auto memorySnapshot = memory->snapshot();
+    expectations.expect(memorySnapshot.currentBytes == 0,
+                        "budget exhaustion: the constrained coordinator's charge returns to zero");
+    const auto artifactSnapshot = coordinator->snapshot();
+    expectations.expect(artifactSnapshot.activeTargetCount == 0,
+                        "budget exhaustion: the lease remained safely destructible after resource "
+                        "exhaustion");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testGreenPathEndToEnd(expectations);
+    testFaultInjection(expectations);
+    testContainerSanityCheckFailure(expectations);
+    testBudgetExhaustion(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/ui/include/bloom/ui/main_window.hpp
+++ b/src/ui/include/bloom/ui/main_window.hpp
@@ -68,6 +68,7 @@ class MainWindow final : public QMainWindow {
     QAction* openProjectAction_ = nullptr;
     QAction* saveProjectAction_ = nullptr;
     QAction* saveProjectAsAction_ = nullptr;
+    QAction* saveProjectCopyAction_ = nullptr;
     QAction* undoAction_ = nullptr;
     QAction* redoAction_ = nullptr;
     QAction* splitLeftRightAction_ = nullptr;

--- a/src/ui/include/bloom/ui/project_host.hpp
+++ b/src/ui/include/bloom/ui/project_host.hpp
@@ -2,6 +2,7 @@
 
 #include <bloom/document/document.hpp>
 #include <bloom/document/ids.hpp>
+#include <bloom/host/copy_async_io.hpp>
 #include <bloom/host/project_session.hpp>
 #include <bloom/host/publication_coordinator.hpp>
 #include <bloom/host/session_async_io.hpp>
@@ -15,12 +16,14 @@
 #include <QString>
 #include <QTimer>
 
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <optional>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace bloom::commands {
 class CommandStack;
@@ -104,6 +107,12 @@ class ProjectHost final : public QObject {
     // Not noexcept: each reads bloom::host::ProjectSession::stateSnapshot(), which copies
     // std::string undo/redo labels and is not itself noexcept.
     [[nodiscard]] bool canSave() const;
+    // Preserved-read-only content with retained original archive bytes, not busy (task SC1, issue
+    // #77). Save Copy is the only operation available on preserved-read-only content
+    // (docs/architecture/project-session.md: "A preserved-read-only project cannot run native Save
+    // or Save As; Save Copy stages, validates, and atomically publishes an asynchronous
+    // byte-for-byte copy").
+    [[nodiscard]] bool canSaveCopy() const;
     [[nodiscard]] bool isDirty() const;
     [[nodiscard]] bool isBusy() const noexcept;
     [[nodiscard]] ProjectHostActivity activity() const noexcept;
@@ -148,10 +157,22 @@ class ProjectHost final : public QObject {
     // dialog seam internally (session.capturePlainSavePathIntent()'s own PathRequired backs this --
     // asking the host here instead of duplicating the check in MainWindow).
     void beginSave();
+    // The "Save a Copy…" menu action's entry point (task SC1, issue #77): enabled only for
+    // preserved-read-only content with retained bytes (see canSaveCopy()); reuses the SAME Save As
+    // dialog provider seam (setSaveAsPathProvider()) rather than adding a third one. Drives
+    // beginCopyPublication() through the single-in-flight variant and poll loop, exactly as
+    // beginSave()/beginSaveAs() drive Save/Open. Never touches session state: Save Copy stages,
+    // validates, and atomically publishes an asynchronous byte-for-byte copy and never claims to
+    // rewrite or migrate the document (docs/architecture/project-session.md).
+    void requestSaveCopy();
     // Lower-level primitives (decision 1's literal list): begin the async op against an
     // already-known path. Public so tests can drive them directly, bypassing the dialog seams.
     void beginOpen(const std::filesystem::path& path);
     void beginSaveAs(std::filesystem::path path);
+    // Lower-level primitive mirroring beginOpen()/beginSaveAs(): begins Save Copy against an
+    // already-known target path, bypassing the Save As dialog seam. Public so tests can drive it
+    // directly.
+    void beginSaveCopy(std::filesystem::path path);
 
   signals:
     // Fires exactly once per successful New replace or successful Open install.
@@ -161,6 +182,10 @@ class ProjectHost final : public QObject {
     // Typed outcome + a display-ready message (never collapses Superseded/failed into success).
     void saveFinished(bloom::ui::ProjectHostOperationOutcome outcome, QString message);
     void openFinished(bloom::ui::ProjectHostOperationOutcome outcome, QString message);
+    // Honest copy outcome (task SC1, issue #77): published / superseded / conflict / failed; the
+    // success message names the target file. Never fired for a state that also changes
+    // dirtyStateChanged()/sessionReplaced() -- Save Copy never touches session state.
+    void copyFinished(bloom::ui::ProjectHostOperationOutcome outcome, QString message);
 
   private:
     void poll();
@@ -168,9 +193,12 @@ class ProjectHost final : public QObject {
     void setActivity(ProjectHostActivity activity);
     void replaceWithNewProject();
     void promptAndBeginSaveAs();
+    void promptAndBeginSaveCopy();
     void startSave(std::filesystem::path targetPath, host::SessionPathIntentCapture intent);
+    void startSaveCopy(std::filesystem::path targetPath);
     void handleSaveResult(host::SessionSaveResult result);
     void handleOpenResult(host::SessionOpenResult result);
+    void handleCopyResult(host::CopyPublicationResult result);
     [[nodiscard]] std::optional<project::ProjectIoOperationMemory> makeOperation() const;
     [[nodiscard]] bool hasDirtyDecodedContent() const;
 
@@ -181,7 +209,28 @@ class ProjectHost final : public QObject {
     std::optional<project::ProjectIoMemoryCoordinator> memoryCoordinator_;
     std::optional<host::ProjectSession> session_;
 
-    std::variant<std::monostate, host::AsyncSessionSave, host::AsyncSessionOpen> inFlight_;
+    // The application-owned bounded original archive for the currently installed preserved-read-
+    // only content (task SC1, issue #77): beginOpen() already owns the bytes it read for the
+    // Installed+PreservedReadOnly path, so this retains them instead of dropping them, rather than
+    // re-reading the source file on every Save a Copy. Plain std::vector, deliberately NOT
+    // PMR-charged through ProjectIoOperationMemory: the resident-budget contract covers the memory
+    // an in-flight Project I/O *operation* charges against its own bounded budget, not this
+    // longer-lived, application-owned retention -- which is itself bounded (at most one archive, no
+    // larger than the archive size limit) independently of any operation's budget. Cleared whenever
+    // installed content is replaced by anything other than a matching preserved-read-only open
+    // (New, a decoded/editable Open, or a failed-to-retain preserved-read-only open).
+    std::vector<std::byte> retainedArchiveBytes_;
+    // Holds the bytes read for an in-flight Open until handleOpenResult() knows whether to promote
+    // them into retainedArchiveBytes_ (Installed + PreservedReadOnly) or drop them (any other
+    // outcome); see beginOpen()'s own comment.
+    std::vector<std::byte> pendingOpenArchiveBytes_;
+    // The target path an in-flight Save Copy is publishing to, retained only to name the file in
+    // copyFinished()'s success message once the async operation completes.
+    std::filesystem::path pendingCopyTargetPath_;
+
+    std::variant<std::monostate, host::AsyncSessionSave, host::AsyncSessionOpen,
+                 host::AsyncCopyPublication>
+        inFlight_;
     QTimer pollTimer_;
     ProjectHostActivity activity_ = ProjectHostActivity::Idle;
 

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -79,6 +79,18 @@ MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession&
                 }
                 QMessageBox::warning(this, tr("Open Project"), message);
             });
+    connect(&projectHost_, &ProjectHost::copyFinished, this,
+            [this](const ProjectHostOperationOutcome outcome, const QString& message) {
+                if (outcome == ProjectHostOperationOutcome::Published) {
+                    statusBar()->showMessage(message, 4000);
+                    return;
+                }
+                if (outcome == ProjectHostOperationOutcome::Cancelled) {
+                    statusBar()->clearMessage();
+                    return;
+                }
+                QMessageBox::warning(this, tr("Save a Copy"), message);
+            });
     updateFileActions();
     updateWindowTitle();
     updateContentSurface();
@@ -186,6 +198,12 @@ void MainWindow::createFileMenu(QMenu& fileMenu) {
     saveProjectAsAction_->setShortcutContext(Qt::WindowShortcut);
     connect(saveProjectAsAction_, &QAction::triggered, &projectHost_, &ProjectHost::requestSaveAs);
 
+    // "Save a Copy…" (task SC1, issue #77): no default shortcut, placed right after Save As.
+    saveProjectCopyAction_ = fileMenu.addAction("Save a &Copy…");
+    saveProjectCopyAction_->setObjectName("saveProjectCopyAction");
+    connect(saveProjectCopyAction_, &QAction::triggered, &projectHost_,
+            &ProjectHost::requestSaveCopy);
+
     fileMenu.addSeparator();
 }
 
@@ -195,6 +213,7 @@ void MainWindow::updateFileActions() {
     openProjectAction_->setEnabled(!busy);
     saveProjectAction_->setEnabled(!busy && projectHost_.canSave());
     saveProjectAsAction_->setEnabled(!busy && projectHost_.canSave());
+    saveProjectCopyAction_->setEnabled(!busy && projectHost_.canSaveCopy());
 
     switch (projectHost_.activity()) {
     case ProjectHostActivity::Saving:
@@ -238,14 +257,15 @@ void MainWindow::updateContentSurface() {
     const QString fileName =
         path.has_value() ? QString::fromStdString(path->filename().string()) : tr("Untitled");
     readOnlyPlaceholderFileNameLabel_->setText(fileName);
-    // Honest reason + options (frozen design decision 1): this file needs capabilities this Bloom
-    // cannot edit safely; it is opened read-only; editing and saving are disabled; a byte-exact
-    // Save Copy will be offered in a future update. No apology, no promise beyond what is true
+    // Honest reason + options (frozen design decision 1, updated by task SC1/issue #77 now that
+    // Save a Copy is live rather than promised): this file needs capabilities this Bloom cannot
+    // edit safely; it is opened read-only; editing and saving are disabled; File → Save a Copy
+    // creates a byte-exact copy of this file today. No apology, no promise beyond what is true
     // today.
     readOnlyPlaceholderBodyLabel_->setText(
         tr("“%1” uses capabilities this version of Bloom cannot edit safely, so it was "
-           "opened read-only. Editing and saving are disabled. A future update will offer Save "
-           "Copy to create a byte-exact copy of this file.")
+           "opened read-only. Editing and saving are disabled. Use File → Save a Copy to create "
+           "a byte-exact copy of this file.")
             .arg(fileName));
     centralStack_->setCurrentWidget(readOnlyPlaceholderPage_);
 }

--- a/src/ui/project_host.cpp
+++ b/src/ui/project_host.cpp
@@ -93,6 +93,8 @@ ProjectHost::~ProjectHost() {
         save->requestCancellation();
     } else if (auto* open = std::get_if<host::AsyncSessionOpen>(&inFlight_)) {
         open->requestCancellation();
+    } else if (auto* copy = std::get_if<host::AsyncCopyPublication>(&inFlight_)) {
+        copy->requestCancellation();
     }
 }
 
@@ -111,6 +113,15 @@ bool ProjectHost::canSave() const {
     return snapshot.valid &&
            snapshot.contentKind == host::ProjectSessionContentKind::DecodedDocument &&
            snapshot.editability == host::DecodedProjectEditability::Editable;
+}
+
+bool ProjectHost::canSaveCopy() const {
+    if (!session_.has_value() || isBusy() || retainedArchiveBytes_.empty()) {
+        return false;
+    }
+    const auto snapshot = session_->stateSnapshot();
+    return snapshot.valid &&
+           snapshot.contentKind == host::ProjectSessionContentKind::PreservedReadOnly;
 }
 
 bool ProjectHost::isDirty() const {
@@ -274,6 +285,36 @@ void ProjectHost::promptAndBeginSaveAs() {
     beginSaveAs(std::move(*chosen));
 }
 
+void ProjectHost::requestSaveCopy() {
+    if (isBusy()) {
+        emit copyFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+    if (!canSaveCopy()) {
+        emit copyFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Save a Copy is not available for this project."));
+        return;
+    }
+    promptAndBeginSaveCopy();
+}
+
+void ProjectHost::promptAndBeginSaveCopy() {
+    // Reuses the SAME Save As dialog provider seam (decision 4: "same seam pattern for the file
+    // dialogs" / "do NOT add a third provider unless something genuinely breaks") -- Save Copy's
+    // dialog is presentation-identical to Save As's: choose a destination file.
+    if (!saveAsPathProvider_) {
+        emit copyFinished(ProjectHostOperationOutcome::Refused,
+                          tr("No Save dialog is configured."));
+        return;
+    }
+    auto chosen = saveAsPathProvider_();
+    if (!chosen.has_value()) {
+        return; // The artist cancelled the dialog; not an error.
+    }
+    beginSaveCopy(std::move(*chosen));
+}
+
 void ProjectHost::beginSave() {
     if (isBusy() || !session_.has_value()) {
         emit saveFinished(ProjectHostOperationOutcome::Refused,
@@ -316,6 +357,15 @@ void ProjectHost::beginSaveAs(std::filesystem::path path) {
     startSave(std::move(path), advance.capture());
 }
 
+void ProjectHost::beginSaveCopy(std::filesystem::path path) {
+    if (isBusy() || !canSaveCopy()) {
+        emit copyFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+    startSaveCopy(std::move(path));
+}
+
 void ProjectHost::startSave(std::filesystem::path targetPath,
                             const host::SessionPathIntentCapture intent) {
     // Callers (beginSave()/beginSaveAs()) already checked isBusy()/session_.has_value(); these
@@ -348,6 +398,43 @@ void ProjectHost::startSave(std::filesystem::path targetPath,
         return;
     }
     inFlight_.emplace<host::AsyncSessionSave>(std::move(begun).takeHandle());
+    setActivity(ProjectHostActivity::Saving);
+    scheduleNextPoll();
+}
+
+void ProjectHost::startSaveCopy(std::filesystem::path targetPath) {
+    // Callers (requestSaveCopy()/beginSaveCopy()) already checked isBusy()/canSaveCopy(); repeated
+    // defensively, matching startSave()'s own precedent.
+    if (!canSaveCopy() || !publicationCoordinator_.has_value() ||
+        !artifactCoordinator_.has_value()) {
+        emit copyFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Another project operation is already in progress."));
+        return;
+    }
+    auto operation = makeOperation();
+    if (!operation.has_value()) {
+        emit copyFinished(ProjectHostOperationOutcome::Refused,
+                          tr("Not enough memory is available to start this copy."));
+        return;
+    }
+    host::AsyncCopyPublicationRequest request{
+        .targetPath = targetPath,
+        .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
+        .expectedTarget = std::nullopt,
+        // Copied, never moved: retainedArchiveBytes_ must survive for a possible future Save Copy.
+        .bytes = retainedArchiveBytes_,
+        .limits = {},
+    };
+    auto begun =
+        host::beginCopyPublication(scheduler_, *publicationCoordinator_, *artifactCoordinator_,
+                                   std::move(request), std::move(*operation));
+    if (!begun) {
+        emit copyFinished(ProjectHostOperationOutcome::Refused,
+                          tr("The copy could not be started."));
+        return;
+    }
+    inFlight_.emplace<host::AsyncCopyPublication>(std::move(begun).takeHandle());
+    pendingCopyTargetPath_ = std::move(targetPath);
     setActivity(ProjectHostActivity::Saving);
     scheduleNextPoll();
 }
@@ -412,9 +499,16 @@ void ProjectHost::beginOpen(const std::filesystem::path& path) {
         return;
     }
 
+    // beginOpen() already owns the bytes it just read (task SC1, issue #77): stash a copy here,
+    // before `bytes` moves into beginSessionOpen(), so handleOpenResult() can retain them on an
+    // Installed+PreservedReadOnly outcome instead of dropping them. Dropped again unconditionally
+    // once that outcome is known (see handleOpenResult()).
+    pendingOpenArchiveBytes_ = bytes;
+
     auto begun = host::beginSessionOpen(*session_, scheduler_, std::move(bytes),
                                         std::move(displayPath), limits, std::move(*operation));
     if (!begun) {
+        pendingOpenArchiveBytes_.clear();
         emit openFinished(ProjectHostOperationOutcome::Refused,
                           tr("The open could not be started."));
         return;
@@ -439,6 +533,9 @@ void ProjectHost::replaceWithNewProject() {
         return;
     }
     session_.emplace(std::move(created).takeSession());
+    // A new project is always decoded, editable content -- never preserved-read-only -- so any
+    // previously retained original archive bytes no longer describe the installed content.
+    retainedArchiveBytes_.clear();
     emit sessionReplaced();
     emit dirtyStateChanged();
 }
@@ -477,6 +574,21 @@ void ProjectHost::poll() {
         setActivity(ProjectHostActivity::Idle);
         if (result.has_value()) {
             handleOpenResult(std::move(*result));
+        }
+        return;
+    }
+    if (auto* copy = std::get_if<host::AsyncCopyPublication>(&inFlight_)) {
+        if (!copy->isReady()) {
+            scheduleNextPoll();
+            return;
+        }
+        // Save Copy's tryComplete() takes no session -- it never proposes ProjectSession
+        // path/dirty changes (see requestSaveCopy()'s own comment).
+        auto result = copy->tryComplete();
+        inFlight_.emplace<std::monostate>();
+        setActivity(ProjectHostActivity::Idle);
+        if (result.has_value()) {
+            handleCopyResult(std::move(*result));
         }
         return;
     }
@@ -618,12 +730,81 @@ void ProjectHost::handleOpenResult(host::SessionOpenResult result) {
     }
     }
 
+    // Retention (task SC1, issue #77): promote the pending bytes read for this open into
+    // retainedArchiveBytes_ only when they actually became the installed preserved-read-only
+    // content; drop them (never retain) for every other outcome, including a failed install --
+    // installed content, and therefore what may be retained for it, is unchanged in that case.
+    if (installed &&
+        result.attemptedContentKind() == host::ProjectSessionContentKind::PreservedReadOnly) {
+        retainedArchiveBytes_ = std::move(pendingOpenArchiveBytes_);
+    } else if (installed) {
+        retainedArchiveBytes_.clear();
+    }
+    pendingOpenArchiveBytes_.clear();
+
     emit dirtyStateChanged();
     emit openFinished(outcome, message);
 
     if (installed) {
         emit sessionReplaced();
     }
+}
+
+void ProjectHost::handleCopyResult(host::CopyPublicationResult result) {
+    // Save Copy never touches session state (docs/architecture/project-session.md: "Save Copy and
+    // frame export never propose ProjectSession path/dirty changes"): no dirtyStateChanged() or
+    // sessionReplaced() emission here, ever.
+    const auto targetName = QString::fromStdString(pendingCopyTargetPath_.filename().string());
+
+    if (!result) {
+        const auto* failure = result.failure();
+        if (failure != nullptr && failure->stage() == host::CopyPublicationStage::Cancelled) {
+            emit copyFinished(ProjectHostOperationOutcome::Cancelled,
+                              tr("The copy was cancelled."));
+            return;
+        }
+        emit copyFinished(ProjectHostOperationOutcome::Failed,
+                          tr("The copy failed before the file could be written."));
+        return;
+    }
+
+    const auto* publication = result.publication();
+    const auto publicationOutcome =
+        publication != nullptr
+            ? publication->outcome
+            : platform::StagedArtifactPublicationOutcome::FailedBeforePublication;
+    auto outcome = ProjectHostOperationOutcome::Failed;
+    QString message;
+    switch (publicationOutcome) {
+    case platform::StagedArtifactPublicationOutcome::Published:
+        outcome = ProjectHostOperationOutcome::Published;
+        message = tr("Saved a copy as %1.").arg(targetName);
+        break;
+    case platform::StagedArtifactPublicationOutcome::PublishedWithDurabilityWarning:
+        outcome = ProjectHostOperationOutcome::PublishedWithWarning;
+        message = tr("Saved a copy as %1, but a later durability step failed. Consider saving a "
+                     "copy again.")
+                      .arg(targetName);
+        break;
+    case platform::StagedArtifactPublicationOutcome::Superseded:
+        outcome = ProjectHostOperationOutcome::Superseded;
+        message = tr("This copy was superseded by a newer save to the same file.");
+        break;
+    case platform::StagedArtifactPublicationOutcome::CancelledBeforePublication:
+        outcome = ProjectHostOperationOutcome::Cancelled;
+        message = tr("The copy was cancelled.");
+        break;
+    case platform::StagedArtifactPublicationOutcome::ExternalModificationConflict:
+        outcome = ProjectHostOperationOutcome::ExternalConflict;
+        message = tr("The target file changed outside Bloom. Choose a different location or "
+                     "overwrite explicitly.");
+        break;
+    case platform::StagedArtifactPublicationOutcome::FailedBeforePublication:
+        outcome = ProjectHostOperationOutcome::Failed;
+        message = tr("The copy failed before the file could be written.");
+        break;
+    }
+    emit copyFinished(outcome, message);
 }
 
 std::optional<project::ProjectIoOperationMemory> ProjectHost::makeOperation() const {

--- a/src/ui/tests/main_window_readonly_placeholder_tests.cpp
+++ b/src/ui/tests/main_window_readonly_placeholder_tests.cpp
@@ -510,6 +510,126 @@ void testPlaceholderSwitchesOnPreservedReadOnlyOpenAndBack(Expectations& expecta
                         "placeholder switch: Save/Save As re-enable for editable content");
 }
 
+// ---------------------------------------------------------------------------------------------
+// Save a Copy from the read-only placeholder (task SC1, issue #77): open a preserved-read-only
+// archive -> the "Save a Copy…" action enables -> drive requestSaveCopy() through the SAME Save As
+// dialog seam to a temp target -> the published file byte-equals the retained original; the
+// session's stateSnapshot (content kind, generations, path) is identical before and after; opening
+// an editable archive afterward clears the retention and disables the action again.
+// ---------------------------------------------------------------------------------------------
+
+void testSaveCopyFromReadOnlyPlaceholder(Expectations& expectations) {
+    TempDirectory directory;
+    if (!directory.isValid()) {
+        expectations.expect(false, "save a copy: temp directory is available");
+        return;
+    }
+    const auto preservedPath = directory.path() / "preserved.bloom";
+    const auto copyTargetPath = directory.path() / "preserved-copy.bloom";
+    const auto editablePath = directory.path() / "editable.bloom";
+    const auto preservedBytes = buildManifestSidePreservedReadOnlyArchiveOrAbort();
+    writeFileOrAbort(preservedPath, preservedBytes);
+    writeFileOrAbort(editablePath, buildEditableArchiveBytesOrAbort());
+
+    EditorRegistry registry;
+    expectations.expect(registerStandInEditors(registry),
+                        "save a copy: the stand-in editors register");
+
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost projectHost(scheduler);
+    auto [initialDocument, initialCommandStack] = projectHost.liveDocumentAndStack();
+    if (initialDocument == nullptr || initialCommandStack == nullptr) {
+        expectations.expect(false,
+                            "save a copy: the fresh ProjectHost exposes a live document/stack");
+        return;
+    }
+    bloom::ui::CompositionSession compositionSession(*initialDocument, *initialCommandStack,
+                                                     projectHost.lowestCompositionId());
+
+    MainWindow window(registry, compositionSession, projectHost);
+    window.show();
+    QApplication::processEvents();
+
+    auto* saveCopyAction = window.findChild<QAction*>("saveProjectCopyAction");
+    expectations.expect(saveCopyAction != nullptr, "save a copy: the menu action exists");
+    if (saveCopyAction == nullptr) {
+        return;
+    }
+    expectations.expect(!saveCopyAction->isEnabled() && !projectHost.canSaveCopy(),
+                        "save a copy: disabled at baseline for a fresh editable project");
+
+    projectHost.beginOpen(preservedPath);
+    expectations.expect(waitUntilIdle(projectHost),
+                        "save a copy: the preserved-read-only open reaches a terminal state");
+    expectations.expect(projectHost.stateSnapshot().contentKind ==
+                            ProjectSessionContentKind::PreservedReadOnly,
+                        "save a copy: the installed content kind is PreservedReadOnly");
+    expectations.expect(saveCopyAction->isEnabled() && projectHost.canSaveCopy(),
+                        "save a copy: enabled once preserved-read-only content with retained "
+                        "bytes is installed");
+
+    const auto beforeSnapshot = projectHost.stateSnapshot();
+
+    bool copyDialogInvoked = false;
+    projectHost.setSaveAsPathProvider([&] {
+        copyDialogInvoked = true;
+        return std::optional(copyTargetPath);
+    });
+    int copyFinishedCount = 0;
+    bloom::ui::ProjectHostOperationOutcome copyOutcome =
+        bloom::ui::ProjectHostOperationOutcome::Failed;
+    QObject::connect(&projectHost, &ProjectHost::copyFinished,
+                     [&](const bloom::ui::ProjectHostOperationOutcome outcome, const QString&) {
+                         ++copyFinishedCount;
+                         copyOutcome = outcome;
+                     });
+
+    projectHost.requestSaveCopy();
+    expectations.expect(waitUntilIdle(projectHost),
+                        "save a copy: the async copy reaches a terminal state");
+    expectations.expect(copyDialogInvoked,
+                        "save a copy: requestSaveCopy() drove the SAME Save As dialog seam");
+    expectations.expect(copyFinishedCount == 1 &&
+                            copyOutcome == bloom::ui::ProjectHostOperationOutcome::Published,
+                        "save a copy: the copy publishes");
+    expectations.expect(std::filesystem::exists(copyTargetPath),
+                        "save a copy: the target file was written");
+
+    // Byte-exact copy: the published file equals the ORIGINAL source archive bytes read from disk.
+    std::ifstream publishedStream(copyTargetPath, std::ios::binary);
+    const std::string publishedText((std::istreambuf_iterator<char>(publishedStream)),
+                                    std::istreambuf_iterator<char>());
+    const std::string sourceText(reinterpret_cast<const char*>(preservedBytes.data()),
+                                 preservedBytes.size());
+    expectations.expect(publishedText == sourceText,
+                        "save a copy: the published file byte-equals the retained original");
+
+    // Session stateSnapshot is identical before/after (kind, generations, path): Save Copy never
+    // proposes ProjectSession changes.
+    const auto afterSnapshot = projectHost.stateSnapshot();
+    expectations.expect(
+        afterSnapshot.contentKind == beforeSnapshot.contentKind &&
+            afterSnapshot.resultAcceptanceGeneration == beforeSnapshot.resultAcceptanceGeneration &&
+            afterSnapshot.openIntentGeneration == beforeSnapshot.openIntentGeneration &&
+            afterSnapshot.pathIntentGeneration == beforeSnapshot.pathIntentGeneration &&
+            afterSnapshot.pathIntentKind == beforeSnapshot.pathIntentKind &&
+            afterSnapshot.displayPath == beforeSnapshot.displayPath,
+        "save a copy: session stateSnapshot (kind, generations, path) is identical before and "
+        "after");
+
+    // Retention is cleared once an editable open replaces the preserved-read-only content; the
+    // action disables again.
+    projectHost.beginOpen(editablePath);
+    expectations.expect(waitUntilIdle(projectHost),
+                        "save a copy: the editable reopen reaches a terminal state");
+    expectations.expect(projectHost.stateSnapshot().contentKind ==
+                            ProjectSessionContentKind::DecodedDocument,
+                        "save a copy: the reopened content kind is DecodedDocument");
+    expectations.expect(!saveCopyAction->isEnabled() && !projectHost.canSaveCopy(),
+                        "save a copy: disabled again once the preserved-read-only content is "
+                        "replaced (retention cleared)");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -517,5 +637,6 @@ int main(int argc, char** argv) {
     QApplication application(argc, argv);
     Expectations expectations;
     testPlaceholderSwitchesOnPreservedReadOnlyOpenAndBack(expectations);
+    testSaveCopyFromReadOnlyPlaceholder(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/tests/project_host_tests.cpp
+++ b/src/ui/tests/project_host_tests.cpp
@@ -146,6 +146,15 @@ void connectOpenCapture(ProjectHost& host, OutcomeCapture& capture) {
                      });
 }
 
+void connectCopyCapture(ProjectHost& host, OutcomeCapture& capture) {
+    QObject::connect(&host, &ProjectHost::copyFinished,
+                     [&capture](const ProjectHostOperationOutcome outcome, const QString& message) {
+                         ++capture.count;
+                         capture.outcome = outcome;
+                         capture.message = message;
+                     });
+}
+
 // ---------------------------------------------------------------------------------------------
 // New-project construction: valid session, clean, not dirty.
 // ---------------------------------------------------------------------------------------------
@@ -453,6 +462,41 @@ void testPathlessSaveRoutesToSaveAsDecision(Expectations& expectations) {
                         "pathless save: the display path is now the chosen Save As target");
 }
 
+// ---------------------------------------------------------------------------------------------
+// Save a Copy is unavailable on ordinary editable content (task SC1, issue #77): canSaveCopy() is
+// false for a fresh new project, and requestSaveCopy() refuses without ever invoking the (shared)
+// Save As dialog seam or touching session state.
+// ---------------------------------------------------------------------------------------------
+
+void testSaveCopyUnavailableOnEditableContent(Expectations& expectations) {
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost host(scheduler);
+    OutcomeCapture copyCapture;
+    connectCopyCapture(host, copyCapture);
+
+    expectations.expect(!host.canSaveCopy(),
+                        "Save Copy unavailable: a fresh editable project cannot Save a Copy");
+
+    bool dialogInvoked = false;
+    host.setSaveAsPathProvider([&] {
+        dialogInvoked = true;
+        return std::optional<std::filesystem::path>(std::filesystem::path("/tmp/unused.bloom"));
+    });
+
+    const auto before = host.stateSnapshot();
+    host.requestSaveCopy();
+    expectations.expect(copyCapture.count == 1 &&
+                            copyCapture.outcome == ProjectHostOperationOutcome::Refused,
+                        "Save Copy unavailable: requestSaveCopy() reports a typed Refused outcome");
+    expectations.expect(!dialogInvoked,
+                        "Save Copy unavailable: the dialog seam is never invoked for content that "
+                        "cannot Save a Copy");
+    const auto after = host.stateSnapshot();
+    expectations.expect(after.contentKind == before.contentKind && after.dirty == before.dirty,
+                        "Save Copy unavailable: session state is completely untouched by the "
+                        "refusal");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -467,5 +511,6 @@ int main(int argc, char** argv) {
     testUnsavedChangeDecisionSeamForNew(expectations);
     testUnsavedChangeDecisionSeamForOpen(expectations);
     testPathlessSaveRoutesToSaveAsDecision(expectations);
+    testSaveCopyUnavailableOnEditableContent(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Closes #77.

**Save Copy is real.** A preserved-read-only project can now publish an asynchronous, byte-for-byte copy of its original archive through the same intent-ordered staging machinery as saves — never claiming to rewrite or migrate the document, never touching the session's clean, path, or dirty state, exactly as the session contract specifies.

**Three thin layers, deliberate parallel construction with the save lanes**: a byte-copy stage (write verbatim, read back, verify byte equality plus the constrained-container preflight as a disk-corruption sanity check), a copy publication executor with the full admission-to-publish sequence including the owned-at-begin admission pattern, and a sessionless async wrapper with its own task-owner placeholder so future owner-scoped cancellation cannot cross lanes. Sharing the save pipeline was considered and declined: the failure payload types differ, and the codebase prefers direct typed dependencies over speculative shared templates.

**The missing contract piece**: the application now *retains* the original archive bytes when a preserved-read-only open installs — previously dropped — cleared whenever content is replaced. "Save a Copy…" appears in the File menu, and the read-only placeholder's "future update" promise becomes a live pointer.

Testing across all three layers plus the offscreen UI flow: byte-exact publishes, fault injection, supersession and conflict refusals, leak-free snapshots, cancellation/abandonment, and the placeholder-to-published-file drive with the session snapshot identical before and after. Desktop suite 82/82, native suite 72/72, format green.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).