### PR TITLE
feat: edit keyframes in the timeline

### DIFF
--- a/src/ui/composition_session.cpp
+++ b/src/ui/composition_session.cpp
@@ -205,18 +205,27 @@ void CompositionSession::selectParameter(const document::ParameterId parameterId
         return;
     }
 
-    std::optional<document::LayerId> contextualLayer;
-    for (const auto& node : current->graph().nodes()) {
-        const auto binding = std::ranges::find_if(node.parameters, [parameterId](const auto& item) {
-            return item.parameterId == parameterId;
-        });
-        if (binding != node.parameters.end()) {
-            contextualLayer = layerForNode(node.id);
-            break;
-        }
+    CompositionSelection next{.primary = parameterId,
+                              .contextualLayer = contextualLayerForParameter(parameterId)};
+    if (selection_ != next) {
+        selection_ = next;
+        emit selectionChanged();
+    }
+}
+
+void CompositionSession::selectKeyframe(const document::AnimationCurveId curveId,
+                                        const document::KeyframeId keyframeId) {
+    Q_ASSERT(QThread::currentThread() == thread());
+    const KeyframeSelection target{curveId, keyframeId};
+    if (!keyframeSelectionExists(target)) {
+        reportUnavailable(QStringLiteral("The selected keyframe is no longer available"));
+        return;
     }
 
-    CompositionSelection next{.primary = parameterId, .contextualLayer = contextualLayer};
+    const auto parameterId = parameterForCurve(curveId);
+    const auto contextualLayer =
+        parameterId.has_value() ? contextualLayerForParameter(*parameterId) : std::nullopt;
+    CompositionSelection next{.primary = target, .contextualLayer = contextualLayer};
     if (selection_ != next) {
         selection_ = next;
         emit selectionChanged();
@@ -543,6 +552,64 @@ bool CompositionSession::moveLayerBefore(const document::LayerSlotId slotId,
     return execute(std::move(transaction));
 }
 
+bool CompositionSession::deleteSelectedKeyframe() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    const auto* keySelection = std::get_if<KeyframeSelection>(&selection_.primary);
+    if (keySelection == nullptr) {
+        return false;
+    }
+    commands::Transaction transaction("Delete Keyframe", snapshot_.revision());
+    transaction.emplace<commands::DeleteKeyframe>(compositionId_, keySelection->curveId,
+                                                  keySelection->keyframeId);
+    return execute(std::move(transaction));
+}
+
+bool CompositionSession::moveSelectedKeyframe(const core::RationalTime newTime) {
+    Q_ASSERT(QThread::currentThread() == thread());
+    const auto* keySelection = std::get_if<KeyframeSelection>(&selection_.primary);
+    if (keySelection == nullptr) {
+        return false;
+    }
+    const auto* current = composition();
+    const auto* record =
+        current == nullptr ? nullptr : current->animationCurves().find(keySelection->curveId);
+    if (record == nullptr) {
+        return false;
+    }
+
+    commands::Transaction transaction("Move Keyframe", snapshot_.revision());
+    if (const auto* scalar = std::get_if<document::ScalarAnimationCurve>(record)) {
+        const auto key = std::ranges::find(scalar->keyframes, keySelection->keyframeId,
+                                           &document::ScalarKeyframe::id);
+        if (key == scalar->keyframes.end()) {
+            return false;
+        }
+        if (key->time == newTime) {
+            // Zero effective change commits nothing (docs/architecture/animation-and-time.md's
+            // zero-move precedent -- mirrors commitPositionInteraction()'s zero-move branch).
+            return true;
+        }
+        transaction.emplace<commands::UpdateScalarKeyframe>(compositionId_, keySelection->curveId,
+                                                            keySelection->keyframeId, newTime,
+                                                            key->value, key->outgoingInterpolation);
+    } else if (const auto* vec2 = std::get_if<document::Vec2AnimationCurve>(record)) {
+        const auto key = std::ranges::find(vec2->keyframes, keySelection->keyframeId,
+                                           &document::Vec2Keyframe::id);
+        if (key == vec2->keyframes.end()) {
+            return false;
+        }
+        if (key->time == newTime) {
+            return true;
+        }
+        transaction.emplace<commands::UpdateVec2Keyframe>(compositionId_, keySelection->curveId,
+                                                          keySelection->keyframeId, newTime,
+                                                          key->value, key->outgoingInterpolation);
+    } else {
+        return false;
+    }
+    return execute(std::move(transaction));
+}
+
 bool CompositionSession::positionInteractionActive() const noexcept {
     return positionInteraction_.has_value();
 }
@@ -773,7 +840,7 @@ CompositionSession::parameterForNode(const document::NodeRecord& node,
                                             : current->parameters().find(binding->parameterId);
 }
 
-bool CompositionSession::selectionExists(const CompositionSelection& selection) const noexcept {
+bool CompositionSession::selectionExists(const CompositionSelection& selection) const {
     const auto* current = composition();
     if (current == nullptr) {
         return false;
@@ -787,8 +854,60 @@ bool CompositionSession::selectionExists(const CompositionSelection& selection) 
     if (const auto* nodeId = std::get_if<document::NodeId>(&selection.primary)) {
         return current->graph().findNode(*nodeId) != nullptr;
     }
+    if (const auto* keySelection = std::get_if<KeyframeSelection>(&selection.primary)) {
+        return keyframeSelectionExists(*keySelection);
+    }
     const auto* parameterId = std::get_if<document::ParameterId>(&selection.primary);
     return parameterId != nullptr && current->parameters().find(*parameterId) != nullptr;
+}
+
+bool CompositionSession::keyframeSelectionExists(const KeyframeSelection& selection) const {
+    const auto* current = composition();
+    if (current == nullptr) {
+        return false;
+    }
+    const auto* record = current->animationCurves().find(selection.curveId);
+    if (record == nullptr) {
+        return false;
+    }
+    return std::visit(
+        [&](const auto& curve) {
+            return std::ranges::any_of(
+                curve.keyframes, [&](const auto& key) { return key.id == selection.keyframeId; });
+        },
+        *record);
+}
+
+std::optional<document::ParameterId>
+CompositionSession::parameterForCurve(const document::AnimationCurveId curveId) const noexcept {
+    const auto* current = composition();
+    if (current == nullptr) {
+        return std::nullopt;
+    }
+    for (const auto& parameter : current->parameters().records()) {
+        const auto* source = std::get_if<document::AnimationCurveSource>(&parameter.source);
+        if (source != nullptr && source->curveId == curveId) {
+            return parameter.id;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<document::LayerId>
+CompositionSession::contextualLayerForParameter(const document::ParameterId parameterId) const {
+    const auto* current = composition();
+    if (current == nullptr) {
+        return std::nullopt;
+    }
+    for (const auto& node : current->graph().nodes()) {
+        const auto binding = std::ranges::find_if(node.parameters, [parameterId](const auto& item) {
+            return item.parameterId == parameterId;
+        });
+        if (binding != node.parameters.end()) {
+            return layerForNode(node.id);
+        }
+    }
+    return std::nullopt;
 }
 
 void CompositionSession::normalizeSelection() {

--- a/src/ui/include/bloom/ui/composition_session.hpp
+++ b/src/ui/include/bloom/ui/composition_session.hpp
@@ -32,8 +32,24 @@ struct Vec2d;
 
 namespace bloom::ui {
 
-using SelectionTarget =
-    std::variant<std::monostate, document::LayerId, document::NodeId, document::ParameterId>;
+// A selected keyframe (issue #84; docs/architecture/animation-and-time.md: "Keyframe selection
+// stores the stable KeyframeId; row index and screen position are presentation details"). curveId
+// is included because it, together with keyframeId, is exactly what DeleteKeyframe/
+// UpdateScalarKeyframe/UpdateVec2Keyframe are keyed by (src/commands/include/bloom/commands/
+// animation_operations.hpp) -- no command needs the owning ParameterId. The owning ParameterId (and
+// from it, the contextual layer) is instead derived on demand from curveId wherever something
+// genuinely needs it (CompositionSession::selectKeyframe() does this once, to populate
+// contextualLayer, the same way selectParameter() already derives it rather than caching it), so it
+// is deliberately NOT stored here.
+struct KeyframeSelection final {
+    document::AnimationCurveId curveId;
+    document::KeyframeId keyframeId;
+
+    friend bool operator==(const KeyframeSelection&, const KeyframeSelection&) = default;
+};
+
+using SelectionTarget = std::variant<std::monostate, document::LayerId, document::NodeId,
+                                     document::ParameterId, KeyframeSelection>;
 
 struct CompositionSelection {
     SelectionTarget primary;
@@ -108,6 +124,11 @@ class CompositionSession final : public QObject {
     void selectLayer(document::LayerId layerId);
     void selectNode(document::NodeId nodeId);
     void selectParameter(document::ParameterId parameterId);
+    // Selecting a keyframe REPLACES the primary selection like every other select* method (one
+    // primary/contextual selection truth -- docs/roadmap.md's Batch-4 gate). A missing curve/key
+    // reports unavailable and leaves the selection untouched, mirroring selectLayer/selectNode/
+    // selectParameter's own not-found handling.
+    void selectKeyframe(document::AnimationCurveId curveId, document::KeyframeId keyframeId);
 
     [[nodiscard]] const document::NodeRecord* selectedNode() const noexcept;
     [[nodiscard]] std::optional<document::LayerId> layerForNode(document::NodeId nodeId) const;
@@ -130,6 +151,18 @@ class CompositionSession final : public QObject {
     [[nodiscard]] bool
     moveLayerBefore(document::LayerSlotId slotId,
                     std::optional<document::LayerSlotId> beforeSlotId = std::nullopt);
+
+    // Keyframe delete/move gestures (issue #84; docs/architecture/animation-and-time.md). Command
+    // construction lives here, not in the widget -- the same "one place" precedent as
+    // executePositionCommand(). Both are a no-op false with no transaction and the selection intact
+    // when nothing is selected or the command layer refuses (e.g. DeleteKeyframe's final-key
+    // refusal, UpdateScalarKeyframe/UpdateVec2Keyframe's duplicate-time refusal).
+    [[nodiscard]] bool deleteSelectedKeyframe();
+    // Reads the selected key's EXISTING value/interpolation from the current snapshot and passes
+    // them unchanged with newTime (scalar vs Vec2d branch resolved once, here). A newTime exactly
+    // equal to the key's current exact time commits nothing and returns true (docs/architecture/
+    // animation-and-time.md's zero-move precedent, mirrored from commitPositionInteraction()).
+    [[nodiscard]] bool moveSelectedKeyframe(core::RationalTime newTime);
 
     // Direct viewer manipulation of the selected layer's position (docs/architecture/
     // animation-and-time.md, "Direct Manipulation And Preview Overrides"; issue #82). Session-only,
@@ -210,7 +243,16 @@ class CompositionSession final : public QObject {
     [[nodiscard]] bool executePositionCommand(document::ParameterId parameterId,
                                               core::RationalTime time, document::Vec2d value,
                                               const QString& commandLabel);
-    [[nodiscard]] bool selectionExists(const CompositionSelection& selection) const noexcept;
+    // Not noexcept (see keyframeSelectionExists()): the KeyframeSelection branch delegates to it.
+    [[nodiscard]] bool selectionExists(const CompositionSelection& selection) const;
+    // Not noexcept: std::visit over the AnimationCurveStore's curve-kind variant cannot be proven
+    // exception-free by clang-tidy's bugprone-exception-escape (the variant is never valueless in
+    // practice, but std::visit's contract still permits bad_variant_access).
+    [[nodiscard]] bool keyframeSelectionExists(const KeyframeSelection& selection) const;
+    [[nodiscard]] std::optional<document::ParameterId>
+    parameterForCurve(document::AnimationCurveId curveId) const noexcept;
+    [[nodiscard]] std::optional<document::LayerId>
+    contextualLayerForParameter(document::ParameterId parameterId) const;
     void normalizeSelection();
     void reportUnavailable(const QString& message);
     // Cancels an active position interaction whose frozen base revision no longer matches

--- a/src/ui/include/bloom/ui/timeline_ruler.hpp
+++ b/src/ui/include/bloom/ui/timeline_ruler.hpp
@@ -4,9 +4,9 @@
 
 #include <QWidget>
 
-#include <optional>
 #include <vector>
 
+class QKeyEvent;
 class QVBoxLayout;
 
 namespace bloom::ui {
@@ -43,33 +43,39 @@ class TimelineRuler final : public QWidget {
 
 // One row per animated parameter of the current selection's layer (position/opacity only in
 // version 1 -- docs/architecture/animation-and-time.md, "Durable Type Model"): a name label plus a
-// key lane painting each key at its exact time. Clicking a key selects it.
+// key lane painting each key at its exact time. Clicking a key selects it; dragging past
+// QApplication::startDragDistance() moves it (a presentation-only ghost until release); Delete/
+// Backspace on the panel deletes the selected key.
 //
-// Selection-model finding: bloom::ui::CompositionSelection (composition_session.hpp) has no
-// keyframe concept -- its SelectionTarget variant covers only LayerId/NodeId/ParameterId. Per this
-// task's decision 3, key selection is therefore kept as TimelineEditor-local state here, keyed by
-// the durable KeyframeId, and survives a rebuild (curve edit, undo/redo) when the key still exists.
-// Unifying it into one primary/contextual selection truth across editors is left to the
-// direct-manipulation slice that consumes it.
+// Selection-model finding (issue #84): bloom::ui::CompositionSelection now carries a
+// bloom::ui::KeyframeSelection alternative (curveId + KeyframeId) as its primary selection, so this
+// panel no longer keeps a local selectedKeyframe_ -- it reads/writes CompositionSession::
+// selection()/selectKeyframe()/deleteSelectedKeyframe()/moveSelectedKeyframe(), the one
+// primary/contextual selection truth every other editor already shares (docs/roadmap.md's Batch-4
+// gate). Pruning a vanished key is likewise centralized: CompositionSession::normalizeSelection()
+// (run after every session-mediated execute/undo/redo) already invalidates any selection kind that
+// no longer resolves against the current snapshot, so this panel needs no local prune pass.
 class TimelineKeyframePanel final : public QWidget {
     Q_OBJECT
 
   public:
     explicit TimelineKeyframePanel(CompositionSession& session, QWidget* parent = nullptr);
 
-    [[nodiscard]] std::optional<document::KeyframeId> selectedKeyframe() const noexcept {
-        return selectedKeyframe_;
-    }
+  protected:
+    void keyPressEvent(QKeyEvent* event) override;
 
   private:
     void rebuild();
-    void handleKeySelected(document::KeyframeId id);
-    void pruneSelectionIfMissing();
 
     CompositionSession& session_;
     QVBoxLayout* rowsLayout_ = nullptr;
     std::vector<class TimelineKeyframeRow*> rows_;
-    std::optional<document::KeyframeId> selectedKeyframe_;
+    // Memoizes which curves currently have a row, so rebuild() only tears down/recreates widgets
+    // when the row SET actually changes (a different contextual layer, or a curve appearing/
+    // disappearing) rather than on every selectionChanged/snapshotChanged -- notably including the
+    // one a row's OWN click/drag emits via CompositionSession::selectKeyframe(). Without this, a
+    // key click would destroy the very row handling the mouse event that triggered it.
+    std::vector<document::AnimationCurveId> lastCurveIds_;
 };
 
 } // namespace bloom::ui

--- a/src/ui/tests/timeline_ruler_tests.cpp
+++ b/src/ui/tests/timeline_ruler_tests.cpp
@@ -21,6 +21,7 @@
 #include <QApplication>
 #include <QElapsedTimer>
 #include <QEventLoop>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPointF>
 #include <QString>
@@ -207,6 +208,17 @@ void sendRelease(QWidget& widget, const qreal pixelX) {
     QCoreApplication::sendEvent(&widget, &release);
 }
 
+void sendMove(QWidget& widget, const qreal pixelX) {
+    const QPointF local(pixelX, widget.height() / 2.0);
+    QMouseEvent move(QEvent::MouseMove, local, local, Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &move);
+}
+
+void sendKey(QWidget& widget, const Qt::Key key) {
+    QKeyEvent press(QEvent::KeyPress, key, Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &press);
+}
+
 // 1 second at 24 fps has frame indices 0..23. A ruler resized to 47 logical pixels (width - 1 = 46
 // = 2 * 23) makes every EVEN pixel land exactly on a frame and every ODD pixel land exactly at the
 // halfway point between two frames -- a deterministic, exactly-representable tie case pinned by
@@ -292,7 +304,12 @@ void testKeyframeRowsAppearOnePerAnimatedParameter(Expectations& expectations) {
                         "rows are removed and the panel hides once nothing is selected");
 }
 
-void testKeyframeClickSelectsExpectedPixelAndSurvivesRebuild(Expectations& expectations) {
+// Selection unification (issue #84, decision 1): a keyframe click no longer sets TimelineEditor-
+// local state -- it calls CompositionSession::selectKeyframe(), which REPLACES the primary
+// selection like every other select* method, and central CompositionSession::normalizeSelection()
+// (run after every session-mediated execute/undo/redo) prunes it once the key no longer resolves,
+// without the panel needing any local prune pass.
+void testKeyframeClickSelectsByIdAndOneTruthSelectionSwap(Expectations& expectations) {
     using namespace bloom;
     const auto duration = time(10);
     auto newProject = makeTestProject("Keyframe Click Test", duration);
@@ -300,30 +317,35 @@ void testKeyframeClickSelectsExpectedPixelAndSurvivesRebuild(Expectations& expec
     document::Document document(std::move(newProject.project));
     commands::CommandStack commands(document);
     const auto ids = addSolidLayer(document, commands, compositionId);
-    (void)animateParameter(document, commands, compositionId, ids.opacity, time(0));
-
-    ui::CompositionSession session(document, commands, compositionId);
-    session.selectLayer(ids.layer);
+    const auto curveId = animateParameter(document, commands, compositionId, ids.opacity, time(0));
 
     // A second exact-time key, five seconds into a ten second composition -- its pixel position
     // (fraction 0.5 of the width) is easy to reason about independent of the row's own painting.
-    expectations.expect(session.setCurrentTime(time(5)), "session accepts the second key's time");
-    expectations.expect(session.setSelectedOpacity(0.4), "the second opacity key is inserted");
-    const auto* opacityParameter = session.composition()->parameters().find(ids.opacity);
-    const auto* animationSource =
-        opacityParameter == nullptr
-            ? nullptr
-            : std::get_if<document::AnimationCurveSource>(&opacityParameter->source);
-    const auto* opacityCurve =
-        animationSource == nullptr
-            ? nullptr
-            : session.composition()->animationCurves().findScalar(animationSource->curveId);
+    // Inserted directly through the CommandStack (not through a not-yet-constructed session) so
+    // CompositionSession's very first cached snapshot already contains it.
+    {
+        commands::Transaction insertSecond("Insert second opacity key",
+                                           document.snapshot().revision());
+        insertSecond.emplace<commands::InsertScalarKeyframe>(compositionId, curveId, time(5), 0.4);
+        expectations.expect(commands.execute(std::move(insertSecond)).changed(),
+                            "fixture inserts a second exact-time opacity key");
+    }
+    const auto* opacityCurve = document.snapshot()
+                                   .project()
+                                   .findComposition(compositionId)
+                                   ->animationCurves()
+                                   .findScalar(curveId);
     expectations.expect(opacityCurve != nullptr && opacityCurve->keyframes.size() == 2,
                         "the opacity curve now holds exactly two keys");
     if (opacityCurve == nullptr || opacityCurve->keyframes.size() != 2) {
         return;
     }
     const auto secondKeyId = opacityCurve->keyframes.back().id;
+
+    ui::CompositionSession session(document, commands, compositionId);
+    session.selectLayer(ids.layer);
+    expectations.expect(std::holds_alternative<document::LayerId>(session.selection().primary),
+                        "the layer starts out as the primary selection");
 
     ui::TimelineKeyframePanel panel(session);
     panel.resize(200, panel.sizeHint().height() > 0 ? panel.sizeHint().height() : 24);
@@ -338,37 +360,309 @@ void testKeyframeClickSelectsExpectedPixelAndSurvivesRebuild(Expectations& expec
     // fraction = 5s / 10s = 0.5; pixel = 0.5 * (width - 1), matching TimelineAxis::pixelForTime.
     const qreal expectedPixel = 0.5 * static_cast<qreal>(row->width() - 1);
     sendClick(*row, expectedPixel);
-    expectations.expect(panel.selectedKeyframe().has_value() &&
-                            *panel.selectedKeyframe() == secondKeyId,
-                        "a click at the key's expected pixel position selects it by id");
+    const auto* firstClickSelection =
+        std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(firstClickSelection != nullptr && firstClickSelection->curveId == curveId &&
+                            firstClickSelection->keyframeId == secondKeyId,
+                        "a click at the key's expected pixel position selects it by curve+key id, "
+                        "REPLACING the layer as the primary selection");
 
-    // Rebuild the rows via an unrelated document edit + undo, which leaves the opacity curve
-    // untouched: the id-keyed selection must survive both rebuilds.
-    expectations.expect(
-        session.addTextLayer(QStringLiteral("Unrelated"), QStringLiteral("Unrelated")),
-        "an unrelated edit triggers a rebuild via snapshotChanged");
-    expectations.expect(panel.selectedKeyframe().has_value() &&
-                            *panel.selectedKeyframe() == secondKeyId,
-                        "the id-keyed selection survives a rebuild when the key still exists");
-    expectations.expect(session.undo(), "the unrelated edit undoes cleanly");
-    expectations.expect(panel.selectedKeyframe().has_value() &&
-                            *panel.selectedKeyframe() == secondKeyId,
-                        "the id-keyed selection also survives the undo's rebuild");
+    // The one-truth swap holds in both directions: selecting the layer again replaces the
+    // keyframe, and the keyframe can then replace the layer again.
+    session.selectLayer(ids.layer);
+    expectations.expect(std::holds_alternative<document::LayerId>(session.selection().primary),
+                        "reselecting the layer REPLACES the keyframe as the primary selection");
+    sendClick(*row, expectedPixel);
+    expectations.expect(std::holds_alternative<ui::KeyframeSelection>(session.selection().primary),
+                        "the key can be reselected after the layer replaced it");
 
-    // Now undo the edit that created the selected key itself: the key no longer exists anywhere,
-    // and the panel must silently clear the selection rather than crash.
-    expectations.expect(session.undo(), "undoing the second opacity edit removes its key");
-    expectations.expect(!panel.selectedKeyframe().has_value(),
-                        "the selection is pruned once its key no longer exists, without crashing");
+    // Central prune: undo the very edit that created the selected key. The key vanishes from the
+    // document and CompositionSession::normalizeSelection() must clear the now-dangling selection
+    // without crashing (the panel keeps no local prune pass of its own).
+    expectations.expect(session.undo(), "undoing the second opacity key insertion succeeds");
+    expectations.expect(std::holds_alternative<std::monostate>(session.selection().primary),
+                        "the selection is pruned centrally once its key no longer exists");
 
-    // AddTextLayer's own command (like AddSolidLayer) moves the primary selection to the layer it
-    // creates, and undoing it back out of existence leaves nothing selected (CompositionSession::
-    // normalizeSelection()) -- reselect the original layer to isolate this assertion to the row
-    // rebuild itself, not session selection semantics covered elsewhere.
     session.selectLayer(ids.layer);
     const auto rowsAfterPrune = panel.findChildren<QWidget*>();
     expectations.expect(rowsAfterPrune.size() == 1,
                         "the opacity row remains (the curve still holds its seeded first key)");
+}
+
+// Delete gesture (issue #84, decision 2): Delete/Backspace on the focused panel executes ONE
+// DeleteKeyframe transaction through CompositionSession::deleteSelectedKeyframe(); the command
+// layer's last-key refusal (DeleteKeyframe rejects a curve's final key -- src/commands/
+// animation_operations.cpp) is pinned with no state change.
+void testDeleteGestureRemovesKeyAndRefusesTheLastOne(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Keyframe Delete Test", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId);
+    const auto curveId = animateParameter(document, commands, compositionId, ids.opacity, time(0));
+
+    document::KeyframeId extraKeyId;
+    {
+        commands::Transaction insertExtra("Insert extra opacity key",
+                                          document.snapshot().revision());
+        insertExtra.emplace<commands::InsertScalarKeyframe>(compositionId, curveId, time(2), 0.3);
+        const auto inserted = commands.execute(std::move(insertExtra));
+        const auto id = inserted.outputId<document::KeyframeId>(commands::kKeyframeOutput);
+        expectations.expect(inserted.changed() && id.has_value(),
+                            "fixture inserts a second exact-time opacity key");
+        if (!id.has_value()) {
+            return;
+        }
+        extraKeyId = *id;
+    }
+
+    ui::CompositionSession session(document, commands, compositionId);
+    session.selectLayer(ids.layer);
+    ui::TimelineKeyframePanel panel(session);
+
+    session.selectKeyframe(curveId, extraKeyId);
+    const auto* selected = std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(selected != nullptr && selected->keyframeId == extraKeyId,
+                        "the extra key is selected before the delete gesture");
+
+    const auto historyBeforeDelete = commands.size();
+    sendKey(panel, Qt::Key_Delete);
+    const auto* curveAfterDelete = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(curveAfterDelete != nullptr && curveAfterDelete->keyframes.size() == 1,
+                        "Delete on the focused panel removes the selected key in one transaction");
+    expectations.expect(commands.size() == historyBeforeDelete + 1,
+                        "the delete gesture is exactly one undoable transaction");
+    expectations.expect(std::holds_alternative<std::monostate>(session.selection().primary),
+                        "the selection is cleared once its key is deleted");
+
+    expectations.expect(session.undo(), "the delete gesture undoes cleanly");
+    const auto* curveAfterUndo = session.composition()->animationCurves().findScalar(curveId);
+    if (curveAfterUndo == nullptr) {
+        expectations.expect(false, "the opacity curve remains addressable after undo");
+        return;
+    }
+    const auto restored =
+        std::ranges::find(curveAfterUndo->keyframes, extraKeyId, &document::ScalarKeyframe::id);
+    expectations.expect(curveAfterUndo->keyframes.size() == 2 &&
+                            restored != curveAfterUndo->keyframes.end() &&
+                            restored->time == time(2) && restored->value == 0.3,
+                        "undo restores the deleted key with the SAME KeyframeId and exact time");
+
+    // Bring the curve back down to its single seeded key, then pin the last-key refusal.
+    session.selectKeyframe(curveId, extraKeyId);
+    expectations.expect(session.deleteSelectedKeyframe(), "the extra key can be deleted again");
+    const auto* seedCurve = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(seedCurve != nullptr && seedCurve->keyframes.size() == 1,
+                        "the curve is back down to its single seeded key");
+    if (seedCurve == nullptr || seedCurve->keyframes.size() != 1) {
+        return;
+    }
+    const auto seedKeyId = seedCurve->keyframes.front().id;
+    const auto seedKeyTime = seedCurve->keyframes.front().time;
+    session.selectKeyframe(curveId, seedKeyId);
+
+    const auto historyBeforeRefusal = commands.size();
+    sendKey(panel, Qt::Key_Backspace);
+    const auto* curveAfterRefusal = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(curveAfterRefusal != nullptr && curveAfterRefusal->keyframes.size() == 1 &&
+                            curveAfterRefusal->keyframes.front().id == seedKeyId &&
+                            curveAfterRefusal->keyframes.front().time == seedKeyTime,
+                        "Backspace on the curve's last key leaves it completely unchanged");
+    expectations.expect(commands.size() == historyBeforeRefusal,
+                        "the command layer's last-key refusal creates no transaction");
+    const auto* selectionAfterRefusal =
+        std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(selectionAfterRefusal != nullptr &&
+                            selectionAfterRefusal->keyframeId == seedKeyId,
+                        "a refused delete leaves the selection intact");
+}
+
+// Drag-move gesture (issue #84, decision 3). Uses a 1-second/24fps composition and a 461-logical-
+// pixel-wide row (width - 1 = 460 = 20 * maxIndex(23)) so that pixel 20*i lands EXACTLY on frame i
+// under frameIndexForPixel()'s checked-integer mapping (proved algebraically: product = 20*i*23 =
+// 460*i is an exact multiple of span 460, so quotient = i with zero remainder -- the same tie-to-
+// greater contract testRulerScrubLandsOnExactFrameTimesIncludingATie() pins for the ruler itself,
+// just scaled up by 10x so drag deltas clear QApplication::startDragDistance() on every platform).
+// PRESS positions instead use the forward, continuous pixelForTime() mapping to hit a key at its
+// own exact time.
+void testDragMoveGestureSnapsCommitsUndoesAndRefuses(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Keyframe Drag Test", time(1));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId);
+    // Seeds k0 at frame 0 (t=0, value 1.0, Linear) -- the occupied-time refusal target below.
+    const auto curveId = animateParameter(document, commands, compositionId, ids.opacity, time(0));
+
+    // A frame-exact key (frame 20) that the drag gesture never touches. Deliberately inserted
+    // FIRST and kept the LATEST key in the curve throughout this whole test (every drag target
+    // below stays below frame 20), so it -- not dragKeyId -- absorbs the command layer's
+    // documented "final key's outgoing interpolation is always normalized to Linear" rule
+    // (docs/architecture/animation-and-time.md). Inserting it before dragKeyId matters: that rule
+    // fires on every mutation, including insertion, so dragKeyId must never be momentarily the
+    // final key or its own requested Hold interpolation below would be silently normalized away.
+    document::KeyframeId sentinelKeyId;
+    {
+        commands::Transaction insertSentinel("Insert sentinel opacity key",
+                                             document.snapshot().revision());
+        insertSentinel.emplace<commands::InsertScalarKeyframe>(compositionId, curveId, time(20, 24),
+                                                               0.6);
+        const auto inserted = commands.execute(std::move(insertSentinel));
+        const auto id = inserted.outputId<document::KeyframeId>(commands::kKeyframeOutput);
+        expectations.expect(inserted.changed() && id.has_value(),
+                            "fixture inserts the sentinel key");
+        if (!id.has_value()) {
+            return;
+        }
+        sentinelKeyId = *id;
+    }
+
+    document::KeyframeId dragKeyId;
+    {
+        // A subframe key (t=1/3), interior to [k0, sentinel], with Hold interpolation distinct
+        // from every other key's kind, so "value and interpolation unchanged" is a real assertion
+        // rather than a coincidence.
+        commands::Transaction insertDrag("Insert subframe opacity key",
+                                         document.snapshot().revision());
+        insertDrag.emplace<commands::InsertScalarKeyframe>(compositionId, curveId, time(1, 3), 0.4,
+                                                           document::KeyframeInterpolation::Hold);
+        const auto inserted = commands.execute(std::move(insertDrag));
+        const auto id = inserted.outputId<document::KeyframeId>(commands::kKeyframeOutput);
+        expectations.expect(inserted.changed() && id.has_value(), "fixture inserts the drag key");
+        if (!id.has_value()) {
+            return;
+        }
+        dragKeyId = *id;
+    }
+
+    ui::CompositionSession session(document, commands, compositionId);
+    session.selectLayer(ids.layer);
+    ui::TimelineKeyframePanel panel(session);
+    panel.resize(461, panel.sizeHint().height() > 0 ? panel.sizeHint().height() : 24);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    const auto rows = panel.findChildren<QWidget*>();
+    expectations.expect(rows.size() == 1, "exactly one row exists for the single animated opacity");
+    if (rows.size() != 1) {
+        return;
+    }
+    auto* row = rows.front();
+    expectations.expect(row->width() == 461, "the row matches the panel's exact pixel width");
+
+    // Forward (continuous) pixelForTime mapping, duration 1s, width 461 (width - 1 = 460): used
+    // only to compute PRESS positions that hit a key at its own exact time.
+    const auto pressPixelForFraction = [](const double numerator, const double denominator) {
+        return 460.0 * numerator / denominator;
+    };
+    const qreal dragKeyPixel = pressPixelForFraction(1.0, 3.0);    // t = 1/3
+    const qreal sentinelPixel = pressPixelForFraction(20.0, 24.0); // frame 20
+    // Reverse (tie-to-greater) frameIndexForPixel mapping: pixel 20*i lands exactly on frame i (see
+    // the file comment above). Frame 2 stays interior to [k0, sentinel] so the drag key's Hold
+    // interpolation is never swept up in the command layer's final-key Linear normalization.
+    constexpr qreal kFrame0Pixel = 0.0;
+    constexpr qreal kFrame2Pixel = 40.0;
+
+    // Select and confirm the sentinel is untouched by everything below.
+    sendClick(*row, sentinelPixel);
+    const auto* sentinelSelection =
+        std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(sentinelSelection != nullptr &&
+                            sentinelSelection->keyframeId == sentinelKeyId,
+                        "the sentinel key can be selected by its own exact-time pixel");
+
+    // Select the drag key and move it to frame 2 (t = 2/24).
+    sendClick(*row, dragKeyPixel);
+    const auto* dragSelection = std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(dragSelection != nullptr && dragSelection->keyframeId == dragKeyId,
+                        "the subframe drag key is selected by its own exact-time pixel");
+
+    const auto historyBeforeMove = commands.size();
+    sendPress(*row, dragKeyPixel);
+    sendMove(*row, kFrame2Pixel);
+    sendRelease(*row, kFrame2Pixel);
+
+    auto findKey = [&](const document::KeyframeId id) -> std::optional<document::ScalarKeyframe> {
+        const auto* curve = session.composition()->animationCurves().findScalar(curveId);
+        if (curve == nullptr) {
+            return std::nullopt;
+        }
+        const auto found = std::ranges::find(curve->keyframes, id, &document::ScalarKeyframe::id);
+        return found == curve->keyframes.end() ? std::nullopt
+                                               : std::optional<document::ScalarKeyframe>(*found);
+    };
+
+    auto dragged = findKey(dragKeyId);
+    expectations.expect(dragged.has_value() && dragged->time == time(2, 24) &&
+                            dragged->value == 0.4 &&
+                            dragged->outgoingInterpolation == document::KeyframeInterpolation::Hold,
+                        "release snaps the drag key to the exact target frame time, preserving "
+                        "its existing value and interpolation");
+    expectations.expect(commands.size() == historyBeforeMove + 1,
+                        "the drag-move gesture is exactly one undoable transaction");
+    auto sentinelAfterMove = findKey(sentinelKeyId);
+    expectations.expect(sentinelAfterMove.has_value() && sentinelAfterMove->time == time(20, 24) &&
+                            sentinelAfterMove->value == 0.6,
+                        "an untouched key elsewhere on the lane keeps its exact time through the "
+                        "move");
+
+    expectations.expect(session.undo(), "the drag-move gesture undoes cleanly");
+    auto draggedAfterUndo = findKey(dragKeyId);
+    expectations.expect(draggedAfterUndo.has_value() && draggedAfterUndo->time == time(1, 3) &&
+                            draggedAfterUndo->value == 0.4 &&
+                            draggedAfterUndo->outgoingInterpolation ==
+                                document::KeyframeInterpolation::Hold,
+                        "undo restores the exact original SUBFRAME time of the same key");
+    expectations.expect(session.redo(), "the drag-move gesture redoes cleanly");
+    dragged = findKey(dragKeyId);
+    expectations.expect(dragged.has_value() && dragged->time == time(2, 24),
+                        "redo restores the moved key at its exact target frame time");
+
+    // Duplicate-time refusal: drag the (now frame-2) key onto frame 0, occupied by the seed key.
+    const auto historyBeforeRefusal = commands.size();
+    sendPress(*row, kFrame2Pixel);
+    sendMove(*row, kFrame0Pixel);
+    sendRelease(*row, kFrame0Pixel);
+    dragged = findKey(dragKeyId);
+    expectations.expect(dragged.has_value() && dragged->time == time(2, 24),
+                        "a duplicate-time drag target is refused: the key does not move");
+    expectations.expect(commands.size() == historyBeforeRefusal,
+                        "the duplicate-time refusal creates no transaction");
+    const auto* selectionAfterRefusal =
+        std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(selectionAfterRefusal != nullptr &&
+                            selectionAfterRefusal->keyframeId == dragKeyId,
+                        "a refused move leaves the selection intact");
+
+    // Zero-displacement: drag away and back to the SAME snapped frame before releasing.
+    const auto historyBeforeZero = commands.size();
+    sendPress(*row, kFrame2Pixel);
+    sendMove(*row, kFrame0Pixel);
+    sendMove(*row, kFrame2Pixel);
+    sendRelease(*row, kFrame2Pixel);
+    dragged = findKey(dragKeyId);
+    expectations.expect(dragged.has_value() && dragged->time == time(2, 24),
+                        "releasing back on the key's own exact frame leaves its time unchanged");
+    expectations.expect(commands.size() == historyBeforeZero,
+                        "a zero-displacement release commits nothing");
+
+    // Escape mid-drag cancels with no transaction.
+    const auto historyBeforeEscape = commands.size();
+    sendPress(*row, kFrame2Pixel);
+    sendMove(*row, kFrame0Pixel);
+    sendKey(*row, Qt::Key_Escape);
+    dragged = findKey(dragKeyId);
+    expectations.expect(dragged.has_value() && dragged->time == time(2, 24),
+                        "Escape mid-drag leaves the key's time unchanged");
+    expectations.expect(commands.size() == historyBeforeEscape,
+                        "Escape mid-drag creates no transaction");
+    // A stray release after Escape must be inert (the row's drag state was already cleared).
+    sendRelease(*row, kFrame0Pixel);
+    dragged = findKey(dragKeyId);
+    expectations.expect(dragged.has_value() && dragged->time == time(2, 24),
+                        "a release after Escape has no further effect");
+    expectations.expect(commands.size() == historyBeforeEscape,
+                        "a release after Escape creates no transaction");
 }
 
 } // namespace
@@ -379,6 +673,8 @@ int main(int argc, char** argv) {
     Expectations expectations;
     testRulerScrubLandsOnExactFrameTimesIncludingATie(expectations);
     testKeyframeRowsAppearOnePerAnimatedParameter(expectations);
-    testKeyframeClickSelectsExpectedPixelAndSurvivesRebuild(expectations);
+    testKeyframeClickSelectsByIdAndOneTruthSelectionSwap(expectations);
+    testDeleteGestureRemovesKeyAndRefusesTheLastOne(expectations);
+    testDragMoveGestureSnapsCommitsUndoesAndRefuses(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/timeline_ruler.cpp
+++ b/src/ui/timeline_ruler.cpp
@@ -9,7 +9,9 @@
 #include <bloom/document/parameter.hpp>
 #include <bloom/document/project.hpp>
 
+#include <QApplication>
 #include <QFontMetrics>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QVBoxLayout>
@@ -17,7 +19,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <functional>
 #include <limits>
 #include <string>
 #include <string_view>
@@ -132,19 +133,31 @@ struct KeyEntry final {
 // TimelineKeyframeRow*` in the FILE_SET header) purely to type its row list, so this definition
 // must live directly in bloom::ui rather than in an anonymous namespace (which would make it a
 // distinct, unrelated type from the header's forward declaration). It does not declare Q_OBJECT (no
-// signals are needed; key selection is reported through a plain callback), keeping it free of moc.
+// signals are needed; selection is reported by calling straight into CompositionSession, which the
+// row already holds a reference to), keeping it free of moc.
+//
+// Press-drag-release gesture (issue #84, decision 3): press selects (existing); once the pointer
+// moves past QApplication::startDragDistance() from the press point, drag mode arms -- a
+// presentation-only ghost diamond at the snapped target frame (this row's own TimelineAxis, the
+// SAME pixel<->frame mapping the ruler scrub uses) with NO document mutation until release, which
+// executes exactly one CompositionSession::moveSelectedKeyframe() transaction. Escape mid-drag
+// cancels with no transaction and clears the ghost; grabKeyboard()/releaseKeyboard() bracket the
+// drag so a real Escape key press reaches this row regardless of focus.
 class TimelineKeyframeRow final : public QWidget {
   public:
     TimelineKeyframeRow(CompositionSession& session, QString label,
                         const document::AnimationCurveId curveId, const bool isVec2,
-                        const std::optional<document::KeyframeId>* selectedKeyframe,
-                        std::function<void(document::KeyframeId)> onKeySelected, QWidget* parent)
+                        QWidget* parent)
         : QWidget(parent), session_(session), label_(std::move(label)), curveId_(curveId),
-          isVec2_(isVec2), selectedKeyframe_(selectedKeyframe),
-          onKeySelected_(std::move(onKeySelected)) {
+          isVec2_(isVec2) {
         setFixedHeight(kKeyframeRowHeight);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
         connect(&session_, &CompositionSession::currentTimeChanged, this, [this] { update(); });
+        // The row set is memoized (TimelineKeyframePanel::rebuild()), so this row instance
+        // typically survives a selection change or a document edit that leaves its own curve
+        // intact -- it must repaint itself on both rather than rely on being recreated.
+        connect(&session_, &CompositionSession::selectionChanged, this, [this] { update(); });
+        connect(&session_, &CompositionSession::snapshotChanged, this, [this] { update(); });
     }
 
   protected:
@@ -168,15 +181,31 @@ class TimelineKeyframeRow final : public QWidget {
         painter.setPen(QPen(palette().color(QPalette::Highlight).lighter(150), 1.0));
         painter.drawLine(QPointF(playheadX, 0.0), QPointF(playheadX, height()));
 
+        const auto* keySelection = std::get_if<KeyframeSelection>(&session_.selection().primary);
         const qreal centerY = height() / 2.0;
         for (const auto& key : collectKeys()) {
             const qreal x = axis->pixelForTime(key.time);
-            const bool selected = selectedKeyframe_ != nullptr && selectedKeyframe_->has_value() &&
-                                  **selectedKeyframe_ == key.id;
+            const bool selected = keySelection != nullptr && keySelection->curveId == curveId_ &&
+                                  keySelection->keyframeId == key.id;
             const QColor fill = selected ? palette().color(QPalette::Highlight)
                                          : palette().color(QPalette::ButtonText);
             painter.setPen(QPen(fill.darker(140), 1.0));
             painter.setBrush(fill);
+            QPolygonF diamond;
+            diamond << QPointF(x, centerY - kKeyDiamondRadius)
+                    << QPointF(x + kKeyDiamondRadius, centerY)
+                    << QPointF(x, centerY + kKeyDiamondRadius)
+                    << QPointF(x - kKeyDiamondRadius, centerY);
+            painter.drawPolygon(diamond);
+        }
+
+        if (dragging_ && ghostTime_.has_value()) {
+            // Presentation-only: paint the snapped drag target, never mutate the document mid-drag.
+            const qreal x = axis->pixelForTime(*ghostTime_);
+            QColor ghostColor = palette().color(QPalette::Highlight);
+            ghostColor.setAlpha(150);
+            painter.setPen(QPen(ghostColor.darker(120), 1.5, Qt::DashLine));
+            painter.setBrush(Qt::NoBrush);
             QPolygonF diamond;
             diamond << QPointF(x, centerY - kKeyDiamondRadius)
                     << QPointF(x + kKeyDiamondRadius, centerY)
@@ -220,12 +249,84 @@ class TimelineKeyframeRow final : public QWidget {
                 closestDistance = distance;
             }
         }
-        if (closest.has_value() && onKeySelected_) {
-            onKeySelected_(*closest);
+        if (!closest.has_value()) {
+            return;
         }
+        session_.selectKeyframe(curveId_, *closest);
+        if (auto* panel = parentWidget()) {
+            // TimelineKeyframePanel accepts focus so a real Delete/Backspace press reaches it after
+            // a click selects a key.
+            panel->setFocus(Qt::MouseFocusReason);
+        }
+        pressedKeyId_ = closest;
+        pressPos_ = event->position();
+        dragging_ = false;
+        ghostTime_.reset();
+    }
+
+    void mouseMoveEvent(QMouseEvent* event) override {
+        if (!pressedKeyId_.has_value()) {
+            QWidget::mouseMoveEvent(event);
+            return;
+        }
+        const QPointF pos = event->position();
+        if (!dragging_) {
+            const QPointF delta = pos - pressPos_;
+            const int manhattan =
+                static_cast<int>(std::abs(delta.x())) + static_cast<int>(std::abs(delta.y()));
+            if (manhattan < QApplication::startDragDistance()) {
+                return;
+            }
+            dragging_ = true;
+            grabKeyboard();
+        }
+        const auto* composition = session_.composition();
+        if (composition == nullptr) {
+            return;
+        }
+        const auto axis = TimelineAxis::create(*composition, width());
+        if (!axis.has_value()) {
+            return;
+        }
+        const auto index = axis->frameIndexForPixel(static_cast<int>(pos.x()));
+        ghostTime_ = frameTimeForIndex(axis->frameRate, axis->duration, index);
+        update();
+    }
+
+    void mouseReleaseEvent(QMouseEvent* event) override {
+        if (event->button() != Qt::LeftButton || !pressedKeyId_.has_value()) {
+            QWidget::mouseReleaseEvent(event);
+            return;
+        }
+        if (dragging_) {
+            releaseKeyboard();
+            if (ghostTime_.has_value()) {
+                // Refusal (duplicate time / model rejection) commits nothing and keeps the
+                // selection; the ghost is cleared unconditionally below either way.
+                (void)session_.moveSelectedKeyframe(*ghostTime_);
+            }
+        }
+        endDrag();
+    }
+
+    void keyPressEvent(QKeyEvent* event) override {
+        if (dragging_ && event->key() == Qt::Key_Escape) {
+            releaseKeyboard();
+            endDrag();
+            event->accept();
+            return;
+        }
+        QWidget::keyPressEvent(event);
     }
 
   private:
+    void endDrag() {
+        dragging_ = false;
+        pressedKeyId_.reset();
+        ghostTime_.reset();
+        update();
+    }
+
     [[nodiscard]] std::vector<KeyEntry> collectKeys() const {
         std::vector<KeyEntry> entries;
         const auto* composition = session_.composition();
@@ -258,8 +359,10 @@ class TimelineKeyframeRow final : public QWidget {
     QString label_;
     document::AnimationCurveId curveId_;
     bool isVec2_;
-    const std::optional<document::KeyframeId>* selectedKeyframe_;
-    std::function<void(document::KeyframeId)> onKeySelected_;
+    bool dragging_ = false;
+    std::optional<document::KeyframeId> pressedKeyId_;
+    QPointF pressPos_;
+    std::optional<core::RationalTime> ghostTime_;
 };
 
 namespace {
@@ -423,6 +526,9 @@ TimelineKeyframePanel::TimelineKeyframePanel(CompositionSession& session, QWidge
     : QWidget(parent), session_(session) {
     setObjectName("timelineKeyframePanel");
     setAccessibleName(tr("Animated parameter keys"));
+    // Accepts focus so a click-selected key (TimelineKeyframeRow::mousePressEvent focuses this
+    // panel) can be deleted with Delete/Backspace (issue #84, decision 2).
+    setFocusPolicy(Qt::StrongFocus);
     rowsLayout_ = new QVBoxLayout(this);
     rowsLayout_->setContentsMargins(0, 0, 0, 0);
     rowsLayout_->setSpacing(0);
@@ -434,63 +540,61 @@ TimelineKeyframePanel::TimelineKeyframePanel(CompositionSession& session, QWidge
     rebuild();
 }
 
+void TimelineKeyframePanel::keyPressEvent(QKeyEvent* event) {
+    if (event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace) {
+        // deleteSelectedKeyframe() is a no-op false (no transaction, selection intact) when
+        // nothing is selected or the command layer refuses (e.g. the curve's last key) -- the
+        // widget has nothing further to do beyond the existing projection updates either way.
+        (void)session_.deleteSelectedKeyframe();
+        event->accept();
+        return;
+    }
+    QWidget::keyPressEvent(event);
+}
+
 void TimelineKeyframePanel::rebuild() {
+    const auto specs = collectAnimatedParameters(session_);
+    std::vector<document::AnimationCurveId> currentCurveIds;
+    currentCurveIds.reserve(specs.size());
+    for (const auto& spec : specs) {
+        currentCurveIds.push_back(spec.curveId);
+    }
+    if (currentCurveIds == lastCurveIds_) {
+        // The row SET is unchanged (e.g. a keyframe selection/move/delete that leaves the same
+        // curves in place) -- existing rows already repaint themselves off selectionChanged/
+        // snapshotChanged, so skip tearing them down. This also sidesteps a real hazard: a row's
+        // own click emits selectionChanged synchronously (CompositionSession::selectKeyframe()),
+        // and destroying that same row from inside its own mousePressEvent would be a use-after-
+        // free.
+        setVisible(!specs.empty());
+        return;
+    }
+    lastCurveIds_ = currentCurveIds;
+
     QLayoutItem* item = nullptr;
     while ((item = rowsLayout_->takeAt(0)) != nullptr) {
-        delete item->widget();
+        if (auto* widget = item->widget()) {
+            // setParent(nullptr) first: takeAt() only detaches the item from the LAYOUT, the
+            // widget stays a child of this panel (and so still visible to findChildren()) until
+            // reparented. deleteLater(), not delete, for the actual destruction: rebuild() can
+            // itself be reached (via selectionChanged) from a row's own mouse event handler when
+            // the row SET does change (e.g. selecting a keyframe on a newly-selected layer's first
+            // row); deferring destruction keeps that call stack safe even in that case.
+            widget->setParent(nullptr);
+            widget->deleteLater();
+        }
         delete item;
     }
     rows_.clear();
 
-    const auto specs = collectAnimatedParameters(session_);
     rows_.reserve(specs.size());
     for (const auto& spec : specs) {
-        auto* row = new TimelineKeyframeRow(
-            session_, spec.label, spec.curveId, spec.isVec2, &selectedKeyframe_,
-            [this](const document::KeyframeId id) { handleKeySelected(id); }, this);
+        auto* row = new TimelineKeyframeRow(session_, spec.label, spec.curveId, spec.isVec2, this);
         rowsLayout_->addWidget(row);
         rows_.push_back(row);
     }
 
-    pruneSelectionIfMissing();
     setVisible(!specs.empty());
-}
-
-void TimelineKeyframePanel::handleKeySelected(const document::KeyframeId id) {
-    if (selectedKeyframe_.has_value() && *selectedKeyframe_ == id) {
-        return;
-    }
-    selectedKeyframe_ = id;
-    for (auto* row : rows_) {
-        row->update();
-    }
-}
-
-void TimelineKeyframePanel::pruneSelectionIfMissing() {
-    if (!selectedKeyframe_.has_value()) {
-        return;
-    }
-    const auto* composition = session_.composition();
-    if (composition == nullptr) {
-        selectedKeyframe_.reset();
-        return;
-    }
-    for (const auto& record : composition->animationCurves().records()) {
-        if (const auto* scalar = std::get_if<document::ScalarAnimationCurve>(&record)) {
-            for (const auto& key : scalar->keyframes) {
-                if (key.id == *selectedKeyframe_) {
-                    return;
-                }
-            }
-        } else if (const auto* vec2 = std::get_if<document::Vec2AnimationCurve>(&record)) {
-            for (const auto& key : vec2->keyframes) {
-                if (key.id == *selectedKeyframe_) {
-                    return;
-                }
-            }
-        }
-    }
-    selectedKeyframe_.reset();
 }
 
 } // namespace bloom::ui


### PR DESCRIPTION
Closes #84.

The timeline's keys are now editable, and keyframe selection joins the shared **one-selection-truth** model — two Batch-4 residue items closed in one slice.

**Selection unified**: a keyframe target (curve + key identity) in the shared model, replacing the primary selection in both directions; the session's existing central normalization prunes vanished keys, and the panel's local selection state is gone entirely. Every other editor's selection handling was verified (not assumed) to degrade gracefully.

**Gestures, one transaction each**: Delete respects the command layer's own refusals — a curve's final key is a pinned full no-op per the model's non-emptiness invariant. Drag-move shows a presentation-only ghost at the frame-snapped target (the same exact tie-to-greater math scrubbing uses) and commits the key's existing value and interpolation to the new exact time; zero displacement commits nothing, duplicate-time targets surface the model's refusal, Escape cancels, and untouched subframe keys stay exact throughout.

**A hazard caught in-flight**: routing key selection through the shared signal exposed a synchronous use-after-free the panel's full-rebuild pattern would have caused; the rebuild now memoizes the row set and true teardown defers destruction, with the reasoning documented at the site.

Insert-at-arbitrary-time stays honestly deferred (interpolated values need the runtime sampler).

Testing: one-truth swaps, central pruning through undo cycles, the full delete and drag cycles including exact subframe restoration and every refusal shape. Desktop 86/86, native 72/72, format green.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).