### PR TITLE
feat: sample animated values for gestures

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
     PRIVATE
         compile_diagnostics.cpp
         compiled_plan.cpp
+        curve_compilation.cpp
         node_definition_registry.cpp
         snapshot_compiler.cpp
         snapshot_compiler_lowering.ipp
@@ -40,6 +41,7 @@ target_sources(
         BASE_DIRS include
         FILES
             include/bloom/runtime/compiled_plan.hpp
+            include/bloom/runtime/curve_compilation.hpp
             include/bloom/runtime/node_definition_registry.hpp
             include/bloom/runtime/snapshot_compiler.hpp
 )

--- a/src/runtime/curve_compilation.cpp
+++ b/src/runtime/curve_compilation.cpp
@@ -1,0 +1,36 @@
+#include <bloom/runtime/curve_compilation.hpp>
+
+#include <utility>
+
+namespace bloom::runtime {
+namespace {
+
+[[nodiscard]] CompiledKeyframeInterpolation
+compiledInterpolation(const document::KeyframeInterpolation mode) noexcept {
+    return mode == document::KeyframeInterpolation::Hold ? CompiledKeyframeInterpolation::Hold
+                                                         : CompiledKeyframeInterpolation::Linear;
+}
+
+} // namespace
+
+CompiledScalarCurve compileAnimationCurve(const document::ScalarAnimationCurve& curve) {
+    std::vector<CompiledScalarKeyframe> keyframes;
+    keyframes.reserve(curve.keyframes.size());
+    for (const auto& keyframe : curve.keyframes) {
+        keyframes.push_back({keyframe.id, keyframe.time, keyframe.value,
+                             compiledInterpolation(keyframe.outgoingInterpolation)});
+    }
+    return {curve.id, std::move(keyframes)};
+}
+
+CompiledVec2Curve compileAnimationCurve(const document::Vec2AnimationCurve& curve) {
+    std::vector<CompiledVec2Keyframe> keyframes;
+    keyframes.reserve(curve.keyframes.size());
+    for (const auto& keyframe : curve.keyframes) {
+        keyframes.push_back({keyframe.id, keyframe.time, keyframe.value,
+                             compiledInterpolation(keyframe.outgoingInterpolation)});
+    }
+    return {curve.id, std::move(keyframes)};
+}
+
+} // namespace bloom::runtime

--- a/src/runtime/include/bloom/runtime/curve_compilation.hpp
+++ b/src/runtime/include/bloom/runtime/curve_compilation.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <bloom/document/animation.hpp>
+#include <bloom/runtime/compiled_plan.hpp>
+
+namespace bloom::runtime {
+
+// Pure document-curve -> compiled-curve conversion (issue #86, task E1), extracted
+// behavior-preserving from snapshot_compiler.cpp's own per-curve lowering
+// (compileReachableCurves() in snapshot_compiler_lowering.ipp), which now calls these instead of
+// duplicating the conversion. Two homes were possible -- animation_sampling.hpp (already public,
+// already includes compiled_plan.hpp) or a dedicated header. This lives here, in
+// bloom_runtime_compiler (the library that already owns document -> compiled-plan lowering),
+// rather than in animation_sampling.hpp/bloom_runtime_evaluator: sampleAnimationCurve() consumes
+// already-compiled curves and has no document-type dependency today, and pulling
+// bloom::document::ScalarAnimationCurve/Vec2AnimationCurve into the evaluator library would blur
+// that boundary. CompositionSession (src/ui) already links bloom_runtime_compiler privately for
+// exactly this kind of use.
+//
+// No cancellation/checkpoint awareness: that is the compiler's own per-curve loop concern
+// (compileReachableCurves() checks cancellation once before and after each curve, matching every
+// other per-item loop in that file), not part of this pure, allocating conversion.
+[[nodiscard]] CompiledScalarCurve
+compileAnimationCurve(const document::ScalarAnimationCurve& curve);
+[[nodiscard]] CompiledVec2Curve compileAnimationCurve(const document::Vec2AnimationCurve& curve);
+
+} // namespace bloom::runtime

--- a/src/runtime/snapshot_compiler.cpp
+++ b/src/runtime/snapshot_compiler.cpp
@@ -5,6 +5,7 @@
 #include <bloom/document/animation.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/parameter.hpp>
+#include <bloom/runtime/curve_compilation.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/src/runtime/snapshot_compiler_lowering.ipp
+++ b/src/runtime/snapshot_compiler_lowering.ipp
@@ -85,12 +85,6 @@
         }
     }
 
