### PR TITLE
feat: add timeline scrubbing and keyframes

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(
         project_host.cpp
         task_monitor_model.cpp
         task_ui_bridge.cpp
+        timeline_frame_math.cpp
+        timeline_ruler.cpp
         viewer_editor.cpp
         workspace_host.cpp
     PUBLIC
@@ -35,6 +37,8 @@ target_sources(
             include/bloom/ui/project_host.hpp
             include/bloom/ui/task_monitor_model.hpp
             include/bloom/ui/task_ui_bridge.hpp
+            include/bloom/ui/timeline_frame_math.hpp
+            include/bloom/ui/timeline_ruler.hpp
             include/bloom/ui/viewer_editor.hpp
             include/bloom/ui/workspace_host.hpp
 )

--- a/src/ui/composition_editors.cpp
+++ b/src/ui/composition_editors.cpp
@@ -1,6 +1,7 @@
 #include <bloom/ui/composition_editors.hpp>
 
 #include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/timeline_ruler.hpp>
 
 #include <bloom/core/color.hpp>
 #include <bloom/document/graph.hpp>
@@ -183,7 +184,8 @@ QToolButton* makeToolButton(const QString& text, const QString& accessibleName, 
 
 } // namespace
 
-TimelineEditor::TimelineEditor(CompositionSession& session, QWidget* parent)
+TimelineEditor::TimelineEditor(CompositionSession& session,
+                               CompositionPreviewController& previewController, QWidget* parent)
     : QWidget(parent), session_(session) {
     setObjectName("timelineEditor");
     setAccessibleName(tr("Layers timeline"));
@@ -223,6 +225,9 @@ TimelineEditor::TimelineEditor(CompositionSession& session, QWidget* parent)
     controlsLayout->addWidget(undoButton_);
     controlsLayout->addWidget(redoButton_);
 
+    ruler_ = new TimelineRuler(session_, previewController, this);
+    keyframes_ = new TimelineKeyframePanel(session_, this);
+
     layers_ = new QTreeWidget(this);
     layers_->setObjectName("layerStackView");
     layers_->setAccessibleName(tr("Composition layers"));
@@ -237,6 +242,8 @@ TimelineEditor::TimelineEditor(CompositionSession& session, QWidget* parent)
     layers_->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
 
     layout->addWidget(controls);
+    layout->addWidget(ruler_);
+    layout->addWidget(keyframes_);
     layout->addWidget(layers_, 1);
 
     connect(addSolidAction, &QAction::triggered, this, [this] {

--- a/src/ui/composition_preview_controller.cpp
+++ b/src/ui/composition_preview_controller.cpp
@@ -71,7 +71,11 @@ CompositionPreviewController::CompositionPreviewController(
             &CompositionPreviewController::handleCurrentTimeChanged);
     connect(&taskUiBridge_, &TaskUiBridge::snapshotsPolled, this,
             &CompositionPreviewController::consumeReadyResult);
-    requestPreview(true);
+    interactiveCadenceTimer_.setSingleShot(true);
+    interactiveCadenceTimer_.setTimerType(Qt::PreciseTimer);
+    connect(&interactiveCadenceTimer_, &QTimer::timeout, this,
+            &CompositionPreviewController::flushCadence);
+    requestPreview(true, PreviewRequestKind::Visible);
 }
 
 CompositionPreviewController::~CompositionPreviewController() { cancelAndDetachActive(); }
@@ -85,14 +89,14 @@ bool CompositionPreviewController::isShuttingDown() const noexcept { return shut
 void CompositionPreviewController::requestRefresh() {
     Q_ASSERT(QThread::currentThread() == thread());
     if (!shuttingDown_) {
-        requestPreview(false);
+        requestPreview(false, PreviewRequestKind::Visible);
     }
 }
 
 void CompositionPreviewController::handleCompositionChanged() {
     Q_ASSERT(QThread::currentThread() == thread());
     if (!shuttingDown_) {
-        requestPreview(true);
+        requestPreview(true, PreviewRequestKind::Visible);
     }
 }
 
@@ -106,7 +110,40 @@ void CompositionPreviewController::handleCurrentTimeChanged() {
         state_.desiredIdentity->time == session_.currentTime()) {
         return;
     }
-    requestPreview(false);
+    // Every current-time change advances the desired request generation (docs/architecture/
+    // animation-and-time.md, "Session Time And Scrubbing"); which priority it advances at depends
+    // on whether the change came from an armed Interactive gesture (see beginInteractiveScrub()) or
+    // a discrete change such as typed time entry, key selection, or document refresh.
+    requestPreview(false, interactiveTimeChangeArmed_ ? PreviewRequestKind::Interactive
+                                                      : PreviewRequestKind::Visible);
+}
+
+void CompositionPreviewController::beginInteractiveScrub() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    interactiveTimeChangeArmed_ = true;
+}
+
+void CompositionPreviewController::notifyScrubEnded() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    interactiveTimeChangeArmed_ = false;
+    if (!interactiveCadenceTimer_.isActive()) {
+        // Either nothing is pending, or the active-request gate is already holding the newest
+        // pending request (it will submit once the active task reaches terminal) -- the gate is
+        // untouched either way.
+        return;
+    }
+    interactiveCadenceTimer_.stop();
+    flushCadence();
+}
+
+void CompositionPreviewController::flushCadence() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (!pending_.has_value() || active_.has_value()) {
+        return;
+    }
+    PendingRequest request = std::move(*pending_);
+    pending_.reset();
+    submitPreview(std::move(request), state_.frame);
 }
 
 void CompositionPreviewController::beginShutdown() {
@@ -117,6 +154,8 @@ void CompositionPreviewController::beginShutdown() {
 
     shuttingDown_ = true;
     disconnect(&session_, nullptr, this, nullptr);
+    interactiveCadenceTimer_.stop();
+    interactiveTimeChangeArmed_ = false;
     pending_.reset();
     cancelAndDetachActive();
 
@@ -129,7 +168,8 @@ void CompositionPreviewController::beginShutdown() {
     publish(std::move(cancelled));
 }
 
-void CompositionPreviewController::requestPreview(const bool clearLastGoodFrame) {
+void CompositionPreviewController::requestPreview(const bool clearLastGoodFrame,
+                                                  const PreviewRequestKind kind) {
     Q_ASSERT(QThread::currentThread() == thread());
 
     const document::Snapshot snapshot = session_.snapshot();
@@ -142,6 +182,7 @@ void CompositionPreviewController::requestPreview(const bool clearLastGoodFrame)
     }
 
     if (generation_ == std::numeric_limits<std::uint64_t>::max()) {
+        interactiveCadenceTimer_.stop();
         pending_.reset();
         if (active_.has_value()) {
             active_->handle.cancel();
@@ -174,6 +215,7 @@ void CompositionPreviewController::requestPreview(const bool clearLastGoodFrame)
 
     const auto publishTerminal = [this, &desiredIdentity,
                                   &retainedFrame](const PreviewActivity activity, QString message) {
+        interactiveCadenceTimer_.stop();
         pending_.reset();
         if (active_.has_value()) {
             active_->handle.cancel();
@@ -209,18 +251,37 @@ void CompositionPreviewController::requestPreview(const bool clearLastGoodFrame)
 
     PendingRequest pendingRequest{.snapshot = snapshot,
                                   .desiredIdentity = desiredIdentity,
-                                  .pixelStorageByteLimit = settings_.pixelStorageByteLimit};
+                                  .pixelStorageByteLimit = settings_.pixelStorageByteLimit,
+                                  .kind = kind};
 
     if (active_.has_value()) {
         active_->handle.cancel();
         // The cancelled handle remains the admission gate until its terminal result is observed.
+        // Cadence is irrelevant beneath this gate: it delays SUBMISSION, and this request cannot
+        // submit before the active task reaches terminal regardless of kind or timer state.
         pending_.emplace(std::move(pendingRequest));
         publishRendering(desiredIdentity, std::nullopt, std::move(retainedFrame));
         taskUiBridge_.wake();
         return;
     }
 
-    Q_ASSERT(!pending_.has_value());
+    if (kind == PreviewRequestKind::Interactive) {
+        // No active task is gating submission, but the trailing cadence still is: hold this as the
+        // newest pending request (superseding any earlier one still waiting out the same window)
+        // and let the cadence timer -- or notifyScrubEnded()'s bypass -- perform the submission.
+        pending_.emplace(std::move(pendingRequest));
+        publishRendering(desiredIdentity, std::nullopt, std::move(retainedFrame));
+        if (!interactiveCadenceTimer_.isActive()) {
+            interactiveCadenceTimer_.start(
+                static_cast<int>(settings_.interactiveTrailingCadence.count()));
+        }
+        return;
+    }
+
+    // Visible bypasses the cadence entirely: any Interactive request still waiting out its window
+    // is superseded immediately.
+    interactiveCadenceTimer_.stop();
+    pending_.reset();
     submitPreview(std::move(pendingRequest), std::move(retainedFrame));
 }
 
@@ -230,12 +291,15 @@ void CompositionPreviewController::submitPreview(PendingRequest pendingRequest,
     Q_ASSERT(!active_.has_value());
 
     const auto desiredIdentity = pendingRequest.desiredIdentity;
+    const auto priority = pendingRequest.kind == PreviewRequestKind::Interactive
+                              ? runtime::TaskPriority::Interactive
+                              : runtime::TaskPriority::Visible;
 
     runtime::TaskRequest request(
         "Render composition preview",
         {.kind = runtime::TaskOwnerKind::Composition,
          .id = runtime::TaskOwnerId::fromRaw(desiredIdentity.compositionId.value())},
-        runtime::TaskPriority::Visible);
+        priority);
     request.coalescingKey = "bloom.preview.render";
     request.sourceVersion = {
         .documentRevision = desiredIdentity.sourceRevision.value(),
@@ -326,7 +390,8 @@ void CompositionPreviewController::consumeReadyResult() {
         return;
     }
     if (!liveSessionMatches(completed.desiredIdentity)) {
-        requestPreview(session_.compositionId() != completed.desiredIdentity.compositionId);
+        requestPreview(session_.compositionId() != completed.desiredIdentity.compositionId,
+                       PreviewRequestKind::Visible);
         return;
     }
 

--- a/src/ui/editor_registry.cpp
+++ b/src/ui/editor_registry.cpp
@@ -41,7 +41,9 @@ bool registerFoundationEditors(EditorRegistry& registry, CompositionSession& ses
                "bloom.nodes", "Nodes",
                [&session](QWidget* parent) { return new NodeGraphEditor(session, parent); }) &&
            addEditor("bloom.timeline", "Timeline",
-                     [&session](QWidget* parent) { return new TimelineEditor(session, parent); }) &&
+                     [&session, &previewController](QWidget* parent) {
+                         return new TimelineEditor(session, previewController, parent);
+                     }) &&
            addEditor("bloom.media", "Media",
                      [&session](QWidget* parent) { return new MediaEditor(session, parent); }) &&
            addEditor("bloom.properties", "Properties",

--- a/src/ui/include/bloom/ui/composition_editors.hpp
+++ b/src/ui/include/bloom/ui/composition_editors.hpp
@@ -10,13 +10,17 @@ class QTreeWidget;
 
 namespace bloom::ui {
 
+class CompositionPreviewController;
 class CompositionSession;
+class TimelineKeyframePanel;
+class TimelineRuler;
 
 class TimelineEditor final : public QWidget {
     Q_OBJECT
 
   public:
-    explicit TimelineEditor(CompositionSession& session, QWidget* parent = nullptr);
+    TimelineEditor(CompositionSession& session, CompositionPreviewController& previewController,
+                   QWidget* parent = nullptr);
 
   private:
     void rebuild();
@@ -24,6 +28,8 @@ class TimelineEditor final : public QWidget {
     void updateHistoryActions();
 
     CompositionSession& session_;
+    TimelineRuler* ruler_ = nullptr;
+    TimelineKeyframePanel* keyframes_ = nullptr;
     QTreeWidget* layers_ = nullptr;
     QToolButton* addButton_ = nullptr;
     QToolButton* undoButton_ = nullptr;

--- a/src/ui/include/bloom/ui/composition_preview_controller.hpp
+++ b/src/ui/include/bloom/ui/composition_preview_controller.hpp
@@ -6,7 +6,9 @@
 
 #include <QObject>
 #include <QString>
+#include <QTimer>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -22,11 +24,23 @@ class TaskUiBridge;
 inline constexpr std::size_t kDefaultPreviewPixelStorageByteLimit =
     std::size_t{512} * 1024U * 1024U;
 
+// docs/architecture/animation-and-time.md, "Session Time And Scrubbing": scrub, playback, and
+// direct manipulation submit at Interactive priority; discrete typed time entry, key selection,
+// and document refresh submit at Visible priority (today's only submission priority).
+enum class PreviewRequestKind : std::uint8_t {
+    Interactive,
+    Visible,
+};
+
 struct CompositionPreviewSettings final {
     runtime::EvaluationResolution resolution = runtime::CompositionFormatResolution{};
     runtime::EvaluationQuality quality = runtime::EvaluationQuality::Reference;
     runtime::EvaluationColorIntent colorIntent = runtime::EvaluationColorIntent::LinearRec709Scene;
     std::size_t pixelStorageByteLimit = kDefaultPreviewPixelStorageByteLimit;
+    // The injectable 16 ms trailing cadence for Interactive requests (pointer storms): a burst of
+    // Interactive requests inside this window coalesces to only the newest, submitted once the
+    // window elapses. Tests inject a tiny interval; production keeps the default.
+    std::chrono::milliseconds interactiveTrailingCadence = std::chrono::milliseconds{16};
 
     friend bool operator==(const CompositionPreviewSettings&,
                            const CompositionPreviewSettings&) = default;
@@ -80,6 +94,15 @@ class CompositionPreviewController final : public QObject {
     void requestRefresh();
     void beginShutdown();
 
+    // Wired from the timeline's mouse-press (or any other Interactive-time-change gesture, e.g. a
+    // future playback transport): while armed, the currentTimeChanged-triggered request below
+    // submits at Interactive priority through the trailing cadence instead of Visible.
+    void beginInteractiveScrub();
+    // Wired from the timeline's mouse-release: disarms beginInteractiveScrub() and bypasses any
+    // remaining trailing-cadence delay, submitting the newest pending Interactive request
+    // immediately -- while still honoring the one-active/one-newest gate below.
+    void notifyScrubEnded();
+
   signals:
     void stateChanged();
 
@@ -93,9 +116,10 @@ class CompositionPreviewController final : public QObject {
         document::Snapshot snapshot;
         runtime::PreviewRequestIdentity desiredIdentity;
         std::size_t pixelStorageByteLimit;
+        PreviewRequestKind kind = PreviewRequestKind::Visible;
     };
 
-    void requestPreview(bool clearLastGoodFrame);
+    void requestPreview(bool clearLastGoodFrame, PreviewRequestKind kind);
     void submitPreview(PendingRequest request, PreparedPreviewFrameHandle retainedFrame);
     void publishRendering(runtime::PreviewRequestIdentity desiredIdentity,
                           std::optional<runtime::TaskId> taskId,
@@ -105,6 +129,7 @@ class CompositionPreviewController final : public QObject {
     void consumeReadyResult();
     void cancelAndDetachActive() noexcept;
     void publish(CompositionPreviewState state);
+    void flushCadence();
     [[nodiscard]] bool isCurrent(const ActiveRequest& request) const;
     [[nodiscard]] bool
     liveSessionMatches(const runtime::PreviewRequestIdentity& desiredIdentity) const noexcept;
@@ -117,6 +142,8 @@ class CompositionPreviewController final : public QObject {
     CompositionPreviewState state_;
     std::optional<ActiveRequest> active_;
     std::optional<PendingRequest> pending_;
+    QTimer interactiveCadenceTimer_;
+    bool interactiveTimeChangeArmed_ = false;
     std::uint64_t generation_ = 0;
     bool shuttingDown_ = false;
 };

--- a/src/ui/include/bloom/ui/timeline_frame_math.hpp
+++ b/src/ui/include/bloom/ui/timeline_frame_math.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace bloom::ui {
+
+// Thin, widget-free adapters over bloom::core::FrameTimeMapping (src/core/include/bloom/core/
+// frame_time_mapping.hpp) implementing docs/architecture/animation-and-time.md, "Session Time And
+// Scrubbing," verbatim:
+//
+//   Frame index i maps to exact time i * frameRate.denominator / frameRate.numerator; the maximum
+//   is the greatest non-negative i whose mapped time is strictly less than duration. Products and
+//   comparisons use checked multiword arithmetic. A UI scrub gesture clamps to frame indices whose
+//   exact time is in [0, duration), then selects the nearest index with an exact halfway tie going
+//   to the greater index.
+//
+// FrameTimeMapping already implements this contract exactly (timeForFrame, maximumFrameIndex,
+// nearestFrameIndex use the same private fixed-width UInt128 checked arithmetic as the sampling
+// interval factor, and are pinned by src/core/tests/frame_time_mapping_tests.cpp). Per AGENTS.md
+// and this task's instruction to reuse the core rational surfaces rather than hand-roll arithmetic
+// where it exists, these three functions do not reimplement any of that math -- each one only
+// constructs a bloom::core::FrameTimeMapping from the composition's document::FrameRate/duration
+// and delegates. A refused mapping (invalid rate, non-positive duration, or an unrepresentable
+// frame range/time) surfaces as std::nullopt rather than UB, matching FrameTimeMapping's own
+// structured-failure contract.
+//
+// Unlike the doc's standalone per-index formula, frameTimeForIndex here also takes the composition
+// duration: FrameTimeMapping::create requires it to build the checked mapping it delegates to, and
+// every real call site (the timeline ruler, keyframe rows) already has a concrete duration in hand.
+// The extra bound is strictly safer, not a behavior change for any in-range index.
+
+// Exact frame index -> exact time, refused (std::nullopt) for an invalid rate/duration, an index
+// beyond the composition's valid range, or an index whose exact time cannot be represented.
+[[nodiscard]] std::optional<core::RationalTime> frameTimeForIndex(document::FrameRate frameRate,
+                                                                  core::RationalTime duration,
+                                                                  std::uint64_t index) noexcept;
+
+// The greatest non-negative frame index whose mapped time is strictly less than duration, refused
+// for an invalid rate/duration or an unrepresentable complete frame range.
+[[nodiscard]] std::optional<std::uint64_t> maxFrameIndex(document::FrameRate frameRate,
+                                                         core::RationalTime duration) noexcept;
+
+// Clamps time into [0, duration) and selects the nearest frame index, with an exact halfway tie
+// going to the greater index; exact rational comparison only, refused for an invalid rate/duration.
+[[nodiscard]] std::optional<std::uint64_t>
+nearestFrameIndexForTime(document::FrameRate frameRate, core::RationalTime duration,
+                         core::RationalTime time) noexcept;
+
+} // namespace bloom::ui

--- a/src/ui/include/bloom/ui/timeline_ruler.hpp
+++ b/src/ui/include/bloom/ui/timeline_ruler.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <bloom/document/ids.hpp>
+
+#include <QWidget>
+
+#include <optional>
+#include <vector>
+
+class QVBoxLayout;
+
+namespace bloom::ui {
+
+class CompositionPreviewController;
+class CompositionSession;
+
+// The scrub ruler above TimelineEditor's layer tree (docs/architecture/animation-and-time.md,
+// "Session Time And Scrubbing"): paints frame ticks and the session's exact-time playhead, and
+// turns click/drag into session.setCurrentTime() calls that request the preview at Interactive
+// priority through the controller's trailing cadence (CompositionPreviewController::
+// beginInteractiveScrub()/notifyScrubEnded()). Projection and scrub only: no direct Viewer
+// manipulation, no playback transport, no key-editing gestures.
+class TimelineRuler final : public QWidget {
+    Q_OBJECT
+
+  public:
+    TimelineRuler(CompositionSession& session, CompositionPreviewController& previewController,
+                  QWidget* parent = nullptr);
+
+  protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+
+  private:
+    void scrubToPixel(int pixelX);
+
+    CompositionSession& session_;
+    CompositionPreviewController& previewController_;
+    bool scrubbing_ = false;
+};
+
+// One row per animated parameter of the current selection's layer (position/opacity only in
+// version 1 -- docs/architecture/animation-and-time.md, "Durable Type Model"): a name label plus a
+// key lane painting each key at its exact time. Clicking a key selects it.
+//
+// Selection-model finding: bloom::ui::CompositionSelection (composition_session.hpp) has no
+// keyframe concept -- its SelectionTarget variant covers only LayerId/NodeId/ParameterId. Per this
+// task's decision 3, key selection is therefore kept as TimelineEditor-local state here, keyed by
+// the durable KeyframeId, and survives a rebuild (curve edit, undo/redo) when the key still exists.
+// Unifying it into one primary/contextual selection truth across editors is left to the
+// direct-manipulation slice that consumes it.
+class TimelineKeyframePanel final : public QWidget {
+    Q_OBJECT
+
+  public:
+    explicit TimelineKeyframePanel(CompositionSession& session, QWidget* parent = nullptr);
+
+    [[nodiscard]] std::optional<document::KeyframeId> selectedKeyframe() const noexcept {
+        return selectedKeyframe_;
+    }
+
+  private:
+    void rebuild();
+    void handleKeySelected(document::KeyframeId id);
+    void pruneSelectionIfMissing();
+
+    CompositionSession& session_;
+    QVBoxLayout* rowsLayout_ = nullptr;
+    std::vector<class TimelineKeyframeRow*> rows_;
+    std::optional<document::KeyframeId> selectedKeyframe_;
+};
+
+} // namespace bloom::ui

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -22,6 +22,12 @@ add_executable(bloom_task_monitor_test
 add_executable(bloom_viewer_editor_test
     viewer_editor_tests.cpp
 )
+add_executable(bloom_timeline_frame_math_test
+    timeline_frame_math_tests.cpp
+)
+add_executable(bloom_timeline_ruler_test
+    timeline_ruler_tests.cpp
+)
 
 # Links ZLIB::ZLIB directly for its own trimmed hand-rolled ZIP-writer fixture (a preserved-
 # read-only archive builder) -- mirroring src/host/CMakeLists.txt's bloom_host_session_open_test,
@@ -41,6 +47,8 @@ target_link_libraries(bloom_application_shutdown_test PRIVATE bloom_ui)
 target_link_libraries(bloom_project_host_test PRIVATE bloom_ui)
 target_link_libraries(bloom_task_monitor_test PRIVATE bloom_ui)
 target_link_libraries(bloom_viewer_editor_test PRIVATE bloom_ui)
+target_link_libraries(bloom_timeline_frame_math_test PRIVATE bloom_ui)
+target_link_libraries(bloom_timeline_ruler_test PRIVATE bloom_ui)
 target_link_libraries(bloom_main_window_readonly_placeholder_test PRIVATE bloom_ui ZLIB::ZLIB)
 bloom_enable_warnings(bloom_composition_projection_test)
 bloom_enable_warnings(bloom_composition_preview_controller_test)
@@ -50,6 +58,8 @@ bloom_enable_warnings(bloom_application_shutdown_test)
 bloom_enable_warnings(bloom_project_host_test)
 bloom_enable_warnings(bloom_task_monitor_test)
 bloom_enable_warnings(bloom_viewer_editor_test)
+bloom_enable_warnings(bloom_timeline_frame_math_test)
+bloom_enable_warnings(bloom_timeline_ruler_test)
 bloom_enable_warnings(bloom_main_window_readonly_placeholder_test)
 
 include(BloomTesting)
@@ -114,6 +124,22 @@ bloom_add_test(
     NAME bloom.ui.viewer_editor
     COMMAND bloom_viewer_editor_test
     LABELS ui unit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.timeline_frame_math
+    COMMAND bloom_timeline_frame_math_test
+    LABELS ui unit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.timeline_ruler
+    COMMAND bloom_timeline_ruler_test
+    LABELS ui integration animation
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )

--- a/src/ui/tests/composition_preview_controller_tests.cpp
+++ b/src/ui/tests/composition_preview_controller_tests.cpp
@@ -338,6 +338,177 @@ void testNewestPendingRequestGate(Expectations& expectations) {
     reachQuiescence(controller, bridge, scheduler, expectations);
 }
 
+std::optional<bloom::runtime::TaskSnapshot>
+snapshotForGeneration(const bloom::runtime::TaskScheduler& scheduler,
+                      const std::uint64_t generation) {
+    for (const auto& snapshot : scheduler.snapshots()) {
+        if (snapshot.sourceVersion.requestGeneration == generation) {
+            return snapshot;
+        }
+    }
+    return std::nullopt;
+}
+
+// docs/architecture/animation-and-time.md, "Session Time And Scrubbing": a burst of Interactive
+// requests inside the injectable trailing cadence window coalesces to only the newest, submitted
+// once the window elapses; Visible requests bypass the cadence entirely.
+void testInteractiveCadenceCoalescesBurstAndVisibleBypasses(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Interactive Cadence Test");
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, compositionId);
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+    PipelineFixture fixture;
+    std::atomic<int> invocationCount = 0;
+    ui::CompositionPreviewSettings settings;
+    settings.interactiveTrailingCadence = 40ms;
+    ui::CompositionPreviewController controller(
+        session, scheduler, bridge,
+        [&invocationCount, pipeline = fixture.pipeline](
+            const document::Snapshot& snapshot,
+            const runtime::PreviewRequestIdentity& desiredIdentity,
+            const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) mutable {
+            ++invocationCount;
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+        },
+        settings);
+
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "initial frame becomes ready before the cadence burst");
+    const auto callsBeforeBurst = invocationCount.load();
+
+    controller.beginInteractiveScrub();
+    std::vector<core::RationalTime> times;
+    for (std::int64_t numerator = 1; numerator <= 6; ++numerator) {
+        const auto time = core::RationalTime::create(numerator, 100);
+        expectations.expect(time.has_value(), "burst time fixture is valid");
+        times.push_back(time.value_or(core::RationalTime{}));
+    }
+    for (const auto& time : times) {
+        expectations.expect(session.setCurrentTime(time),
+                            "each distinct burst time is accepted by the session");
+    }
+    const auto newestGeneration = generation(controller.state());
+    expectations.expect(controller.state().desiredIdentity.has_value() &&
+                            controller.state().desiredIdentity->time == times.back(),
+                        "the desired identity advances immediately to the newest scrub time");
+    expectations.expect(invocationCount.load() == callsBeforeBurst,
+                        "no preparation call fires before the trailing cadence window elapses");
+
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "the coalesced newest Interactive request completes");
+    expectations.expect(invocationCount.load() == callsBeforeBurst + 1,
+                        "the entire burst submits only once, for the newest request");
+    const auto interactiveSnapshot = snapshotForGeneration(scheduler, newestGeneration);
+    expectations.expect(interactiveSnapshot.has_value() &&
+                            interactiveSnapshot->priority == runtime::TaskPriority::Interactive,
+                        "the coalesced burst submits at Interactive priority");
+
+    // A Visible request (discrete typed time entry, key selection, or document refresh) bypasses
+    // the cadence entirely, even while a scrub gesture is still armed.
+    const auto callsBeforeVisible = invocationCount.load();
+    controller.requestRefresh();
+    const auto visibleGeneration = generation(controller.state());
+    expectations.expect(waitUntil([&] { return invocationCount.load() > callsBeforeVisible; }),
+                        "a Visible request submits without waiting for any cadence window");
+    const auto visibleSnapshot = snapshotForGeneration(scheduler, visibleGeneration);
+    expectations.expect(visibleSnapshot.has_value() &&
+                            visibleSnapshot->priority == runtime::TaskPriority::Visible,
+                        "the Visible request submits at Visible priority");
+
+    controller.notifyScrubEnded();
+    reachQuiescence(controller, bridge, scheduler, expectations);
+}
+
+// The one-active/one-newest gate is untouched beneath the cadence: while a task is active, an
+// Interactive burst never invokes preparation again; the superseded active request still runs to
+// terminal before the newest pending request submits, and notifyScrubEnded() bypasses the
+// remaining trailing delay once the gate opens (docs/architecture/animation-and-time.md).
+void testActiveGateHoldsAndScrubEndBypassesRemainingCadence(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Interactive Gate Test");
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, compositionId);
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+    PipelineFixture fixture;
+    WorkerGate firstRequest;
+    std::atomic<int> invocationCount = 0;
+    ui::CompositionPreviewSettings settings;
+    // A long cadence window proves notifyScrubEnded() bypasses it rather than merely outlasting it.
+    settings.interactiveTrailingCadence = 2000ms;
+    ui::CompositionPreviewController controller(
+        session, scheduler, bridge,
+        [&firstRequest, &invocationCount, pipeline = fixture.pipeline](
+            const document::Snapshot& snapshot,
+            const runtime::PreviewRequestIdentity& desiredIdentity,
+            const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) mutable {
+            if (invocationCount.fetch_add(1) == 0) {
+                firstRequest.enterAndWait();
+            }
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+        },
+        settings);
+
+    expectations.expect(waitUntil([&] { return firstRequest.entered(); }),
+                        "the initial Visible request occupies the active-request gate");
+
+    controller.beginInteractiveScrub();
+    std::vector<core::RationalTime> times;
+    for (std::int64_t numerator = 1; numerator <= 4; ++numerator) {
+        const auto time = core::RationalTime::create(numerator, 100);
+        expectations.expect(time.has_value(), "gate burst time fixture is valid");
+        times.push_back(time.value_or(core::RationalTime{}));
+    }
+    for (const auto& time : times) {
+        expectations.expect(session.setCurrentTime(time), "each gated burst time is accepted");
+    }
+    const auto newestGeneration = generation(controller.state());
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    expectations.expect(invocationCount.load() == 1,
+                        "an Interactive burst behind the active gate never invokes preparation");
+    expectations.expect(controller.state().activity == ui::PreviewActivity::Rendering &&
+                            !controller.state().taskId.has_value(),
+                        "the newest pending Interactive request is not yet submitted");
+
+    firstRequest.release();
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "the pending Interactive request submits once the active task terminates");
+    expectations.expect(invocationCount.load() == 2,
+                        "the superseded active request ran to terminal before the pending request "
+                        "submitted, and only the newest pending request was ever prepared");
+    const auto interactiveSnapshot = snapshotForGeneration(scheduler, newestGeneration);
+    expectations.expect(interactiveSnapshot.has_value() &&
+                            interactiveSnapshot->priority == runtime::TaskPriority::Interactive,
+                        "the gate-held request still submits at Interactive priority");
+
+    // Now that nothing is active, a fresh Interactive request genuinely starts the (long) trailing
+    // cadence timer; notifyScrubEnded() must bypass it rather than merely outlast it.
+    const auto callsBeforeSecondScrub = invocationCount.load();
+    const auto secondTime = core::RationalTime::create(37, 100);
+    expectations.expect(secondTime.has_value() && session.setCurrentTime(*secondTime),
+                        "a fresh post-gate scrub time is accepted");
+    expectations.expect(invocationCount.load() == callsBeforeSecondScrub,
+                        "the fresh Interactive request is held by the 2 second cadence, not yet "
+                        "submitted");
+    QElapsedTimer bypassTimer;
+    bypassTimer.start();
+    controller.notifyScrubEnded();
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "notifyScrubEnded() flushes the pending Interactive request");
+    expectations.expect(bypassTimer.elapsed() < 1000,
+                        "the flush happens immediately, far under the 2 second cadence window");
+    expectations.expect(invocationCount.load() == callsBeforeSecondScrub + 1,
+                        "exactly one additional preparation call services the bypassed request");
+
+    reachQuiescence(controller, bridge, scheduler, expectations);
+}
+
 void testSameRevisionGenerationAndSelection(Expectations& expectations) {
     using namespace bloom;
     auto newProject = makeTestProject("Generation Test");
@@ -604,6 +775,8 @@ int main(int argc, char** argv) {
     Expectations expectations;
     testRevisionAndPanelSuppression(expectations);
     testNewestPendingRequestGate(expectations);
+    testInteractiveCadenceCoalescesBurstAndVisibleBypasses(expectations);
+    testActiveGateHoldsAndScrubEndBypassesRemainingCadence(expectations);
     testSameRevisionGenerationAndSelection(expectations);
     testLastGoodAndOutcomeMapping(expectations);
     testCompositionSwitchClearsPixels(expectations);

--- a/src/ui/tests/composition_projection_test.cpp
+++ b/src/ui/tests/composition_projection_test.cpp
@@ -83,7 +83,15 @@ parameterForRole(const bloom::document::Composition& composition,
     document::Document document(std::move(newProject.project));
     commands::CommandStack commands(document);
     ui::CompositionSession session(document, commands, compositionId);
-    ui::TimelineEditor timeline(session);
+    runtime::TaskScheduler scheduler;
+    ui::TaskUiBridge taskUiBridge(scheduler, nullptr, std::chrono::milliseconds{1});
+    ui::CompositionPreviewController previewController(
+        session, scheduler, taskUiBridge,
+        [](const document::Snapshot&, const runtime::PreviewRequestIdentity&, std::size_t,
+           runtime::TaskContext&) {
+            return runtime::TaskResult<ui::PreviewPreparationResultHandle>::cancelled();
+        });
+    ui::TimelineEditor timeline(session, previewController);
     auto* addSolidAction = timeline.findChild<QAction*>("addSolidLayerAction");
     if (!require(addSolidAction != nullptr &&
                      addSolidAction->toolTip().contains(QStringLiteral("reference-linear-sRGB")),
@@ -113,12 +121,18 @@ parameterForRole(const bloom::document::Composition& composition,
     const auto secondColor =
         secondParameter == nullptr ? std::nullopt : session.constantColorValue(secondParameter->id);
 
-    return require(firstColor == core::Color4d{0.62, 0.08, 0.04, 1.0},
-                   "first built-in solid uses the warm proof color") &&
-           require(secondColor == core::Color4d{0.04, 0.20, 0.72, 1.0},
-                   "second built-in solid uses a clearly distinct cool proof color") &&
-           require(firstColor != secondColor,
-                   "consecutive built-in solids make layer ordering visually distinguishable");
+    const bool paletteOk =
+        require(firstColor == core::Color4d{0.62, 0.08, 0.04, 1.0},
+                "first built-in solid uses the warm proof color") &&
+        require(secondColor == core::Color4d{0.04, 0.20, 0.72, 1.0},
+                "second built-in solid uses a clearly distinct cool proof color") &&
+        require(firstColor != secondColor,
+                "consecutive built-in solids make layer ordering visually distinguishable");
+
+    previewController.beginShutdown();
+    taskUiBridge.beginShutdown();
+    return paletteOk && require(waitUntil([&scheduler] { return scheduler.isQuiescent(); }),
+                                "solid palette fixture reaches scheduler quiescence");
 }
 
 [[nodiscard]] bool runProjectionTest() {
@@ -156,7 +170,7 @@ parameterForRole(const bloom::document::Composition& composition,
                  "foundation registration exposes five replaceable editor types")) {
         return false;
     }
-    ui::TimelineEditor timeline(session);
+    ui::TimelineEditor timeline(session, previewController);
     ui::NodeGraphEditor nodes(session);
     ui::PropertiesEditor properties(session);
     [[maybe_unused]] ui::MediaEditor media(session);

--- a/src/ui/tests/timeline_frame_math_tests.cpp
+++ b/src/ui/tests/timeline_frame_math_tests.cpp
@@ -1,0 +1,127 @@
+#include <bloom/ui/timeline_frame_math.hpp>
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string_view>
+
+namespace {
+
+using namespace bloom;
+
+[[noreturn]] void fail(const std::string_view message) {
+    std::cerr << "timeline frame math test failed: " << message << '\n';
+    std::exit(1);
+}
+
+void require(const bool condition, const std::string_view message) {
+    if (!condition) {
+        fail(message);
+    }
+}
+
+[[nodiscard]] core::RationalTime time(const std::int64_t numerator,
+                                      const std::int64_t denominator = 1) {
+    const auto value = core::RationalTime::create(numerator, denominator);
+    require(value.has_value(), "test rational must be valid");
+    return value.value_or(core::RationalTime{});
+}
+
+[[nodiscard]] document::FrameRate rate(const std::uint32_t numerator,
+                                       const std::uint32_t denominator = 1) {
+    const auto value = document::FrameRate::create(numerator, denominator);
+    require(value.has_value(), "test frame rate must be valid");
+    return value.value_or(document::FrameRate::framesPerSecond24());
+}
+
+void testRoundTripAndBoundary() {
+    const auto fps24 = rate(24, 1);
+    const auto oneSecond = time(1);
+
+    const auto max = ui::maxFrameIndex(fps24, oneSecond);
+    require(max.has_value() && *max == 23, "one second at 24 fps ends at frame 23");
+
+    const auto last = ui::frameTimeForIndex(fps24, oneSecond, 23);
+    require(last.has_value() && *last == time(23, 24),
+            "the maximum index maps to its exact rational time");
+
+    const auto pastEnd = ui::frameTimeForIndex(fps24, oneSecond, 24);
+    require(!pastEnd.has_value(),
+            "the duration endpoint is excluded, matching the strictly-less rule");
+
+    for (std::uint64_t index = 0; index <= 23; ++index) {
+        const auto mapped = ui::frameTimeForIndex(fps24, oneSecond, index);
+        if (!mapped.has_value()) {
+            require(false, "every in-range index maps to an exact time");
+            continue;
+        }
+        const auto nearest = ui::nearestFrameIndexForTime(fps24, oneSecond, *mapped);
+        require(nearest.has_value() && *nearest == index,
+                "an exact frame time round-trips to the same index");
+    }
+}
+
+void testTieToGreaterAtExactHalfway() {
+    // 1 second at 24 fps: frame 0 is at 0/24, frame 1 is at 1/24. The exact halfway point between
+    // them is 1/48, chosen so it is exactly representable as a RationalTime (matching the contract
+    // doc's own worked example in "Session Time And Scrubbing").
+    const auto fps24 = rate(24, 1);
+    const auto oneSecond = time(1);
+
+    require(ui::nearestFrameIndexForTime(fps24, oneSecond, time(1, 49)) ==
+                std::optional<std::uint64_t>(0),
+            "a time just below halfway selects the lower frame");
+    require(ui::nearestFrameIndexForTime(fps24, oneSecond, time(1, 48)) ==
+                std::optional<std::uint64_t>(1),
+            "an exact halfway time selects the greater frame");
+    require(ui::nearestFrameIndexForTime(fps24, oneSecond, time(1, 47)) ==
+                std::optional<std::uint64_t>(1),
+            "a time just above halfway selects the greater frame");
+}
+
+void testClampBelowZeroAndAboveRange() {
+    const auto fps24 = rate(24, 1);
+    const auto oneSecond = time(1);
+
+    require(ui::nearestFrameIndexForTime(fps24, oneSecond, time(-5)) ==
+                std::optional<std::uint64_t>(0),
+            "a negative time clamps to the first frame");
+    require(ui::nearestFrameIndexForTime(fps24, oneSecond, time(0)) ==
+                std::optional<std::uint64_t>(0),
+            "zero clamps to the first frame");
+    require(ui::nearestFrameIndexForTime(fps24, oneSecond, time(1000)) ==
+                std::optional<std::uint64_t>(23),
+            "a time at or beyond duration clamps to the final valid frame");
+}
+
+void testCheckedOverflowRefusal() {
+    constexpr auto maximumInt = std::numeric_limits<std::int64_t>::max();
+    constexpr auto maximumRate = std::numeric_limits<std::uint32_t>::max();
+    const auto absurdRate = rate(maximumRate, 1);
+
+    require(!ui::maxFrameIndex(absurdRate, time(maximumInt)).has_value(),
+            "a complete frame range that cannot be represented in 64 bits is refused");
+    require(ui::frameTimeForIndex(absurdRate, time(1), 0).has_value(),
+            "a representable in-range index still succeeds (sanity check for the refusal test)");
+
+    require(!ui::maxFrameIndex(rate(1, 1), time(0)).has_value(),
+            "a non-positive duration is refused, never UB");
+    require(!ui::maxFrameIndex(rate(1, 1), time(-1)).has_value(),
+            "a negative duration is refused, never UB");
+    require(!ui::nearestFrameIndexForTime(rate(1, 1), time(0), time(0)).has_value(),
+            "an invalid mapping refuses the nearest-index query too");
+}
+
+} // namespace
+
+int main() {
+    testRoundTripAndBoundary();
+    testTieToGreaterAtExactHalfway();
+    testClampBelowZeroAndAboveRange();
+    testCheckedOverflowRefusal();
+    return 0;
+}

--- a/src/ui/tests/timeline_ruler_tests.cpp
+++ b/src/ui/tests/timeline_ruler_tests.cpp
@@ -1,0 +1,384 @@
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/animation.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/reference_display_preparation.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_preview_pipeline.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+#include <bloom/ui/timeline_ruler.hpp>
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QMouseEvent>
+#include <QPointF>
+#include <QString>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <thread>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+template <typename Predicate> bool waitUntil(Predicate predicate) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 4'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (std::invoke(predicate)) {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return std::invoke(predicate);
+}
+
+bloom::runtime::TaskSchedulerConfig testSchedulerConfig() {
+    return {.cpuWorkerCount = 1,
+            .blockingIoWorkerCount = 1,
+            .cpuQueueCapacity = 16,
+            .blockingIoQueueCapacity = 4,
+            .terminalHistoryCapacity = 32,
+            .diagnosticsPerTask = 8,
+            .groupRegistryCapacity = 8};
+}
+
+bloom::document::CompositionFormat smallFormat() {
+    const auto format = bloom::document::CompositionFormat::create(4, 3);
+    if (!format.has_value()) {
+        std::abort();
+    }
+    return *format;
+}
+
+[[nodiscard]] bloom::core::RationalTime time(const std::int64_t numerator,
+                                             const std::int64_t denominator = 1) {
+    const auto value = bloom::core::RationalTime::create(numerator, denominator);
+    if (!value.has_value()) {
+        std::abort();
+    }
+    return *value;
+}
+
+bloom::document::NewProject makeTestProject(std::string projectName,
+                                            const bloom::core::RationalTime duration) {
+    return bloom::document::makeNewProject(std::move(projectName), "Main", duration, smallFormat());
+}
+
+struct PipelineFixture final {
+    bloom::runtime::NodeDefinitionRegistry definitions;
+    bloom::runtime::SnapshotCompiler compiler;
+    bloom::runtime::CpuCompositionEvaluator evaluator;
+    bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    bloom::ui::PreviewPreparationFunction pipeline;
+
+    PipelineFixture() : compiler(definitions) {
+        if (!bloom::runtime::registerBuiltInNodeDefinitions(definitions)) {
+            std::abort();
+        }
+        definitions.freeze();
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer);
+    }
+};
+
+// A fixture bundling everything a TimelineRuler/TimelineKeyframePanel test needs: a real document,
+// command stack, session, scheduler, bridge, and preview controller (offscreen, matching the
+// idiom in composition_preview_controller_tests.cpp and viewer_editor's own construction pattern).
+struct SessionFixture final {
+    bloom::document::Document document;
+    bloom::commands::CommandStack commands;
+    bloom::ui::CompositionSession session;
+    bloom::runtime::TaskScheduler scheduler;
+    bloom::ui::TaskUiBridge bridge;
+    PipelineFixture pipeline;
+    bloom::ui::CompositionPreviewController controller;
+
+    explicit SessionFixture(bloom::document::NewProject newProject)
+        : document(std::move(newProject.project)), commands(document),
+          session(document, commands, newProject.initialCompositionId),
+          scheduler(testSchedulerConfig()), bridge(scheduler, nullptr, 1ms),
+          controller(session, scheduler, bridge, pipeline.pipeline) {}
+};
+
+struct LayerIds final {
+    bloom::document::LayerId layer;
+    bloom::document::ParameterId position;
+    bloom::document::ParameterId opacity;
+};
+
+[[nodiscard]] LayerIds addSolidLayer(bloom::document::Document& document,
+                                     bloom::commands::CommandStack& stack,
+                                     const bloom::document::CompositionId compositionId) {
+    using namespace bloom;
+    commands::Transaction transaction("Add test layer", document.snapshot().revision());
+    transaction.emplace<commands::AddSolidLayer>(
+        compositionId, "Solid", core::Color4d{0.2, 0.3, 0.4, 1.0}, document::Vec2d{2.0, 1.5});
+    const auto result = stack.execute(std::move(transaction));
+    const auto layer = result.outputId<document::LayerId>(commands::kAddSolidLayerLayerOutput);
+    const auto position =
+        result.outputId<document::ParameterId>(commands::kAddSolidLayerPositionParameterOutput);
+    const auto opacity =
+        result.outputId<document::ParameterId>(commands::kAddSolidLayerOpacityParameterOutput);
+    if (!(result.changed() && layer.has_value() && position.has_value() && opacity.has_value())) {
+        std::abort();
+    }
+    return {*layer, *position, *opacity};
+}
+
+[[nodiscard]] bloom::document::AnimationCurveId
+animateParameter(bloom::document::Document& document, bloom::commands::CommandStack& stack,
+                 const bloom::document::CompositionId compositionId,
+                 const bloom::document::ParameterId parameterId,
+                 const bloom::core::RationalTime seedTime) {
+    using namespace bloom;
+    commands::Transaction transaction("Animate test parameter", document.snapshot().revision());
+    transaction.emplace<commands::CreateAnimationForParameter>(compositionId, parameterId,
+                                                               seedTime);
+    const auto result = stack.execute(std::move(transaction));
+    const auto curve = result.outputId<document::AnimationCurveId>(commands::kAnimationCurveOutput);
+    if (!(result.changed() && curve.has_value())) {
+        std::abort();
+    }
+    return *curve;
+}
+
+void sendClick(QWidget& widget, const qreal pixelX, const qreal pixelY = -1.0) {
+    const qreal y = pixelY >= 0.0 ? pixelY : widget.height() / 2.0;
+    const QPointF local(pixelX, y);
+    QMouseEvent press(QEvent::MouseButtonPress, local, local, Qt::LeftButton, Qt::LeftButton,
+                      Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &press);
+    QMouseEvent release(QEvent::MouseButtonRelease, local, local, Qt::LeftButton, Qt::NoButton,
+                        Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &release);
+}
+
+void sendPress(QWidget& widget, const qreal pixelX) {
+    const QPointF local(pixelX, widget.height() / 2.0);
+    QMouseEvent press(QEvent::MouseButtonPress, local, local, Qt::LeftButton, Qt::LeftButton,
+                      Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &press);
+}
+
+void sendRelease(QWidget& widget, const qreal pixelX) {
+    const QPointF local(pixelX, widget.height() / 2.0);
+    QMouseEvent release(QEvent::MouseButtonRelease, local, local, Qt::LeftButton, Qt::NoButton,
+                        Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &release);
+}
+
+// 1 second at 24 fps has frame indices 0..23. A ruler resized to 47 logical pixels (width - 1 = 46
+// = 2 * 23) makes every EVEN pixel land exactly on a frame and every ODD pixel land exactly at the
+// halfway point between two frames -- a deterministic, exactly-representable tie case pinned by
+// docs/architecture/animation-and-time.md's tie-to-greater rule.
+void testRulerScrubLandsOnExactFrameTimesIncludingATie(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Ruler Scrub Test", time(1)));
+    expectations.expect(waitUntil([&] {
+                            return fixture.controller.state().activity !=
+                                   ui::PreviewActivity::Rendering;
+                        }),
+                        "the initial preview leaves the Rendering activity before scrubbing");
+
+    ui::TimelineRuler ruler(fixture.session, fixture.controller);
+    ruler.resize(47, 26);
+
+    sendClick(ruler, 0.0);
+    expectations.expect(fixture.session.currentTime() == time(0, 24),
+                        "the leftmost pixel scrubs to frame 0");
+
+    sendClick(ruler, 2.0);
+    expectations.expect(fixture.session.currentTime() == time(1, 24),
+                        "an even pixel scrubs to its exact frame time");
+
+    sendClick(ruler, 1.0);
+    expectations.expect(fixture.session.currentTime() == time(1, 24),
+                        "an exact pixel-space halfway tie scrubs to the GREATER frame index");
+
+    sendClick(ruler, 45.0);
+    expectations.expect(fixture.session.currentTime() == time(23, 24),
+                        "the tie immediately below the final frame also resolves to the greater "
+                        "index");
+
+    sendClick(ruler, 46.0);
+    expectations.expect(fixture.session.currentTime() == time(23, 24),
+                        "the rightmost pixel scrubs to the final valid frame, never the excluded "
+                        "duration endpoint");
+
+    // A press/move/release drag lands on the final move's exact frame time, and release calls
+    // scrub-end (verified indirectly: the request still reaches Ready without ever hanging).
+    sendPress(ruler, 0.0);
+    QMouseEvent move(QEvent::MouseMove, QPointF(20.0, ruler.height() / 2.0),
+                     QPointF(20.0, ruler.height() / 2.0), Qt::NoButton, Qt::LeftButton,
+                     Qt::NoModifier);
+    QCoreApplication::sendEvent(&ruler, &move);
+    expectations.expect(fixture.session.currentTime() == time(10, 24),
+                        "a pointer move during a drag scrubs to its own exact frame time");
+    sendRelease(ruler, 20.0);
+    expectations.expect(
+        waitUntil(
+            [&] { return fixture.controller.state().activity == ui::PreviewActivity::Ready; }),
+        "scrub-end still reaches a ready preview frame for the final scrubbed time");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the ruler fixture reaches asynchronous scheduler quiescence");
+}
+
+void testKeyframeRowsAppearOnePerAnimatedParameter(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Keyframe Rows Test", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId);
+    (void)animateParameter(document, commands, compositionId, ids.position, time(0));
+    (void)animateParameter(document, commands, compositionId, ids.opacity, time(0));
+
+    ui::CompositionSession session(document, commands, compositionId);
+    ui::TimelineKeyframePanel panel(session);
+    expectations.expect(panel.findChildren<QWidget*>().empty() && !panel.isVisible(),
+                        "no rows appear before any layer is selected");
+
+    session.selectLayer(ids.layer);
+    const auto rows = panel.findChildren<QWidget*>();
+    expectations.expect(rows.size() == 2 && panel.isVisible(),
+                        "one row per animated parameter (position, opacity) appears for the "
+                        "selected layer");
+
+    session.clearSelection();
+    expectations.expect(panel.findChildren<QWidget*>().empty() && !panel.isVisible(),
+                        "rows are removed and the panel hides once nothing is selected");
+}
+
+void testKeyframeClickSelectsExpectedPixelAndSurvivesRebuild(Expectations& expectations) {
+    using namespace bloom;
+    const auto duration = time(10);
+    auto newProject = makeTestProject("Keyframe Click Test", duration);
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId);
+    (void)animateParameter(document, commands, compositionId, ids.opacity, time(0));
+
+    ui::CompositionSession session(document, commands, compositionId);
+    session.selectLayer(ids.layer);
+
+    // A second exact-time key, five seconds into a ten second composition -- its pixel position
+    // (fraction 0.5 of the width) is easy to reason about independent of the row's own painting.
+    expectations.expect(session.setCurrentTime(time(5)), "session accepts the second key's time");
+    expectations.expect(session.setSelectedOpacity(0.4), "the second opacity key is inserted");
+    const auto* opacityParameter = session.composition()->parameters().find(ids.opacity);
+    const auto* animationSource =
+        opacityParameter == nullptr
+            ? nullptr
+            : std::get_if<document::AnimationCurveSource>(&opacityParameter->source);
+    const auto* opacityCurve =
+        animationSource == nullptr
+            ? nullptr
+            : session.composition()->animationCurves().findScalar(animationSource->curveId);
+    expectations.expect(opacityCurve != nullptr && opacityCurve->keyframes.size() == 2,
+                        "the opacity curve now holds exactly two keys");
+    if (opacityCurve == nullptr || opacityCurve->keyframes.size() != 2) {
+        return;
+    }
+    const auto secondKeyId = opacityCurve->keyframes.back().id;
+
+    ui::TimelineKeyframePanel panel(session);
+    panel.resize(200, panel.sizeHint().height() > 0 ? panel.sizeHint().height() : 24);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    const auto rows = panel.findChildren<QWidget*>();
+    expectations.expect(rows.size() == 1, "exactly one row exists for the single animated opacity");
+    if (rows.size() != 1) {
+        return;
+    }
+    auto* row = rows.front();
+
+    // fraction = 5s / 10s = 0.5; pixel = 0.5 * (width - 1), matching TimelineAxis::pixelForTime.
+    const qreal expectedPixel = 0.5 * static_cast<qreal>(row->width() - 1);
+    sendClick(*row, expectedPixel);
+    expectations.expect(panel.selectedKeyframe().has_value() &&
+                            *panel.selectedKeyframe() == secondKeyId,
+                        "a click at the key's expected pixel position selects it by id");
+
+    // Rebuild the rows via an unrelated document edit + undo, which leaves the opacity curve
+    // untouched: the id-keyed selection must survive both rebuilds.
+    expectations.expect(
+        session.addTextLayer(QStringLiteral("Unrelated"), QStringLiteral("Unrelated")),
+        "an unrelated edit triggers a rebuild via snapshotChanged");
+    expectations.expect(panel.selectedKeyframe().has_value() &&
+                            *panel.selectedKeyframe() == secondKeyId,
+                        "the id-keyed selection survives a rebuild when the key still exists");
+    expectations.expect(session.undo(), "the unrelated edit undoes cleanly");
+    expectations.expect(panel.selectedKeyframe().has_value() &&
+                            *panel.selectedKeyframe() == secondKeyId,
+                        "the id-keyed selection also survives the undo's rebuild");
+
+    // Now undo the edit that created the selected key itself: the key no longer exists anywhere,
+    // and the panel must silently clear the selection rather than crash.
+    expectations.expect(session.undo(), "undoing the second opacity edit removes its key");
+    expectations.expect(!panel.selectedKeyframe().has_value(),
+                        "the selection is pruned once its key no longer exists, without crashing");
+
+    // AddTextLayer's own command (like AddSolidLayer) moves the primary selection to the layer it
+    // creates, and undoing it back out of existence leaves nothing selected (CompositionSession::
+    // normalizeSelection()) -- reselect the original layer to isolate this assertion to the row
+    // rebuild itself, not session selection semantics covered elsewhere.
+    session.selectLayer(ids.layer);
+    const auto rowsAfterPrune = panel.findChildren<QWidget*>();
+    expectations.expect(rowsAfterPrune.size() == 1,
+                        "the opacity row remains (the curve still holds its seeded first key)");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testRulerScrubLandsOnExactFrameTimesIncludingATie(expectations);
+    testKeyframeRowsAppearOnePerAnimatedParameter(expectations);
+    testKeyframeClickSelectsExpectedPixelAndSurvivesRebuild(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/timeline_frame_math.cpp
+++ b/src/ui/timeline_frame_math.cpp
@@ -1,0 +1,43 @@
+#include <bloom/ui/timeline_frame_math.hpp>
+
+#include <bloom/core/frame_time_mapping.hpp>
+
+namespace bloom::ui {
+
+std::optional<core::RationalTime> frameTimeForIndex(const document::FrameRate frameRate,
+                                                    const core::RationalTime duration,
+                                                    const std::uint64_t index) noexcept {
+    const auto created =
+        core::FrameTimeMapping::create(duration, frameRate.numerator(), frameRate.denominator());
+    if (!created.hasValue()) {
+        return std::nullopt;
+    }
+    const auto mapped = created.value()->timeForFrame(index);
+    if (!mapped.hasValue()) {
+        return std::nullopt;
+    }
+    return *mapped.value();
+}
+
+std::optional<std::uint64_t> maxFrameIndex(const document::FrameRate frameRate,
+                                           const core::RationalTime duration) noexcept {
+    const auto created =
+        core::FrameTimeMapping::create(duration, frameRate.numerator(), frameRate.denominator());
+    if (!created.hasValue()) {
+        return std::nullopt;
+    }
+    return created.value()->maximumFrameIndex();
+}
+
+std::optional<std::uint64_t> nearestFrameIndexForTime(const document::FrameRate frameRate,
+                                                      const core::RationalTime duration,
+                                                      const core::RationalTime time) noexcept {
+    const auto created =
+        core::FrameTimeMapping::create(duration, frameRate.numerator(), frameRate.denominator());
+    if (!created.hasValue()) {
+        return std::nullopt;
+    }
+    return created.value()->nearestFrameIndex(time);
+}
+
+} // namespace bloom::ui

--- a/src/ui/timeline_ruler.cpp
+++ b/src/ui/timeline_ruler.cpp
@@ -1,0 +1,496 @@
+#include <bloom/ui/timeline_ruler.hpp>
+
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/timeline_frame_math.hpp>
+
+#include <bloom/document/animation.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+
+#include <QFontMetrics>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace bloom::ui {
+namespace {
+
+constexpr int kRulerHeight = 26;
+constexpr int kKeyframeRowHeight = 24;
+constexpr qreal kKeyDiamondRadius = 4.5;
+constexpr qreal kKeyHitToleranceLogicalPixels = 6.0;
+constexpr qreal kMinimumPixelsPerTick = 28.0;
+
+// Maps this widget's pixel-space x axis onto composition frame indices/time using
+// bloom::ui::maxFrameIndex()/frameTimeForIndex() (src/ui/include/bloom/ui/timeline_frame_math.hpp),
+// which delegate to bloom::core::FrameTimeMapping's checked, exact-rational contract math. Pixel
+// coordinates are UI-space integers, not RationalTime values, so the reverse pixel -> frame-index
+// direction below (used only for scrubbing) is a separate, deliberately exact integer mapping using
+// the same tie-to-greater rule as the time-domain contract, kept local to this file since it is not
+// part of that contract. The forward frame/time -> pixel direction (used only for painting) is
+// ordinary presentational arithmetic, not a clamp/tie/mapping decision.
+struct TimelineAxis final {
+    document::FrameRate frameRate;
+    core::RationalTime duration;
+    int widthPixels = 0;
+    std::uint64_t maxIndex = 0;
+
+    [[nodiscard]] static std::optional<TimelineAxis>
+    create(const document::Composition& composition, const int widthPixels) {
+        const auto frameRate = composition.format().frameRate();
+        const auto duration = composition.duration();
+        const auto maxIndex = ui::maxFrameIndex(frameRate, duration);
+        if (!maxIndex.has_value()) {
+            return std::nullopt;
+        }
+        return TimelineAxis{frameRate, duration, widthPixels, *maxIndex};
+    }
+
+    // Exact pixel -> frame index, clamped into the widget bounds, with an exact halfway pixel tie
+    // going to the greater index (checked integer arithmetic). Falls back to a defensively clamped
+    // floating approximation only if the exact product would overflow std::uint64_t -- unreachable
+    // for any realistic composition duration/frame rate combined with a practical widget width, but
+    // kept safe rather than UB, matching FrameTimeMapping's own defensive-clamp precedent.
+    [[nodiscard]] std::uint64_t frameIndexForPixel(const int pixelX) const noexcept {
+        if (widthPixels <= 1 || maxIndex == 0) {
+            return 0;
+        }
+        const int clamped = std::clamp(pixelX, 0, widthPixels - 1);
+        const auto span = static_cast<std::uint64_t>(widthPixels - 1);
+        const auto position = static_cast<std::uint64_t>(clamped);
+        if (position != 0 && maxIndex > std::numeric_limits<std::uint64_t>::max() / position) {
+            const double fraction = static_cast<double>(clamped) / static_cast<double>(span);
+            const double approximate = std::clamp(fraction * static_cast<double>(maxIndex), 0.0,
+                                                  static_cast<double>(maxIndex));
+            return static_cast<std::uint64_t>(approximate);
+        }
+        const auto product = position * maxIndex;
+        const auto quotient = product / span;
+        const auto remainder = product % span;
+        const auto tiedUp = (remainder * 2 >= span) ? quotient + 1 : quotient;
+        return std::min(tiedUp, maxIndex);
+    }
+
+    // Presentational time -> pixel (not a contract decision): clamps into [0, duration] so a key or
+    // playhead fractionally outside the composition's range still paints at a visible edge.
+    [[nodiscard]] qreal pixelForTime(const core::RationalTime time) const noexcept {
+        if (widthPixels <= 1) {
+            return 0.0;
+        }
+        const double durationSeconds = duration.toSeconds();
+        if (!(durationSeconds > 0.0)) {
+            return 0.0;
+        }
+        const double fraction = std::clamp(time.toSeconds() / durationSeconds, 0.0, 1.0);
+        return static_cast<qreal>(fraction * static_cast<double>(widthPixels - 1));
+    }
+};
+
+[[nodiscard]] std::uint64_t tickStepFrames(const TimelineAxis& axis) {
+    if (axis.maxIndex == 0 || axis.widthPixels <= 1) {
+        return 1;
+    }
+    const double pixelsPerFrame =
+        static_cast<double>(axis.widthPixels - 1) / static_cast<double>(axis.maxIndex);
+    if (pixelsPerFrame >= kMinimumPixelsPerTick) {
+        return 1;
+    }
+    return static_cast<std::uint64_t>(std::ceil(kMinimumPixelsPerTick / pixelsPerFrame));
+}
+
+QString titleCase(const std::string_view role) {
+    if (role.empty()) {
+        return QStringLiteral("Parameter");
+    }
+    QString text = QString::fromUtf8(role.data(), static_cast<qsizetype>(role.size()));
+    text.replace(0, 1, text.left(1).toUpper());
+    return text;
+}
+
+struct KeyEntry final {
+    document::KeyframeId id;
+    core::RationalTime time;
+};
+
+} // namespace
+
+// A single animated-parameter row: name label plus key lane. Deliberately not exposed via the
+// header -- TimelineKeyframePanel owns it exclusively and forward-declares it (`class
+// TimelineKeyframeRow*` in the FILE_SET header) purely to type its row list, so this definition
+// must live directly in bloom::ui rather than in an anonymous namespace (which would make it a
+// distinct, unrelated type from the header's forward declaration). It does not declare Q_OBJECT (no
+// signals are needed; key selection is reported through a plain callback), keeping it free of moc.
+class TimelineKeyframeRow final : public QWidget {
+  public:
+    TimelineKeyframeRow(CompositionSession& session, QString label,
+                        const document::AnimationCurveId curveId, const bool isVec2,
+                        const std::optional<document::KeyframeId>* selectedKeyframe,
+                        std::function<void(document::KeyframeId)> onKeySelected, QWidget* parent)
+        : QWidget(parent), session_(session), label_(std::move(label)), curveId_(curveId),
+          isVec2_(isVec2), selectedKeyframe_(selectedKeyframe),
+          onKeySelected_(std::move(onKeySelected)) {
+        setFixedHeight(kKeyframeRowHeight);
+        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+        connect(&session_, &CompositionSession::currentTimeChanged, this, [this] { update(); });
+    }
+
+  protected:
+    void paintEvent(QPaintEvent* event) override {
+        Q_UNUSED(event)
+        QPainter painter(this);
+        painter.fillRect(rect(), palette().color(QPalette::AlternateBase));
+        painter.setPen(QPen(palette().color(QPalette::Mid), 1.0));
+        painter.drawLine(QPointF(0.0, height() - 0.5), QPointF(width(), height() - 0.5));
+
+        const auto* composition = session_.composition();
+        if (composition == nullptr) {
+            return;
+        }
+        const auto axis = TimelineAxis::create(*composition, width());
+        if (!axis.has_value()) {
+            return;
+        }
+
+        const qreal playheadX = axis->pixelForTime(session_.currentTime());
+        painter.setPen(QPen(palette().color(QPalette::Highlight).lighter(150), 1.0));
+        painter.drawLine(QPointF(playheadX, 0.0), QPointF(playheadX, height()));
+
+        const qreal centerY = height() / 2.0;
+        for (const auto& key : collectKeys()) {
+            const qreal x = axis->pixelForTime(key.time);
+            const bool selected = selectedKeyframe_ != nullptr && selectedKeyframe_->has_value() &&
+                                  **selectedKeyframe_ == key.id;
+            const QColor fill = selected ? palette().color(QPalette::Highlight)
+                                         : palette().color(QPalette::ButtonText);
+            painter.setPen(QPen(fill.darker(140), 1.0));
+            painter.setBrush(fill);
+            QPolygonF diamond;
+            diamond << QPointF(x, centerY - kKeyDiamondRadius)
+                    << QPointF(x + kKeyDiamondRadius, centerY)
+                    << QPointF(x, centerY + kKeyDiamondRadius)
+                    << QPointF(x - kKeyDiamondRadius, centerY);
+            painter.drawPolygon(diamond);
+        }
+
+        const QFontMetrics metrics = painter.fontMetrics();
+        const QRectF chip(2.0, 2.0, metrics.horizontalAdvance(label_) + 10.0, height() - 4.0);
+        QColor chipColor = palette().color(QPalette::Window);
+        chipColor.setAlpha(212);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(chipColor);
+        painter.drawRoundedRect(chip, 3.0, 3.0);
+        painter.setPen(palette().color(QPalette::WindowText));
+        painter.drawText(chip, Qt::AlignCenter, label_);
+    }
+
+    void mousePressEvent(QMouseEvent* event) override {
+        if (event->button() != Qt::LeftButton) {
+            QWidget::mousePressEvent(event);
+            return;
+        }
+        const auto* composition = session_.composition();
+        if (composition == nullptr) {
+            return;
+        }
+        const auto axis = TimelineAxis::create(*composition, width());
+        if (!axis.has_value()) {
+            return;
+        }
+
+        const qreal clickX = event->position().x();
+        std::optional<document::KeyframeId> closest;
+        qreal closestDistance = std::numeric_limits<qreal>::max();
+        for (const auto& key : collectKeys()) {
+            const qreal distance = std::abs(axis->pixelForTime(key.time) - clickX);
+            if (distance <= kKeyHitToleranceLogicalPixels && distance < closestDistance) {
+                closest = key.id;
+                closestDistance = distance;
+            }
+        }
+        if (closest.has_value() && onKeySelected_) {
+            onKeySelected_(*closest);
+        }
+    }
+
+  private:
+    [[nodiscard]] std::vector<KeyEntry> collectKeys() const {
+        std::vector<KeyEntry> entries;
+        const auto* composition = session_.composition();
+        if (composition == nullptr) {
+            return entries;
+        }
+        if (isVec2_) {
+            const auto* curve = composition->animationCurves().findVec2(curveId_);
+            if (curve == nullptr) {
+                return entries;
+            }
+            entries.reserve(curve->keyframes.size());
+            for (const auto& key : curve->keyframes) {
+                entries.push_back({key.id, key.time});
+            }
+        } else {
+            const auto* curve = composition->animationCurves().findScalar(curveId_);
+            if (curve == nullptr) {
+                return entries;
+            }
+            entries.reserve(curve->keyframes.size());
+            for (const auto& key : curve->keyframes) {
+                entries.push_back({key.id, key.time});
+            }
+        }
+        return entries;
+    }
+
+    CompositionSession& session_;
+    QString label_;
+    document::AnimationCurveId curveId_;
+    bool isVec2_;
+    const std::optional<document::KeyframeId>* selectedKeyframe_;
+    std::function<void(document::KeyframeId)> onKeySelected_;
+};
+
+namespace {
+
+struct AnimatedParameterRow final {
+    QString label;
+    document::AnimationCurveId curveId;
+    bool isVec2 = false;
+};
+
+[[nodiscard]] std::vector<AnimatedParameterRow>
+collectAnimatedParameters(const CompositionSession& session) {
+    std::vector<AnimatedParameterRow> rows;
+    const auto* composition = session.composition();
+    if (composition == nullptr) {
+        return rows;
+    }
+
+    std::optional<document::LayerId> layerId = session.selection().contextualLayer;
+    if (!layerId.has_value()) {
+        if (const auto* direct = std::get_if<document::LayerId>(&session.selection().primary)) {
+            layerId = *direct;
+        }
+    }
+    if (!layerId.has_value()) {
+        return rows;
+    }
+
+    const auto boundaryNodeId = session.boundaryNodeForLayer(*layerId);
+    if (!boundaryNodeId.has_value()) {
+        return rows;
+    }
+    const auto* node = composition->graph().findNode(*boundaryNodeId);
+    if (node == nullptr) {
+        return rows;
+    }
+
+    for (const auto& binding : node->parameters) {
+        const auto* parameter = composition->parameters().find(binding.parameterId);
+        if (parameter == nullptr) {
+            continue;
+        }
+        const auto* source = std::get_if<document::AnimationCurveSource>(&parameter->source);
+        if (source == nullptr) {
+            continue;
+        }
+        const bool isVec2 = composition->animationCurves().findVec2(source->curveId) != nullptr;
+        rows.push_back({titleCase(binding.role), source->curveId, isVec2});
+    }
+    return rows;
+}
+
+} // namespace
+
+TimelineRuler::TimelineRuler(CompositionSession& session,
+                             CompositionPreviewController& previewController, QWidget* parent)
+    : QWidget(parent), session_(session), previewController_(previewController) {
+    setObjectName("timelineRuler");
+    setAccessibleName(tr("Scrub ruler"));
+    setFixedHeight(kRulerHeight);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    connect(&session_, &CompositionSession::currentTimeChanged, this,
+            qOverload<>(&TimelineRuler::update));
+    connect(&session_, &CompositionSession::compositionChanged, this,
+            qOverload<>(&TimelineRuler::update));
+    connect(&session_, &CompositionSession::snapshotChanged, this,
+            qOverload<>(&TimelineRuler::update));
+}
+
+void TimelineRuler::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.fillRect(rect(), palette().color(QPalette::Base));
+    painter.setPen(QPen(palette().color(QPalette::Mid), 1.0));
+    painter.drawLine(QPointF(0.0, height() - 0.5), QPointF(width(), height() - 0.5));
+
+    const auto* composition = session_.composition();
+    if (composition == nullptr) {
+        return;
+    }
+    const auto axis = TimelineAxis::create(*composition, width());
+    if (!axis.has_value()) {
+        return;
+    }
+
+    painter.setPen(palette().color(QPalette::WindowText));
+    QFont tickFont = painter.font();
+    tickFont.setPointSizeF(tickFont.pointSizeF() * 0.85);
+    painter.setFont(tickFont);
+
+    const auto step = tickStepFrames(*axis);
+    for (std::uint64_t index = 0; index <= axis->maxIndex; index += step) {
+        const auto time = frameTimeForIndex(axis->frameRate, axis->duration, index);
+        if (!time.has_value()) {
+            continue;
+        }
+        const qreal x = axis->pixelForTime(*time);
+        painter.drawLine(QPointF(x, height() - 8.0), QPointF(x, height() - 1.0));
+        painter.drawText(QRectF(x + 2.0, 0.0, 60.0, height() - 9.0),
+                         Qt::AlignLeft | Qt::AlignVCenter, QString::number(index));
+    }
+
+    const qreal playheadX = axis->pixelForTime(session_.currentTime());
+    const QColor playheadColor = palette().color(QPalette::Highlight);
+    painter.setPen(QPen(playheadColor, 2.0));
+    painter.drawLine(QPointF(playheadX, 0.0), QPointF(playheadX, height()));
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(playheadColor);
+    QPolygonF marker;
+    marker << QPointF(playheadX - 5.0, 0.0) << QPointF(playheadX + 5.0, 0.0)
+           << QPointF(playheadX, 6.0);
+    painter.drawPolygon(marker);
+}
+
+void TimelineRuler::mousePressEvent(QMouseEvent* event) {
+    if (event->button() != Qt::LeftButton) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    scrubbing_ = true;
+    previewController_.beginInteractiveScrub();
+    scrubToPixel(static_cast<int>(event->position().x()));
+}
+
+void TimelineRuler::mouseMoveEvent(QMouseEvent* event) {
+    if (!scrubbing_) {
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+    scrubToPixel(static_cast<int>(event->position().x()));
+}
+
+void TimelineRuler::mouseReleaseEvent(QMouseEvent* event) {
+    if (event->button() != Qt::LeftButton || !scrubbing_) {
+        QWidget::mouseReleaseEvent(event);
+        return;
+    }
+    scrubbing_ = false;
+    scrubToPixel(static_cast<int>(event->position().x()));
+    previewController_.notifyScrubEnded();
+}
+
+void TimelineRuler::scrubToPixel(const int pixelX) {
+    const auto* composition = session_.composition();
+    if (composition == nullptr) {
+        return;
+    }
+    const auto axis = TimelineAxis::create(*composition, width());
+    if (!axis.has_value()) {
+        return;
+    }
+    const auto index = axis->frameIndexForPixel(pixelX);
+    const auto exactTime = frameTimeForIndex(axis->frameRate, axis->duration, index);
+    if (!exactTime.has_value()) {
+        return;
+    }
+    (void)session_.setCurrentTime(*exactTime);
+}
+
+TimelineKeyframePanel::TimelineKeyframePanel(CompositionSession& session, QWidget* parent)
+    : QWidget(parent), session_(session) {
+    setObjectName("timelineKeyframePanel");
+    setAccessibleName(tr("Animated parameter keys"));
+    rowsLayout_ = new QVBoxLayout(this);
+    rowsLayout_->setContentsMargins(0, 0, 0, 0);
+    rowsLayout_->setSpacing(0);
+    connect(&session_, &CompositionSession::snapshotChanged, this, &TimelineKeyframePanel::rebuild);
+    connect(&session_, &CompositionSession::compositionChanged, this,
+            &TimelineKeyframePanel::rebuild);
+    connect(&session_, &CompositionSession::selectionChanged, this,
+            &TimelineKeyframePanel::rebuild);
+    rebuild();
+}
+
+void TimelineKeyframePanel::rebuild() {
+    QLayoutItem* item = nullptr;
+    while ((item = rowsLayout_->takeAt(0)) != nullptr) {
+        delete item->widget();
+        delete item;
+    }
+    rows_.clear();
+
+    const auto specs = collectAnimatedParameters(session_);
+    rows_.reserve(specs.size());
+    for (const auto& spec : specs) {
+        auto* row = new TimelineKeyframeRow(
+            session_, spec.label, spec.curveId, spec.isVec2, &selectedKeyframe_,
+            [this](const document::KeyframeId id) { handleKeySelected(id); }, this);
+        rowsLayout_->addWidget(row);
+        rows_.push_back(row);
+    }
+
+    pruneSelectionIfMissing();
+    setVisible(!specs.empty());
+}
+
+void TimelineKeyframePanel::handleKeySelected(const document::KeyframeId id) {
+    if (selectedKeyframe_.has_value() && *selectedKeyframe_ == id) {
+        return;
+    }
+    selectedKeyframe_ = id;
+    for (auto* row : rows_) {
+        row->update();
+    }
+}
+
+void TimelineKeyframePanel::pruneSelectionIfMissing() {
+    if (!selectedKeyframe_.has_value()) {
+        return;
+    }
+    const auto* composition = session_.composition();
+    if (composition == nullptr) {
+        selectedKeyframe_.reset();
+        return;
+    }
+    for (const auto& record : composition->animationCurves().records()) {
+        if (const auto* scalar = std::get_if<document::ScalarAnimationCurve>(&record)) {
+            for (const auto& key : scalar->keyframes) {
+                if (key.id == *selectedKeyframe_) {
+                    return;
+                }
+            }
+        } else if (const auto* vec2 = std::get_if<document::Vec2AnimationCurve>(&record)) {
+            for (const auto& key : vec2->keyframes) {
+                if (key.id == *selectedKeyframe_) {
+                    return;
+                }
+            }
+        }
+    }
+    selectedKeyframe_.reset();
+}
+
+} // namespace bloom::ui


### PR DESCRIPTION
Closes #80.

Batch 4 slice 4: **the timeline scrubs and shows keyframes**, driving the animation engine at the contract's interactive cadence.

**Exact math, fully reused**: core's existing frame-time mapping already implemented the contract's formulas (checked multiword arithmetic, tie-to-greater); the UI adapter delegates completely with zero new arithmetic. Pixel-space frame picking mirrors the tie rule in integers — no floating point in any decision.

**Correct priority by construction**: an armed interactive gesture (scrub press → release) makes every time-change request Interactive through an injectable 16 ms trailing cadence coalescing pointer storms to the newest request; discrete entry and refresh stay Visible. The arming design closes a subtle hole where the first scrub frame could have submitted at the wrong priority. The one-active/one-newest gate is untouched beneath the cadence, and scrub end bypasses only the remaining delay — never the gate.

**Projection, id-stable**: a scrub ruler with an exact-time playhead, one keyframe row per animated parameter of the selected layer, keys at exact times, selection by stable `KeyframeId` (pruned, never crashed, when an edit removes the key; panel-local until the direct-manipulation slice unifies selection truth — the model has no keyframe concept yet, as the report documents).

Also documented for a future pass: layer-add commands unconditionally steal primary selection (pre-existing).

Testing: frame-math contract pins (boundary, exact halfway tie, clamps, overflow refusal), controller cadence/priority/gate proofs, and offscreen ruler tests including a constructed pixel-space tie and id-stable selection across undo/redo. Desktop 84/84, native 72/72, format green.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).