### PR TITLE
feat: add direct viewer manipulation of layers

### DIFF
--- a/src/ui/composition_preview_controller.cpp
+++ b/src/ui/composition_preview_controller.cpp
@@ -69,6 +69,8 @@ CompositionPreviewController::CompositionPreviewController(
             &CompositionPreviewController::handleCompositionChanged);
     connect(&session_, &CompositionSession::currentTimeChanged, this,
             &CompositionPreviewController::handleCurrentTimeChanged);
+    connect(&session_, &CompositionSession::positionInteractionChanged, this,
+            &CompositionPreviewController::handlePositionInteractionChanged);
     connect(&taskUiBridge_, &TaskUiBridge::snapshotsPolled, this,
             &CompositionPreviewController::consumeReadyResult);
     interactiveCadenceTimer_.setSingleShot(true);
@@ -114,6 +116,20 @@ void CompositionPreviewController::handleCurrentTimeChanged() {
     // animation-and-time.md, "Session Time And Scrubbing"); which priority it advances at depends
     // on whether the change came from an armed Interactive gesture (see beginInteractiveScrub()) or
     // a discrete change such as typed time entry, key selection, or document refresh.
+    requestPreview(false, interactiveTimeChangeArmed_ ? PreviewRequestKind::Interactive
+                                                      : PreviewRequestKind::Visible);
+}
+
+void CompositionPreviewController::handlePositionInteractionChanged() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (shuttingDown_) {
+        return;
+    }
+    // docs/architecture/animation-and-time.md: "Scrub, playback, and direct manipulation use
+    // Interactive priority". beginInteractiveScrub()'s arming flag already means exactly "an
+    // Interactive pointer gesture is driving preview-affecting signals right now" -- the Viewer
+    // arms it for a position-interaction gesture the same way TimelineRuler arms it for a scrub, so
+    // this reuses it rather than adding a duplicate boolean.
     requestPreview(false, interactiveTimeChangeArmed_ ? PreviewRequestKind::Interactive
                                                       : PreviewRequestKind::Visible);
 }
@@ -249,10 +265,18 @@ void CompositionPreviewController::requestPreview(const bool clearLastGoodFrame,
         return;
     }
 