-    const auto interpolation = [](const document::KeyframeInterpolation mode) {
-        return mode == document::KeyframeInterpolation::Hold
-                   ? runtime::CompiledKeyframeInterpolation::Hold
-                   : runtime::CompiledKeyframeInterpolation::Linear;
-    };
-
     CompiledCurveTables tables;
     for (const auto& record : composition_->animationCurves().records()) {
         if (cancelled()) {
@@ -100,41 +94,21 @@
         if (!reachableCurveIds.contains(curveId)) {
             continue;
         }
+        // The document -> compiled per-curve conversion itself is the shared, pure
+        // runtime::compileAnimationCurve() (issue #86, task E1; bloom/runtime/curve_compilation.hpp)
+        // -- this loop keeps only the per-curve index bookkeeping and cancellation checkpoints that
+        // are specific to compiling a REACHABLE SET of curves.
         std::visit(
             [&](const auto& curve) {
                 using Curve = std::decay_t<decltype(curve)>;
                 if constexpr (std::is_same_v<Curve, document::ScalarAnimationCurve>) {
-                    std::vector<runtime::CompiledScalarKeyframe> keyframes;
-                    keyframes.reserve(curve.keyframes.size());
-                    for (const auto& keyframe : curve.keyframes) {
-                        if (cancelled()) {
-                            return;
-                        }
-                        keyframes.push_back({keyframe.id, keyframe.time, keyframe.value,
-                                             interpolation(keyframe.outgoingInterpolation)});
-                    }
-                    if (cancelled()) {
-                        return;
-                    }
                     scalarCurveIndices_.emplace(
                         curve.id, runtime::ScalarCurveIndex::fromRaw(tables.scalar.size()));
-                    tables.scalar.push_back({curve.id, std::move(keyframes)});
+                    tables.scalar.push_back(runtime::compileAnimationCurve(curve));
                 } else {
-                    std::vector<runtime::CompiledVec2Keyframe> keyframes;
-                    keyframes.reserve(curve.keyframes.size());
-                    for (const auto& keyframe : curve.keyframes) {
-                        if (cancelled()) {
-                            return;
-                        }
-                        keyframes.push_back({keyframe.id, keyframe.time, keyframe.value,
-                                             interpolation(keyframe.outgoingInterpolation)});
-                    }
-                    if (cancelled()) {
-                        return;
-                    }
                     vec2CurveIndices_.emplace(curve.id,
                                               runtime::Vec2CurveIndex::fromRaw(tables.vec2.size()));
-                    tables.vec2.push_back({curve.id, std::move(keyframes)});
+                    tables.vec2.push_back(runtime::compileAnimationCurve(curve));
                 }
             },
             record);

--- a/src/runtime/tests/CMakeLists.txt
+++ b/src/runtime/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(bloom_runtime_registry_test node_definition_registry_tests.cpp)
 add_executable(bloom_runtime_snapshot_compiler_test snapshot_compiler_tests.cpp)
 add_executable(bloom_runtime_cpu_composition_evaluator_test cpu_composition_evaluator_tests.cpp)
 add_executable(bloom_runtime_animation_sampling_test animation_sampling_tests.cpp)
+add_executable(bloom_runtime_curve_compilation_test curve_compilation_tests.cpp)
 
 target_link_libraries(bloom_runtime_task_test PRIVATE bloom_runtime)
 target_link_libraries(bloom_runtime_regression_test PRIVATE bloom_runtime)
@@ -19,6 +20,7 @@ target_link_libraries(
     PRIVATE bloom_runtime_evaluator
 )
 target_link_libraries(bloom_runtime_animation_sampling_test PRIVATE bloom_runtime_evaluator)
+target_link_libraries(bloom_runtime_curve_compilation_test PRIVATE bloom_runtime_compiler)
 target_include_directories(bloom_runtime_regression_test PRIVATE ..)
 target_include_directories(bloom_runtime_gpu_task_test PRIVATE ..)
 target_include_directories(bloom_runtime_snapshot_compiler_test PRIVATE ..)
@@ -29,6 +31,7 @@ bloom_enable_warnings(bloom_runtime_registry_test)
 bloom_enable_warnings(bloom_runtime_snapshot_compiler_test)
 bloom_enable_warnings(bloom_runtime_cpu_composition_evaluator_test)
 bloom_enable_warnings(bloom_runtime_animation_sampling_test)
+bloom_enable_warnings(bloom_runtime_curve_compilation_test)
 bloom_enable_strict_floating_point(bloom_runtime_cpu_composition_evaluator_test)
 bloom_enable_strict_floating_point(bloom_runtime_animation_sampling_test)
 
@@ -80,5 +83,12 @@ bloom_add_test(
     NAME bloom.runtime.animation_sampling
     COMMAND bloom_runtime_animation_sampling_test
     LABELS runtime unit primitives
+    TIMEOUT 30
+)
+
+bloom_add_test(
+    NAME bloom.runtime.curve_compilation
+    COMMAND bloom_runtime_curve_compilation_test
+    LABELS runtime unit
     TIMEOUT 30
 )

--- a/src/runtime/tests/curve_compilation_tests.cpp
+++ b/src/runtime/tests/curve_compilation_tests.cpp
@@ -1,0 +1,134 @@
+// Direct unit tests for bloom::runtime::compileAnimationCurve() (issue #86, task E1): the public
+// document-curve -> compiled-curve conversion extracted, behavior-preserving, from
+// snapshot_compiler.cpp's own per-curve lowering (compileReachableCurves() in
+// snapshot_compiler_lowering.ipp). snapshot_compiler_tests.cpp's
+// testParameterSourcesAndDiagnosticIds already pins the SAME conversion end-to-end through the
+// compiler (a full CompiledScalarCurve operator== against hand-written expected keyframes) and that
+// test suite passes unchanged after the extraction, so equivalence through the compiler is not
+// re-proven here. This file instead exercises the extracted function pair directly: Hold and Linear
+// source interpolation, an exact subframe source time, and the "final key's outgoing interpolation
+// is always normalized to Linear" fact (docs/architecture/animation-and-time.md) -- proving this is
+// a PURE mechanical mapping that preserves whatever interpolation value the document curve already
+// carries, rather than a second enforcement point for that document-layer invariant.
+
+#include <bloom/runtime/curve_compilation.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string_view>
+
+namespace {
+
+using namespace bloom;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] core::RationalTime time(const std::int64_t numerator,
+                                      const std::int64_t denominator = 1) {
+    const auto value = core::RationalTime::create(numerator, denominator);
+    if (!value.has_value()) {
+        std::abort();
+    }
+    return *value;
+}
+
+void testScalarCurveMapsEveryFieldIncludingHoldAndLinear(Expectations& expectations) {
+    // Three keys: a Hold-outgoing key at an exact subframe time (1/3), a Linear-outgoing interior
+    // key, and a canonical Linear-outgoing final key (K1's normalization fact -- the final key is
+    // always Linear on any published document curve).
+    const document::ScalarAnimationCurve curve{
+        document::AnimationCurveId::fromRaw(7),
+        {{document::KeyframeId::fromRaw(70), time(1, 3), -0.0,
+          document::KeyframeInterpolation::Hold},
+         {document::KeyframeId::fromRaw(71), time(2), 0.5, document::KeyframeInterpolation::Linear},
+         {document::KeyframeId::fromRaw(72), time(5), 1.0,
+          document::KeyframeInterpolation::Linear}}};
+
+    const auto compiled = runtime::compileAnimationCurve(curve);
+    const runtime::CompiledScalarCurve expected{
+        document::AnimationCurveId::fromRaw(7),
+        {{document::KeyframeId::fromRaw(70), time(1, 3), -0.0,
+          runtime::CompiledKeyframeInterpolation::Hold},
+         {document::KeyframeId::fromRaw(71), time(2), 0.5,
+          runtime::CompiledKeyframeInterpolation::Linear},
+         {document::KeyframeId::fromRaw(72), time(5), 1.0,
+          runtime::CompiledKeyframeInterpolation::Linear}}};
+
+    expectations.expect(
+        compiled == expected,
+        "scalar conversion preserves curve id, exact key id/time/value, and maps "
+        "Hold/Linear interpolation 1:1, including an exact subframe source time and "
+        "a signed -0.0 value");
+    expectations.expect(compiled.keyframes.back().outgoingInterpolation ==
+                            runtime::CompiledKeyframeInterpolation::Linear,
+                        "the canonical Linear final-key fact (docs/architecture/animation-and-time."
+                        "md) survives the conversion unchanged");
+}
+
+void testVec2CurveMapsEveryFieldIncludingHoldAndLinear(Expectations& expectations) {
+    const document::Vec2AnimationCurve curve{
+        document::AnimationCurveId::fromRaw(8),
+        {{document::KeyframeId::fromRaw(80), time(0), document::Vec2d{1.0, 2.0},
+          document::KeyframeInterpolation::Linear},
+         {document::KeyframeId::fromRaw(81), time(7, 4), document::Vec2d{3.0, -4.0},
+          document::KeyframeInterpolation::Hold},
+         {document::KeyframeId::fromRaw(82), time(9), document::Vec2d{5.0, 6.0},
+          document::KeyframeInterpolation::Linear}}};
+
+    const auto compiled = runtime::compileAnimationCurve(curve);
+    const runtime::CompiledVec2Curve expected{
+        document::AnimationCurveId::fromRaw(8),
+        {{document::KeyframeId::fromRaw(80), time(0), document::Vec2d{1.0, 2.0},
+          runtime::CompiledKeyframeInterpolation::Linear},
+         {document::KeyframeId::fromRaw(81), time(7, 4), document::Vec2d{3.0, -4.0},
+          runtime::CompiledKeyframeInterpolation::Hold},
+         {document::KeyframeId::fromRaw(82), time(9), document::Vec2d{5.0, 6.0},
+          runtime::CompiledKeyframeInterpolation::Linear}}};
+
+    expectations.expect(compiled == expected,
+                        "Vec2 conversion preserves curve id, exact key id/time/value, and maps "
+                        "Hold/Linear interpolation 1:1, including an exact subframe source time");
+}
+
+void testConversionIsMechanicalAndDoesNotEnforceTheFinalKeyInvariant(Expectations& expectations) {
+    // compileAnimationCurve() is a PURE mapping with no validation pass (validation/normalization
+    // is owned by src/commands, and sampling-time validation by animation_sampling.cpp). Feeding it
+    // a deliberately non-canonical curve (a Hold final key, which src/commands never produces)
+    // proves it carries the source value through verbatim rather than silently re-normalizing it --
+    // the extraction must not become a second enforcement point for a document-layer invariant.
+    const document::ScalarAnimationCurve nonCanonical{
+        document::AnimationCurveId::fromRaw(9),
+        {{document::KeyframeId::fromRaw(90), time(0), 0.0, document::KeyframeInterpolation::Hold}}};
+    const auto compiled = runtime::compileAnimationCurve(nonCanonical);
+    expectations.expect(compiled.keyframes.size() == 1 &&
+                            compiled.keyframes.front().outgoingInterpolation ==
+                                runtime::CompiledKeyframeInterpolation::Hold,
+                        "a non-canonical Hold final key is passed through unchanged: this "
+                        "conversion does not itself enforce the final-key Linear invariant");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testScalarCurveMapsEveryFieldIncludingHoldAndLinear(expectations);
+    testVec2CurveMapsEveryFieldIncludingHoldAndLinear(expectations);
+    testConversionIsMechanicalAndDoesNotEnforceTheFinalKeyInvariant(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/ui/composition_session.cpp
+++ b/src/ui/composition_session.cpp
@@ -6,6 +6,8 @@
 #include <bloom/document/graph.hpp>
 #include <bloom/document/parameter.hpp>
 #include <bloom/document/project.hpp>
+#include <bloom/runtime/animation_sampling.hpp>
+#include <bloom/runtime/curve_compilation.hpp>
 
 #include <QThread>
 
@@ -610,6 +612,45 @@ bool CompositionSession::moveSelectedKeyframe(const core::RationalTime newTime) 
     return execute(std::move(transaction));
 }
 
+bool CompositionSession::insertKeyframeAtTime(const document::AnimationCurveId curveId,
+                                              const core::RationalTime time) {
+    Q_ASSERT(QThread::currentThread() == thread());
+    const auto* current = composition();
+    if (current == nullptr) {
+        return false;
+    }
+    const auto parameterId = parameterForCurve(curveId);
+    const auto* parameter =
+        parameterId.has_value() ? current->parameters().find(*parameterId) : nullptr;
+    if (parameter == nullptr) {
+        return false;
+    }
+    const auto sample = sampleParameterValue(*parameter, time);
+    if (!sample.has_value()) {
+        return false;
+    }
+
+    commands::Transaction transaction("Insert Keyframe", snapshot_.revision());
+    if (const auto* scalar = std::get_if<double>(&*sample)) {
+        transaction.emplace<commands::InsertScalarKeyframe>(compositionId_, curveId, time, *scalar);
+    } else if (const auto* vector = std::get_if<document::Vec2d>(&*sample)) {
+        transaction.emplace<commands::InsertVec2Keyframe>(compositionId_, curveId, time, *vector);
+    } else {
+        return false;
+    }
+
+    const auto result = commandStack_->execute(std::move(transaction));
+    const auto keyframeId = result.outputId<document::KeyframeId>(commands::kKeyframeOutput);
+    if (!handleResult(result)) {
+        return false;
+    }
+    if (keyframeId.has_value()) {
+        // One-truth selection swap, same as every other select* method (K1's precedent).
+        selectKeyframe(curveId, *keyframeId);
+    }
+    return true;
+}
+
 bool CompositionSession::positionInteractionActive() const noexcept {
     return positionInteraction_.has_value();
 }
@@ -650,25 +691,17 @@ CompositionSession::beginPositionInteraction(PositionInteractionMapping mapping)
             return PositionInteractionRejection::NoResolvablePosition;
         }
         baseValue = *value;
-    } else if (const auto* animationSource =
-                   std::get_if<document::AnimationCurveSource>(&position->source)) {
-        // CompositionSession cannot sample runtime's exact rational interpolation, so an animated
-        // position only resolves a base value when the playhead sits exactly on a key (docs/
-        // architecture/animation-and-time.md; see PositionInteractionRejection::
-        // AnimatedWithoutExactKey).
-        const auto* current = composition();
-        const auto* curve = current == nullptr
-                                ? nullptr
-                                : current->animationCurves().findVec2(animationSource->curveId);
-        if (curve == nullptr) {
+    } else if (std::holds_alternative<document::AnimationCurveSource>(position->source)) {
+        // D1's relaxation (issue #86, task E1; docs/architecture/animation-and-time.md): the base
+        // value for an animated position is its exact sampled value at the current session time,
+        // whether or not an exact key sits there. sampleParameterValue() compiles the curve
+        // (decision 1) and samples it (the existing runtime::sampleAnimationCurve()) synchronously.
+        const auto sample = sampleParameterValue(*position, currentTime_);
+        const auto* vector = sample.has_value() ? std::get_if<document::Vec2d>(&*sample) : nullptr;
+        if (vector == nullptr) {
             return PositionInteractionRejection::NoResolvablePosition;
         }
-        const auto exactKey = std::ranges::find_if(
-            curve->keyframes, [this](const auto& key) { return key.time == currentTime_; });
-        if (exactKey == curve->keyframes.end()) {
-            return PositionInteractionRejection::AnimatedWithoutExactKey;
-        }
-        baseValue = exactKey->value;
+        baseValue = *vector;
     } else {
         return PositionInteractionRejection::DrivenParameter;
     }
@@ -889,6 +922,39 @@ CompositionSession::parameterForCurve(const document::AnimationCurveId curveId) 
         if (source != nullptr && source->curveId == curveId) {
             return parameter.id;
         }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::variant<double, document::Vec2d>>
+CompositionSession::sampleParameterValue(const document::ParameterRecord& parameter,
+                                         const core::RationalTime time) const {
+    const auto* current = composition();
+    if (current == nullptr) {
+        return std::nullopt;
+    }
+    const auto* source = std::get_if<document::AnimationCurveSource>(&parameter.source);
+    if (source == nullptr) {
+        // Only for animation-sourced parameters (decision 2); constant/driven callers keep their
+        // existing paths (constantValue()/constantVec2Value(), the explicit driven-refusal
+        // branches).
+        return std::nullopt;
+    }
+    if (const auto* scalarCurve = current->animationCurves().findScalar(source->curveId)) {
+        const auto sample =
+            runtime::sampleAnimationCurve(runtime::compileAnimationCurve(*scalarCurve), time);
+        if (!sample || !sample.value.has_value()) {
+            return std::nullopt;
+        }
+        return std::variant<double, document::Vec2d>(*sample.value);
+    }
+    if (const auto* vec2Curve = current->animationCurves().findVec2(source->curveId)) {
+        const auto sample =
+            runtime::sampleAnimationCurve(runtime::compileAnimationCurve(*vec2Curve), time);
+        if (!sample || !sample.value.has_value()) {
+            return std::nullopt;
+        }
+        return std::variant<double, document::Vec2d>(*sample.value);
     }
     return std::nullopt;
 }

--- a/src/ui/include/bloom/ui/composition_session.hpp
+++ b/src/ui/include/bloom/ui/composition_session.hpp
@@ -86,21 +86,25 @@ struct PositionInteractionMapping final {
 
 // Typed rejection for CompositionSession::beginPositionInteraction (docs/architecture/
 // animation-and-time.md, "Direct Manipulation And Preview Overrides").
+//
+// issue #86 (task E1) removed the former AnimatedWithoutExactKey rejection: the contract never
+// forbade beginning a gesture on an animated base without an exact key at the current time -- D1's
+// refusal was an implementation gap (CompositionSession had no synchronous access to runtime's
+// exact rational curve sampling). sampleParameterValue() now closes that gap by compiling the
+// parameter's curve (runtime::compileAnimationCurve()) and sampling it (runtime::
+// sampleAnimationCurve()) synchronously, so an animated position with no exact key at the current
+// time begins from the exact interpolated base instead of refusing. No other code referenced the
+// removed enumerator (verified: composition_session.cpp/.hpp and its own tests were the only
+// occurrences), so it was deleted rather than kept as a documented-unreachable value.
 enum class PositionInteractionRejection : std::uint8_t {
     // No layer is the session's primary selection.
     NoLayerSelected,
-    // The selected layer exposes no position parameter, or its constant value does not match the
-    // Vec2d schema.
+    // The selected layer exposes no position parameter, its constant value does not match the
+    // Vec2d schema, or its animated curve fails to resolve/sample at the current session time.
     NoResolvablePosition,
     // The position parameter is bound to a driver; a gesture never disconnects a driven parameter
     // silently, so it never begins on one.
     DrivenParameter,
-    // The position parameter is animated but has no exact-time key at the current session time.
-    // CompositionSession has no synchronous access to runtime's exact rational curve sampling
-    // (src/runtime owns sampling; src/ui does not get a private evaluator), so it cannot resolve
-    // an interpolated base value without guessing. Refusing to begin is the honest v1 behavior;
-    // dragging is supported for animated parameters exactly when the playhead sits on a key.
-    AnimatedWithoutExactKey,
     // The supplied mapping has an empty/degenerate display rectangle.
     EmptyMapping,
 };
@@ -163,6 +167,19 @@ class CompositionSession final : public QObject {
     // equal to the key's current exact time commits nothing and returns true (docs/architecture/
     // animation-and-time.md's zero-move precedent, mirrored from commitPositionInteraction()).
     [[nodiscard]] bool moveSelectedKeyframe(core::RationalTime newTime);
+    // Timeline insert gesture (issue #86, task E1): double-clicking a keyframe lane's row
+    // BACKGROUND (never an existing key -- that hit-testing is the widget's job, same tolerance as
+    // the click-select/drag gestures) inserts a new key at the exact frame-snapped `time`, valued
+    // at the curve's own exactly sampled value at that time (sampleParameterValue(), via decision
+    // 1's compileAnimationCurve() + the existing sampleAnimationCurve()). Uses
+    // InsertScalarKeyframe/ InsertVec2Keyframe -- their default outgoing interpolation is Linear,
+    // matching exactly what SetKeyframeAtTime already does for a newly inserted key
+    // (src/commands/animation_operations.cpp) rather than inventing new policy. An occupied exact
+    // time is the commands layer's existing refusal (InvalidOrder): no transaction, selection
+    // untouched. On success the new key becomes the selected keyframe (K1's one-truth
+    // selectKeyframe() swap), in exactly one transaction.
+    [[nodiscard]] bool insertKeyframeAtTime(document::AnimationCurveId curveId,
+                                            core::RationalTime time);
 
     // Direct viewer manipulation of the selected layer's position (docs/architecture/
     // animation-and-time.md, "Direct Manipulation And Preview Overrides"; issue #82). Session-only,
@@ -243,6 +260,17 @@ class CompositionSession final : public QObject {
     [[nodiscard]] bool executePositionCommand(document::ParameterId parameterId,
                                               core::RationalTime time, document::Vec2d value,
                                               const QString& commandLabel);
+    // The one session-level exact-sampling helper (issue #86, task E1; docs/architecture/
+    // animation-and-time.md): for an animation-sourced parameter, compiles its curve
+    // (runtime::compileAnimationCurve(), decision 1's extracted pure conversion) and samples it at
+    // `time` via the existing runtime::sampleAnimationCurve() -- the SAME exact rational sampler
+    // src/runtime uses everywhere else. Returns std::nullopt for a constant/driven source (those
+    // callers keep their existing paths -- constantValue()/constantVec2Value(), the driven refusal
+    // branches) or if the curve fails to resolve/sample. Both beginPositionInteraction() (the
+    // relaxed animated-base rule) and insertKeyframeAtTime() (the timeline insert gesture) call
+    // this one place rather than each re-deriving the curve/sample logic.
+    [[nodiscard]] std::optional<std::variant<double, document::Vec2d>>
+    sampleParameterValue(const document::ParameterRecord& parameter, core::RationalTime time) const;
     // Not noexcept (see keyframeSelectionExists()): the KeyframeSelection branch delegates to it.
     [[nodiscard]] bool selectionExists(const CompositionSelection& selection) const;
     // Not noexcept: std::visit over the AnimationCurveStore's curve-kind variant cannot be proven

--- a/src/ui/tests/composition_session_position_interaction_tests.cpp
+++ b/src/ui/tests/composition_session_position_interaction_tests.cpp
@@ -25,6 +25,7 @@
 #include <QCoreApplication>
 #include <QRectF>
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <optional>
@@ -238,8 +239,101 @@ void testDrivenAndAnimatedParameterRejections() {
             "the driven rejection leaves no interaction");
 }
 
-void testAnimatedParameterExactKeyOnlyAndCommitUpdatesTheKey() {
-    auto newProject = document::makeNewProject("Animated Gesture", "Main", time(10));
+// D1's relaxation (issue #86, task E1; docs/architecture/animation-and-time.md): an animated
+// position with NO exact key at the current time now begins from the exact sampled interpolated
+// base instead of refusing with the former AnimatedWithoutExactKey rejection. Commit still goes
+// through executePositionCommand() -> SetKeyframeAtTime(), which INSERTS a key at the current time
+// since none exists there yet.
+void testAnimatedParameterSampledBaseInsertsKeyAtCurrentTimeAndUndoRemovesOnlyIt() {
+    auto newProject = document::makeNewProject("Animated Sampled Base", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack, compositionId, document::Vec2d{3.0, 4.0});
+    const auto format = document.snapshot().project().findComposition(compositionId)->format();
+    const auto mapping = makeMapping(QRectF(0.0, 0.0, 100.0, 100.0), format);
+
+    commands::Transaction animate("Animate position", document.snapshot().revision());
+    animate.emplace<commands::CreateAnimationForParameter>(compositionId, ids.position, time(0));
+    const auto animateResult = stack.execute(std::move(animate));
+    const auto curveId =
+        animateResult.outputId<document::AnimationCurveId>(commands::kAnimationCurveOutput);
+    require(animateResult.changed() && curveId.has_value(), "position becomes animated");
+    if (!curveId.has_value()) {
+        return;
+    }
+
+    // A second exact key at t=10 gives a genuinely interpolated midpoint at t=5 (factor exactly
+    // 0.5, endpoints chosen so Linear Mix is exact in binary64: (3,4) -> (8,14) -> (13,24)),
+    // exercising the sampled base rather than degenerating to a single-key clamp.
+    commands::Transaction insertSecond("Insert second position key",
+                                       document.snapshot().revision());
+    insertSecond.emplace<commands::InsertVec2Keyframe>(compositionId, *curveId, time(10),
+                                                       document::Vec2d{13.0, 24.0});
+    require(stack.execute(std::move(insertSecond)).changed(), "fixture inserts a second exact key");
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+    require(session.setCurrentTime(time(5)), "session moves to a time between the two keys");
+
+    require(!session.beginPositionInteraction(mapping).has_value(),
+            "an animated position with no exact key at the current time now begins (D1's "
+            "relaxation), rather than refusing");
+    const auto freshOverride = session.positionInteractionOverride();
+    require(freshOverride.has_value(), "an active interaction always reports an override");
+    if (freshOverride.has_value()) {
+        const auto* value = std::get_if<document::Vec2d>(&freshOverride->value);
+        require(value != nullptr && *value == document::Vec2d{8.0, 14.0},
+                "begin freezes the exact Linear-interpolated base at the current time (halfway "
+                "between (3,4) and (13,24))");
+    }
+
+    session.updatePositionInteraction(10.0, 0.0);
+    const auto revisionBeforeCommit = session.snapshot().revision();
+    require(session.commitPositionInteraction(), "commit succeeds for the sampled-base gesture");
+    require(session.snapshot().revision().value() == revisionBeforeCommit.value() + 1,
+            "commit is exactly one transaction");
+
+    const auto* curve = session.composition()->animationCurves().findVec2(*curveId);
+    require(curve != nullptr && curve->keyframes.size() == 3,
+            "commit INSERTS a new key at the current time rather than mutating an existing one");
+    if (curve == nullptr || curve->keyframes.size() != 3) {
+        return;
+    }
+    const auto inserted =
+        std::ranges::find(curve->keyframes, time(5), &document::Vec2Keyframe::time);
+    require(inserted != curve->keyframes.end() &&
+                inserted->value == document::Vec2d{8.0 + 10.0 / 100.0 * format.width(), 14.0},
+            "the inserted key holds the sampled-base-plus-displacement value at the exact current "
+            "time");
+    const auto seed = std::ranges::find(curve->keyframes, time(0), &document::Vec2Keyframe::time);
+    const auto second =
+        std::ranges::find(curve->keyframes, time(10), &document::Vec2Keyframe::time);
+    require(seed != curve->keyframes.end() && seed->value == document::Vec2d{3.0, 4.0} &&
+                second != curve->keyframes.end() && second->value == document::Vec2d{13.0, 24.0},
+            "the curve's other two keys are untouched by the insert");
+
+    require(session.undo(), "the sampled-base commit undoes cleanly");
+    curve = session.composition()->animationCurves().findVec2(*curveId);
+    require(curve != nullptr && curve->keyframes.size() == 2,
+            "undo removes EXACTLY the inserted key, restoring the original two");
+    if (curve != nullptr) {
+        const auto seedAfterUndo =
+            std::ranges::find(curve->keyframes, time(0), &document::Vec2Keyframe::time);
+        const auto secondAfterUndo =
+            std::ranges::find(curve->keyframes, time(10), &document::Vec2Keyframe::time);
+        require(seedAfterUndo != curve->keyframes.end() &&
+                    seedAfterUndo->value == document::Vec2d{3.0, 4.0} &&
+                    secondAfterUndo != curve->keyframes.end() &&
+                    secondAfterUndo->value == document::Vec2d{13.0, 24.0},
+                "undo leaves the curve's other keys exactly as they were");
+    }
+}
+
+// Regression on D1's original had-a-key behavior (issue #86, task E1): when the playhead DOES sit
+// exactly on a key, commit must still update that SAME key rather than insert a second one.
+void testAnimatedParameterExactKeyStillUpdatesThatKey() {
+    auto newProject = document::makeNewProject("Animated Exact Key", "Main", time(10));
     const auto compositionId = newProject.initialCompositionId;
     document::Document document(std::move(newProject.project));
     commands::CommandStack stack(document);
@@ -259,18 +353,8 @@ void testAnimatedParameterExactKeyOnlyAndCommitUpdatesTheKey() {
 
     ui::CompositionSession session(document, stack, compositionId);
     session.selectLayer(ids.layer);
-
-    // No exact key at the current time (currentTime_ defaults to zero, matching the seeded key --
-    // move off it first).
-    require(session.setCurrentTime(time(5)), "session moves off the seeded key's time");
-    require(session.beginPositionInteraction(mapping) ==
-                ui::PositionInteractionRejection::AnimatedWithoutExactKey,
-            "an animated position with no exact key at the current time refuses the gesture rather "
-            "than guess an interpolated base value");
-    require(!session.positionInteractionActive(), "the refusal leaves no active interaction");
-
-    // Back on the seeded key: the gesture proceeds and commit updates that exact key.
-    require(session.setCurrentTime(time(0)), "session returns to the seeded key's exact time");
+    require(session.currentTime() == time(0),
+            "the session's default current time already sits exactly on the seeded key's time");
     require(!session.beginPositionInteraction(mapping).has_value(),
             "an animated position with an exact key at the current time begins");
     session.updatePositionInteraction(10.0, 0.0);
@@ -435,7 +519,8 @@ int main(int argc, char** argv) {
     testDisplacementMathNonSquareNegativeAndBaseTotal();
     testBeginRejectionsAndFreezing();
     testDrivenAndAnimatedParameterRejections();
-    testAnimatedParameterExactKeyOnlyAndCommitUpdatesTheKey();
+    testAnimatedParameterSampledBaseInsertsKeyAtCurrentTimeAndUndoRemovesOnlyIt();
+    testAnimatedParameterExactKeyStillUpdatesThatKey();
     testCommitIsExactlyOneTransactionAndUndoRestoresExactPriorValue();
     testZeroMoveCommitsNothing();
     testCancelClearsState();

--- a/src/ui/tests/timeline_ruler_tests.cpp
+++ b/src/ui/tests/timeline_ruler_tests.cpp
@@ -194,6 +194,13 @@ void sendClick(QWidget& widget, const qreal pixelX, const qreal pixelY = -1.0) {
     QCoreApplication::sendEvent(&widget, &release);
 }
 
+void sendDoubleClick(QWidget& widget, const qreal pixelX) {
+    const QPointF local(pixelX, widget.height() / 2.0);
+    QMouseEvent doubleClick(QEvent::MouseButtonDblClick, local, local, Qt::LeftButton,
+                            Qt::LeftButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &doubleClick);
+}
+
 void sendPress(QWidget& widget, const qreal pixelX) {
     const QPointF local(pixelX, widget.height() / 2.0);
     QMouseEvent press(QEvent::MouseButtonPress, local, local, Qt::LeftButton, Qt::LeftButton,
@@ -665,6 +672,259 @@ void testDragMoveGestureSnapsCommitsUndoesAndRefuses(Expectations& expectations)
                         "a release after Escape creates no transaction");
 }
 
+// Insert gesture (issue #86, task E1, decision 4): double-clicking a keyframe lane's row
+// BACKGROUND -- never an existing key -- inserts a new key at the exact frame-snapped time, valued
+// at the curve's own exactly sampled value there (CompositionSession::insertKeyframeAtTime()).
+// Width/frame-rate are chosen (1s @ 24fps, 2301 logical pixels, span 2300 = 100 * 23) so the
+// REVERSE pixel->frame-index snap used for the click (100 * index, an exact zero-remainder
+// multiple, same proof idiom as the drag test) lands more than kKeyHitToleranceLogicalPixels away
+// from every existing key's own FORWARD pixelForTime() paint position -- including the just-
+// inserted key's -- so a repeat double-click at the SAME pixel is never absorbed by hit-testing and
+// genuinely reaches the command layer's occupied-time refusal.
+void testDoubleClickInsertsWithSampledValueSelectsAndRefusesOccupiedTime(
+    Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Keyframe Insert Test", time(1));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId);
+    // Seeds k0 at t=0, value 1.0 (AddSolidLayer's default opacity) -- not itself part of the
+    // interpolation this test exercises.
+    const auto curveId = animateParameter(document, commands, compositionId, ids.opacity, time(0));
+
+    // The final key is inserted FIRST, before the sentinel: the model normalizes whichever key is
+    // currently LAST to outgoing Linear on every mutation
+    // (docs/architecture/animation-and-time.md), so inserting the sentinel first would make IT the
+    // momentary final key and silently normalize away its requested Hold interpolation (the same
+    // ordering trap the drag-move gesture test's own fixture documents).
+    {
+        commands::Transaction insertFinal("Insert final opacity key",
+                                          document.snapshot().revision());
+        insertFinal.emplace<commands::InsertScalarKeyframe>(compositionId, curveId, time(2, 3),
+                                                            0.25);
+        expectations.expect(commands.execute(std::move(insertFinal)).changed(),
+                            "fixture inserts the final opacity key");
+    }
+
+    // A genuinely off-grid ("subframe") key: 24 * (1/10) = 2.4 is not an integer frame index. Hold
+    // interpolation makes its own segment's sampled value a pure passthrough (no interpolation
+    // arithmetic to reason about) and marks it distinctly from every other key's kind. It stays
+    // interior (never final) since the final key above is already in place.
+    document::KeyframeId sentinelKeyId;
+    {
+        commands::Transaction insertSentinel("Insert sentinel opacity key",
+                                             document.snapshot().revision());
+        insertSentinel.emplace<commands::InsertScalarKeyframe>(
+            compositionId, curveId, time(1, 10), 0.6, document::KeyframeInterpolation::Hold);
+        const auto inserted = commands.execute(std::move(insertSentinel));
+        const auto id = inserted.outputId<document::KeyframeId>(commands::kKeyframeOutput);
+        expectations.expect(inserted.changed() && id.has_value(),
+                            "fixture inserts the subframe sentinel key");
+        if (!id.has_value()) {
+            return;
+        }
+        sentinelKeyId = *id;
+    }
+
+    ui::CompositionSession session(document, commands, compositionId);
+    session.selectLayer(ids.layer);
+    ui::TimelineKeyframePanel panel(session);
+    panel.resize(2301, panel.sizeHint().height() > 0 ? panel.sizeHint().height() : 24);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    const auto rows = panel.findChildren<QWidget*>();
+    expectations.expect(rows.size() == 1, "exactly one row exists for the single animated opacity");
+    if (rows.size() != 1) {
+        return;
+    }
+    auto* row = rows.front();
+    expectations.expect(row->width() == 2301, "the row matches the panel's exact pixel width");
+
+    auto findKey = [&](const document::KeyframeId id) -> std::optional<document::ScalarKeyframe> {
+        const auto* curve = session.composition()->animationCurves().findScalar(curveId);
+        if (curve == nullptr) {
+            return std::nullopt;
+        }
+        const auto found = std::ranges::find(curve->keyframes, id, &document::ScalarKeyframe::id);
+        return found == curve->keyframes.end() ? std::nullopt
+                                               : std::optional<document::ScalarKeyframe>(*found);
+    };
+
+    // Target: frame index 4 (t = 4/24 = 1/6), interior to [sentinel(1/10), finalKey(2/3)] -- the
+    // sentinel's Hold segment governs, so the exactly sampled value at 1/6 is the sentinel's OWN
+    // value (0.6) verbatim.
+    constexpr qreal kTargetPixel = 400.0; // 100 * 4, exact zero-remainder reverse snap to frame 4.
+    const auto historyBeforeInsert = commands.size();
+    sendDoubleClick(*row, kTargetPixel);
+
+    const auto* curveAfterInsert = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(curveAfterInsert != nullptr && curveAfterInsert->keyframes.size() == 4,
+                        "double-click on the lane background inserts exactly one new key");
+    expectations.expect(commands.size() == historyBeforeInsert + 1,
+                        "the insert gesture is exactly one undoable transaction");
+    if (curveAfterInsert == nullptr || curveAfterInsert->keyframes.size() != 4) {
+        return;
+    }
+    const auto insertedKeyIterator =
+        std::ranges::find(curveAfterInsert->keyframes, time(1, 6), &document::ScalarKeyframe::time);
+    expectations.expect(insertedKeyIterator != curveAfterInsert->keyframes.end() &&
+                            insertedKeyIterator->value == 0.6,
+                        "the inserted key sits at the exact frame-snapped time with the curve's "
+                        "exactly sampled value (the sentinel's Hold-held value)");
+    if (insertedKeyIterator == curveAfterInsert->keyframes.end()) {
+        return;
+    }
+    const auto insertedKeyId = insertedKeyIterator->id;
+    const auto* selectedAfterInsert =
+        std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(selectedAfterInsert != nullptr &&
+                            selectedAfterInsert->keyframeId == insertedKeyId,
+                        "the newly inserted key becomes the selected keyframe");
+
+    const auto sentinelAfterInsert = findKey(sentinelKeyId);
+    expectations.expect(
+        sentinelAfterInsert.has_value() && sentinelAfterInsert->time == time(1, 10) &&
+            sentinelAfterInsert->value == 0.6 &&
+            sentinelAfterInsert->outgoingInterpolation == document::KeyframeInterpolation::Hold,
+        "the subframe sentinel key survives the insert completely unchanged");
+
+    // Occupied-time refusal: a repeat double-click at the SAME pixel snaps to the SAME now-occupied
+    // exact time again -- the inserted key's own forward paint pixel (383.33) is far enough from
+    // the click pixel (400) that hit-testing does not intercept it, so the attempt genuinely
+    // reaches InsertScalarKeyframe's occupied-time refusal.
+    const auto historyBeforeRefusal = commands.size();
+    sendDoubleClick(*row, kTargetPixel);
+    const auto* curveAfterRefusal = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(curveAfterRefusal != nullptr && curveAfterRefusal->keyframes.size() == 4,
+                        "a double-click on an already-occupied exact time inserts no key");
+    expectations.expect(commands.size() == historyBeforeRefusal,
+                        "the occupied-time refusal creates no transaction");
+    const auto* selectionAfterRefusal =
+        std::get_if<ui::KeyframeSelection>(&session.selection().primary);
+    expectations.expect(selectionAfterRefusal != nullptr &&
+                            selectionAfterRefusal->keyframeId == insertedKeyId,
+                        "a refused insert leaves the prior selection intact");
+
+    // Undo/redo id-stability.
+    expectations.expect(session.undo(), "the insert gesture undoes cleanly");
+    const auto* curveAfterUndo = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(curveAfterUndo != nullptr && curveAfterUndo->keyframes.size() == 3,
+                        "undo removes exactly the inserted key");
+    const auto sentinelAfterUndo = findKey(sentinelKeyId);
+    expectations.expect(sentinelAfterUndo.has_value() && sentinelAfterUndo->value == 0.6 &&
+                            sentinelAfterUndo->outgoingInterpolation ==
+                                document::KeyframeInterpolation::Hold,
+                        "undo leaves the sentinel key untouched");
+
+    expectations.expect(session.redo(), "the insert gesture redoes cleanly");
+    const auto reinserted = findKey(insertedKeyId);
+    expectations.expect(reinserted.has_value() && reinserted->time == time(1, 6) &&
+                            reinserted->value == 0.6,
+                        "redo restores the inserted key with the SAME KeyframeId and exact value");
+}
+
+// Sampling helper boundary semantics (docs/architecture/animation-and-time.md: "At or before the
+// first key, return the first value" / "At or after the last key, return the last value"), pinned
+// through the insert gesture: double-clicking before the first key or after the last key inserts a
+// new key holding the CLAMPED endpoint value, not an extrapolated one.
+void testDoubleClickInsertClampsToBoundaryValuesBeforeFirstAndAfterLastKey(
+    Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Keyframe Insert Boundary Test", time(1));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    const auto ids = addSolidLayer(document, commands, compositionId);
+    // Seeds the first key away from t=0 (frame 8, t=1/3) so a click before it is genuinely "before
+    // the first key" rather than clamped by the composition's own [0, duration) range.
+    const auto curveId =
+        animateParameter(document, commands, compositionId, ids.opacity, time(1, 3));
+    document::KeyframeId lastKeyId;
+    {
+        commands::Transaction insertLast("Insert last opacity key", document.snapshot().revision());
+        insertLast.emplace<commands::InsertScalarKeyframe>(compositionId, curveId, time(2, 3), 0.9);
+        const auto inserted = commands.execute(std::move(insertLast));
+        const auto id = inserted.outputId<document::KeyframeId>(commands::kKeyframeOutput);
+        expectations.expect(inserted.changed() && id.has_value(),
+                            "fixture inserts the last opacity key");
+        if (!id.has_value()) {
+            return;
+        }
+        lastKeyId = *id;
+    }
+    const auto* fixtureCurve = document.snapshot()
+                                   .project()
+                                   .findComposition(compositionId)
+                                   ->animationCurves()
+                                   .findScalar(curveId);
+    expectations.expect(fixtureCurve != nullptr && fixtureCurve->keyframes.size() == 2,
+                        "the fixture curve holds exactly the seeded first and inserted last key");
+    if (fixtureCurve == nullptr || fixtureCurve->keyframes.size() != 2) {
+        return;
+    }
+    const auto firstKeyValue =
+        fixtureCurve->keyframes.front().value; // AddSolidLayer's default 1.0.
+
+    ui::CompositionSession session(document, commands, compositionId);
+    session.selectLayer(ids.layer);
+    ui::TimelineKeyframePanel panel(session);
+    panel.resize(2301, panel.sizeHint().height() > 0 ? panel.sizeHint().height() : 24);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    const auto rows = panel.findChildren<QWidget*>();
+    expectations.expect(rows.size() == 1, "exactly one row exists for the single animated opacity");
+    if (rows.size() != 1) {
+        return;
+    }
+    auto* row = rows.front();
+
+    // Both clicks land before undoing anything (commands::CommandStack::size() reflects total
+    // history entries and is unaffected by undo() -- it only truncates on the NEXT execute() -- so
+    // interleaving an undo between the two inserts would make a size()-delta check of the second
+    // insert ambiguous).
+
+    // Before the first key: frame index 2 (t = 2/24 = 1/12), well left of the first key at 1/3.
+    const auto historyBeforeFirst = commands.size();
+    sendDoubleClick(*row, 200.0); // 100 * 2, exact zero-remainder reverse snap to frame 2.
+    const auto* curveAfterBefore = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(curveAfterBefore != nullptr && curveAfterBefore->keyframes.size() == 3,
+                        "a double-click before the first key still inserts");
+    expectations.expect(commands.size() == historyBeforeFirst + 1,
+                        "the before-first-key insert is exactly one transaction");
+    if (curveAfterBefore != nullptr) {
+        const auto before = std::ranges::find(curveAfterBefore->keyframes, time(1, 12),
+                                              &document::ScalarKeyframe::time);
+        expectations.expect(before != curveAfterBefore->keyframes.end() &&
+                                before->value == firstKeyValue,
+                            "the inserted key clamps to the first key's value (sampler rule: at or "
+                            "before the first key, return the first value)");
+    }
+
+    // After the last key: frame index 20 (t = 20/24 = 5/6), well right of the last key at 2/3.
+    const auto historyBeforeLast = commands.size();
+    sendDoubleClick(*row, 2000.0); // 100 * 20, exact zero-remainder reverse snap to frame 20.
+    const auto* curveAfterAfter = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(curveAfterAfter != nullptr && curveAfterAfter->keyframes.size() == 4,
+                        "a double-click after the last key inserts");
+    expectations.expect(commands.size() == historyBeforeLast + 1,
+                        "the after-last-key insert is exactly one transaction");
+    if (curveAfterAfter != nullptr) {
+        const auto after = std::ranges::find(curveAfterAfter->keyframes, time(5, 6),
+                                             &document::ScalarKeyframe::time);
+        expectations.expect(after != curveAfterAfter->keyframes.end() && after->value == 0.9,
+                            "the inserted key clamps to the last key's value (sampler rule: at or "
+                            "after the last key, return the last value)");
+    }
+
+    expectations.expect(session.undo(), "the after-last-key insert undoes cleanly");
+    expectations.expect(session.undo(), "the before-first-key insert undoes cleanly");
+    const auto* curveAfterUndo = session.composition()->animationCurves().findScalar(curveId);
+    expectations.expect(
+        curveAfterUndo != nullptr && curveAfterUndo->keyframes.size() == 2 &&
+            std::ranges::any_of(curveAfterUndo->keyframes,
+                                [&](const auto& key) { return key.id == lastKeyId; }),
+        "undo leaves exactly the original two keys in place");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -676,5 +936,7 @@ int main(int argc, char** argv) {
     testKeyframeClickSelectsByIdAndOneTruthSelectionSwap(expectations);
     testDeleteGestureRemovesKeyAndRefusesTheLastOne(expectations);
     testDragMoveGestureSnapsCommitsUndoesAndRefuses(expectations);
+    testDoubleClickInsertsWithSampledValueSelectsAndRefusesOccupiedTime(expectations);
+    testDoubleClickInsertClampsToBoundaryValuesBeforeFirstAndAfterLastKey(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/timeline_ruler.cpp
+++ b/src/ui/timeline_ruler.cpp
@@ -240,15 +240,7 @@ class TimelineKeyframeRow final : public QWidget {
         }
 
         const qreal clickX = event->position().x();
-        std::optional<document::KeyframeId> closest;
-        qreal closestDistance = std::numeric_limits<qreal>::max();
-        for (const auto& key : collectKeys()) {
-            const qreal distance = std::abs(axis->pixelForTime(key.time) - clickX);
-            if (distance <= kKeyHitToleranceLogicalPixels && distance < closestDistance) {
-                closest = key.id;
-                closestDistance = distance;
-            }
-        }
+        const auto closest = hitTestKey(*axis, clickX);
         if (!closest.has_value()) {
             return;
         }
@@ -262,6 +254,42 @@ class TimelineKeyframeRow final : public QWidget {
         pressPos_ = event->position();
         dragging_ = false;
         ghostTime_.reset();
+    }
+
+    // Insert gesture (issue #86, task E1; decision 4): double-clicking the row BACKGROUND (never an
+    // existing key -- same hit-test tolerance/idiom as press-select above) inserts a new key at the
+    // clicked frame-snapped time, using the SAME TimelineAxis pixel<->frame mapping the drag
+    // gesture already snaps to (frameIndexForPixel() + frameTimeForIndex()). CompositionSession::
+    // insertKeyframeAtTime() owns the command construction, value sampling, occupied-time refusal,
+    // and the one-truth selection swap on success; this handler is pure hit-testing/dispatch.
+    void mouseDoubleClickEvent(QMouseEvent* event) override {
+        if (event->button() != Qt::LeftButton) {
+            QWidget::mouseDoubleClickEvent(event);
+            return;
+        }
+        const auto* composition = session_.composition();
+        if (composition == nullptr) {
+            return;
+        }
+        const auto axis = TimelineAxis::create(*composition, width());
+        if (!axis.has_value()) {
+            return;
+        }
+        const qreal clickX = event->position().x();
+        if (hitTestKey(*axis, clickX).has_value()) {
+            // Landed on an existing key, not the lane background -- no insert gesture.
+            return;
+        }
+        const auto index = axis->frameIndexForPixel(static_cast<int>(clickX));
+        const auto snappedTime = frameTimeForIndex(axis->frameRate, axis->duration, index);
+        if (!snappedTime.has_value()) {
+            return;
+        }
+        if (session_.insertKeyframeAtTime(curveId_, *snappedTime)) {
+            if (auto* panel = parentWidget()) {
+                panel->setFocus(Qt::MouseFocusReason);
+            }
+        }
     }
 
     void mouseMoveEvent(QMouseEvent* event) override {
@@ -325,6 +353,23 @@ class TimelineKeyframeRow final : public QWidget {
         pressedKeyId_.reset();
         ghostTime_.reset();
         update();
+    }
+
+    // Shared hit-test (press-select and double-click-insert both use it, same tolerance): the
+    // closest key within kKeyHitToleranceLogicalPixels of `pixelX`, or nullopt if none is close
+    // enough -- the latter is what marks a click as landing on the lane BACKGROUND.
+    [[nodiscard]] std::optional<document::KeyframeId> hitTestKey(const TimelineAxis& axis,
+                                                                 const qreal pixelX) const {
+        std::optional<document::KeyframeId> closest;
+        qreal closestDistance = std::numeric_limits<qreal>::max();
+        for (const auto& key : collectKeys()) {
+            const qreal distance = std::abs(axis.pixelForTime(key.time) - pixelX);
+            if (distance <= kKeyHitToleranceLogicalPixels && distance < closestDistance) {
+                closest = key.id;
+                closestDistance = distance;
+            }
+        }
+        return closest;
     }
 
     [[nodiscard]] std::vector<KeyEntry> collectKeys() const {


### PR DESCRIPTION
Closes #86.

The exact rational sampler is now reachable synchronously — closing the last two deferred interaction gaps at their shared root. **Animated layers drag from their interpolated base, and the timeline inserts keys at exactly sampled values.**

**One extraction, proven equivalent**: per-curve compilation becomes a public runtime pair extracted from the snapshot compiler's internal lowering; the compiler calls the shared function and its pinned output-equality tests pass unchanged. One disclosed narrowing (cancellation per-curve rather than per-keyframe during lowering) is unobserved by any test and bounded by curve sizes.

**The gate relaxed, not weakened**: direct manipulation's animated-without-exact-key refusal is gone — the base is the exact sampled value at the current time, and the existing insert-or-update-at-time commit covers both cases, each pinned. The removed enum value had no other references.

**Insert without invented policy**: double-click lands the sampled value at the frame-snapped time using the insert commands' own Linear default — matching the set-at-time path, verified in the command sources. New keys become the selection; occupied times refuse; undo removes exactly the inserted key.

Testing: compilation-pair units, sampler pins (Linear midpoints on rational times, Hold passthrough, boundary clamps), both drag cases, the full insert cycle, and two fixture traps caught and documented in place. Desktop 87/87, native 73/73, format green.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session (zero-defect round).