### PR TITLE
feat: add sequential DOM migration framework

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
         document_decode.cpp
         document_decode_composition.cpp
         document_decode_internal.hpp
+        document_migration.cpp
         document_reconstruct.cpp
         manifest_decode.cpp
         manifest_requirements.cpp
@@ -47,6 +48,7 @@ target_sources(
             include/bloom/project/canonical_json_writer.hpp
             include/bloom/project/canonical_manifest.hpp
             include/bloom/project/document_decode.hpp
+            include/bloom/project/document_migration.hpp
             include/bloom/project/document_reconstruct.hpp
             include/bloom/project/manifest_decode.hpp
             include/bloom/project/manifest_requirements.hpp
@@ -121,6 +123,15 @@ if(BUILD_TESTING)
     bloom_add_test(
         NAME bloom.project.document_decode
         COMMAND bloom_project_document_decode_test
+        LABELS unit project persistence document
+    )
+
+    add_executable(bloom_project_document_migration_test tests/document_migration_tests.cpp)
+    target_link_libraries(bloom_project_document_migration_test PRIVATE bloom_project)
+    bloom_enable_warnings(bloom_project_document_migration_test)
+    bloom_add_test(
+        NAME bloom.project.document_migration
+        COMMAND bloom_project_document_migration_test
         LABELS unit project persistence document
     )
 

--- a/src/project/document_migration.cpp
+++ b/src/project/document_migration.cpp
@@ -1,0 +1,179 @@
+#include <bloom/project/document_migration.hpp>
+
+#include <bloom/project/project_io_memory_resource.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <new>
+#include <utility>
+
+namespace {
+
+using bloom::project::JsonValue;
+using bloom::project::MigrationStepDescriptor;
+using bloom::project::StrictJsonDomError;
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::span<const char> bytes) noexcept {
+    return {reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()};
+}
+
+// Linear scan is intentional and sufficient: even a large future production table stays small
+// (one entry per shipped minor), and this only ever runs once per migration step, never per JSON
+// value.
+[[nodiscard]] const MigrationStepDescriptor*
+findStep(const std::span<const MigrationStepDescriptor> steps,
+         const bloom::document::SchemaVersion version) noexcept {
+    for (const auto& candidate : steps) {
+        if (candidate.sourceVersion == version) {
+            return &candidate;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+namespace bloom::project {
+
+MigrationPathText MigrationPathText::from(const std::string_view text) noexcept {
+    MigrationPathText result;
+    const auto count = std::min(text.size(), result.chars_.size());
+    std::memcpy(result.chars_.data(), text.data(), count);
+    result.size_ = static_cast<std::uint16_t>(count);
+    result.truncated_ = count != text.size();
+    return result;
+}
+
+MigrationStepOutcome MigrationStepOutcome::success() noexcept { return MigrationStepOutcome{}; }
+
+MigrationStepOutcome MigrationStepOutcome::failure(const std::string_view path) noexcept {
+    MigrationStepOutcome result;
+    result.error_ = MigrationStepError::TransformFailed;
+    result.path_ = MigrationPathText::from(path);
+    return result;
+}
+
+MigrationResult MigrationResult::identity() noexcept {
+    MigrationResult result;
+    result.outcome_ = MigrationOutcome::Identity;
+    result.stepsApplied_ = 0;
+    return result;
+}
+
+MigrationResult MigrationResult::migrated(StrictJsonDomResult finalParse,
+                                          const std::uint32_t stepsApplied) noexcept {
+    MigrationResult result;
+    result.outcome_ = MigrationOutcome::Migrated;
+    result.stepsApplied_ = stepsApplied;
+    result.parse_.emplace(std::move(finalParse));
+    return result;
+}
+
+MigrationResult MigrationResult::failure(const MigrationError error,
+                                         const std::uint32_t stepsApplied,
+                                         const document::SchemaVersion failedStepSourceVersion,
+                                         const document::SchemaVersion failedStepTargetVersion,
+                                         const std::string_view path,
+                                         const StrictJsonDomError reparseError,
+                                         const std::size_t reparseByteOffset) noexcept {
+    MigrationResult result;
+    result.outcome_ = MigrationOutcome::Failed;
+    result.stepsApplied_ = stepsApplied;
+    result.error_ = error;
+    result.failedStepSourceVersion_ = failedStepSourceVersion;
+    result.failedStepTargetVersion_ = failedStepTargetVersion;
+    result.path_ = MigrationPathText::from(path);
+    result.reparseError_ = reparseError;
+    result.reparseByteOffset_ = reparseByteOffset;
+    return result;
+}
+
+// See this file's header comment for the overall representation/re-parse contract. Each iteration
+// below: (1) looks up the step registered for the version reached so far -- a miss is
+// UnknownSourceVersion if no step has run yet, otherwise ChainGap; (2) runs that step's transform
+// against the current DOM into a budget-charged output buffer; (3) strict-re-parses the step's
+// output, which both re-validates it against the exact same gate real document.json bytes pass
+// AND becomes the input DOM for the next iteration (or the final result). `currentParse` -- not
+// `initialRoot` -- therefore owns every representation this function itself produces; the very
+// first step still reads `initialRoot` (owned by the caller), never copying or re-parsing it
+// redundantly before that first step has something to say about it.
+MigrationResult migrateDocumentDom(const JsonValue& initialRoot,
+                                   const document::SchemaVersion detectedVersion,
+                                   const document::SchemaVersion currentVersion,
+                                   const std::span<const MigrationStepDescriptor> steps,
+                                   const StrictJsonDomLimits& reparseLimits,
+                                   const ProjectIoOperationMemory& operation) noexcept {
+    if (detectedVersion == currentVersion) {
+        return MigrationResult::identity();
+    }
+
+    std::optional<StrictJsonDomResult> currentParse;
+    const JsonValue* currentRoot = &initialRoot;
+    auto version = detectedVersion;
+    std::uint32_t stepsApplied = 0;
+
+    while (version != currentVersion) {
+        const auto* step = findStep(steps, version);
+        if (step == nullptr) {
+            return MigrationResult::failure(
+                stepsApplied == 0 ? MigrationError::UnknownSourceVersion : MigrationError::ChainGap,
+                stepsApplied, version, currentVersion, std::string_view{});
+        }
+
+        try {
+            // Bound to `operation` exactly like every other transient Project I/O representation
+            // (e.g. verifySaveArchive()'s own reencodeResource): this step's freshly-written bytes
+            // and the DOM it read from both stay charged for as long as both are simultaneously
+            // live, satisfying the "two live representations charge both" budget contract.
+            ProjectIoMemoryResource stepResource(operation);
+            std::pmr::vector<char> output(&stepResource);
+            const auto stepOutcome = step->transform(*currentRoot, &stepResource, output);
+            if (!stepOutcome) {
+                return MigrationResult::failure(MigrationError::StepTransformFailed, stepsApplied,
+                                                step->sourceVersion, step->targetVersion,
+                                                stepOutcome.path());
+            }
+
+            auto reparsed = parseStrictJsonDom(asBytes(output), reparseLimits, operation);
+            if (!reparsed) {
+                // A budget rejection during re-parse is ResourceExhausted, not
+                // StepEmittedInvalidJson: the bytes were never actually judged invalid, the parse
+                // just could not run to completion under the current budget.
+                const auto mappedError = reparsed.error() == StrictJsonDomError::ResourceExhausted
+                                             ? MigrationError::ResourceExhausted
+                                             : MigrationError::StepEmittedInvalidJson;
+                return MigrationResult::failure(mappedError, stepsApplied, step->sourceVersion,
+                                                step->targetVersion, reparsed.memberPath(),
+                                                reparsed.error(), reparsed.byteOffset());
+            }
+
+            // The previous currentParse (if any) is destroyed here, releasing its charge, only
+            // after the new one has been fully constructed and charged -- so the two
+            // representations legitimately overlap for the assignment's duration rather than one
+            // ever being freed early.
+            currentParse.emplace(std::move(reparsed));
+            currentRoot = &currentParse->document()->root();
+            version = step->targetVersion;
+            ++stepsApplied;
+        } catch (const std::bad_alloc&) {
+            return MigrationResult::failure(MigrationError::ResourceExhausted, stepsApplied,
+                                            step->sourceVersion, step->targetVersion,
+                                            std::string_view{});
+        }
+    }
+
+    if (!currentParse.has_value()) {
+        // Unreachable: the loop only exits when `version == currentVersion`, and `version` only
+        // ever changes inside the loop body after a successful step has populated `currentParse`.
+        // detectedVersion == currentVersion was already handled as Identity above, so reaching
+        // here with no step ever having run is a framework invariant break, not a legitimate
+        // outcome -- reported rather than trusted blindly, matching this codebase's existing
+        // "should not occur" precedent (see StrictJsonDomError::ParseFailed's own comment).
+        return MigrationResult::failure(MigrationError::ChainGap, stepsApplied, detectedVersion,
+                                        currentVersion, std::string_view{});
+    }
+    return MigrationResult::migrated(std::move(*currentParse), stepsApplied);
+}
+
+} // namespace bloom::project

--- a/src/project/include/bloom/project/document_migration.hpp
+++ b/src/project/include/bloom/project/document_migration.hpp
@@ -1,0 +1,249 @@
+#pragma once
+
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory_resource>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+// Sequential DOM-to-DOM document migration (see docs/architecture/project-format.md, "Versions,
+// Migrations, And Preservation": "supported older versions migrate through sequential
+// deterministic DOM migrations before trusted document decoding").
+//
+// Representation: StrictJsonDomDocument (strict_json_dom.hpp) is an immutable parsed tree, so a
+// step cannot transform it in place -- doing bytes-to-bytes at the raw JSON level would also lose
+// the strict-parse guarantee for whatever a step produces. Instead, one MigrationStep reads the
+// current parsed DOM (read-only) and writes brand-new canonical JSON bytes for the *next* schema
+// version's document.json shape, using the same canonical writer primitives document.json's own
+// encoder uses (canonical_json_writer.hpp, unknown_json_number.hpp); migrateDocumentDom() then
+// strict-re-parses those bytes through parseStrictJsonDom() before handing the result to the next
+// step, or to the caller. Re-parsing between every step keeps every intermediate stage behind the
+// exact same strict gate real document.json bytes must pass, and makes the whole chain
+// byte-checkable for determinism -- two runs of the same steps over the same input produce
+// byte-identical intermediate and final JSON. For the short window each step runs in, both the DOM
+// being read and the bytes being written (and, once re-parsed, the next DOM) are simultaneously
+// live and both charge the caller's ProjectIoOperationMemory budget, exactly like every other
+// Project I/O representation swap (see docs/architecture/project-format.md, "Resource Limits":
+// migration is a named charged operation whose resident footprint includes "canonical output").
+//
+// Document DOM only: manifest.json has no migration step of its own in this slice. Manifest
+// round-trip capture is already called out as later work in manifest_decode.hpp's own file
+// comment; a manifest migration analogue (mirroring this module one layer up) would naturally
+// follow that capture work, not precede it, since a manifest step would need the same DOM-in/
+// bytes-out shape this module already establishes.
+//
+// Registry: kProductionDocumentMigrationSteps below is the real production table -- currently
+// empty, because schema {1,0} is the only version Bloom has ever shipped. document_decode.hpp's
+// own gates (UnsupportedMajorVersion via DomainViolation for an unrecognized major; the
+// newer-minor RT1 capture/PreservationRequired route for a same-major newer minor) already reject
+// or redirect everything that is not exactly {1,0}, without this module ever being consulted for
+// either case -- see save_archive.cpp's runReopenChain(), the one production call site, for the
+// exact routing condition that keeps this module out of both paths. migrateDocumentDom() itself is
+// fully generic and injectable over both the step table and the "current" version it migrates to,
+// which is what lets document_migration_tests.cpp prove the chaining/failure/determinism machinery
+// end-to-end with a synthetic version pair no production schema uses, without needing a production
+// seam of its own.
+//
+// Version detection is not this module's job: the caller already lexically reads the document
+// root's schemaVersion before trusted decode, as part of its own existing version-agreement check
+// (see save_archive.cpp's documentRootVersion()); this module only consumes that already-detected
+// value through its `detectedVersion` parameter.
+
+namespace bloom::project {
+
+// One migration step's outcome: either the step wrote complete canonical bytes into its output
+// buffer, or it reports a typed failure with a bounded diagnostic path into the DOM it was reading
+// (mirroring StrictJsonDomPathText / DocumentDecodePathText's shape and truncation contract).
+enum class MigrationStepError : std::uint8_t {
+    None,
+    // The transform did not recognize the DOM shape it was given: a member it required was
+    // missing, held the wrong JSON kind, or held a value outside the domain this exact step knows
+    // how to migrate.
+    TransformFailed,
+};
+
+// A bounded diagnostic path, formatted as `/key/0/key`, mirroring every other decode-layer path
+// text type in this codebase (StrictJsonDomPathText, DocumentDecodePathText,
+// ManifestDecodePathText). Deliberately a fresh local type rather than a reused one: this module
+// sits below save_archive.hpp's composition boundary (which is what defines SaveArchiveErrorPath),
+// exactly as document_decode.hpp and manifest_decode.hpp each keep their own.
+class MigrationPathText final {
+  public:
+    constexpr MigrationPathText() noexcept = default;
+
+    [[nodiscard]] static MigrationPathText from(std::string_view text) noexcept;
+
+    [[nodiscard]] std::string_view view() const& noexcept { return {chars_.data(), size_}; }
+    [[nodiscard]] std::string_view view() const&& = delete;
+    [[nodiscard]] bool truncated() const noexcept { return truncated_; }
+
+  private:
+    std::array<char, 512> chars_{};
+    std::uint16_t size_ = 0;
+    bool truncated_ = false;
+};
+
+class [[nodiscard]] MigrationStepOutcome final {
+  public:
+    [[nodiscard]] static MigrationStepOutcome success() noexcept;
+    [[nodiscard]] static MigrationStepOutcome failure(std::string_view path) noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error_ == MigrationStepError::None;
+    }
+    [[nodiscard]] MigrationStepError error() const noexcept { return error_; }
+    [[nodiscard]] std::string_view path() const noexcept { return path_.view(); }
+
+  private:
+    MigrationStepError error_ = MigrationStepError::None;
+    MigrationPathText path_;
+};
+
+// One step's deterministic DOM-in/bytes-out transform. `root` is the source version's parsed
+// document root (read-only; the DOM is immutable and this signature enforces that -- see the file
+// comment above). `resource` is bound to the caller's ProjectIoOperationMemory budget for the
+// duration of this call; every allocation the transform makes through it (including `output`'s own
+// growth) is charged automatically, exactly like every other Project I/O PMR use in this codebase
+// (e.g. save_archive.cpp's own ProjectIoMemoryResource use for its re-encode stages). The transform
+// writes the target version's complete canonical document.json bytes into `output` (which starts
+// empty, already bound to `resource`) and returns success(), or leaves `output` in an unspecified
+// state and returns failure() with a path into `root`. May throw std::bad_alloc on budget
+// rejection, mirroring decodeDocumentEnvelope()'s own throwing contract; migrateDocumentDom() is
+// the termination-free boundary that catches it.
+using MigrationStepTransform = MigrationStepOutcome (*)(const JsonValue& root,
+                                                        std::pmr::memory_resource* resource,
+                                                        std::pmr::vector<char>& output);
+
+// One registered step: the exact {major, minor} it consumes, the exact next version it produces
+// (migrateDocumentDom() requires this to be either the chain's final `currentVersion` or another
+// registered step's sourceVersion -- see MigrationError::ChainGap below), and its transform.
+// Deliberately a trivial aggregate (no user-declared constructor) so a registry can be a
+// compile-time constexpr array -- see kProductionDocumentMigrationSteps.
+struct MigrationStepDescriptor final {
+    document::SchemaVersion sourceVersion;
+    document::SchemaVersion targetVersion;
+    MigrationStepTransform transform = nullptr;
+};
+
+// v1 ships no real migration steps -- see this file's own top comment. Kept as the fixed
+// production table so the registration mechanism (a std::span<const MigrationStepDescriptor>
+// parameter on migrateDocumentDom(), never a compiled-in global) has exactly one production
+// caller, matching its real future shape once a schema bump adds the first real step.
+inline constexpr std::array<MigrationStepDescriptor, 0> kProductionDocumentMigrationSteps{};
+
+enum class MigrationOutcome : std::uint8_t {
+    // detectedVersion == currentVersion: no step ran, and this result owns no DOM. The caller must
+    // keep using its own already-parsed DOM instead -- see migratedRoot()'s own contract. This
+    // pins byte identity for the already-current, by far the overwhelmingly common, case: nothing
+    // is re-encoded or re-parsed.
+    Identity,
+    // One or more steps ran; migratedRoot() names the final re-parsed DOM.
+    Migrated,
+    // A typed framework error occurred; error()/stepsApplied()/failedStepSourceVersion()/
+    // failedStepTargetVersion()/path() are valid, and, only for StepEmittedInvalidJson,
+    // reparseError()/reparseByteOffset() are too.
+    Failed,
+};
+
+enum class MigrationError : std::uint8_t {
+    None,
+    // detectedVersion is neither currentVersion nor any registered step's sourceVersion: there is
+    // no chain that could ever reach currentVersion from here.
+    UnknownSourceVersion,
+    // A step's targetVersion was reached but is neither currentVersion nor any registered step's
+    // sourceVersion: the chain has a hole between two otherwise-valid steps.
+    ChainGap,
+    // A step's transform() returned MigrationStepError::TransformFailed.
+    StepTransformFailed,
+    // A step wrote bytes that failed the mandatory strict re-parse -- the framework catching its
+    // own step's bug rather than trusting step output blindly (see this file's top comment).
+    StepEmittedInvalidJson,
+    // A budget reservation or PMR allocation was rejected while running a step or re-parsing its
+    // output.
+    ResourceExhausted,
+};
+
+// [[nodiscard]] move-only result (owns a StrictJsonDomResult -- and therefore, transitively, a
+// live PMR resource -- on Migrated, matching StrictJsonDomDocument's own move-only, non-copyable
+// resource ownership).
+class [[nodiscard]] MigrationResult final {
+  public:
+    MigrationResult(MigrationResult&&) noexcept = default;
+    MigrationResult& operator=(MigrationResult&&) noexcept = default;
+    MigrationResult(const MigrationResult&) = delete;
+    MigrationResult& operator=(const MigrationResult&) = delete;
+    ~MigrationResult() = default;
+
+    [[nodiscard]] static MigrationResult identity() noexcept;
+    [[nodiscard]] static MigrationResult migrated(StrictJsonDomResult finalParse,
+                                                  std::uint32_t stepsApplied) noexcept;
+    [[nodiscard]] static MigrationResult
+    failure(MigrationError error, std::uint32_t stepsApplied,
+            document::SchemaVersion failedStepSourceVersion,
+            document::SchemaVersion failedStepTargetVersion, std::string_view path,
+            StrictJsonDomError reparseError = StrictJsonDomError::None,
+            std::size_t reparseByteOffset = 0) noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return outcome_ != MigrationOutcome::Failed;
+    }
+    [[nodiscard]] MigrationOutcome outcome() const noexcept { return outcome_; }
+    // Valid for every outcome: 0 for Identity, the count of steps that actually ran for Migrated,
+    // and the count that ran before the failing step (0 if the very first lookup failed) for
+    // Failed.
+    [[nodiscard]] std::uint32_t stepsApplied() const noexcept { return stepsApplied_; }
+    // Non-null only when outcome() == Migrated. Identity callers must keep using their own
+    // already-parsed DOM (see MigrationOutcome::Identity); Failed callers have no DOM at all.
+    [[nodiscard]] const JsonValue* migratedRoot() const& noexcept {
+        return (outcome_ == MigrationOutcome::Migrated && parse_.has_value())
+                   ? &parse_->document()->root()
+                   : nullptr;
+    }
+    [[nodiscard]] const JsonValue* migratedRoot() const&& = delete;
+
+    [[nodiscard]] MigrationError error() const noexcept { return error_; }
+    [[nodiscard]] document::SchemaVersion failedStepSourceVersion() const noexcept {
+        return failedStepSourceVersion_;
+    }
+    [[nodiscard]] document::SchemaVersion failedStepTargetVersion() const noexcept {
+        return failedStepTargetVersion_;
+    }
+    [[nodiscard]] std::string_view path() const noexcept { return path_.view(); }
+    [[nodiscard]] StrictJsonDomError reparseError() const noexcept { return reparseError_; }
+    [[nodiscard]] std::size_t reparseByteOffset() const noexcept { return reparseByteOffset_; }
+
+  private:
+    MigrationResult() = default;
+
+    MigrationOutcome outcome_ = MigrationOutcome::Failed;
+    std::uint32_t stepsApplied_ = 0;
+    std::optional<StrictJsonDomResult> parse_;
+    MigrationError error_ = MigrationError::None;
+    document::SchemaVersion failedStepSourceVersion_;
+    document::SchemaVersion failedStepTargetVersion_;
+    MigrationPathText path_;
+    StrictJsonDomError reparseError_ = StrictJsonDomError::None;
+    std::size_t reparseByteOffset_ = 0;
+};
+
+// Applies `steps` sequentially from `detectedVersion` to `currentVersion` against `initialRoot`
+// (an already strict-parsed, but not yet trusted-decoded, document DOM root). `currentVersion` and
+// `steps` are both explicit parameters -- rather than fixed constants -- specifically so tests can
+// exercise the full chaining/failure/determinism machinery with a synthetic version pair no
+// production schema uses; the one production caller instead passes
+// kCanonicalDocumentSchemaVersionV1 and kProductionDocumentMigrationSteps (see save_archive.cpp's
+// runReopenChain()). `reparseLimits`/`operation` bound and charge every re-parse exactly like the
+// caller's own initial parseStrictJsonDom() call. Never throws.
+[[nodiscard]] MigrationResult migrateDocumentDom(
+    const JsonValue& initialRoot, document::SchemaVersion detectedVersion,
+    document::SchemaVersion currentVersion, std::span<const MigrationStepDescriptor> steps,
+    const StrictJsonDomLimits& reparseLimits, const ProjectIoOperationMemory& operation) noexcept;
+
+} // namespace bloom::project

--- a/src/project/include/bloom/project/save_archive.hpp
+++ b/src/project/include/bloom/project/save_archive.hpp
@@ -5,6 +5,7 @@
 #include <bloom/project/canonical_document.hpp>
 #include <bloom/project/canonical_manifest.hpp>
 #include <bloom/project/document_decode.hpp>
+#include <bloom/project/document_migration.hpp>
 #include <bloom/project/document_reconstruct.hpp>
 #include <bloom/project/manifest_decode.hpp>
 #include <bloom/project/project_io_memory.hpp>
@@ -43,6 +44,12 @@ enum class SaveArchiveStage : std::uint8_t {
     DocumentParse,
     ManifestDecode,
     VersionAgreement,
+    // Routes a same-major, at-or-below-current-minor document DOM through migrateDocumentDom()
+    // (document_migration.hpp) before trusted decode; see runReopenChain()'s own call-site comment
+    // for the exact routing condition and why an unknown major or a same-major newer minor never
+    // reach this stage at all (both keep their existing DocumentDecode-stage/PreservationRequired
+    // handling, unchanged by this stage's addition).
+    DocumentMigration,
     DocumentDecode,
     Reconstruction,
     RequirementsValidation,
@@ -115,6 +122,22 @@ struct SaveArchiveVersionAgreementFailure final {
     document::SchemaVersion capturedInputVersion;
 };
 
+// A typed failure from the DocumentMigration stage (document_migration.hpp's MigrationResult,
+// flattened for this composition boundary exactly like every other stage's failure payload).
+// `detectedVersion`/`currentVersion` are the same pair migrateDocumentDom() was called with;
+// `failedStepSourceVersion`/`failedStepTargetVersion` and `stepsApplied` are only meaningful for
+// error == ChainGap/StepTransformFailed/StepEmittedInvalidJson (they read as {0,0}/0 for
+// UnknownSourceVersion, which fails before any step is even looked up beyond the first).
+struct SaveArchiveDocumentMigrationFailure final {
+    MigrationError error = MigrationError::None;
+    document::SchemaVersion detectedVersion;
+    document::SchemaVersion currentVersion;
+    std::uint32_t stepsApplied = 0;
+    document::SchemaVersion failedStepSourceVersion;
+    document::SchemaVersion failedStepTargetVersion;
+    SaveArchiveErrorPath path;
+};
+
 struct SaveArchiveDocumentDecodeFailure final {
     DocumentDecodeOutcome outcome = DocumentDecodeOutcome::Failed;
     DocumentDecodeError error = DocumentDecodeError::None;
@@ -142,8 +165,9 @@ using SaveArchiveFailurePayload = std::variant<
     std::monostate, SaveArchiveManifestEncodingFailure, SaveArchiveDocumentEncodingFailure,
     SaveArchiveContainerWriteFailure, SaveArchiveContainerReadFailure, SaveArchiveJsonParseFailure,
     SaveArchiveManifestDecodeFailure, SaveArchiveVersionAgreementFailure,
-    SaveArchiveDocumentDecodeFailure, SaveArchiveRequirementsFailure, ReconstructionRejected,
-    SaveArchiveVerificationMismatch, SaveArchiveResourceExhausted, SaveArchiveUnexpectedFailure>;
+    SaveArchiveDocumentMigrationFailure, SaveArchiveDocumentDecodeFailure,
+    SaveArchiveRequirementsFailure, ReconstructionRejected, SaveArchiveVerificationMismatch,
+    SaveArchiveResourceExhausted, SaveArchiveUnexpectedFailure>;
 
 class SaveArchiveFailure final {
   public:

--- a/src/project/include/bloom/project/save_archive.hpp
+++ b/src/project/include/bloom/project/save_archive.hpp
@@ -124,10 +124,11 @@ struct SaveArchiveVersionAgreementFailure final {
 
 // A typed failure from the DocumentMigration stage (document_migration.hpp's MigrationResult,
 // flattened for this composition boundary exactly like every other stage's failure payload).
-// `detectedVersion`/`currentVersion` are the same pair migrateDocumentDom() was called with;
-// `failedStepSourceVersion`/`failedStepTargetVersion` and `stepsApplied` are only meaningful for
-// error == ChainGap/StepTransformFailed/StepEmittedInvalidJson (they read as {0,0}/0 for
-// UnknownSourceVersion, which fails before any step is even looked up beyond the first).
+// `detectedVersion`/`currentVersion` are the same pair migrateDocumentDom() was called with. For
+// StepTransformFailed/StepEmittedInvalidJson the failed-step versions name the step that ran; for
+// UnknownSourceVersion/ChainGap -- where no registered step exists to name -- they carry the
+// unreachable version reached and the chain's target version, and `stepsApplied` counts the steps
+// that ran before the failed lookup (0 for UnknownSourceVersion by definition).
 struct SaveArchiveDocumentMigrationFailure final {
     MigrationError error = MigrationError::None;
     document::SchemaVersion detectedVersion;

--- a/src/project/reopen_chain_internal.hpp
+++ b/src/project/reopen_chain_internal.hpp
@@ -21,10 +21,15 @@
 // cross-file implementation seam within one CMake target.
 //
 // runReopenChain() runs exactly the prefix the two callers share: container read, strict parse of
-// both entries under one shared JSON value budget, manifest decode, version agreement, document
-// decode, reconstruction, and manifest-requirements validation against the reconstructed project
-// (see save_archive.hpp's SaveArchiveStage enum, whose ContainerRead..RequirementsValidation
-// members name this exact prefix). Save's own re-encode and byte-comparison stages
+// both entries under one shared JSON value budget, manifest decode, version agreement, a routed
+// document migration pass, document decode, reconstruction, and manifest-requirements validation
+// against the reconstructed project (see save_archive.hpp's SaveArchiveStage enum, whose
+// ContainerRead..RequirementsValidation members -- now including DocumentMigration -- name this
+// exact prefix). The migration pass itself (document_migration.hpp's migrateDocumentDom()) only
+// ever does real work for a same-major, at-or-below-current-minor document; today that is only the
+// identity case, since schema {1,0} is the only version Bloom has ever shipped -- see this file's
+// implementation in save_archive.cpp for the exact routing condition. Save's own re-encode and
+// byte-comparison stages
 // (ManifestReencode..DocumentByteComparison) are not part of this routine; they run only in
 // verifySaveArchive() against the state this routine hands back. Every allocation is charged
 // through `operation`, identically to the pre-split verifySaveArchive() this was extracted from.

--- a/src/project/save_archive.cpp
+++ b/src/project/save_archive.cpp
@@ -419,14 +419,55 @@ ReopenChainResult runReopenChain(const std::span<const std::byte> archive,
                            capturedInputVersion.value_or(manifestValue.documentSchemaVersion)}));
         }
 
+        // A same-major document at or below the current minor is the "supported older version"
+        // migrateDocumentDom() exists for (see docs/architecture/project-format.md, "Versions,
+        // Migrations, And Preservation"); an unknown major or a same-major *newer* minor must NOT
+        // reach this stage -- both keep their existing, unmodified handling: an unknown major
+        // fails at DocumentDecode below with DomainViolation exactly as before, and a newer minor
+        // still takes decode's own RT1 PreservationRequired route below, also exactly as before.
+        // decodedDocumentVersion.minor <= current.minor (with major already pinned equal) is the
+        // exact complement of "newer minor" that keeps both those paths untouched. Today current
+        // is exactly {1,0}, so the only value satisfying this guard is {1,0} itself: production
+        // wiring is real (this stage always runs for an otherwise-decodable document) but only
+        // ever exercises MigrationOutcome::Identity -- see document_migration_tests.cpp for the
+        // synthetic coverage of every other outcome this stage can produce once a real older
+        // version ever exists.
+        stage = SaveArchiveStage::DocumentMigration;
+        const JsonValue* trustedDocumentRoot = &documentDom.document()->root();
+        auto effectiveDocumentVersion = decodedDocumentVersion;
+        auto effectiveDocumentValueCount = documentValueCount;
+        std::optional<MigrationResult> documentMigration;
+        if (decodedDocumentVersion.has_value() &&
+            decodedDocumentVersion->major == kCanonicalDocumentSchemaVersionV1.major &&
+            decodedDocumentVersion->minor <= kCanonicalDocumentSchemaVersionV1.minor) {
+            documentMigration.emplace(migrateDocumentDom(
+                *trustedDocumentRoot, *decodedDocumentVersion, kCanonicalDocumentSchemaVersionV1,
+                kProductionDocumentMigrationSteps, documentJsonLimits(limits, remainingValues),
+                operation));
+            if (!*documentMigration) {
+                return ReopenChainResult::failure(SaveArchiveFailure(
+                    stage, SaveArchiveDocumentMigrationFailure{
+                               documentMigration->error(), *decodedDocumentVersion,
+                               kCanonicalDocumentSchemaVersionV1, documentMigration->stepsApplied(),
+                               documentMigration->failedStepSourceVersion(),
+                               documentMigration->failedStepTargetVersion(),
+                               SaveArchiveErrorPath::from(documentMigration->path())}));
+            }
+            if (documentMigration->outcome() == MigrationOutcome::Migrated) {
+                trustedDocumentRoot = documentMigration->migratedRoot();
+                effectiveDocumentVersion = kCanonicalDocumentSchemaVersionV1;
+                effectiveDocumentValueCount = countJsonValues(*trustedDocumentRoot);
+            }
+        }
+
         stage = SaveArchiveStage::DocumentDecode;
-        auto decodeReservation =
-            reserveRepresentation(operation, entries->documentBytes().size(), documentValueCount);
+        auto decodeReservation = reserveRepresentation(operation, entries->documentBytes().size(),
+                                                       effectiveDocumentValueCount);
         if (!decodeReservation.has_value()) {
             return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
         }
-        auto decodedDocument = decodeDocumentEnvelope(documentDom.document()->root());
+        auto decodedDocument = decodeDocumentEnvelope(*trustedDocumentRoot);
         if (decodedDocument.outcome() == DocumentDecodeOutcome::PreservedReadOnlyRequired) {
             return ReopenChainResult::documentPreservedReadOnlyRequired(
                 decodedDocument.preservationReason(),
@@ -441,8 +482,8 @@ ReopenChainResult runReopenChain(const std::span<const std::byte> archive,
         }
 
         stage = SaveArchiveStage::Reconstruction;
-        auto reconstructionReservation =
-            reserveRepresentation(operation, entries->documentBytes().size(), documentValueCount);
+        auto reconstructionReservation = reserveRepresentation(
+            operation, entries->documentBytes().size(), effectiveDocumentValueCount);
         if (!reconstructionReservation.has_value()) {
             return ReopenChainResult::failure(
                 SaveArchiveFailure(stage, SaveArchiveResourceExhausted{}));
@@ -488,7 +529,7 @@ ReopenChainResult runReopenChain(const std::span<const std::byte> archive,
             .zipRead = std::move(reopened),
             .document = std::move(*reconstructed.value()),
             .manifest = *decodedManifest.value(),
-            .documentRootVersion = decodedDocumentVersion,
+            .documentRootVersion = effectiveDocumentVersion,
             .roundTrip = std::move(roundTrip),
             .manifestReservation = std::move(*manifestReservation),
             .decodeReservation = std::move(*decodeReservation),

--- a/src/project/tests/document_migration_tests.cpp
+++ b/src/project/tests/document_migration_tests.cpp
@@ -1,0 +1,590 @@
+#include <bloom/project/document_migration.hpp>
+
+#include <bloom/document/schema_version.hpp>
+#include <bloom/project/canonical_decimal.hpp>
+#include <bloom/project/canonical_json_writer.hpp>
+#include <bloom/project/project_io_memory.hpp>
+#include <bloom/project/strict_json_dom.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <memory_resource>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Synthetic proof suite for migrateDocumentDom() (document_migration.hpp). This is the ONLY
+// exerciser of the version pair/step table used below: no production schema is {1,1} or {1,2},
+// and the "current" version each test migrates to is passed explicitly to migrateDocumentDom()
+// rather than read from kCanonicalDocumentSchemaVersionV1 -- exactly the injection seam the
+// framework's own header comment describes. save_archive.cpp's runReopenChain() is the one
+// production call site, and it always passes the real {1,0} current version and the (currently
+// empty) production step table; see open_archive_tests.cpp / save_archive_tests.cpp for the
+// existing identity-path coverage of that production wiring with real archives.
+//
+// The two synthetic steps below migrate a tiny fictional document shape
+// `{"schemaVersion":{...},"legacyName"|"name":<string>,"value":<number>}` forward one minor at a
+// time: {1,0} -> {1,1} renames "legacyName" to "name" and normalizes "value"'s number spelling
+// (the fixture-normalization clause in docs/architecture/project-format.md, "Decimal Strings And
+// JSON Integers", made concrete -- "a supported older schema may normalize [non-canonical
+// spellings] only through an explicit migration fixture"); {1,1} -> {1,2} renames "name" to
+// "label". Chaining both from {1,0} proves real sequential, two-step migration.
+
+namespace {
+
+using bloom::document::SchemaVersion;
+using bloom::project::CanonicalJsonWriter;
+using bloom::project::JsonValue;
+using bloom::project::JsonValueKind;
+using bloom::project::migrateDocumentDom;
+using bloom::project::MigrationError;
+using bloom::project::MigrationOutcome;
+using bloom::project::MigrationResult;
+using bloom::project::MigrationStepDescriptor;
+using bloom::project::MigrationStepOutcome;
+using bloom::project::parseKnownFloat64;
+using bloom::project::parseStrictJsonDom;
+using bloom::project::ProjectIoMemoryCoordinator;
+using bloom::project::ProjectIoOperationMemory;
+using bloom::project::StrictJsonDomError;
+using bloom::project::StrictJsonDomLimits;
+using bloom::project::StrictJsonDomResult;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr std::uint64_t kGenerousOperationBudget = 8ULL << 20U; // 8 MiB: ample for every fixture.
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation(const std::uint64_t limitBytes) {
+    auto coordinator = ProjectIoMemoryCoordinator::create(limitBytes);
+    if (!coordinator.has_value()) {
+        std::abort();
+    }
+    auto operation = coordinator->createOperation(limitBytes, limitBytes);
+    if (!operation.has_value()) {
+        std::abort();
+    }
+    return std::move(*operation);
+}
+
+[[nodiscard]] ProjectIoOperationMemory makeOperation() {
+    return makeOperation(kGenerousOperationBudget);
+}
+
+[[nodiscard]] std::span<const std::byte> asBytes(const std::string_view text) noexcept {
+    return {reinterpret_cast<const std::byte*>(text.data()), text.size()};
+}
+
+constexpr SchemaVersion kVersion0{1, 0};
+constexpr SchemaVersion kVersion1{1, 1};
+constexpr SchemaVersion kVersion2{1, 2};
+// Never a registered step's sourceVersion or targetVersion in any test below -- used only to
+// exercise the "detected version isn't even in this table" branch.
+constexpr SchemaVersion kNeverRegisteredVersion{1, 5};
+
+constexpr std::string_view kInputV0Json =
+    R"({"schemaVersion":{"major":1,"minor":0},"legacyName":"widget","value":1.50})";
+constexpr std::string_view kInputV0MissingLegacyNameJson =
+    R"({"schemaVersion":{"major":1,"minor":0},"value":1.50})";
+
+void requireWriterSuccess(const bloom::project::CanonicalJsonWriterResult result) noexcept {
+    if (!result) {
+        std::abort();
+    }
+}
+
+// Shared emission for both synthetic steps: `{"schemaVersion":{"major":1,"minor":<minor>},
+// "<memberName>":"<stringValue>","value":<numberValue>}`. Called once in counting mode to size
+// `output`, then again in write mode -- the same measure-then-write pattern
+// canonical_document.cpp/canonical_manifest.cpp use for the real document/manifest encoders.
+void emitSyntheticDocument(CanonicalJsonWriter& writer, const std::uint32_t minor,
+                           const std::string_view memberName, const std::string_view stringValue,
+                           const double numberValue) noexcept {
+    requireWriterSuccess(writer.beginObject());
+    requireWriterSuccess(writer.memberName("schemaVersion"));
+    requireWriterSuccess(writer.beginObject());
+    requireWriterSuccess(writer.memberName("major"));
+    requireWriterSuccess(writer.integerValue(std::uint32_t{1}));
+    requireWriterSuccess(writer.memberName("minor"));
+    requireWriterSuccess(writer.integerValue(minor));
+    requireWriterSuccess(writer.endObject());
+    requireWriterSuccess(writer.memberName(memberName));
+    requireWriterSuccess(writer.stringValue(stringValue));
+    requireWriterSuccess(writer.memberName("value"));
+    requireWriterSuccess(writer.float64Value(numberValue));
+    requireWriterSuccess(writer.endObject());
+    requireWriterSuccess(writer.finish());
+}
+
+void writeSyntheticDocument(std::pmr::vector<char>& output, const std::uint32_t minor,
+                            const std::string_view memberName, const std::string_view stringValue,
+                            const double numberValue) {
+    auto counter = CanonicalJsonWriter::counting();
+    emitSyntheticDocument(counter, minor, memberName, stringValue, numberValue);
+    output.resize(counter.bytesRequired());
+    CanonicalJsonWriter writer(output, {});
+    emitSyntheticDocument(writer, minor, memberName, stringValue, numberValue);
+    if (writer.bytesWritten() != output.size()) {
+        std::abort();
+    }
+}
+
+// A real DOM transform: renames `sourceMember` to `targetMember`, and -- only for the {1,0} ->
+// {1,1} step, where sourceMember is "legacyName" -- normalizes "value"'s number spelling via
+// parseKnownFloat64()/CanonicalJsonWriter::float64Value() (parseKnownFloat64 accepts any finite
+// RFC 8259 decimal spelling; float64Value() independently re-derives Bloom's canonical Float64
+// token from the resulting double -- see docs/architecture/project-format.md, "Float64": "The
+// reader may accept another finite RFC 8259 decimal spelling and normalizes it on save". This is
+// the fixture-normalization clause -- "Decimal Strings And JSON Integers": "A supported older
+// schema may normalize [non-canonical spellings] only through an explicit migration fixture" --
+// made concrete). Reports MigrationStepError::TransformFailed with a path into `root` for any
+// shape this fictional schema doesn't recognize.
+[[nodiscard]] MigrationStepOutcome
+renameTransform(const std::string_view sourceMember, const std::string_view targetMember,
+                const std::uint32_t targetMinor, const JsonValue& root,
+                std::pmr::memory_resource* /*resource*/, std::pmr::vector<char>& output) {
+    if (root.kind() != JsonValueKind::Object) {
+        return MigrationStepOutcome::failure("/");
+    }
+    const auto* sourceValue = root.findMember(sourceMember);
+    if (sourceValue == nullptr || sourceValue->kind() != JsonValueKind::String) {
+        return MigrationStepOutcome::failure(sourceMember == "legacyName" ? "/legacyName"
+                                                                          : "/name");
+    }
+    // asString()/asNumberToken() are documented to return a value whenever kind() already
+    // matches, but that invariant is not visible to static analysis -- every use re-checks
+    // has_value() immediately before dereferencing rather than trusting the prior kind() check
+    // alone (mirrors document_decode.cpp's decodeStringMember()/decodeUInt32Member() idiom).
+    const auto sourceText = sourceValue->asString();
+    if (!sourceText.has_value()) {
+        return MigrationStepOutcome::failure(sourceMember == "legacyName" ? "/legacyName"
+                                                                          : "/name");
+    }
+    const auto* value = root.findMember("value");
+    if (value == nullptr || value->kind() != JsonValueKind::Number) {
+        return MigrationStepOutcome::failure("/value");
+    }
+    const auto numberToken = value->asNumberToken();
+    if (!numberToken.has_value()) {
+        return MigrationStepOutcome::failure("/value");
+    }
+    const auto parsedNumber = parseKnownFloat64(*numberToken);
+    if (!parsedNumber) {
+        return MigrationStepOutcome::failure("/value");
+    }
+    const auto* numberValue = parsedNumber.value();
+    if (numberValue == nullptr) {
+        return MigrationStepOutcome::failure("/value");
+    }
+    writeSyntheticDocument(output, targetMinor, targetMember, *sourceText, *numberValue);
+    return MigrationStepOutcome::success();
+}
+
+[[nodiscard]] MigrationStepOutcome stepRenameAndNormalize(const JsonValue& root,
+                                                          std::pmr::memory_resource* resource,
+                                                          std::pmr::vector<char>& output) {
+    return renameTransform("legacyName", "name", std::uint32_t{1}, root, resource, output);
+}
+
+[[nodiscard]] MigrationStepOutcome stepRenameLabel(const JsonValue& root,
+                                                   std::pmr::memory_resource* resource,
+                                                   std::pmr::vector<char>& output) {
+    return renameTransform("name", "label", std::uint32_t{2}, root, resource, output);
+}
+
+// Deliberately buggy: reports its own success while writing bytes that are not valid JSON at all,
+// to prove migrateDocumentDom()'s mandatory strict re-parse catches a step's own bug rather than
+// trusting a step's self-reported outcome.
+[[nodiscard]] MigrationStepOutcome stepEmitsInvalidJson(const JsonValue& /*root*/,
+                                                        std::pmr::memory_resource* /*resource*/,
+                                                        std::pmr::vector<char>& output) {
+    static constexpr std::string_view kBrokenJson = "{ this is not valid json";
+    output.assign(kBrokenJson.begin(), kBrokenJson.end());
+    return MigrationStepOutcome::success();
+}
+
+constexpr MigrationStepDescriptor kStepV0ToV1{kVersion0, kVersion1, &stepRenameAndNormalize};
+constexpr MigrationStepDescriptor kStepV1ToV2{kVersion1, kVersion2, &stepRenameLabel};
+// A version pair no other test uses, so it can never accidentally chain into the fixtures above.
+constexpr SchemaVersion kBuggyStepSource{9, 0};
+constexpr SchemaVersion kBuggyStepTarget{9, 1};
+constexpr MigrationStepDescriptor kStepEmitsInvalidJson{kBuggyStepSource, kBuggyStepTarget,
+                                                        &stepEmitsInvalidJson};
+
+[[nodiscard]] StrictJsonDomResult parseFixture(const std::string_view json,
+                                               const ProjectIoOperationMemory& operation) {
+    return parseStrictJsonDom(asBytes(json), StrictJsonDomLimits{}, operation);
+}
+
+// Structural, order-sensitive JSON equality: proves determinism at the value level (member order,
+// exact number token spelling, exact string content) without needing raw bytes out of
+// MigrationResult, which intentionally exposes only the re-parsed DOM (see this module's header
+// comment on why re-parsing -- not raw byte return -- is the contract between steps).
+[[nodiscard]] bool jsonEqual(const JsonValue& left, const JsonValue& right) noexcept {
+    if (left.kind() != right.kind()) {
+        return false;
+    }
+    switch (left.kind()) {
+    case JsonValueKind::Null:
+        return true;
+    case JsonValueKind::Boolean:
+        return left.asBoolean() == right.asBoolean();
+    case JsonValueKind::Number:
+        return left.asNumberToken() == right.asNumberToken();
+    case JsonValueKind::String:
+        return left.asString() == right.asString();
+    case JsonValueKind::Array: {
+        const auto leftElements = left.arrayElements();
+        const auto rightElements = right.arrayElements();
+        if (leftElements.size() != rightElements.size()) {
+            return false;
+        }
+        for (std::size_t index = 0; index < leftElements.size(); ++index) {
+            if (!jsonEqual(leftElements[index], rightElements[index])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    case JsonValueKind::Object: {
+        const auto leftMembers = left.objectMembers();
+        const auto rightMembers = right.objectMembers();
+        if (leftMembers.size() != rightMembers.size()) {
+            return false;
+        }
+        for (std::size_t index = 0; index < leftMembers.size(); ++index) {
+            if (leftMembers[index].key() != rightMembers[index].key()) {
+                return false;
+            }
+            if (!jsonEqual(leftMembers[index].value(), rightMembers[index].value())) {
+                return false;
+            }
+        }
+        return true;
+    }
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Identity: detectedVersion == currentVersion reports zero steps applied and owns no DOM, for any
+// step table (including one that would otherwise apply) -- migrateDocumentDom() never even looks
+// at `steps` in this case. This is the exact case save_archive.cpp's runReopenChain() always hits
+// in production today (see this file's own top comment).
+// ---------------------------------------------------------------------------------------------
+
+void testIdentity(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 2> steps{kStepV0ToV1, kStepV1ToV2};
+    auto operation = makeOperation();
+    auto fixture = parseFixture(kInputV0Json, operation);
+    expectations.expect(static_cast<bool>(fixture), "identity: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto result = migrateDocumentDom(fixture.document()->root(), kVersion0, kVersion0, steps,
+                                     StrictJsonDomLimits{}, operation);
+    expectations.expect(result.outcome() == MigrationOutcome::Identity,
+                        "identity: detectedVersion == currentVersion reports Identity");
+    expectations.expect(result.stepsApplied() == 0, "identity: zero steps applied");
+    expectations.expect(result.migratedRoot() == nullptr,
+                        "identity: owns no DOM (caller keeps using its own)");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Single-step transform correctness (golden values): {1,0} -> {1,1} renames "legacyName" to
+// "name" and normalizes "value" from the non-canonical "1.50" spelling to the canonical "1.5"
+// token.
+// ---------------------------------------------------------------------------------------------
+
+void testSingleStepGoldenValues(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 1> steps{kStepV0ToV1};
+    auto operation = makeOperation();
+    auto fixture = parseFixture(kInputV0Json, operation);
+    expectations.expect(static_cast<bool>(fixture), "single step: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto result = migrateDocumentDom(fixture.document()->root(), kVersion0, kVersion1, steps,
+                                     StrictJsonDomLimits{}, operation);
+    expectations.expect(result.outcome() == MigrationOutcome::Migrated,
+                        "single step: one registered step migrates");
+    expectations.expect(result.stepsApplied() == 1, "single step: exactly one step applied");
+    const auto* root = result.migratedRoot();
+    expectations.expect(root != nullptr, "single step: migrated DOM is present");
+    if (root == nullptr) {
+        return;
+    }
+    const auto* schemaVersion = root->findMember("schemaVersion");
+    expectations.expect(schemaVersion != nullptr && schemaVersion->findMember("minor") != nullptr &&
+                            schemaVersion->findMember("minor")->asNumberToken() == "1",
+                        "single step: schemaVersion.minor bumped to 1");
+    expectations.expect(root->findMember("legacyName") == nullptr,
+                        "single step: legacyName no longer present");
+    const auto* name = root->findMember("name");
+    expectations.expect(name != nullptr && name->asString() == "widget",
+                        "single step: legacyName's value moved to name verbatim");
+    const auto* value = root->findMember("value");
+    expectations.expect(value != nullptr && value->asNumberToken() == "1.5",
+                        "single step: value renormalized from non-canonical \"1.50\" to "
+                        "canonical \"1.5\" (golden token)");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Two-step sequential chaining: {1,0} -> {1,1} -> {1,2}, registered in reverse array order to
+// prove the chain is driven by version linkage (sourceVersion lookup), not by registration
+// position.
+// ---------------------------------------------------------------------------------------------
+
+void testTwoStepSequencing(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 2> reversedSteps{kStepV1ToV2, kStepV0ToV1};
+    auto operation = makeOperation();
+    auto fixture = parseFixture(kInputV0Json, operation);
+    expectations.expect(static_cast<bool>(fixture), "two step: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto result = migrateDocumentDom(fixture.document()->root(), kVersion0, kVersion2,
+                                     reversedSteps, StrictJsonDomLimits{}, operation);
+    expectations.expect(result.outcome() == MigrationOutcome::Migrated,
+                        "two step: chain from {1,0} to {1,2} migrates");
+    expectations.expect(result.stepsApplied() == 2, "two step: both steps applied in sequence");
+    const auto* root = result.migratedRoot();
+    expectations.expect(root != nullptr, "two step: migrated DOM is present");
+    if (root == nullptr) {
+        return;
+    }
+    const auto* schemaVersion = root->findMember("schemaVersion");
+    expectations.expect(schemaVersion != nullptr &&
+                            schemaVersion->findMember("minor")->asNumberToken() == "2",
+                        "two step: schemaVersion.minor bumped to 2 by the final step");
+    expectations.expect(root->findMember("legacyName") == nullptr &&
+                            root->findMember("name") == nullptr,
+                        "two step: both intermediate member names are gone");
+    const auto* label = root->findMember("label");
+    expectations.expect(label != nullptr && label->asString() == "widget",
+                        "two step: final member carries the original string through both steps");
+    const auto* value = root->findMember("value");
+    expectations.expect(value != nullptr && value->asNumberToken() == "1.5",
+                        "two step: value stays canonically normalized through both steps");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Determinism: two independent runs of the same two-step chain over the same input produce
+// structurally (and therefore byte-) identical migrated DOMs.
+// ---------------------------------------------------------------------------------------------
+
+void testDeterminism(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 2> steps{kStepV0ToV1, kStepV1ToV2};
+    auto firstOperation = makeOperation();
+    auto secondOperation = makeOperation();
+    auto firstFixture = parseFixture(kInputV0Json, firstOperation);
+    auto secondFixture = parseFixture(kInputV0Json, secondOperation);
+    expectations.expect(static_cast<bool>(firstFixture) && static_cast<bool>(secondFixture),
+                        "determinism: both independent fixtures parse");
+    if (!firstFixture || !secondFixture) {
+        return;
+    }
+
+    auto firstResult = migrateDocumentDom(firstFixture.document()->root(), kVersion0, kVersion2,
+                                          steps, StrictJsonDomLimits{}, firstOperation);
+    auto secondResult = migrateDocumentDom(secondFixture.document()->root(), kVersion0, kVersion2,
+                                           steps, StrictJsonDomLimits{}, secondOperation);
+    expectations.expect(firstResult.outcome() == MigrationOutcome::Migrated &&
+                            secondResult.outcome() == MigrationOutcome::Migrated,
+                        "determinism: both independent runs migrate");
+    expectations.expect(firstResult.stepsApplied() == secondResult.stepsApplied(),
+                        "determinism: both runs apply the same number of steps");
+    const auto* firstRoot = firstResult.migratedRoot();
+    const auto* secondRoot = secondResult.migratedRoot();
+    expectations.expect(firstRoot != nullptr && secondRoot != nullptr,
+                        "determinism: both migrated DOMs are present");
+    if (firstRoot == nullptr || secondRoot == nullptr) {
+        return;
+    }
+    expectations.expect(jsonEqual(*firstRoot, *secondRoot),
+                        "determinism: two runs over the same input are structurally (and "
+                        "therefore byte-) identical");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Typed failures: unknown source version, chain gap, step-failure-with-path, and the framework's
+// own strict re-parse rejection of a buggy step's output.
+// ---------------------------------------------------------------------------------------------
+
+void testUnknownSourceVersion(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 1> steps{kStepV0ToV1};
+    auto operation = makeOperation();
+    auto fixture = parseFixture(kInputV0Json, operation);
+    expectations.expect(static_cast<bool>(fixture), "unknown source: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto result = migrateDocumentDom(fixture.document()->root(), kNeverRegisteredVersion, kVersion2,
+                                     steps, StrictJsonDomLimits{}, operation);
+    expectations.expect(result.outcome() == MigrationOutcome::Failed,
+                        "unknown source: an unregistered detected version fails");
+    expectations.expect(result.error() == MigrationError::UnknownSourceVersion,
+                        "unknown source: typed as UnknownSourceVersion");
+    expectations.expect(result.stepsApplied() == 0,
+                        "unknown source: no step ever ran (the very first lookup failed)");
+}
+
+void testChainGap(Expectations& expectations) {
+    // Only the {1,0} -> {1,1} step is registered; {1,1} -> {1,2} is deliberately withheld so the
+    // chain has a real hole after one successful step.
+    const std::array<MigrationStepDescriptor, 1> steps{kStepV0ToV1};
+    auto operation = makeOperation();
+    auto fixture = parseFixture(kInputV0Json, operation);
+    expectations.expect(static_cast<bool>(fixture), "chain gap: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto result = migrateDocumentDom(fixture.document()->root(), kVersion0, kVersion2, steps,
+                                     StrictJsonDomLimits{}, operation);
+    expectations.expect(result.outcome() == MigrationOutcome::Failed,
+                        "chain gap: reaching {1,1} with currentVersion {1,2} and no next step "
+                        "fails");
+    expectations.expect(result.error() == MigrationError::ChainGap,
+                        "chain gap: typed as ChainGap, not UnknownSourceVersion");
+    expectations.expect(result.stepsApplied() == 1,
+                        "chain gap: the one available step still ran before the gap was found");
+}
+
+void testStepFailurePropagatesPath(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 1> steps{kStepV0ToV1};
+    auto operation = makeOperation();
+    // Missing "legacyName" entirely: stepRenameAndNormalize must report a typed failure rather
+    // than crash or silently write a partial document.
+    auto fixture = parseFixture(kInputV0MissingLegacyNameJson, operation);
+    expectations.expect(static_cast<bool>(fixture), "step failure: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto result = migrateDocumentDom(fixture.document()->root(), kVersion0, kVersion1, steps,
+                                     StrictJsonDomLimits{}, operation);
+    expectations.expect(result.outcome() == MigrationOutcome::Failed,
+                        "step failure: a step transform failure fails the whole migration");
+    expectations.expect(result.error() == MigrationError::StepTransformFailed,
+                        "step failure: typed as StepTransformFailed");
+    expectations.expect(result.path() == "/legacyName",
+                        "step failure: the step's own path diagnostic propagates unchanged");
+    expectations.expect(result.failedStepSourceVersion() == kVersion0 &&
+                            result.failedStepTargetVersion() == kVersion1,
+                        "step failure: names the exact step that failed");
+}
+
+void testStrictReparseRejectsInvalidStepOutput(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 1> steps{kStepEmitsInvalidJson};
+    auto operation = makeOperation();
+    // Content is irrelevant: stepEmitsInvalidJson ignores its input DOM entirely.
+    auto fixture = parseFixture(kInputV0Json, operation);
+    expectations.expect(static_cast<bool>(fixture), "invalid step output: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto result = migrateDocumentDom(fixture.document()->root(), kBuggyStepSource, kBuggyStepTarget,
+                                     steps, StrictJsonDomLimits{}, operation);
+    expectations.expect(result.outcome() == MigrationOutcome::Failed,
+                        "invalid step output: a step reporting success() but writing invalid "
+                        "JSON still fails the migration");
+    expectations.expect(result.error() == MigrationError::StepEmittedInvalidJson,
+                        "invalid step output: typed as StepEmittedInvalidJson -- the framework "
+                        "catches its own step's bug rather than trusting it");
+    expectations.expect(result.reparseError() == StrictJsonDomError::InvalidSyntax,
+                        "invalid step output: the underlying strict-parse error is preserved");
+}
+
+// ---------------------------------------------------------------------------------------------
+// Budget exhaustion, with a zeroed coordinator snapshot once the failed result goes out of scope
+// -- mirrors open_archive_tests.cpp's own expectOpenResourceExhausted() oracle.
+// ---------------------------------------------------------------------------------------------
+
+void testBudgetExhaustion(Expectations& expectations) {
+    const std::array<MigrationStepDescriptor, 1> steps{kStepV0ToV1};
+    // Parsed under an independent, generous operation: only the migrateDocumentDom() call below
+    // runs under the constrained budget.
+    auto generousOperation = makeOperation();
+    auto fixture = parseFixture(kInputV0Json, generousOperation);
+    expectations.expect(static_cast<bool>(fixture), "budget exhaustion: fixture parses");
+    if (!fixture) {
+        return;
+    }
+
+    auto coordinator = ProjectIoMemoryCoordinator::create(1ULL << 20U);
+    expectations.expect(coordinator.has_value(), "budget exhaustion: coordinator constructs");
+    if (!coordinator.has_value()) {
+        return;
+    }
+    {
+        // Too small for even the step's own tiny output buffer to be reserved.
+        constexpr std::uint64_t kTinyBudget = 16;
+        auto operation = coordinator->createOperation(kTinyBudget, kTinyBudget);
+        expectations.expect(operation.has_value(), "budget exhaustion: operation constructs");
+        if (!operation.has_value()) {
+            return;
+        }
+        auto result = migrateDocumentDom(fixture.document()->root(), kVersion0, kVersion1, steps,
+                                         StrictJsonDomLimits{}, *operation);
+        expectations.expect(result.outcome() == MigrationOutcome::Failed,
+                            "budget exhaustion: a starved budget fails the migration");
+        expectations.expect(result.error() == MigrationError::ResourceExhausted,
+                            "budget exhaustion: typed as ResourceExhausted");
+        expectations.expect(result.stepsApplied() == 0,
+                            "budget exhaustion: the step never completed");
+    } // `result`/`operation` (holding no resident state on failure) are destroyed before the
+      // snapshot check below.
+    const auto snapshot = coordinator->snapshot();
+    expectations.expect(snapshot.currentBytes == 0,
+                        "budget exhaustion: every charge released once the failed result and its "
+                        "operation handle are gone");
+}
+
+} // namespace
+
+int main() try {
+    Expectations expectations;
+    testIdentity(expectations);
+    testSingleStepGoldenValues(expectations);
+    testTwoStepSequencing(expectations);
+    testDeterminism(expectations);
+    testUnknownSourceVersion(expectations);
+    testChainGap(expectations);
+    testStepFailurePropagatesPath(expectations);
+    testStrictReparseRejectsInvalidStepOutput(expectations);
+    testBudgetExhaustion(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+} catch (const std::exception& exception) {
+    std::cerr << "FAILED: unexpected exception: " << exception.what() << '\n';
+    return EXIT_FAILURE;
+} catch (...) {
+    std::cerr << "FAILED: unexpected non-standard exception\n";
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Implements the format contract's "sequential deterministic DOM migrations before trusted decoding" as a real, wired pipeline stage:

- **Framework** (`document_migration.{hpp,cpp}`): a migration step consumes the strict-parsed DOM read-only and produces canonical JSON bytes via the existing writer primitives; the framework strict-re-parses after every step so each stage sits behind the identical gate real document bytes pass. Constexpr step registry (empty production table); pipeline injectable over both the step span and the current version for test proof. Typed failures: unknown source version, chain gap, step transform failure with path, step-emitted-invalid-JSON (the framework catches its own steps' bugs), resource exhaustion. Both live representations charge the operation budget per the resource-limits contract.
- **Wiring** (`runReopenChain`): a new DocumentMigration stage between version agreement and trusted decode routes exactly same-major, at-or-below-current-minor documents; unknown majors and newer minors keep their existing rejection/preservation paths untouched. Today only {1,0} satisfies the guard, so production exercises the identity path (zero re-encode, byte identity pinned); both reopen-chain callers (save-verify and open) inherit the stage.
- **Tests**: 9-function synthetic suite over a fictional {1,0}→{1,1}→{1,2} chain — golden single-step normalization of a non-canonical number spelling, two-step sequencing proven version-driven (reversed registration order), determinism across runs, typed failure propagation with paths, strict re-parse rejection, budget exhaustion with zeroed snapshots.

Desktop 88/88 and native 74/74 locally, format check clean.

Closes #88.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.