+    // Overrides ride ONLY Interactive requests from an active gesture (docs/architecture/
+    // animation-and-time.md), and are read fresh here -- never cached across requests.
+    std::optional<runtime::SnapshotParameterOverride> interactionOverride;
+    if (kind == PreviewRequestKind::Interactive) {
+        interactionOverride = session_.positionInteractionOverride();
+    }
+
     PendingRequest pendingRequest{.snapshot = snapshot,
                                   .desiredIdentity = desiredIdentity,
                                   .pixelStorageByteLimit = settings_.pixelStorageByteLimit,
-                                  .kind = kind};
+                                  .kind = kind,
+                                  .interactionOverride = interactionOverride};
 
     if (active_.has_value()) {
         active_->handle.cancel();
@@ -308,14 +332,17 @@ void CompositionPreviewController::submitPreview(PendingRequest pendingRequest,
 
     auto preparation = preparation_;
     const std::size_t pixelStorageByteLimit = pendingRequest.pixelStorageByteLimit;
+    const auto interactionOverride = pendingRequest.interactionOverride;
     auto submission = scheduler_.submit<PreviewPreparationResultHandle>(
         std::move(request),
         [snapshot = std::move(pendingRequest.snapshot), desiredIdentity, pixelStorageByteLimit,
+         interactionOverride,
          preparation = std::move(preparation)](runtime::TaskContext& context) mutable {
             if (context.isCancellationRequested()) {
                 return runtime::TaskResult<PreviewPreparationResultHandle>::cancelled();
             }
-            return preparation(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+            return preparation(snapshot, desiredIdentity, pixelStorageByteLimit,
+                               interactionOverride, context);
         });
 
     if (!submission.accepted()) {

--- a/src/ui/composition_preview_pipeline.cpp
+++ b/src/ui/composition_preview_pipeline.cpp
@@ -154,7 +154,9 @@ makeCompositionPreviewPipeline(const runtime::SnapshotCompiler& compiler,
     return [&compiler, &evaluator, &displayPreparer](
                const document::Snapshot& snapshot,
                const runtime::PreviewRequestIdentity& desiredIdentity,
-               const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) {
+               const std::size_t pixelStorageByteLimit,
+               const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+               runtime::TaskContext& context) {
         using TaskResult = runtime::TaskResult<PreviewPreparationResultHandle>;
 
         if (context.isCancellationRequested()) {
@@ -172,9 +174,15 @@ makeCompositionPreviewPipeline(const runtime::SnapshotCompiler& compiler,
                                 .subphase = "Compiling the reachable composition graph",
                                 .completed = 0,
                                 .total = std::nullopt});
-        auto compileResult =
-            compiler.compile({.snapshot = snapshot, .compositionId = desiredIdentity.compositionId},
-                             context.cancellation());
+        // docs/architecture/animation-and-time.md, "Direct Manipulation And Preview Overrides":
+        // SnapshotCompileRequest carries zero or one typed parameter override; admission
+        // (revision/target/reachability/schema/kind/domain, then source kind) is entirely
+        // SnapshotCompiler's -- this only threads the override the controller already sourced from
+        // the session's active interaction.
+        auto compileResult = compiler.compile({.snapshot = snapshot,
+                                               .compositionId = desiredIdentity.compositionId,
+                                               .parameterOverride = interactionOverride},
+                                              context.cancellation());
         auto diagnostics = taskDiagnostics(compileResult);
 
         switch (compileResult.status) {

--- a/src/ui/composition_session.cpp
+++ b/src/ui/composition_session.cpp
@@ -93,6 +93,9 @@ void CompositionSession::rebind(document::Document& document, commands::CommandS
     compositionId_ = compositionId;
     currentTime_ = core::RationalTime::fromInteger(0);
     selection_ = {};
+    // The OLD document/command-stack are left untouched, but this session's own interaction state
+    // targets them and must not survive the swap.
+    positionInteraction_.reset();
 
     // One coherent transition (docs/architecture/project-session.md, "Session Publication"):
     // observers must never see a new document paired with stale selection/time/history, so every
@@ -128,6 +131,10 @@ bool CompositionSession::setComposition(const document::CompositionId compositio
         return false;
     }
 
+    // A composition switch cancels any active interaction (docs/architecture/animation-and-time.md,
+    // "Direct Manipulation And Preview Overrides"): its frozen target/mapping belong to the OLD
+    // composition.
+    cancelPositionInteraction();
     compositionId_ = compositionId;
     const bool timeChanged = currentTime_ != core::RationalTime::fromInteger(0);
     currentTime_ = core::RationalTime::fromInteger(0);
@@ -482,8 +489,23 @@ bool CompositionSession::setSelectedPosition(const double x, const double y) {
         reportUnavailable(QStringLiteral("Position values must be finite"));
         return false;
     }
-    const document::Vec2d value{x, y};
-    commands::Transaction transaction("Set Position", snapshot_.revision());
+    return executePositionCommand(position->id, currentTime_, document::Vec2d{x, y},
+                                  QStringLiteral("Set Position"));
+}
+
+bool CompositionSession::executePositionCommand(const document::ParameterId parameterId,
+                                                const core::RationalTime time,
+                                                const document::Vec2d value,
+                                                const QString& commandLabel) {
+    Q_ASSERT(QThread::currentThread() == thread());
+    const auto* current = composition();
+    const auto* position = current == nullptr ? nullptr : current->parameters().find(parameterId);
+    if (position == nullptr) {
+        reportUnavailable(QStringLiteral("The selected object does not expose a position"));
+        return false;
+    }
+
+    commands::Transaction transaction(commandLabel.toStdString(), snapshot_.revision());
     if (const auto* constantSource =
             std::get_if<document::ConstantValueSource>(&position->source)) {
         if (std::get_if<document::Vec2d>(&constantSource->value) == nullptr) {
@@ -495,7 +517,7 @@ bool CompositionSession::setSelectedPosition(const double x, const double y) {
     } else if (const auto* animationSource =
                    std::get_if<document::AnimationCurveSource>(&position->source)) {
         transaction.emplace<commands::SetKeyframeAtTime>(compositionId_, animationSource->curveId,
-                                                         currentTime_, value);
+                                                         time, value);
     } else {
         reportUnavailable(
             QStringLiteral("Disconnect the driven position before editing its value"));
@@ -519,6 +541,149 @@ bool CompositionSession::moveLayerBefore(const document::LayerSlotId slotId,
     commands::Transaction transaction("Reorder Layer", snapshot_.revision());
     transaction.emplace<commands::MoveLayerBefore>(compositionId_, slotId, beforeSlotId);
     return execute(std::move(transaction));
+}
+
+bool CompositionSession::positionInteractionActive() const noexcept {
+    return positionInteraction_.has_value();
+}
+
+std::optional<runtime::SnapshotParameterOverride>
+CompositionSession::positionInteractionOverride() const {
+    if (!positionInteraction_.has_value()) {
+        return std::nullopt;
+    }
+    return runtime::SnapshotParameterOverride{
+        .sourceRevision = positionInteraction_->baseRevision,
+        .parameterId = positionInteraction_->parameterId,
+        .value = positionInteraction_->currentOverride,
+    };
+}
+
+std::optional<PositionInteractionRejection>
+CompositionSession::beginPositionInteraction(PositionInteractionMapping mapping) {
+    Q_ASSERT(QThread::currentThread() == thread());
+    // A stray second begin (should not happen given the Viewer is the sole caller) restarts state
+    // cleanly rather than layering interactions.
+    cancelPositionInteraction();
+
+    const auto* layerId = std::get_if<document::LayerId>(&selection_.primary);
+    if (layerId == nullptr) {
+        return PositionInteractionRejection::NoLayerSelected;
+    }
+    const auto* position = parameterForSelection(document::kPositionParameterRole);
+    if (position == nullptr) {
+        return PositionInteractionRejection::NoResolvablePosition;
+    }
+
+    document::Vec2d baseValue{};
+    if (const auto* constantSource =
+            std::get_if<document::ConstantValueSource>(&position->source)) {
+        const auto* value = std::get_if<document::Vec2d>(&constantSource->value);
+        if (value == nullptr) {
+            return PositionInteractionRejection::NoResolvablePosition;
+        }
+        baseValue = *value;
+    } else if (const auto* animationSource =
+                   std::get_if<document::AnimationCurveSource>(&position->source)) {
+        // CompositionSession cannot sample runtime's exact rational interpolation, so an animated
+        // position only resolves a base value when the playhead sits exactly on a key (docs/
+        // architecture/animation-and-time.md; see PositionInteractionRejection::
+        // AnimatedWithoutExactKey).
+        const auto* current = composition();
+        const auto* curve = current == nullptr
+                                ? nullptr
+                                : current->animationCurves().findVec2(animationSource->curveId);
+        if (curve == nullptr) {
+            return PositionInteractionRejection::NoResolvablePosition;
+        }
+        const auto exactKey = std::ranges::find_if(
+            curve->keyframes, [this](const auto& key) { return key.time == currentTime_; });
+        if (exactKey == curve->keyframes.end()) {
+            return PositionInteractionRejection::AnimatedWithoutExactKey;
+        }
+        baseValue = exactKey->value;
+    } else {
+        return PositionInteractionRejection::DrivenParameter;
+    }
+
+    if (mapping.displayRect.isEmpty()) {
+        return PositionInteractionRejection::EmptyMapping;
+    }
+
+    positionInteraction_ = PositionInteraction{.baseRevision = snapshot_.revision(),
+                                               .parameterId = position->id,
+                                               .layerId = *layerId,
+                                               .time = currentTime_,
+                                               .baseValue = baseValue,
+                                               .currentOverride = baseValue,
+                                               .mapping = mapping};
+    emit positionInteractionChanged();
+    return std::nullopt;
+}
+
+void CompositionSession::updatePositionInteraction(const double screenDx, const double screenDy) {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (!positionInteraction_.has_value()) {
+        return;
+    }
+
+    const auto& mapping = positionInteraction_->mapping;
+    const double displayWidth = mapping.displayRect.width();
+    const double displayHeight = mapping.displayRect.height();
+    if (displayWidth <= 0.0 || displayHeight <= 0.0) {
+        cancelPositionInteraction();
+        return;
+    }
+
+    // docs/architecture/animation-and-time.md: base value plus TOTAL gesture displacement, never a
+    // chain of already-rounded intermediates.
+    const double compositionWidth = static_cast<double>(mapping.compositionFormat.width());
+    const double compositionHeight = static_cast<double>(mapping.compositionFormat.height());
+    const double compositionDx = screenDx / displayWidth * compositionWidth;
+    const double compositionDy = screenDy / displayHeight * compositionHeight;
+    positionInteraction_->currentOverride =
+        document::Vec2d{positionInteraction_->baseValue.x + compositionDx,
+                        positionInteraction_->baseValue.y + compositionDy};
+    emit positionInteractionChanged();
+}
+
+void CompositionSession::cancelPositionInteraction() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (!positionInteraction_.has_value()) {
+        return;
+    }
+    positionInteraction_.reset();
+    emit positionInteractionChanged();
+}
+
+void CompositionSession::invalidatePositionInteraction() { cancelPositionInteraction(); }
+
+bool CompositionSession::commitPositionInteraction() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (!positionInteraction_.has_value()) {
+        return false;
+    }
+    const PositionInteraction interaction = *positionInteraction_;
+    positionInteraction_.reset();
+    emit positionInteractionChanged();
+
+    if (interaction.baseRevision != snapshot_.revision()) {
+        // The invalidation hooks below should already have cancelled a stale interaction; treat
+        // this defensively as a no-op rather than mutate against a revision the caller no longer
+        // recognizes.
+        return false;
+    }
+    if (interaction.currentOverride == interaction.baseValue) {
+        // A zero move commits nothing (docs/architecture/animation-and-time.md).
+        return true;
+    }
+
+    // Same command-selection decision as setSelectedPosition() (see executePositionCommand()),
+    // targeted at the FROZEN parameter/time rather than re-deriving from live selection (docs/
+    // architecture/animation-and-time.md: "On release, a constant position receives one
+    // set-constant transaction. An animated position updates the exact-time key or inserts one.").
+    return executePositionCommand(interaction.parameterId, interaction.time,
+                                  interaction.currentOverride, QStringLiteral("Move Layer"));
 }
 
 bool CompositionSession::canUndo() const noexcept { return commandStack_->canUndo(); }
@@ -556,6 +721,7 @@ bool CompositionSession::execute(commands::Transaction&& transaction) {
 bool CompositionSession::handleResult(const commands::CommandResult& result) {
     const auto previousRevision = snapshot_.revision();
     snapshot_ = document_->snapshot();
+    invalidatePositionInteractionOnStaleRevision();
 
     if (!result.succeeded()) {
         const auto message = statusMessage(result);
@@ -635,6 +801,13 @@ void CompositionSession::normalizeSelection() {
 
 void CompositionSession::reportUnavailable(const QString& message) {
     emit commandRejected(message);
+}
+
+void CompositionSession::invalidatePositionInteractionOnStaleRevision() {
+    if (positionInteraction_.has_value() &&
+        positionInteraction_->baseRevision != snapshot_.revision()) {
+        cancelPositionInteraction();
+    }
 }
 
 } // namespace bloom::ui

--- a/src/ui/include/bloom/ui/composition_preview_controller.hpp
+++ b/src/ui/include/bloom/ui/composition_preview_controller.hpp
@@ -2,6 +2,7 @@
 
 #include <bloom/document/document.hpp>
 #include <bloom/runtime/prepared_preview_frame.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
 
 #include <QObject>
@@ -48,10 +49,15 @@ struct CompositionPreviewSettings final {
 
 using PreparedPreviewFrameHandle = std::shared_ptr<const runtime::PreparedPreviewFrame>;
 using PreviewPreparationResultHandle = runtime::PreviewPreparationResultHandle;
+// The fourth parameter carries the session's active-interaction override (docs/architecture/
+// animation-and-time.md, "Direct Manipulation And Preview Overrides"): populated only for
+// Interactive requests built while a position interaction is armed, std::nullopt otherwise. It
+// rides straight into SnapshotCompileRequest::parameterOverride in
+// makeCompositionPreviewPipeline().
 using PreviewPreparationFunction =
     std::function<runtime::TaskResult<PreviewPreparationResultHandle>(
         const document::Snapshot&, const runtime::PreviewRequestIdentity&, std::size_t,
-        runtime::TaskContext&)>;
+        const std::optional<runtime::SnapshotParameterOverride>&, runtime::TaskContext&)>;
 
 enum class PreviewActivity : std::uint8_t {
     Rendering,
@@ -117,6 +123,9 @@ class CompositionPreviewController final : public QObject {
         runtime::PreviewRequestIdentity desiredIdentity;
         std::size_t pixelStorageByteLimit;
         PreviewRequestKind kind = PreviewRequestKind::Visible;
+        // Sourced fresh from the session at requestPreview() build time; never cached across
+        // requests (docs/architecture/animation-and-time.md).
+        std::optional<runtime::SnapshotParameterOverride> interactionOverride;
     };
 
     void requestPreview(bool clearLastGoodFrame, PreviewRequestKind kind);
@@ -126,6 +135,7 @@ class CompositionPreviewController final : public QObject {
                           PreparedPreviewFrameHandle retainedFrame);
     void handleCompositionChanged();
     void handleCurrentTimeChanged();
+    void handlePositionInteractionChanged();
     void consumeReadyResult();
     void cancelAndDetachActive() noexcept;
     void publish(CompositionPreviewState state);

--- a/src/ui/include/bloom/ui/composition_session.hpp
+++ b/src/ui/include/bloom/ui/composition_session.hpp
@@ -2,11 +2,17 @@
 
 #include <bloom/commands/command_stack.hpp>
 #include <bloom/core/color.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
 #include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
 #include <bloom/document/document.hpp>
 #include <bloom/document/ids.hpp>
+#include <bloom/render/display_buffer.hpp>
+#include <bloom/runtime/evaluation.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
 
 #include <QObject>
+#include <QRectF>
 #include <QString>
 
 #include <optional>
@@ -34,6 +40,53 @@ struct CompositionSelection {
     std::optional<document::LayerId> contextualLayer;
 
     friend bool operator==(const CompositionSelection&, const CompositionSelection&) = default;
+};
+
+// docs/architecture/animation-and-time.md, "Direct Manipulation And Preview Overrides": gesture
+// begin freezes "a non-empty mapping rectangle, composition format, proxy, pixel aspect, and
+// display descriptor for the current composition". The Viewer is the only owner of screen/display
+// geometry, so it computes this snapshot and hands it to
+// CompositionSession::beginPositionInteraction; the session freezes it into the session-only
+// PositionInteraction and never recomputes it.
+struct PositionInteractionMapping final {
+    // The frozen fitted composition rectangle (already accounts for proxy scaling and pixel
+    // aspect -- see fitDisplayRect() in viewer_editor.cpp).
+    QRectF displayRect;
+    // The frozen composition format; its width/height are the "compositionWidth"/
+    // "compositionHeight" of the displacement formulas.
+    document::CompositionFormat compositionFormat;
+    // The frozen proxy factor, if any (today always CompositionFormatResolution{} -- no proxy
+    // pipeline exists yet).
+    runtime::EvaluationResolution resolution;
+    // The frozen pixel aspect of the displayed frame.
+    core::PixelAspectRatio pixelAspect;
+    // The frozen display descriptor identity (extent, pixel aspect, and packed layout) used to
+    // detect format/proxy/pixel-aspect/descriptor changes.
+    render::ReferenceDisplayBufferDescriptor displayDescriptor;
+
+    friend bool operator==(const PositionInteractionMapping&,
+                           const PositionInteractionMapping&) = default;
+};
+
+// Typed rejection for CompositionSession::beginPositionInteraction (docs/architecture/
+// animation-and-time.md, "Direct Manipulation And Preview Overrides").
+enum class PositionInteractionRejection : std::uint8_t {
+    // No layer is the session's primary selection.
+    NoLayerSelected,
+    // The selected layer exposes no position parameter, or its constant value does not match the
+    // Vec2d schema.
+    NoResolvablePosition,
+    // The position parameter is bound to a driver; a gesture never disconnects a driven parameter
+    // silently, so it never begins on one.
+    DrivenParameter,
+    // The position parameter is animated but has no exact-time key at the current session time.
+    // CompositionSession has no synchronous access to runtime's exact rational curve sampling
+    // (src/runtime owns sampling; src/ui does not get a private evaluator), so it cannot resolve
+    // an interpolated base value without guessing. Refusing to begin is the honest v1 behavior;
+    // dragging is supported for animated parameters exactly when the playhead sits on a key.
+    AnimatedWithoutExactKey,
+    // The supplied mapping has an empty/degenerate display rectangle.
+    EmptyMapping,
 };
 
 class CompositionSession final : public QObject {
@@ -78,6 +131,36 @@ class CompositionSession final : public QObject {
     moveLayerBefore(document::LayerSlotId slotId,
                     std::optional<document::LayerSlotId> beforeSlotId = std::nullopt);
 
+    // Direct viewer manipulation of the selected layer's position (docs/architecture/
+    // animation-and-time.md, "Direct Manipulation And Preview Overrides"; issue #82). Session-only,
+    // never persisted or undoable by itself: exactly one command transaction lands on
+    // commitPositionInteraction(). The Viewer owns the whole gesture -- press, move, release,
+    // Escape, and invalidation -- and is the only caller.
+    [[nodiscard]] bool positionInteractionActive() const noexcept;
+    // Sourced fresh by CompositionPreviewController's request path on every Interactive request
+    // build while an interaction is armed; never cached across requests.
+    [[nodiscard]] std::optional<runtime::SnapshotParameterOverride>
+    positionInteractionOverride() const;
+    // Validates the selected layer, a resolvable position parameter, and a non-empty mapping;
+    // freezes `mapping` and the base value/revision/time. Returns the typed rejection, or
+    // std::nullopt on success.
+    [[nodiscard]] std::optional<PositionInteractionRejection>
+    beginPositionInteraction(PositionInteractionMapping mapping);
+    // Recomputes the override from the frozen base value plus the TOTAL gesture displacement
+    // (never a chain of already-rounded intermediates). No-op if no interaction is active.
+    void updatePositionInteraction(double screenDx, double screenDy);
+    // Clears interaction state; creates no command. No-op if no interaction is active.
+    void cancelPositionInteraction();
+    // Called by the Viewer on resize/DPI/format/proxy/pixel-aspect/display-descriptor changes it
+    // detects; today identical to cancelPositionInteraction() (docs/architecture/
+    // animation-and-time.md: both "clear[ ] the override and create[ ] no command").
+    void invalidatePositionInteraction();
+    // Executes exactly one transaction through the same command surface as setSelectedPosition()
+    // (SetParameterSource for a constant source, SetKeyframeAtTime at the frozen time for an
+    // animated source), targeted at the frozen parameter/time rather than live selection. A stale
+    // base revision or a zero-displacement move commits nothing. Always clears interaction state.
+    [[nodiscard]] bool commitPositionInteraction();
+
     [[nodiscard]] bool canUndo() const noexcept;
     [[nodiscard]] bool canRedo() const noexcept;
     [[nodiscard]] QString undoLabel() const;
@@ -103,6 +186,11 @@ class CompositionSession final : public QObject {
     void selectionChanged();
     void historyChanged();
     void commandRejected(const QString& message);
+    // Emitted on begin/update/cancel/commit of a position interaction (docs/architecture/
+    // animation-and-time.md, "Direct Manipulation And Preview Overrides").
+    // CompositionPreviewController consumes it to (re)build a preview request carrying the fresh
+    // override.
+    void positionInteractionChanged();
 
   private:
     [[nodiscard]] bool execute(commands::Transaction&& transaction);
@@ -113,9 +201,34 @@ class CompositionSession final : public QObject {
     parameterForNode(const document::NodeRecord& node, std::string_view role) const noexcept;
     [[nodiscard]] bool setSelectionScalarParameter(std::string_view role, double value,
                                                    const QString& commandLabel);
+    // The one command-selection decision for writing a position value (constant source ->
+    // SetParameterSource; animation source -> SetKeyframeAtTime at `time`; driver source ->
+    // rejected), executed as exactly one transaction. setSelectedPosition() calls this with its
+    // live-derived parameter/time; commitPositionInteraction() calls it with the FROZEN
+    // parameter/time -- a single copy of the branch so the two callers cannot silently drift if the
+    // command surface ever changes.
+    [[nodiscard]] bool executePositionCommand(document::ParameterId parameterId,
+                                              core::RationalTime time, document::Vec2d value,
+                                              const QString& commandLabel);
     [[nodiscard]] bool selectionExists(const CompositionSelection& selection) const noexcept;
     void normalizeSelection();
     void reportUnavailable(const QString& message);
+    // Cancels an active position interaction whose frozen base revision no longer matches
+    // snapshot_ (docs/architecture/animation-and-time.md: "snapshot changes that break the frozen
+    // revision also cancel"). Called after handleResult() adopts a new snapshot.
+    void invalidatePositionInteractionOnStaleRevision();
+
+    // Session-only, never persisted (docs/architecture/animation-and-time.md, "Direct
+    // Manipulation And Preview Overrides"). Named after exactly what the contract freezes.
+    struct PositionInteraction final {
+        document::Revision baseRevision;
+        document::ParameterId parameterId;
+        document::LayerId layerId;
+        core::RationalTime time;
+        document::Vec2d baseValue;
+        document::Vec2d currentOverride;
+        PositionInteractionMapping mapping;
+    };
 
     // Pointers, not references (task U1, issue #72): rebind() must be able to atomically retarget
     // which document/command-stack this session projects after ProjectHost replaces the live
@@ -127,6 +240,7 @@ class CompositionSession final : public QObject {
     document::CompositionId compositionId_;
     core::RationalTime currentTime_ = core::RationalTime::fromInteger(0);
     CompositionSelection selection_;
+    std::optional<PositionInteraction> positionInteraction_;
 };
 
 } // namespace bloom::ui

--- a/src/ui/include/bloom/ui/viewer_editor.hpp
+++ b/src/ui/include/bloom/ui/viewer_editor.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <bloom/ui/composition_session.hpp>
+
+#include <QPointF>
 #include <QRectF>
 #include <QWidget>
+
+#include <optional>
 
 namespace bloom::core {
 class PixelAspectRatio;
@@ -11,10 +16,13 @@ namespace bloom::render {
 class ImageExtent;
 }
 
+class QKeyEvent;
+class QMouseEvent;
+class QResizeEvent;
+
 namespace bloom::ui {
 
 class CompositionPreviewController;
-class CompositionSession;
 
 [[nodiscard]] QRectF fitDisplayRect(const QRectF& available, render::ImageExtent extent,
                                     core::PixelAspectRatio pixelAspect) noexcept;
@@ -28,12 +36,35 @@ class ViewerEditor final : public QWidget {
 
   protected:
     void paintEvent(QPaintEvent* event) override;
+    // Direct viewer manipulation of the selected layer's position (docs/architecture/
+    // animation-and-time.md, "Direct Manipulation And Preview Overrides"; issue #82). press ->
+    // beginPositionInteraction (+ beginInteractiveScrub() arming so drag previews ride Interactive
+    // cadence); move -> updatePositionInteraction; release -> commit + disarm; Escape or a detected
+    // resize/format/proxy/pixel-aspect/display-descriptor change -> cancel + disarm.
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
   private:
     void updatePreviewAccessibility();
+    // Recomputes the mapping context (fitted display rectangle, composition format, proxy
+    // resolution, pixel aspect, display descriptor) from the currently displayed preview frame and
+    // this widget's current geometry. Returns std::nullopt when there is no current-composition
+    // frame to map from -- a stale frame from another composition (or an older revision) is never
+    // a mapping source.
+    [[nodiscard]] std::optional<PositionInteractionMapping> currentMapping() const;
+    // True while a gesture is active AND the freshly recomputed mapping still matches the one
+    // frozen at gesture begin.
+    [[nodiscard]] bool mappingStillValid() const;
+    void endDrag(bool commit);
 
     CompositionSession& session_;
     CompositionPreviewController& previewController_;
+    bool dragActive_ = false;
+    QPointF dragOrigin_;
+    std::optional<PositionInteractionMapping> activeMapping_;
 };
 
 } // namespace bloom::ui

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -28,6 +28,12 @@ add_executable(bloom_timeline_frame_math_test
 add_executable(bloom_timeline_ruler_test
     timeline_ruler_tests.cpp
 )
+add_executable(bloom_composition_session_position_interaction_test
+    composition_session_position_interaction_tests.cpp
+)
+add_executable(bloom_direct_manipulation_test
+    direct_manipulation_tests.cpp
+)
 
 # Links ZLIB::ZLIB directly for its own trimmed hand-rolled ZIP-writer fixture (a preserved-
 # read-only archive builder) -- mirroring src/host/CMakeLists.txt's bloom_host_session_open_test,
@@ -49,6 +55,8 @@ target_link_libraries(bloom_task_monitor_test PRIVATE bloom_ui)
 target_link_libraries(bloom_viewer_editor_test PRIVATE bloom_ui)
 target_link_libraries(bloom_timeline_frame_math_test PRIVATE bloom_ui)
 target_link_libraries(bloom_timeline_ruler_test PRIVATE bloom_ui)
+target_link_libraries(bloom_composition_session_position_interaction_test PRIVATE bloom_ui)
+target_link_libraries(bloom_direct_manipulation_test PRIVATE bloom_ui)
 target_link_libraries(bloom_main_window_readonly_placeholder_test PRIVATE bloom_ui ZLIB::ZLIB)
 bloom_enable_warnings(bloom_composition_projection_test)
 bloom_enable_warnings(bloom_composition_preview_controller_test)
@@ -60,6 +68,8 @@ bloom_enable_warnings(bloom_task_monitor_test)
 bloom_enable_warnings(bloom_viewer_editor_test)
 bloom_enable_warnings(bloom_timeline_frame_math_test)
 bloom_enable_warnings(bloom_timeline_ruler_test)
+bloom_enable_warnings(bloom_composition_session_position_interaction_test)
+bloom_enable_warnings(bloom_direct_manipulation_test)
 bloom_enable_warnings(bloom_main_window_readonly_placeholder_test)
 
 include(BloomTesting)
@@ -140,6 +150,22 @@ bloom_add_test(
     NAME bloom.ui.timeline_ruler
     COMMAND bloom_timeline_ruler_test
     LABELS ui integration animation
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.composition_session_position_interaction
+    COMMAND bloom_composition_session_position_interaction_test
+    LABELS ui unit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.direct_manipulation
+    COMMAND bloom_direct_manipulation_test
+    LABELS ui integration
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )

--- a/src/ui/tests/application_shutdown_tests.cpp
+++ b/src/ui/tests/application_shutdown_tests.cpp
@@ -117,7 +117,7 @@ void testShutdownAndCloseRouting(Expectations& expectations) {
     ui::CompositionPreviewController controller(
         session, scheduler, bridge,
         [&gate](const document::Snapshot&, const runtime::PreviewRequestIdentity&, std::size_t,
-                runtime::TaskContext&) {
+                const std::optional<runtime::SnapshotParameterOverride>&, runtime::TaskContext&) {
             gate.enterAndWait();
             return runtime::TaskResult<ui::PreviewPreparationResultHandle>::cancelled();
         });

--- a/src/ui/tests/composition_preview_controller_tests.cpp
+++ b/src/ui/tests/composition_preview_controller_tests.cpp
@@ -204,11 +204,14 @@ void testRevisionAndPanelSuppression(Expectations& expectations) {
         [&firstRequest, &invocationCount, pipeline = fixture.pipeline](
             const document::Snapshot& snapshot,
             const runtime::PreviewRequestIdentity& desiredIdentity,
-            const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) mutable {
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
             if (invocationCount.fetch_add(1) == 0) {
                 firstRequest.enterAndWait();
             }
-            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, interactionOverride,
+                            context);
         });
     auto* viewer = new ui::ViewerEditor(session, controller);
 
@@ -268,10 +271,12 @@ void testNewestPendingRequestGate(Expectations& expectations) {
     ui::CompositionPreviewController controller(
         session, scheduler, bridge,
         [&firstRequest, &invocationMutex, &invokedGenerations, &inFlight, &maximumInFlight,
-         pipeline = fixture.pipeline](const document::Snapshot& snapshot,
-                                      const runtime::PreviewRequestIdentity& desiredIdentity,
-                                      const std::size_t pixelStorageByteLimit,
-                                      runtime::TaskContext& context) mutable {
+         pipeline = fixture.pipeline](
+            const document::Snapshot& snapshot,
+            const runtime::PreviewRequestIdentity& desiredIdentity,
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
             const int concurrent = inFlight.fetch_add(1) + 1;
             int previousMaximum = maximumInFlight.load();
             while (concurrent > previousMaximum &&
@@ -286,7 +291,8 @@ void testNewestPendingRequestGate(Expectations& expectations) {
             if (invocationIndex == 0) {
                 firstRequest.enterAndWait();
             }
-            auto result = pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+            auto result = pipeline(snapshot, desiredIdentity, pixelStorageByteLimit,
+                                   interactionOverride, context);
             --inFlight;
             return result;
         });
@@ -370,9 +376,12 @@ void testInteractiveCadenceCoalescesBurstAndVisibleBypasses(Expectations& expect
         [&invocationCount, pipeline = fixture.pipeline](
             const document::Snapshot& snapshot,
             const runtime::PreviewRequestIdentity& desiredIdentity,
-            const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) mutable {
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
             ++invocationCount;
-            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, interactionOverride,
+                            context);
         },
         settings);
 
@@ -447,11 +456,14 @@ void testActiveGateHoldsAndScrubEndBypassesRemainingCadence(Expectations& expect
         [&firstRequest, &invocationCount, pipeline = fixture.pipeline](
             const document::Snapshot& snapshot,
             const runtime::PreviewRequestIdentity& desiredIdentity,
-            const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) mutable {
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
             if (invocationCount.fetch_add(1) == 0) {
                 firstRequest.enterAndWait();
             }
-            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, interactionOverride,
+                            context);
         },
         settings);
 
@@ -525,9 +537,12 @@ void testSameRevisionGenerationAndSelection(Expectations& expectations) {
         [&invocationCount, pipeline = fixture.pipeline](
             const document::Snapshot& snapshot,
             const runtime::PreviewRequestIdentity& desiredIdentity,
-            const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) mutable {
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
             ++invocationCount;
-            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, interactionOverride,
+                            context);
         });
 
     expectations.expect(waitUntil([&] { return isReady(controller); }),
@@ -610,10 +625,13 @@ void testLastGoodAndOutcomeMapping(Expectations& expectations) {
         [&outcome, &slowFailure, pipeline = fixture.pipeline](
             const document::Snapshot& snapshot,
             const runtime::PreviewRequestIdentity& desiredIdentity,
-            const std::size_t pixelStorageByteLimit, runtime::TaskContext& context) mutable {
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
             switch (outcome.load()) {
             case Outcome::Prepared:
-                return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, context);
+                return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit,
+                                interactionOverride, context);
             case Outcome::SlowFailed:
                 slowFailure.enterAndWait();
                 return PipelineResult::failed({.code = "bloom.preview.test-slow-failure",
@@ -643,7 +661,8 @@ void testLastGoodAndOutcomeMapping(Expectations& expectations) {
             case Outcome::Mismatch: {
                 auto mismatched = desiredIdentity;
                 ++mismatched.requestGeneration;
-                return pipeline(snapshot, mismatched, pixelStorageByteLimit, context);
+                return pipeline(snapshot, mismatched, pixelStorageByteLimit, interactionOverride,
+                                context);
             }
             }
             return PipelineResult::failed({.code = "bloom.preview.invalid-test-outcome",

--- a/src/ui/tests/composition_projection_test.cpp
+++ b/src/ui/tests/composition_projection_test.cpp
@@ -88,7 +88,7 @@ parameterForRole(const bloom::document::Composition& composition,
     ui::CompositionPreviewController previewController(
         session, scheduler, taskUiBridge,
         [](const document::Snapshot&, const runtime::PreviewRequestIdentity&, std::size_t,
-           runtime::TaskContext&) {
+           const std::optional<runtime::SnapshotParameterOverride>&, runtime::TaskContext&) {
             return runtime::TaskResult<ui::PreviewPreparationResultHandle>::cancelled();
         });
     ui::TimelineEditor timeline(session, previewController);

--- a/src/ui/tests/composition_session_position_interaction_tests.cpp
+++ b/src/ui/tests/composition_session_position_interaction_tests.cpp
@@ -1,0 +1,444 @@
+// Tests for CompositionSession's direct-manipulation position interaction (docs/architecture/
+// animation-and-time.md, "Direct Manipulation And Preview Overrides"; issue #82, task D1).
+// Deliberately pure-session (QCoreApplication, no widgets, no preview pipeline) mirroring
+// composition_session_animation_tests.cpp's idiom: PositionInteractionMapping is supplied directly
+// rather than sourced from a rendered frame, since only ViewerEditor is responsible for computing
+// it from real display geometry (covered separately by the viewer gesture tests).
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/animation.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/render/display_buffer.hpp>
+#include <bloom/render/image_types.hpp>
+#include <bloom/runtime/evaluation.hpp>
+#include <bloom/ui/composition_session.hpp>
+
+#include <QCoreApplication>
+#include <QRectF>
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace {
+
+using namespace bloom;
+
+[[noreturn]] void fail(const std::string_view message) {
+    std::cerr << "composition session position interaction test failed: " << message << '\n';
+    std::exit(1);
+}
+
+void require(const bool condition, const std::string_view message) {
+    if (!condition) {
+        fail(message);
+    }
+}
+
+[[nodiscard]] core::RationalTime time(const std::int64_t numerator,
+                                      const std::int64_t denominator = 1) {
+    const auto result = core::RationalTime::create(numerator, denominator);
+    if (!result.has_value()) {
+        fail("test time must be valid");
+    }
+    return *result;
+}
+
+// A non-square display rectangle (2:1) mapped against a non-square, differently-proportioned
+// composition format (10:1) so X and Y scale factors genuinely differ -- this exercises the
+// per-axis formulas independently rather than a uniform scale that would hide an axis-swap bug.
+[[nodiscard]] document::CompositionFormat wideFormat() {
+    const auto format = document::CompositionFormat::create(1000, 100);
+    if (!format.has_value()) {
+        fail("wide composition format fixture must be valid");
+    }
+    return *format;
+}
+
+[[nodiscard]] ui::PositionInteractionMapping
+makeMapping(const QRectF& displayRect, const document::CompositionFormat compositionFormat) {
+    const auto window =
+        render::ImageWindow::create(0, 0, compositionFormat.width(), compositionFormat.height());
+    if (!window) {
+        fail("mapping fixture display window must be valid");
+    }
+    const auto descriptor = render::ReferenceDisplayBufferDescriptor::create(
+        *window.value(), compositionFormat.pixelAspect());
+    if (!descriptor) {
+        fail("mapping fixture display descriptor must be valid");
+    }
+    return ui::PositionInteractionMapping{
+        .displayRect = displayRect,
+        .compositionFormat = compositionFormat,
+        .resolution = runtime::CompositionFormatResolution{},
+        .pixelAspect = compositionFormat.pixelAspect(),
+        .displayDescriptor = *descriptor.value(),
+    };
+}
+
+struct LayerIds final {
+    document::LayerId layer;
+    document::ParameterId position;
+};
+
+[[nodiscard]] LayerIds addSolidLayer(document::Document& document, commands::CommandStack& stack,
+                                     const document::CompositionId compositionId,
+                                     const document::Vec2d position) {
+    commands::Transaction transaction("Add test layer", document.snapshot().revision());
+    transaction.emplace<commands::AddSolidLayer>(compositionId, "Solid",
+                                                 core::Color4d{0.2, 0.3, 0.4, 1.0}, position);
+    const auto result = stack.execute(std::move(transaction));
+    const auto layer = result.outputId<document::LayerId>(commands::kAddSolidLayerLayerOutput);
+    const auto positionId =
+        result.outputId<document::ParameterId>(commands::kAddSolidLayerPositionParameterOutput);
+    if (!(result.changed() && layer.has_value() && positionId.has_value())) {
+        fail("solid layer command must expose its stable IDs");
+    }
+    return {*layer, *positionId};
+}
+
+void testDisplacementMathNonSquareNegativeAndBaseTotal() {
+    auto newProject = document::makeNewProject("Displacement Math", "Main", time(10), wideFormat());
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{100.0, 10.0});
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+
+    // displayRect is 200x100 (2:1); compositionFormat is 1000x100 (10:1): scaleX = 1000/200 = 5,
+    // scaleY = 100/100 = 1 -- deliberately different per-axis scale factors.
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 200.0, 100.0), wideFormat());
+    require(!session.beginPositionInteraction(mapping).has_value(),
+            "begin succeeds for a selected layer with a resolvable constant position");
+
+    session.updatePositionInteraction(20.0, 10.0);
+    const auto override1 = session.positionInteractionOverride();
+    require(override1.has_value(), "an active interaction always reports an override");
+    if (override1.has_value()) {
+        const auto* value1 = std::get_if<document::Vec2d>(&override1->value);
+        require(value1 != nullptr && value1->x == 100.0 + 20.0 / 200.0 * 1000.0 &&
+                    value1->y == 10.0 + 10.0 / 100.0 * 100.0,
+                "compositionDx/Dy = screenDx/Dy / displayWidth/Height * compositionWidth/Height, "
+                "per axis independently");
+    }
+
+    // Negative displacement.
+    session.updatePositionInteraction(-40.0, -5.0);
+    const auto override2 = session.positionInteractionOverride();
+    require(override2.has_value(), "an active interaction always reports an override");
+    if (override2.has_value()) {
+        const auto* value2 = std::get_if<document::Vec2d>(&override2->value);
+        require(value2 != nullptr && value2->x == 100.0 + (-40.0) / 200.0 * 1000.0 &&
+                    value2->y == 10.0 + (-5.0) / 100.0 * 100.0,
+                "negative screen displacement maps to negative composition displacement");
+    }
+
+    // Base + TOTAL displacement, never a chain of already-rounded intermediates: two sequential
+    // updates must land exactly where one single combined update lands, not at
+    // base + f(first) + f(second).
+    session.cancelPositionInteraction();
+    require(!session.beginPositionInteraction(mapping).has_value(), "restart the interaction");
+    session.updatePositionInteraction(5.0, 5.0);
+    session.updatePositionInteraction(37.0, -13.0);
+    const auto chained = session.positionInteractionOverride();
+
+    session.cancelPositionInteraction();
+    require(!session.beginPositionInteraction(mapping).has_value(),
+            "restart the interaction again");
+    session.updatePositionInteraction(37.0, -13.0);
+    const auto direct = session.positionInteractionOverride();
+
+    require(chained.has_value() && direct.has_value(),
+            "both restarted interactions report overrides");
+    if (chained.has_value() && direct.has_value()) {
+        const auto* chainedValue = std::get_if<document::Vec2d>(&chained->value);
+        const auto* directValue = std::get_if<document::Vec2d>(&direct->value);
+        require(chainedValue != nullptr && directValue != nullptr && *chainedValue == *directValue,
+                "two updates land exactly where one combined update lands (base + TOTAL "
+                "displacement)");
+    }
+    session.cancelPositionInteraction();
+}
+
+void testBeginRejectionsAndFreezing() {
+    auto newProject = document::makeNewProject("Begin Rejections", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{1.0, 2.0});
+    const auto format = document.snapshot().project().findComposition(compositionId)->format();
+    const auto validMapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    ui::CompositionSession session(document, stack, compositionId);
+
+    // No selection.
+    require(session.beginPositionInteraction(validMapping) ==
+                ui::PositionInteractionRejection::NoLayerSelected,
+            "no selection is a typed NoLayerSelected rejection");
+    require(!session.positionInteractionActive(), "a rejected begin leaves no active interaction");
+
+    // Empty mapping.
+    session.selectLayer(ids.layer);
+    require(session.beginPositionInteraction(makeMapping(QRectF(), format)) ==
+                ui::PositionInteractionRejection::EmptyMapping,
+            "an empty display rectangle is a typed EmptyMapping rejection");
+    require(!session.positionInteractionActive(),
+            "an empty-mapping rejection leaves no active interaction");
+
+    // Successful begin freezes the base value/revision.
+    require(!session.beginPositionInteraction(validMapping).has_value(),
+            "a selected layer with a resolvable position and a non-empty mapping begins");
+    require(session.positionInteractionActive(), "begin leaves the interaction active");
+    const auto freshOverride = session.positionInteractionOverride();
+    require(freshOverride.has_value() && freshOverride->parameterId == ids.position &&
+                freshOverride->sourceRevision == document.snapshot().revision() &&
+                std::get_if<document::Vec2d>(&freshOverride->value) != nullptr &&
+                *std::get_if<document::Vec2d>(&freshOverride->value) == document::Vec2d{1.0, 2.0},
+            "a fresh begin's override starts at exactly the base value/revision/target");
+    session.cancelPositionInteraction();
+}
+
+void testDrivenAndAnimatedParameterRejections() {
+    auto newProject = document::makeNewProject("Driven And Animated", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{5.0, 6.0});
+    const auto format = document.snapshot().project().findComposition(compositionId)->format();
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    // Driven.
+    {
+        commands::Transaction drive("Drive position", document.snapshot().revision());
+        drive.emplace<commands::SetParameterSource>(
+            compositionId, ids.position,
+            document::DriverBindingSource{document::DriverBindingId::fromRaw(1)});
+        require(stack.execute(std::move(drive)).changed(), "test position becomes driver-backed");
+    }
+    ui::CompositionSession drivenSession(document, stack, compositionId);
+    drivenSession.selectLayer(ids.layer);
+    require(drivenSession.beginPositionInteraction(mapping) ==
+                ui::PositionInteractionRejection::DrivenParameter,
+            "a driven position parameter never begins a gesture (never silently disconnects it)");
+    require(!drivenSession.positionInteractionActive(),
+            "the driven rejection leaves no interaction");
+}
+
+void testAnimatedParameterExactKeyOnlyAndCommitUpdatesTheKey() {
+    auto newProject = document::makeNewProject("Animated Gesture", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{3.0, 4.0});
+    const auto format = document.snapshot().project().findComposition(compositionId)->format();
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    commands::Transaction animate("Animate position", document.snapshot().revision());
+    animate.emplace<commands::CreateAnimationForParameter>(compositionId, ids.position, time(0));
+    const auto animateResult = stack.execute(std::move(animate));
+    const auto curveId =
+        animateResult.outputId<document::AnimationCurveId>(commands::kAnimationCurveOutput);
+    require(animateResult.changed() && curveId.has_value(), "position becomes animated");
+    if (!curveId.has_value()) {
+        return;
+    }
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+
+    // No exact key at the current time (currentTime_ defaults to zero, matching the seeded key --
+    // move off it first).
+    require(session.setCurrentTime(time(5)), "session moves off the seeded key's time");
+    require(session.beginPositionInteraction(mapping) ==
+                ui::PositionInteractionRejection::AnimatedWithoutExactKey,
+            "an animated position with no exact key at the current time refuses the gesture rather "
+            "than guess an interpolated base value");
+    require(!session.positionInteractionActive(), "the refusal leaves no active interaction");
+
+    // Back on the seeded key: the gesture proceeds and commit updates that exact key.
+    require(session.setCurrentTime(time(0)), "session returns to the seeded key's exact time");
+    require(!session.beginPositionInteraction(mapping).has_value(),
+            "an animated position with an exact key at the current time begins");
+    session.updatePositionInteraction(10.0, 0.0);
+    const auto revisionBeforeCommit = session.snapshot().revision();
+    require(session.commitPositionInteraction(), "commit succeeds for the animated key update");
+    require(session.snapshot().revision().value() == revisionBeforeCommit.value() + 1,
+            "commit is exactly one transaction");
+
+    const auto* curve = session.composition()->animationCurves().findVec2(*curveId);
+    require(curve != nullptr && curve->keyframes.size() == 1,
+            "the commit updates the existing seeded key rather than inserting a second one");
+    require(curve->keyframes.front().value ==
+                document::Vec2d{3.0 + 10.0 / 100.0 * format.width(), 4.0},
+            "the updated key holds the base-plus-displacement value");
+
+    require(session.undo(), "the animated commit undoes cleanly");
+    curve = session.composition()->animationCurves().findVec2(*curveId);
+    require(curve != nullptr && curve->keyframes.size() == 1 &&
+                curve->keyframes.front().value == document::Vec2d{3.0, 4.0},
+            "undo restores the exact prior key value");
+}
+
+void testCommitIsExactlyOneTransactionAndUndoRestoresExactPriorValue() {
+    auto newProject = document::makeNewProject("Commit Undo", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{50.0, 60.0});
+    const auto format = document.snapshot().project().findComposition(compositionId)->format();
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+    require(!session.beginPositionInteraction(mapping).has_value(), "begin succeeds");
+    session.updatePositionInteraction(30.0, -20.0);
+
+    const auto revisionBeforeCommit = session.snapshot().revision();
+    require(session.commitPositionInteraction(), "commit succeeds");
+    require(!session.positionInteractionActive(), "commit always clears interaction state");
+    require(session.snapshot().revision().value() == revisionBeforeCommit.value() + 1,
+            "one drag creates exactly one document transaction (one undo step)");
+    require(session.constantVec2Value(ids.position) ==
+                document::Vec2d{50.0 + 30.0 / 100.0 * format.width(),
+                                60.0 + (-20.0) / 100.0 * format.height()},
+            "the committed value matches base plus the frozen mapping's total displacement");
+
+    require(session.undo(), "the commit undoes cleanly");
+    require(session.constantVec2Value(ids.position) == document::Vec2d{50.0, 60.0},
+            "undo restores the exact prior value");
+}
+
+void testZeroMoveCommitsNothing() {
+    auto newProject = document::makeNewProject("Zero Move", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{7.0, 8.0});
+    const auto format = document.snapshot().project().findComposition(compositionId)->format();
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+    require(!session.beginPositionInteraction(mapping).has_value(), "begin succeeds");
+    const auto revisionBeforeCommit = session.snapshot().revision();
+    require(session.commitPositionInteraction(), "a zero-displacement commit reports success");
+    require(session.snapshot().revision() == revisionBeforeCommit,
+            "a zero move creates no command / no undo step");
+    require(session.constantVec2Value(ids.position) == document::Vec2d{7.0, 8.0},
+            "the value is untouched by a zero-move commit");
+}
+
+void testCancelClearsState() {
+    auto newProject = document::makeNewProject("Cancel Clears", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{0.0, 0.0});
+    const auto format = document.snapshot().project().findComposition(compositionId)->format();
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+    require(!session.beginPositionInteraction(mapping).has_value(), "begin succeeds");
+    session.updatePositionInteraction(99.0, 99.0);
+    const auto revisionBeforeCancel = session.snapshot().revision();
+
+    session.cancelPositionInteraction();
+    require(!session.positionInteractionActive(), "cancel clears interaction state");
+    require(!session.positionInteractionOverride().has_value(), "cancel leaves no override");
+    require(session.snapshot().revision() == revisionBeforeCancel, "cancel creates no command");
+    require(session.constantVec2Value(ids.position) == document::Vec2d{0.0, 0.0},
+            "cancel never mutates project truth");
+
+    // invalidatePositionInteraction() is the same clearing effect, for the Viewer's own detected
+    // environment changes.
+    require(!session.beginPositionInteraction(mapping).has_value(), "begin succeeds again");
+    session.invalidatePositionInteraction();
+    require(!session.positionInteractionActive(), "invalidate clears interaction state");
+}
+
+void testInvalidationOnCompositionSwitchAndStaleRevision() {
+    auto newProject = document::makeNewProject("Invalidation", "Main", time(10));
+    const auto firstCompositionId = newProject.initialCompositionId;
+    const auto secondCompositionId = document::CompositionId::fromRaw(2);
+    {
+        using namespace document;
+        const auto stackId = NodeId::fromRaw(100);
+        const auto outputId = NodeId::fromRaw(101);
+        const auto edgeId = EdgeId::fromRaw(100);
+        CanonicalGraph graph(stackId);
+        const bool built =
+            graph.addNode(
+                {stackId, std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion}) &&
+            graph.addNode({outputId,
+                           std::string(kCompositionOutputNodeType),
+                           {},
+                           kCompositionOutputNodeSchemaVersion}) &&
+            graph.addEdge({edgeId,
+                           {stackId, std::string(kLayerStackOutputPort)},
+                           NodeInputRef{outputId, std::string(kCompositionOutputInputPort)}});
+        graph.setCompositionOutput({outputId, std::string(kCompositionOutputOutputPort)});
+        require(built, "second composition graph fixture builds");
+        const auto format = document::CompositionFormat::create(64, 36);
+        require(format.has_value(), "second composition format fixture is valid");
+        if (!format.has_value()) {
+            return;
+        }
+        require(newProject.project.addComposition(Composition(secondCompositionId, "Second",
+                                                              time(10), std::move(graph), *format)),
+                "second composition fixture is added");
+    }
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, firstCompositionId, document::Vec2d{1.0, 1.0});
+    const auto format = document.snapshot().project().findComposition(firstCompositionId)->format();
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    ui::CompositionSession session(document, stack, firstCompositionId);
+    session.selectLayer(ids.layer);
+
+    // Composition switch cancels.
+    require(!session.beginPositionInteraction(mapping).has_value(), "begin succeeds");
+    require(session.setComposition(secondCompositionId), "session switches composition");
+    require(!session.positionInteractionActive(),
+            "a composition switch cancels an active interaction (its target belongs to the OLD "
+            "composition)");
+
+    // An unrelated document edit (stale base revision) cancels.
+    require(session.setComposition(firstCompositionId), "session switches back");
+    session.selectLayer(ids.layer);
+    require(!session.beginPositionInteraction(mapping).has_value(), "begin succeeds again");
+    require(session.addTextLayer(QStringLiteral("Unrelated"), QStringLiteral("Unrelated")),
+            "an unrelated edit advances the document revision");
+    require(!session.positionInteractionActive(),
+            "a snapshot change that breaks the frozen base revision cancels the interaction");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    QCoreApplication application(argc, argv);
+    testDisplacementMathNonSquareNegativeAndBaseTotal();
+    testBeginRejectionsAndFreezing();
+    testDrivenAndAnimatedParameterRejections();
+    testAnimatedParameterExactKeyOnlyAndCommitUpdatesTheKey();
+    testCommitIsExactlyOneTransactionAndUndoRestoresExactPriorValue();
+    testZeroMoveCommitsNothing();
+    testCancelClearsState();
+    testInvalidationOnCompositionSwitchAndStaleRevision();
+    return 0;
+}

--- a/src/ui/tests/direct_manipulation_tests.cpp
+++ b/src/ui/tests/direct_manipulation_tests.cpp
@@ -1,0 +1,640 @@
+// Tests for direct viewer manipulation of layer position (docs/architecture/animation-and-time.md,
+// "Direct Manipulation And Preview Overrides"; issue #82, task D1):
+//  - CompositionPreviewController's override threading (attaches only to Interactive requests built
+//    while an interaction is armed; never to Visible; gone after commit/cancel; an
+//    admission-rejected override surfaces the error state without killing the interaction).
+//  - ViewerEditor's synthesized-mouse gesture (press/move/release, empty/unselected no-op, a
+//    mid-drag resize cancels).
+// Mirrors composition_preview_controller_tests.cpp's PipelineFixture/Expectations/waitUntil idiom
+// and timeline_ruler_tests.cpp's synthesized-mouse-event idiom.
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/render/display_buffer.hpp>
+#include <bloom/render/image_types.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/reference_display_preparation.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_preview_pipeline.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+#include <bloom/ui/viewer_editor.hpp>
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPointF>
+#include <QResizeEvent>
+#include <QSize>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+template <typename Predicate> bool waitUntil(Predicate predicate) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 4'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (std::invoke(predicate)) {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return std::invoke(predicate);
+}
+
+bloom::runtime::TaskSchedulerConfig testSchedulerConfig() {
+    return {.cpuWorkerCount = 1,
+            .blockingIoWorkerCount = 1,
+            .cpuQueueCapacity = 16,
+            .blockingIoQueueCapacity = 4,
+            .terminalHistoryCapacity = 32,
+            .diagnosticsPerTask = 8,
+            .groupRegistryCapacity = 8};
+}
+
+bloom::document::CompositionFormat wideFormat() {
+    const auto format = bloom::document::CompositionFormat::create(1000, 500);
+    if (!format.has_value()) {
+        std::abort();
+    }
+    return *format;
+}
+
+bloom::document::NewProject makeTestProject(std::string projectName) {
+    return bloom::document::makeNewProject(
+        std::move(projectName), "Main", bloom::core::RationalTime::fromInteger(10), wideFormat());
+}
+
+struct LayerIds final {
+    bloom::document::LayerId layer;
+    bloom::document::ParameterId position;
+};
+
+// Adds the layer directly through the CommandStack BEFORE any CompositionSession exists, so the
+// session's constructor-time snapshot() already reflects it (a session that already exists caches
+// its own snapshot_ and only refreshes it through its own execute()/undo()/redo(); mutating the
+// stack behind its back would leave it stale).
+[[nodiscard]] LayerIds addSolidLayer(bloom::document::Document& document,
+                                     bloom::commands::CommandStack& stack,
+                                     const bloom::document::CompositionId compositionId,
+                                     const bloom::document::Vec2d position) {
+    using namespace bloom;
+    commands::Transaction transaction("Add test layer", document.snapshot().revision());
+    transaction.emplace<commands::AddSolidLayer>(compositionId, "Solid",
+                                                 core::Color4d{0.2, 0.3, 0.4, 1.0}, position);
+    const auto result = stack.execute(std::move(transaction));
+    const auto layer = result.outputId<document::LayerId>(commands::kAddSolidLayerLayerOutput);
+    const auto positionId =
+        result.outputId<document::ParameterId>(commands::kAddSolidLayerPositionParameterOutput);
+    if (!(result.changed() && layer.has_value() && positionId.has_value())) {
+        std::abort();
+    }
+    return {*layer, *positionId};
+}
+
+struct PipelineFixture final {
+    bloom::runtime::NodeDefinitionRegistry definitions;
+    bloom::runtime::SnapshotCompiler compiler;
+    bloom::runtime::CpuCompositionEvaluator evaluator;
+    bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    bloom::ui::PreviewPreparationFunction pipeline;
+
+    PipelineFixture() : compiler(definitions) {
+        if (!bloom::runtime::registerBuiltInNodeDefinitions(definitions)) {
+            std::abort();
+        }
+        definitions.freeze();
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer);
+    }
+};
+
+bool isReady(const bloom::ui::CompositionPreviewController& controller) {
+    return controller.state().activity == bloom::ui::PreviewActivity::Ready;
+}
+
+std::uint64_t currentGeneration(const bloom::ui::CompositionPreviewController& controller) {
+    const auto& desiredIdentity = controller.state().desiredIdentity;
+    return desiredIdentity.has_value() ? desiredIdentity->requestGeneration : 0;
+}
+
+void reachQuiescence(bloom::ui::CompositionPreviewController& controller,
+                     bloom::ui::TaskUiBridge& bridge, bloom::runtime::TaskScheduler& scheduler,
+                     Expectations& expectations) {
+    bool quiescentSignal = false;
+    QObject::connect(&bridge, &bloom::ui::TaskUiBridge::shutdownQuiescent, &bridge,
+                     [&quiescentSignal] { quiescentSignal = true; });
+    controller.beginShutdown();
+    bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return quiescentSignal && scheduler.isQuiescent(); }),
+                        "direct manipulation fixture reaches asynchronous scheduler quiescence");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Controller override threading
+// ---------------------------------------------------------------------------------------------
+
+// docs/architecture/animation-and-time.md: the fitted display rectangle a real gesture would use is
+// ViewerEditor's job (covered by the gesture tests below); here a manually built mapping is enough
+// to prove the CONTROLLER threads whatever the session reports.
+bloom::ui::PositionInteractionMapping makeMapping(const bloom::document::CompositionFormat format) {
+    using namespace bloom;
+    const auto window = render::ImageWindow::create(0, 0, format.width(), format.height());
+    if (!window) {
+        std::abort();
+    }
+    const auto descriptor =
+        render::ReferenceDisplayBufferDescriptor::create(*window.value(), format.pixelAspect());
+    if (!descriptor) {
+        std::abort();
+    }
+    return ui::PositionInteractionMapping{
+        .displayRect = QRectF(0.0, 0.0, 200.0, 100.0),
+        .compositionFormat = format,
+        .resolution = runtime::CompositionFormatResolution{},
+        .pixelAspect = format.pixelAspect(),
+        .displayDescriptor = *descriptor.value(),
+    };
+}
+
+void testControllerAttachesOverrideOnlyToArmedInteractiveRequests(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Controller Override Threading");
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId, document::Vec2d{10.0, 20.0});
+    ui::CompositionSession session(document, commands, compositionId);
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+    PipelineFixture fixture;
+
+    struct Invocation final {
+        std::uint64_t generation = 0;
+        bool hasOverride = false;
+        std::optional<document::Vec2d> overrideValue;
+    };
+    std::mutex invocationMutex;
+    std::vector<Invocation> invocations;
+    ui::CompositionPreviewController controller(
+        session, scheduler, bridge,
+        [&invocationMutex, &invocations, pipeline = fixture.pipeline](
+            const document::Snapshot& snapshot,
+            const runtime::PreviewRequestIdentity& desiredIdentity,
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
+            {
+                std::scoped_lock lock(invocationMutex);
+                std::optional<document::Vec2d> value;
+                if (interactionOverride.has_value()) {
+                    if (const auto* vector =
+                            std::get_if<document::Vec2d>(&interactionOverride->value)) {
+                        value = *vector;
+                    }
+                }
+                invocations.push_back(
+                    {desiredIdentity.requestGeneration, interactionOverride.has_value(), value});
+            }
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, interactionOverride,
+                            context);
+        });
+
+    const auto invocationForGeneration =
+        [&](const std::uint64_t generation) -> std::optional<Invocation> {
+        std::scoped_lock lock(invocationMutex);
+        for (const auto& invocation : invocations) {
+            if (invocation.generation == generation) {
+                return invocation;
+            }
+        }
+        return std::nullopt;
+    };
+
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "the initial Visible frame becomes ready");
+    {
+        const auto initial = invocationForGeneration(currentGeneration(controller));
+        expectations.expect(initial.has_value() && !initial->hasOverride,
+                            "the initial Visible request (no interaction yet) carries no override");
+    }
+
+    session.selectLayer(ids.layer);
+    const auto mapping = makeMapping(wideFormat());
+    controller.beginInteractiveScrub();
+    expectations.expect(!session.beginPositionInteraction(mapping).has_value(),
+                        "the interaction begins for the selected layer");
+    {
+        const auto generation = currentGeneration(controller);
+        expectations.expect(waitUntil([&] { return isReady(controller); }),
+                            "the armed begin's Interactive request reaches Ready");
+        const auto invocation = invocationForGeneration(generation);
+        expectations.expect(
+            invocation.has_value() && invocation->hasOverride &&
+                invocation->overrideValue == document::Vec2d{10.0, 20.0},
+            "an armed interaction attaches the (unmoved) override to its Interactive "
+            "request build");
+    }
+
+    session.updatePositionInteraction(40.0, 20.0);
+    {
+        const auto generation = currentGeneration(controller);
+        expectations.expect(waitUntil([&] { return isReady(controller); }),
+                            "the updated Interactive request reaches Ready");
+        const auto invocation = invocationForGeneration(generation);
+        const document::Vec2d expected{10.0 + 40.0 / 200.0 * 1000.0, 20.0 + 20.0 / 100.0 * 500.0};
+        expectations.expect(invocation.has_value() && invocation->hasOverride &&
+                                invocation->overrideValue == expected,
+                            "the update's Interactive request carries the freshly recomputed "
+                            "override (read fresh, not cached)");
+    }
+
+    // A Visible request bypasses the override entirely, even while the interaction is still active.
+    controller.requestRefresh();
+    {
+        const auto generation = currentGeneration(controller);
+        expectations.expect(waitUntil([&] { return isReady(controller); }),
+                            "the Visible refresh reaches Ready");
+        const auto invocation = invocationForGeneration(generation);
+        expectations.expect(invocation.has_value() && !invocation->hasOverride,
+                            "a Visible request never carries the active interaction's override");
+        expectations.expect(session.positionInteractionActive(),
+                            "the Visible refresh does not disturb the still-active interaction");
+    }
+
+    // Commit clears the interaction; the next (still-armed) Interactive-priority request carries no
+    // override.
+    expectations.expect(session.commitPositionInteraction(), "commit succeeds");
+    controller.notifyScrubEnded();
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "the post-commit request reaches Ready");
+    expectations.expect(!session.positionInteractionOverride().has_value(),
+                        "the override is gone after commit");
+
+    reachQuiescence(controller, bridge, scheduler, expectations);
+}
+
+void testAdmissionRejectedOverrideSurfacesErrorWithoutKillingInteraction(
+    Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Admission Rejected Override");
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId, document::Vec2d{0.0, 0.0});
+    ui::CompositionSession session(document, commands, compositionId);
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+    PipelineFixture fixture;
+
+    // Simulates a SnapshotCompiler admission rejection (InvalidParameterOverride /
+    // UnsupportedParameterOverride) without needing to engineer a genuine one: whenever the
+    // controller threads a non-null override, the pipeline reports Failed, exactly like a real
+    // rejected compile would surface through the existing plan-state/diagnostics projection.
+    ui::CompositionPreviewController controller(
+        session, scheduler, bridge,
+        [pipeline = fixture.pipeline](
+            const document::Snapshot& snapshot,
+            const runtime::PreviewRequestIdentity& desiredIdentity,
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
+            if (interactionOverride.has_value()) {
+                return runtime::TaskResult<ui::PreviewPreparationResultHandle>::failed(
+                    {.code = "bloom.preview.test-override-rejected",
+                     .severity = runtime::DiagnosticSeverity::Error,
+                     .summary = "Simulated parameter override admission rejection",
+                     .detail = {},
+                     .suggestedAction = {}});
+            }
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, interactionOverride,
+                            context);
+        });
+
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "the initial (override-free) frame becomes ready");
+
+    session.selectLayer(ids.layer);
+    const auto mapping = makeMapping(wideFormat());
+    controller.beginInteractiveScrub();
+    expectations.expect(!session.beginPositionInteraction(mapping).has_value(), "begin succeeds");
+    session.updatePositionInteraction(10.0, 10.0);
+
+    expectations.expect(
+        waitUntil([&] { return controller.state().activity == ui::PreviewActivity::Failed; }),
+        "the rejected override surfaces as a Failed preview, never a crash");
+    expectations.expect(session.positionInteractionActive(),
+                        "an admission-rejected override never kills the live interaction -- the "
+                        "gesture stays draggable");
+
+    session.cancelPositionInteraction();
+    controller.notifyScrubEnded();
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "clearing the override recovers a Ready preview");
+
+    reachQuiescence(controller, bridge, scheduler, expectations);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Viewer gesture (synthesized mouse)
+// ---------------------------------------------------------------------------------------------
+
+void sendMouse(QWidget& widget, const QEvent::Type type, const QPointF& local,
+               const Qt::MouseButton button, const Qt::MouseButtons buttons) {
+    QMouseEvent mouseEvent(type, local, local, button, buttons, Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &mouseEvent);
+}
+
+void sendPress(QWidget& widget, const QPointF& local) {
+    sendMouse(widget, QEvent::MouseButtonPress, local, Qt::LeftButton, Qt::LeftButton);
+}
+
+void sendMove(QWidget& widget, const QPointF& local) {
+    sendMouse(widget, QEvent::MouseMove, local, Qt::NoButton, Qt::LeftButton);
+}
+
+void sendRelease(QWidget& widget, const QPointF& local) {
+    sendMouse(widget, QEvent::MouseButtonRelease, local, Qt::LeftButton, Qt::NoButton);
+}
+
+// Mirrors ViewerEditor::currentMapping()'s display-rect derivation so the test can compute the
+// expected composition displacement the same way production code does, without hardcoding it.
+QRectF expectedDisplayRect(const QWidget& viewer,
+                           const bloom::ui::CompositionPreviewController& controller) {
+    using namespace bloom;
+    const auto& frame = controller.state().frame;
+    if (frame == nullptr) {
+        return {};
+    }
+    const auto viewResult = frame->displayBuffer().view();
+    if (!viewResult) {
+        return {};
+    }
+    const auto view = *viewResult.value();
+    const auto descriptorResult = view.descriptor();
+    if (!descriptorResult.has_value()) {
+        return {};
+    }
+    const QRectF frameRect = QRectF(viewer.rect()).adjusted(28.0, 28.0, -28.0, -28.0);
+    return ui::fitDisplayRect(frameRect, descriptorResult->displayWindow().extent(),
+                              descriptorResult->pixelAspect());
+}
+
+// document::Document is non-movable/non-copyable (its constructor and snapshot() own the live
+// project truth), so the fixture owns document/commands/session end to end and any test-specific
+// layer is added afterward through the session's own addSolidLayer() -- the real command surface,
+// which also keeps session.snapshot() correctly caching what it just created (see addSolidLayer()
+// above for why mutating a CommandStack behind an existing session's back is the wrong shape).
+struct GestureFixture final {
+    bloom::document::Document document;
+    bloom::commands::CommandStack commands;
+    bloom::ui::CompositionSession session;
+    bloom::runtime::TaskScheduler scheduler;
+    bloom::ui::TaskUiBridge bridge;
+    PipelineFixture pipeline;
+    bloom::ui::CompositionPreviewController controller;
+    bloom::ui::ViewerEditor viewer;
+
+    explicit GestureFixture(bloom::document::NewProject newProject)
+        : document(std::move(newProject.project)), commands(document),
+          session(document, commands, newProject.initialCompositionId),
+          scheduler(testSchedulerConfig()), bridge(scheduler, nullptr, 1ms),
+          controller(session, scheduler, bridge, pipeline.pipeline), viewer(session, controller) {
+        viewer.resize(400, 300);
+    }
+};
+
+void testDragMovesSelectedSolidLayerCommitsAndUndoes(Expectations& expectations) {
+    using namespace bloom;
+    GestureFixture fixture(makeTestProject("Viewer Drag Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the initial frame becomes ready before dragging");
+    // addSolidLayer() places the new layer at the composition center (1000x500 -> (500, 250)) and
+    // selects it, exactly like a real "Add Solid Layer" action would.
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.2, 0.3, 0.4, 1.0}),
+        "the fixture layer is added and selected");
+    // addSolidLayer() advances the document revision, which makes the frame currentMapping() would
+    // use stale until a fresh Ready frame for the new revision arrives.
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the frame becomes ready again for the post-add revision");
+    const auto* layerId = std::get_if<document::LayerId>(&fixture.session.selection().primary);
+    expectations.expect(layerId != nullptr, "addSolidLayer() leaves the new layer selected");
+    if (layerId == nullptr) {
+        return;
+    }
+    const auto* position = fixture.session.parameterForSelection(document::kPositionParameterRole);
+    expectations.expect(position != nullptr, "the new solid layer exposes a position parameter");
+    if (position == nullptr) {
+        return;
+    }
+    const auto positionId = position->id;
+    const auto base = fixture.session.constantVec2Value(positionId);
+    expectations.expect(base.has_value(),
+                        "the new layer's position starts as a resolvable constant");
+    if (!base.has_value()) {
+        return;
+    }
+
+    const QRectF displayRect = expectedDisplayRect(fixture.viewer, fixture.controller);
+    expectations.expect(!displayRect.isEmpty(), "the fixture's display rectangle is non-empty");
+
+    const QPointF pressPoint(200.0, 150.0);
+    const QPointF releasePoint(260.0, 110.0);
+    const QPointF delta = releasePoint - pressPoint;
+
+    const auto revisionBeforeDrag = fixture.session.snapshot().revision();
+    sendPress(fixture.viewer, pressPoint);
+    expectations.expect(fixture.session.positionInteractionActive(),
+                        "pressing on the viewer with a selected layer begins the interaction");
+    sendMove(fixture.viewer, releasePoint);
+    sendRelease(fixture.viewer, releasePoint);
+
+    expectations.expect(!fixture.session.positionInteractionActive(),
+                        "release ends the interaction");
+    expectations.expect(fixture.session.snapshot().revision().value() ==
+                            revisionBeforeDrag.value() + 1,
+                        "release commits exactly one document transaction -- one undo step");
+
+    const document::Vec2d expected{base->x + delta.x() / displayRect.width() * 1000.0,
+                                   base->y + delta.y() / displayRect.height() * 500.0};
+    expectations.expect(fixture.session.constantVec2Value(positionId) == expected,
+                        "the committed position matches base plus the screen-to-composition "
+                        "mapped total displacement");
+
+    expectations.expect(fixture.session.undo(), "the drag's commit undoes cleanly");
+    expectations.expect(fixture.session.constantVec2Value(positionId) == *base,
+                        "undo restores the exact pre-drag position");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the drag fixture reaches asynchronous scheduler quiescence");
+}
+
+void testDragOnEmptyOrUnselectedDoesNothing(Expectations& expectations) {
+    using namespace bloom;
+    GestureFixture fixture(makeTestProject("Viewer Drag Unselected Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the initial frame becomes ready");
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.2, 0.3, 0.4, 1.0}),
+        "the fixture layer is added");
+    // A layer exists in the composition, but nothing is selected -- matching an empty/unselected
+    // viewer, not merely an empty composition.
+    fixture.session.clearSelection();
+    const auto revisionBeforeDrag = fixture.session.snapshot().revision();
+
+    sendPress(fixture.viewer, QPointF(200.0, 150.0));
+    expectations.expect(!fixture.session.positionInteractionActive(),
+                        "pressing with nothing selected never begins an interaction");
+    sendMove(fixture.viewer, QPointF(260.0, 110.0));
+    sendRelease(fixture.viewer, QPointF(260.0, 110.0));
+
+    expectations.expect(fixture.session.snapshot().revision() == revisionBeforeDrag,
+                        "a drag on an empty/unselected viewer creates no command");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the unselected-drag fixture reaches asynchronous scheduler quiescence");
+}
+
+void testMidDragResizeCancelsWithNoCommitAndNoOverrideLeft(Expectations& expectations) {
+    using namespace bloom;
+    GestureFixture fixture(makeTestProject("Viewer Drag Resize Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the initial frame becomes ready before dragging");
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.2, 0.3, 0.4, 1.0}),
+        "the fixture layer is added and selected");
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the frame becomes ready again for the post-add revision");
+    const auto* position = fixture.session.parameterForSelection(document::kPositionParameterRole);
+    expectations.expect(position != nullptr, "the new solid layer exposes a position parameter");
+    if (position == nullptr) {
+        return;
+    }
+    const auto positionId = position->id;
+    const auto base = fixture.session.constantVec2Value(positionId);
+    const auto revisionBeforeDrag = fixture.session.snapshot().revision();
+
+    sendPress(fixture.viewer, QPointF(200.0, 150.0));
+    sendMove(fixture.viewer, QPointF(230.0, 170.0));
+    expectations.expect(fixture.session.positionInteractionActive() &&
+                            fixture.session.positionInteractionOverride().has_value(),
+                        "the interaction is live and overriding mid-drag");
+
+    // resize() alone only updates geometry; QWidget may defer dispatching the resizeEvent()
+    // override rather than sending it synchronously, so send one directly -- matching this file's
+    // synthesized-event idiom for presses/moves/releases/Escape -- to deterministically exercise
+    // ViewerEditor::resizeEvent() within this statement.
+    const QSize oldSize = fixture.viewer.size();
+    fixture.viewer.resize(250, 200);
+    QResizeEvent resize(fixture.viewer.size(), oldSize);
+    QCoreApplication::sendEvent(&fixture.viewer, &resize);
+    expectations.expect(!fixture.session.positionInteractionActive(),
+                        "a mid-drag resize cancels the interaction");
+    expectations.expect(!fixture.session.positionInteractionOverride().has_value(),
+                        "no override is left after the resize cancels it");
+
+    // The release that follows is a no-op: the gesture already ended at the resize.
+    sendRelease(fixture.viewer, QPointF(230.0, 170.0));
+    expectations.expect(fixture.session.snapshot().revision() == revisionBeforeDrag,
+                        "a mid-drag resize commits nothing");
+    expectations.expect(fixture.session.constantVec2Value(positionId) == base,
+                        "the position is untouched by the cancelled drag");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the resize-cancel fixture reaches asynchronous scheduler quiescence");
+}
+
+void testEscapeCancelsMidDrag(Expectations& expectations) {
+    using namespace bloom;
+    GestureFixture fixture(makeTestProject("Viewer Drag Escape Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the initial frame becomes ready before dragging");
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.2, 0.3, 0.4, 1.0}),
+        "the fixture layer is added and selected");
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the frame becomes ready again for the post-add revision");
+    const auto revisionBeforeDrag = fixture.session.snapshot().revision();
+
+    sendPress(fixture.viewer, QPointF(200.0, 150.0));
+    sendMove(fixture.viewer, QPointF(220.0, 160.0));
+    expectations.expect(fixture.session.positionInteractionActive(), "the interaction is live");
+
+    QKeyEvent escape(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &escape);
+    expectations.expect(!fixture.session.positionInteractionActive(),
+                        "Escape cancels the live interaction");
+    expectations.expect(fixture.session.snapshot().revision() == revisionBeforeDrag,
+                        "Escape commits nothing");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the escape-cancel fixture reaches asynchronous scheduler quiescence");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testControllerAttachesOverrideOnlyToArmedInteractiveRequests(expectations);
+    testAdmissionRejectedOverrideSurfacesErrorWithoutKillingInteraction(expectations);
+    testDragMovesSelectedSolidLayerCommitsAndUndoes(expectations);
+    testDragOnEmptyOrUnselectedDoesNothing(expectations);
+    testMidDragResizeCancelsWithNoCommitAndNoOverrideLeft(expectations);
+    testEscapeCancelsMidDrag(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/viewer_editor.cpp
+++ b/src/ui/viewer_editor.cpp
@@ -9,11 +9,15 @@
 #include <bloom/render/image_types.hpp>
 
 #include <QImage>
+#include <QKeyEvent>
+#include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QResizeEvent>
 
 #include <algorithm>
 #include <limits>
+#include <variant>
 
 namespace bloom::ui {
 namespace {
@@ -127,6 +131,13 @@ void drawDiagnosticBanner(QPainter& painter, const QRectF& available, const QStr
     painter.drawText(banner.adjusted(10.0, 0.0, -10.0, 0.0), Qt::AlignCenter, visible);
 }
 
+// The composed-frame rectangle paintEvent() draws pixels into (see the identical expression
+// there); shared with currentMapping() so direct manipulation maps screen deltas against exactly
+// the rectangle the user sees.
+QRectF viewerFrame(const QWidget& widget) {
+    return QRectF(widget.rect()).adjusted(28.0, 28.0, -28.0, -28.0);
+}
+
 } // namespace
 
 QRectF fitDisplayRect(const QRectF& available, const render::ImageExtent extent,
@@ -158,6 +169,8 @@ ViewerEditor::ViewerEditor(CompositionSession& session,
     setAccessibleName(tr("Composition viewer"));
     setMinimumSize(220, 150);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    // StrongFocus lets a press-to-drag gesture also receive the Escape key that cancels it.
+    setFocusPolicy(Qt::StrongFocus);
     connect(&session_, &CompositionSession::snapshotChanged, this,
             qOverload<>(&ViewerEditor::update));
     connect(&session_, &CompositionSession::compositionChanged, this,
@@ -166,6 +179,12 @@ ViewerEditor::ViewerEditor(CompositionSession& session,
             qOverload<>(&ViewerEditor::update));
     connect(&previewController_, &CompositionPreviewController::stateChanged, this, [this] {
         updatePreviewAccessibility();
+        // A newly delivered frame may carry a format/proxy/pixel-aspect/display-descriptor change
+        // (docs/architecture/animation-and-time.md); a mid-drag mapping change cancels the gesture
+        // rather than silently mis-mapping the rest of it.
+        if (dragActive_ && !mappingStillValid()) {
+            endDrag(false);
+        }
         update();
     });
     updatePreviewAccessibility();
@@ -176,7 +195,7 @@ void ViewerEditor::paintEvent(QPaintEvent* event) {
     QPainter painter(this);
     painter.fillRect(rect(), QColor(15, 16, 18));
 
-    const QRectF frame = QRectF(rect()).adjusted(28.0, 28.0, -28.0, -28.0);
+    const QRectF frame = viewerFrame(*this);
     painter.fillRect(frame, QColor(39, 41, 45));
     painter.setPen(QPen(QColor(77, 80, 87), 1.0));
     painter.drawRect(frame.adjusted(0.0, 0.0, -1.0, -1.0));
@@ -289,6 +308,137 @@ void ViewerEditor::updatePreviewAccessibility() {
     }
     setAccessibleDescription(
         tr("%1. %2. Reference display.").arg(preview.message, frameDescription));
+}
+
+std::optional<PositionInteractionMapping> ViewerEditor::currentMapping() const {
+    const auto& preview = previewController_.state();
+    const PreparedPreviewFrameHandle& frameHandle = preview.frame;
+    if (frameHandle == nullptr) {
+        return std::nullopt;
+    }
+    // A stale frame from another composition -- or an older revision of this one -- is never a
+    // mapping source (docs/architecture/animation-and-time.md, "Direct Manipulation And Preview
+    // Overrides").
+    if (frameHandle->desiredIdentity().compositionId != session_.compositionId() ||
+        frameHandle->desiredIdentity().sourceRevision != session_.snapshot().revision()) {
+        return std::nullopt;
+    }
+    const auto* composition = session_.composition();
+    if (composition == nullptr) {
+        return std::nullopt;
+    }
+    const auto viewResult = frameHandle->displayBuffer().view();
+    if (!viewResult) {
+        return std::nullopt;
+    }
+    const auto view = *viewResult.value();
+    const auto descriptorResult = view.descriptor();
+    if (!descriptorResult.has_value()) {
+        return std::nullopt;
+    }
+    const auto descriptor = *descriptorResult;
+    const QRectF displayRect = fitDisplayRect(
+        viewerFrame(*this), descriptor.displayWindow().extent(), descriptor.pixelAspect());
+    if (displayRect.isEmpty()) {
+        return std::nullopt;
+    }
+    return PositionInteractionMapping{
+        .displayRect = displayRect,
+        .compositionFormat = composition->format(),
+        .resolution = frameHandle->desiredIdentity().resolution,
+        .pixelAspect = descriptor.pixelAspect(),
+        .displayDescriptor = descriptor,
+    };
+}
+
+bool ViewerEditor::mappingStillValid() const {
+    if (!activeMapping_.has_value()) {
+        return false;
+    }
+    const auto mapping = currentMapping();
+    return mapping.has_value() && *mapping == *activeMapping_;
+}
+
+void ViewerEditor::endDrag(const bool commit) {
+    dragActive_ = false;
+    activeMapping_.reset();
+    if (commit) {
+        (void)session_.commitPositionInteraction();
+    } else {
+        session_.cancelPositionInteraction();
+    }
+    // Reuses TimelineRuler's Interactive-cadence arming (docs/architecture/animation-and-time.md,
+    // "Session Time And Scrubbing"): bypasses any remaining trailing delay and disarms it.
+    previewController_.notifyScrubEnded();
+}
+
+void ViewerEditor::mousePressEvent(QMouseEvent* event) {
+    if (event->button() != Qt::LeftButton ||
+        !std::holds_alternative<document::LayerId>(session_.selection().primary)) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    auto mapping = currentMapping();
+    if (!mapping.has_value()) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    if (session_.beginPositionInteraction(*mapping).has_value()) {
+        // Typed rejection (no selection, no resolvable/animated-without-a-key/driven position, or
+        // an empty mapping): the drag simply never starts. No cursor/handle art communicates this
+        // in v1 -- the gesture itself is the whole slice.
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    dragActive_ = true;
+    dragOrigin_ = event->position();
+    activeMapping_ = mapping;
+    setFocus(Qt::MouseFocusReason);
+    previewController_.beginInteractiveScrub();
+    event->accept();
+}
+
+void ViewerEditor::mouseMoveEvent(QMouseEvent* event) {
+    if (!dragActive_) {
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+    if (!mappingStillValid()) {
+        endDrag(false);
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+    // Total displacement from the ORIGINAL press point, not from the previous move -- base value
+    // plus TOTAL gesture displacement, never a chain of already-rounded intermediates (docs/
+    // architecture/animation-and-time.md).
+    const QPointF delta = event->position() - dragOrigin_;
+    session_.updatePositionInteraction(delta.x(), delta.y());
+    event->accept();
+}
+
+void ViewerEditor::mouseReleaseEvent(QMouseEvent* event) {
+    if (!dragActive_ || event->button() != Qt::LeftButton) {
+        QWidget::mouseReleaseEvent(event);
+        return;
+    }
+    endDrag(true);
+    event->accept();
+}
+
+void ViewerEditor::keyPressEvent(QKeyEvent* event) {
+    if (dragActive_ && event->key() == Qt::Key_Escape) {
+        endDrag(false);
+        event->accept();
+        return;
+    }
+    QWidget::keyPressEvent(event);
+}
+
+void ViewerEditor::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+    if (dragActive_) {
+        endDrag(false);
+    }
 }
 
 } // namespace bloom::ui


### PR DESCRIPTION
Closes #82.

Batch 4 slice 5, completing the batch's interactive slices: **drag the selected layer in the viewer, watch the preview follow live, release for exactly one undo step.**

**The contract's PositionInteraction, verbatim**: gesture begin freezes the mapping rectangle, format, proxy, pixel aspect, and display-descriptor identity from the displayed frame — after verifying it belongs to the live composition and revision (a stale frame is never a mapping source). Typed refusals for missing mapping, unresolvable position, driven parameters, and animated parameters without an exact key at the current time — interpolated bases are never guessed; the honest v1 gates on an exact key and updates it on commit.

**Exact displacement**: base value plus total gesture displacement through the contract formulas, never chained rounded intermediates. Resize, DPI, display, composition, or revision changes cancel cleanly.

**Overrides ride the existing machinery**: attached only to armed Interactive requests through the cadence, read fresh per request, threaded into the compiler's existing admission; rejections surface the honest error state without killing the gesture.

**One decision, one place**: the review round extracted the command-selection branch (constant → set parameter, animated → update exact-time key, driven → refuse) into a single shared helper both the property path and the gesture path use.

Testing: displacement pins, every typed refusal and invalidation, exact-one-transaction commits with exact undo, override threading proofs, and synthesized-mouse drag/commit/undo/cancel/Escape cycles. Desktop 86/86, native 72/72, format green.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (one review round).