### PR TITLE
feat: show color-managed frames in the viewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,13 @@ add_subdirectory(tools/quality/dependency_artifact_checks)
 add_subdirectory(src/platform)
 add_subdirectory(src/document)
 add_subdirectory(src/project)
+# src/color must precede src/runtime: bloom_runtime_evaluator's qualified display-preparation
+# stage (issue #97, task C3) links bloom_color_ocio, and target_link_libraries() requires that
+# target to already exist. src/color itself only depends on src/core/src/render (both already
+# added above), never on src/runtime, so this reordering introduces no cycle.
 add_subdirectory(src/render)
-add_subdirectory(src/runtime)
 add_subdirectory(src/color)
+add_subdirectory(src/runtime)
 add_subdirectory(src/output)
 add_subdirectory(src/commands)
 add_subdirectory(src/host)

--- a/apps/bloom/main.cpp
+++ b/apps/bloom/main.cpp
@@ -1,5 +1,6 @@
 #include <bloom/runtime/cpu_composition_evaluator.hpp>
 #include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
 #include <bloom/runtime/reference_display_preparation.hpp>
 #include <bloom/runtime/snapshot_compiler.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
@@ -11,6 +12,7 @@
 #include <bloom/ui/jobs_editor.hpp>
 #include <bloom/ui/main_window.hpp>
 #include <bloom/ui/project_host.hpp>
+#include <bloom/ui/qualified_display_processor_bootstrap.hpp>
 #include <bloom/ui/task_monitor_model.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 
@@ -70,11 +72,19 @@ int main(int argc, char* argv[]) {
     bloom::runtime::SnapshotCompiler snapshotCompiler(nodeDefinitions);
     bloom::runtime::CpuCompositionEvaluator cpuEvaluator;
     bloom::runtime::CpuReferenceDisplayPreparer referenceDisplayPreparer;
+    // Issue #97 (task C3): resolved and built once, on the shared TaskScheduler's blocking-I/O
+    // lane, at this same session/pipeline-construction point (design decision 3). Declared before
+    // taskUiBridge/qualifiedDisplayProcessorBootstrap/previewController so it outlives every
+    // reference into it those objects hold (locals destruct in reverse declaration order).
+    bloom::runtime::QualifiedDisplayProcessorProvider qualifiedDisplayProcessorProvider;
     bloom::ui::TaskUiBridge taskUiBridge(taskScheduler);
+    bloom::ui::QualifiedDisplayProcessorBootstrap qualifiedDisplayProcessorBootstrap(
+        taskScheduler, taskUiBridge, qualifiedDisplayProcessorProvider);
     bloom::ui::CompositionPreviewController previewController(
         compositionSession, taskScheduler, taskUiBridge,
         bloom::ui::makeCompositionPreviewPipeline(snapshotCompiler, cpuEvaluator,
-                                                  referenceDisplayPreparer));
+                                                  referenceDisplayPreparer,
+                                                  qualifiedDisplayProcessorProvider));
     bloom::ui::ApplicationShutdownCoordinator shutdownCoordinator(previewController, taskUiBridge);
     application.installEventFilter(&shutdownCoordinator);
     bloom::ui::TaskMonitorModel taskMonitor(taskUiBridge);

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -60,6 +60,8 @@ target_sources(
         cpu_composition_evaluator_support.hpp
         evaluation.cpp
         prepared_preview_frame.cpp
+        qualified_display_preparation.cpp
+        qualified_display_processor_provider.cpp
         reference_display_preparation.cpp
     PUBLIC
         FILE_SET HEADERS
@@ -69,11 +71,22 @@ target_sources(
             include/bloom/runtime/cpu_composition_evaluator.hpp
             include/bloom/runtime/evaluation.hpp
             include/bloom/runtime/prepared_preview_frame.hpp
+            include/bloom/runtime/qualified_display_preparation.hpp
+            include/bloom/runtime/qualified_display_processor_provider.hpp
             include/bloom/runtime/reference_display_preparation.hpp
 )
 
 target_compile_features(bloom_runtime_evaluator PUBLIC cxx_std_20)
-target_link_libraries(bloom_runtime_evaluator PUBLIC bloom_runtime_compiler bloom_render)
+# bloom_color_ocio (issue #97, task C3): the qualified display-preparation stage applies the C2
+# qualified Bloom Neutral CPU display processor (bloom/color/ocio_cpu_display_frame.hpp,
+# ocio_cpu_display_processor.hpp) to a ProcessFrame. runtime->color is the correct dependency
+# direction (docs/architecture/color-management.md's staged-graph "CPU Display Processor Boundary"
+# has color own the adapter and runtime own the staged application); PUBLIC because
+# qualified_display_preparation.hpp and qualified_display_processor_provider.hpp expose
+# bloom::color value types (PreparedCpuDisplayProcessorHandle, PreparedDisplayFrame) directly in
+# their own public signatures, exactly like the existing PUBLIC bloom_render dependency below.
+target_link_libraries(bloom_runtime_evaluator PUBLIC bloom_runtime_compiler bloom_render
+                                                     bloom_color_ocio)
 bloom_enable_warnings(bloom_runtime_evaluator)
 bloom_enable_strict_floating_point(bloom_runtime_evaluator)
 

--- a/src/runtime/include/bloom/runtime/prepared_preview_frame.hpp
+++ b/src/runtime/include/bloom/runtime/prepared_preview_frame.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <bloom/runtime/qualified_display_preparation.hpp>
 #include <bloom/runtime/reference_display_preparation.hpp>
 
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <span>
+#include <variant>
 
 namespace bloom::runtime {
 
@@ -26,49 +29,94 @@ struct PreviewRequestIdentity final {
     friend bool operator==(const PreviewRequestIdentity&, const PreviewRequestIdentity&) = default;
 };
 
+// The viewer's normalized, alternative-agnostic view of a published display buffer (issue #97,
+// task C3, design decision 2): "The viewer consumes the packed RGBA8 buffer identically in both
+// cases (same packing/alpha association) -- the difference is identity/provenance and the
+// qualified flag." Both render::ReferenceDisplayBufferDescriptor/View and
+// color::PreparedDisplayFrame already expose the same shape (display window, pixel aspect, packed
+// layout, packed RGBA8 pixels); this struct is that shared shape, sourced from whichever
+// alternative PreparedPreviewFrame actually holds. isOcioQualified is the ONLY place that
+// distinguishes them -- it is never inferred from anything else, and the reference alternative
+// always reports false here exactly as render::ReferenceDisplayBufferDescriptor::isOcioQualified()
+// itself always does.
+struct PreviewDisplayBufferView final {
+    render::ImageWindow displayWindow;
+    core::PixelAspectRatio pixelAspect;
+    render::PackedImageLayout layout;
+    std::span<const render::Rgba8> pixels;
+    bool isOcioQualified = false;
+};
+
+// A closed alternative over the two production display products (issue #97, task C3, design
+// decision 2): EITHER the temporary built-in reference product (ReferenceDisplayFrame) OR the
+// qualified OCIO product (QualifiedDisplayFrame), never both and never a third kind. The reference
+// alternative's own accessors (displayFrame(), displayIdentity(), displayBuffer()) keep their exact
+// pre-existing signatures and behavior for backward compatibility -- calling one of them when the
+// qualified alternative is active is a precondition violation (std::get throws bad_variant_access,
+// which a noexcept accessor turns into std::terminate): no existing or new caller does this, since
+// isOcioQualified()/qualifiedDisplayFrame()/displayBufferView() are how a caller that does not
+// already know which alternative it holds finds out.
 class PreparedPreviewFrame final {
   public:
     [[nodiscard]] static std::optional<PreparedPreviewFrame>
     create(std::uint64_t requestGeneration,
            std::shared_ptr<const ReferenceDisplayFrame> displayFrame) noexcept;
+    [[nodiscard]] static std::optional<PreparedPreviewFrame>
+    createQualified(std::uint64_t requestGeneration,
+                    std::shared_ptr<const QualifiedDisplayFrame> displayFrame) noexcept;
 
     [[nodiscard]] const PreviewRequestIdentity& desiredIdentity() const& noexcept {
         return desiredIdentity_;
     }
     [[nodiscard]] const PreviewRequestIdentity& desiredIdentity() const&& = delete;
-    [[nodiscard]] const ProcessFrameIdentity& processIdentity() const& noexcept {
-        return displayFrame_->identity().processFrame;
+
+    // True exactly when the qualified alternative is active. The reference alternative always
+    // reports false here, never silently relabeled (design decision 2).
+    [[nodiscard]] bool isOcioQualified() const noexcept {
+        return std::holds_alternative<std::shared_ptr<const QualifiedDisplayFrame>>(displayFrame_);
     }
+
+    [[nodiscard]] const ProcessFrameIdentity& processIdentity() const& noexcept;
     [[nodiscard]] const ProcessFrameIdentity& processIdentity() const&& = delete;
-    [[nodiscard]] const ReferenceDisplayFrameIdentity& displayIdentity() const& noexcept {
-        return displayFrame_->identity();
-    }
-    [[nodiscard]] const ReferenceDisplayFrameIdentity& displayIdentity() const&& = delete;
-    [[nodiscard]] const std::shared_ptr<const ProcessFrame>& processFrame() const& noexcept {
-        return displayFrame_->processFrame();
-    }
+    [[nodiscard]] const std::shared_ptr<const ProcessFrame>& processFrame() const& noexcept;
     [[nodiscard]] const std::shared_ptr<const ProcessFrame>& processFrame() const&& = delete;
-    [[nodiscard]] const std::shared_ptr<const ReferenceDisplayFrame>&
-    displayFrame() const& noexcept {
-        return displayFrame_;
-    }
-    [[nodiscard]] const std::shared_ptr<const ReferenceDisplayFrame>&
-    displayFrame() const&& = delete;
     [[nodiscard]] const render::Rgba32fImage& processImage() const& noexcept {
-        return displayFrame_->processFrame()->processImage();
+        return processFrame()->processImage();
     }
     [[nodiscard]] const render::Rgba32fImage& processImage() const&& = delete;
-    [[nodiscard]] const render::PreparedReferenceDisplayBuffer& displayBuffer() const& noexcept {
-        return displayFrame_->buffer();
-    }
+
+    // Alternative-agnostic packed-buffer accessor (design decision 2); std::nullopt only if the
+    // active alternative's own buffer is unexpectedly invalid (never observed for a successfully
+    // published frame -- both preparers reject publishing an invalid buffer).
+    [[nodiscard]] std::optional<PreviewDisplayBufferView> displayBufferView() const noexcept;
+
+    // Reference-only accessors; see the class-level precondition documentation above.
+    [[nodiscard]] const std::shared_ptr<const ReferenceDisplayFrame>&
+    displayFrame() const& noexcept;
+    [[nodiscard]] const std::shared_ptr<const ReferenceDisplayFrame>&
+    displayFrame() const&& = delete;
+    [[nodiscard]] const ReferenceDisplayFrameIdentity& displayIdentity() const& noexcept;
+    [[nodiscard]] const ReferenceDisplayFrameIdentity& displayIdentity() const&& = delete;
+    [[nodiscard]] const render::PreparedReferenceDisplayBuffer& displayBuffer() const& noexcept;
     [[nodiscard]] const render::PreparedReferenceDisplayBuffer& displayBuffer() const&& = delete;
 
+    // Qualified-only accessors; precondition mirrors the reference-only accessors above.
+    [[nodiscard]] const std::shared_ptr<const QualifiedDisplayFrame>&
+    qualifiedDisplayFrame() const& noexcept;
+    [[nodiscard]] const std::shared_ptr<const QualifiedDisplayFrame>&
+    qualifiedDisplayFrame() const&& = delete;
+    [[nodiscard]] const QualifiedDisplayFrameIdentity& qualifiedDisplayIdentity() const& noexcept;
+    [[nodiscard]] const QualifiedDisplayFrameIdentity& qualifiedDisplayIdentity() const&& = delete;
+
   private:
+    using DisplayFrameVariant = std::variant<std::shared_ptr<const ReferenceDisplayFrame>,
+                                             std::shared_ptr<const QualifiedDisplayFrame>>;
+
     PreparedPreviewFrame(PreviewRequestIdentity desiredIdentity,
-                         std::shared_ptr<const ReferenceDisplayFrame> displayFrame) noexcept;
+                         DisplayFrameVariant displayFrame) noexcept;
 
     PreviewRequestIdentity desiredIdentity_;
-    std::shared_ptr<const ReferenceDisplayFrame> displayFrame_;
+    DisplayFrameVariant displayFrame_;
 };
 
 enum class PreviewPreparationStatus : std::uint8_t {

--- a/src/runtime/include/bloom/runtime/qualified_display_preparation.hpp
+++ b/src/runtime/include/bloom/runtime/qualified_display_preparation.hpp
@@ -1,0 +1,213 @@
+#pragma once
+
+#include <bloom/color/ocio_cpu_display_frame.hpp>
+#include <bloom/color/ocio_cpu_display_processor.hpp>
+#include <bloom/runtime/cancellation.hpp>
+#include <bloom/runtime/evaluation.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// The qualified counterpart of reference_display_preparation.hpp (issue #97, task C3): applies the
+// C2 qualified Bloom Neutral CPU display processor (bloom/color/ocio_cpu_display_frame.hpp) to a
+// ProcessFrame instead of the temporary built-in reference mapper. This header deliberately mirrors
+// CpuReferenceDisplayPreparer's shape (request/identity/frame/result/preparer) so the two paths
+// stay side by side; see docs/architecture/color-management.md, "CPU Display Processor Boundary"
+// and "Process And Display Separation".
+//
+// Display-window mechanism (design decision 1): produceBloomNeutralDisplayFrame() windows its
+// output to the source ProcessFrame's DATA window, not its display window (C2's recorded scope
+// decision -- "the prepared frame's window equals the source process frame's data window, no
+// padding composite"). CpuReferenceDisplayPreparer instead composites into the process descriptor's
+// full DISPLAY window, padding any area outside the data window with transparent black
+// (bloom::render::mapLinearRec709SceneToSrgbRow). This preparer reproduces that reference behavior
+// exactly under the one invariant every ProcessFrame this application produces currently satisfies:
+// bloom::runtime::CpuCompositionEvaluator always constructs Rgba32fImageDescriptor with dataWindow
+// == displayWindow (see cpu_composition_evaluator.cpp's Rgba32fImageDescriptor::create(window,
+// window, pixelAspect) call) -- so C2's data-window-sized output already covers the process frame's
+// entire display window and no separate padding composite is ever needed to match the reference
+// path bit-for-bit. If a future evaluator slice introduces a data window narrower than the display
+// window, the two paths would visibly diverge (this preparer would report the narrower data window
+// rather than a padded display window) until a later change teaches this preparer to composite
+// around C2's frame the way the reference preparer composites around its own row-mapped pixels --
+// this is a disclosed, currently-inert scope edge, not a silent behavior gap.
+namespace bloom::runtime {
+
+// Bounded pixels-per-call granularity handed to color::produceBloomNeutralDisplayFrame's own
+// internal chunking/cancellation loop. Overridable per request for tests; production requests use
+// this default.
+inline constexpr std::size_t kDefaultQualifiedDisplayChunkPixelCount = 65536;
+
+inline constexpr std::uint32_t kQualifiedDisplayPreparerSemanticsVersion = 1;
+
+struct QualifiedDisplayPreparationRequest final {
+    std::size_t aggregatePixelStorageByteLimit = 0;
+    std::size_t chunkPixelCount = kDefaultQualifiedDisplayChunkPixelCount;
+};
+
+enum class QualifiedDisplayProvider : std::uint8_t {
+    CpuBloomNeutral,
+};
+
+enum class QualifiedDisplayPacking : std::uint8_t {
+    StraightRgba8,
+};
+
+// Deliberately does NOT embed color::DisplayProcessorIdentityV1 (move-construct-only, no
+// operator==; see display_processor_identity.hpp) -- the complete portable display-processor
+// identity is retained where C2 already owns it, on the embedded color::PreparedDisplayFrame's own
+// identity() accessor (QualifiedDisplayFrame::buffer().identity()), exactly as
+// ReferenceDisplayFrameIdentity does not duplicate render::PreparedReferenceDisplayBuffer's own
+// layout/window fields either. This identity struct stays a small, comparable value like its
+// reference counterpart.
+struct QualifiedDisplayFrameIdentity final {
+    ProcessFrameIdentity processFrame;
+    QualifiedDisplayProvider provider = QualifiedDisplayProvider::CpuBloomNeutral;
+    QualifiedDisplayPacking packing = QualifiedDisplayPacking::StraightRgba8;
+    std::uint32_t preparerSemanticsVersion = kQualifiedDisplayPreparerSemanticsVersion;
+
+    friend bool operator==(const QualifiedDisplayFrameIdentity&,
+                           const QualifiedDisplayFrameIdentity&) = default;
+};
+
+enum class QualifiedDisplayPreparationStatus : std::uint8_t {
+    Prepared,
+    Cancelled,
+    Failed,
+};
+
+enum class QualifiedDisplayDiagnosticCode : std::uint8_t {
+    InvalidRequest,
+    PixelStorageBudgetExceeded,
+    AllocationFailure,
+    InvalidPixel,
+    UnsupportedFloatingPointEnvironment,
+    IncompatibleImageDescriptor,
+    InternalInvariant,
+};
+
+[[nodiscard]] std::string_view
+qualifiedDisplayDiagnosticCodeId(QualifiedDisplayDiagnosticCode code) noexcept;
+
+struct QualifiedDisplayDiagnostic final {
+    QualifiedDisplayDiagnosticCode code = QualifiedDisplayDiagnosticCode::InternalInvariant;
+    DiagnosticSeverity severity = DiagnosticSeverity::Error;
+    std::string summary;
+    std::string detail;
+
+    friend bool operator==(const QualifiedDisplayDiagnostic&,
+                           const QualifiedDisplayDiagnostic&) = default;
+};
+
+enum class QualifiedDisplayProgressStage : std::uint8_t {
+    Preflight,
+    Applying,
+};
+
+struct QualifiedDisplayProgress final {
+    QualifiedDisplayProgressStage stage = QualifiedDisplayProgressStage::Preflight;
+    std::uint64_t completed = 0;
+    std::uint64_t total = 0;
+
+    friend bool operator==(const QualifiedDisplayProgress&,
+                           const QualifiedDisplayProgress&) = default;
+};
+
+using QualifiedDisplayProgressCallback = std::function<void(const QualifiedDisplayProgress&)>;
+
+// Boundary product 1 of this task: identity + retained shared_ptr<const ProcessFrame> + the color
+// module's PreparedDisplayFrame, the same ownership split as ReferenceDisplayFrame (design decision
+// 1). Move-assignment is deleted, not omitted: color::PreparedDisplayFrame itself deletes
+// move-assignment (one of its own members -- DisplayProcessorIdentityV1 -- is not
+// move-assignable), so this class cannot be either.
+class QualifiedDisplayFrame final {
+  public:
+    QualifiedDisplayFrame(const QualifiedDisplayFrame&) = delete;
+    QualifiedDisplayFrame& operator=(const QualifiedDisplayFrame&) = delete;
+    QualifiedDisplayFrame(QualifiedDisplayFrame&&) noexcept = default;
+    QualifiedDisplayFrame& operator=(QualifiedDisplayFrame&&) = delete;
+    ~QualifiedDisplayFrame() = default;
+
+    [[nodiscard]] const QualifiedDisplayFrameIdentity& identity() const& noexcept {
+        return identity_;
+    }
+    [[nodiscard]] const QualifiedDisplayFrameIdentity& identity() const&& = delete;
+    [[nodiscard]] const std::shared_ptr<const ProcessFrame>& processFrame() const& noexcept {
+        return processFrame_;
+    }
+    [[nodiscard]] const std::shared_ptr<const ProcessFrame>& processFrame() const&& = delete;
+    [[nodiscard]] const color::PreparedDisplayFrame& buffer() const& noexcept { return buffer_; }
+    [[nodiscard]] const color::PreparedDisplayFrame& buffer() const&& = delete;
+
+  private:
+    friend class CpuQualifiedDisplayPreparer;
+
+    QualifiedDisplayFrame(QualifiedDisplayFrameIdentity identity,
+                          std::shared_ptr<const ProcessFrame> processFrame,
+                          color::PreparedDisplayFrame buffer) noexcept;
+
+    QualifiedDisplayFrameIdentity identity_;
+    std::shared_ptr<const ProcessFrame> processFrame_;
+    color::PreparedDisplayFrame buffer_;
+};
+
+class QualifiedDisplayPreparationResult final {
+  public:
+    [[nodiscard]] static QualifiedDisplayPreparationResult
+    prepared(std::shared_ptr<const QualifiedDisplayFrame> frame,
+             std::vector<QualifiedDisplayDiagnostic> diagnostics = {});
+    [[nodiscard]] static QualifiedDisplayPreparationResult
+    cancelled(std::vector<QualifiedDisplayDiagnostic> diagnostics = {});
+    [[nodiscard]] static QualifiedDisplayPreparationResult
+    failed(QualifiedDisplayDiagnostic diagnostic);
+    [[nodiscard]] static QualifiedDisplayPreparationResult
+    failed(std::vector<QualifiedDisplayDiagnostic> diagnostics);
+
+    [[nodiscard]] QualifiedDisplayPreparationStatus status() const noexcept { return status_; }
+    [[nodiscard]] const std::shared_ptr<const QualifiedDisplayFrame>& frame() const noexcept {
+        return frame_;
+    }
+    [[nodiscard]] const std::vector<QualifiedDisplayDiagnostic>& diagnostics() const noexcept {
+        return diagnostics_;
+    }
+
+  private:
+    QualifiedDisplayPreparationResult(QualifiedDisplayPreparationStatus status,
+                                      std::shared_ptr<const QualifiedDisplayFrame> frame,
+                                      std::vector<QualifiedDisplayDiagnostic> diagnostics) noexcept;
+
+    QualifiedDisplayPreparationStatus status_ = QualifiedDisplayPreparationStatus::Failed;
+    std::shared_ptr<const QualifiedDisplayFrame> frame_;
+    std::vector<QualifiedDisplayDiagnostic> diagnostics_;
+};
+
+// Mirrors CpuReferenceDisplayPreparer's shape exactly: a small value type whose prepare() takes
+// (processFrame, request, cancellation, progress). The one addition is the
+// PreparedCpuDisplayProcessorHandle this preparer applies, supplied at CONSTRUCTION (design
+// decision 3) rather than as a fifth prepare() parameter -- callers construct a fresh preparer
+// around whichever handle QualifiedDisplayProcessorProvider currently publishes (see
+// qualified_display_processor_provider.hpp), exactly the way CpuReferenceDisplayPreparer itself is
+// a stateless value constructed fresh per use. The handle reference must outlive every prepare()
+// call made through this preparer.
+class CpuQualifiedDisplayPreparer final {
+  public:
+    explicit CpuQualifiedDisplayPreparer(
+        const color::PreparedCpuDisplayProcessorHandle& handle) noexcept
+        : handle_(&handle) {}
+
+    [[nodiscard]] QualifiedDisplayPreparationResult
+    prepare(std::shared_ptr<const ProcessFrame> processFrame,
+            const QualifiedDisplayPreparationRequest& request,
+            const CancellationToken& cancellation,
+            const QualifiedDisplayProgressCallback& progress = {}) const;
+
+  private:
+    const color::PreparedCpuDisplayProcessorHandle* handle_;
+};
+
+} // namespace bloom::runtime

--- a/src/runtime/include/bloom/runtime/qualified_display_processor_provider.hpp
+++ b/src/runtime/include/bloom/runtime/qualified_display_processor_provider.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <bloom/color/bloom_neutral_builtin.hpp>
+#include <bloom/color/ocio_cpu_display_processor.hpp>
+#include <bloom/runtime/task_types.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+// The one-time blocking-stage handoff (issue #97, task C3, design decision 3): "Processor
+// preparation is a one-time blocking stage, not per-frame ... at pipeline/session construction,
+// resolve Bloom Neutral through the C2 registry and build the processor ON THE EXISTING
+// BLOCKING-I/O WORKER PATH ... The handle reaches the pipeline through the established handoff
+// idiom (typed mailbox/shared state as the controller already does for frames)." This header owns
+// the pure (Qt-free) build step and the thread-safe published-state slot; bloom::ui::
+// QualifiedDisplayProcessorBootstrap (src/ui) owns submitting the build through
+// bloom::runtime::TaskScheduler's TaskExecutor::BlockingIo lane and polling its completion the same
+// non-blocking way bloom::ui::CompositionPreviewController already polls preview results (see
+// TaskUiBridge::snapshotsPolled) -- no task ever calls wait/get, joins a worker, or blocks a UI
+// callback.
+namespace bloom::runtime {
+
+// Runs entirely on a blocking-I/O worker thread; never on the UI thread. Resolves exactly the
+// embedded Bloom Neutral v1 built-in through the C2 registry (bloom::color::
+// resolveBloomNeutralV1BuiltIn) and, on success, builds its CPU display processor (bloom::color::
+// buildBloomNeutralCpuDisplayProcessor). Per docs/architecture/color-management.md's "Configuration
+// Resolution States", this should not fail for the embedded neutral asset, but the states are real
+// -- every non-Ready registry outcome and every processor-build error is mapped to a typed,
+// human-readable diagnostic rather than assumed unreachable.
+class QualifiedDisplayProcessorBuildResult final {
+  public:
+    [[nodiscard]] static QualifiedDisplayProcessorBuildResult
+    ready(std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle) noexcept;
+    [[nodiscard]] static QualifiedDisplayProcessorBuildResult
+    failed(TaskDiagnostic diagnostic) noexcept;
+
+    [[nodiscard]] bool succeeded() const noexcept { return handle_ != nullptr; }
+    [[nodiscard]] const std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle>&
+    handle() const& noexcept {
+        return handle_;
+    }
+    [[nodiscard]] const std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle>&
+    handle() const&& = delete;
+    // Valid content only when !succeeded().
+    [[nodiscard]] const TaskDiagnostic& diagnostic() const& noexcept { return diagnostic_; }
+    [[nodiscard]] const TaskDiagnostic& diagnostic() const&& = delete;
+
+  private:
+    explicit QualifiedDisplayProcessorBuildResult(
+        std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle) noexcept;
+    explicit QualifiedDisplayProcessorBuildResult(TaskDiagnostic diagnostic) noexcept;
+
+    std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle_;
+    TaskDiagnostic diagnostic_;
+};
+
+[[nodiscard]] QualifiedDisplayProcessorBuildResult
+buildBloomNeutralQualifiedDisplayProcessor() noexcept;
+
+enum class QualifiedDisplayProcessorReadiness : std::uint8_t {
+    // The honest startup window (design decision 3): the blocking build has not completed yet.
+    // Preview requests take the reference path, labeled unqualified -- never a fallback from
+    // failure.
+    Pending,
+    Ready,
+    // Fail-closed, terminal (design decision 4 / decision 6 "no caches" -- no retry slice exists
+    // yet): registry resolution or processor build failed. Preview requests never auto-substitute
+    // the reference transform for a qualified one once this state is observed.
+    Failed,
+};
+
+// A single consistent read of readiness + handle + failure diagnostic together (one lock
+// acquisition). Preview-pipeline callers must use this rather than separate readiness()/handle()
+// calls whenever the same decision depends on more than one field: publish() is one-shot but not
+// synchronous with a preview-render worker's own reads, so two SEPARATE locked reads could
+// otherwise straddle the one publish() call and observe an inconsistent pair (for example,
+// readiness() == Pending followed moments later by handle() == nullptr because publish() landed
+// Failed in between -- which would look identical to "still Pending" to a caller that only checks
+// handle() for nullness, silently reintroducing the reference fallback design decision 4 forbids
+// after a genuine failure).
+struct QualifiedDisplayProcessorSnapshot final {
+    QualifiedDisplayProcessorReadiness readiness = QualifiedDisplayProcessorReadiness::Pending;
+    std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle;
+    TaskDiagnostic failureDiagnostic;
+};
+
+// Mutex-guarded rather than lock-free: the one write happens once per process lifetime (or never,
+// if the build never completes before shutdown); every preview-render worker thread's read is a
+// short, uncontended critical section. This stays auditable without relying on
+// std::atomic<std::shared_ptr<T>> library support.
+class QualifiedDisplayProcessorProvider final {
+  public:
+    QualifiedDisplayProcessorProvider() = default;
+    QualifiedDisplayProcessorProvider(const QualifiedDisplayProcessorProvider&) = delete;
+    QualifiedDisplayProcessorProvider& operator=(const QualifiedDisplayProcessorProvider&) = delete;
+
+    [[nodiscard]] QualifiedDisplayProcessorReadiness readiness() const noexcept;
+    // Non-null exactly when readiness() == Ready; nullptr otherwise (including Failed).
+    [[nodiscard]] std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle>
+    handle() const noexcept;
+    // Meaningful only when readiness() == Failed; default-constructed otherwise.
+    [[nodiscard]] TaskDiagnostic failureDiagnostic() const;
+    // The single-locked-read accessor documented above; prefer this over readiness()/handle()/
+    // failureDiagnostic() whenever a caller's decision depends on more than one of them.
+    [[nodiscard]] QualifiedDisplayProcessorSnapshot snapshot() const;
+
+    // Called at most once, from the authoring/UI thread, by QualifiedDisplayProcessorBootstrap once
+    // the blocking-stage task reaches a scheduler-terminal state. A call after the first is a no-op
+    // -- this is a one-shot startup handoff (design decision 3), not a retryable or cached slot
+    // (design decision 6: "no caches").
+    void publish(const QualifiedDisplayProcessorBuildResult& result);
+
+  private:
+    mutable std::mutex mutex_;
+    QualifiedDisplayProcessorReadiness readiness_ = QualifiedDisplayProcessorReadiness::Pending;
+    std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle_;
+    TaskDiagnostic failureDiagnostic_;
+};
+
+} // namespace bloom::runtime

--- a/src/runtime/prepared_preview_frame.cpp
+++ b/src/runtime/prepared_preview_frame.cpp
@@ -31,13 +31,122 @@ PreparedPreviewFrame::create(const std::uint64_t requestGeneration,
         .quality = processIdentity.quality,
         .colorIntent = processIdentity.colorIntent,
     };
-    return PreparedPreviewFrame(desiredIdentity, std::move(displayFrame));
+    return PreparedPreviewFrame(desiredIdentity, DisplayFrameVariant(std::move(displayFrame)));
 }
 
-PreparedPreviewFrame::PreparedPreviewFrame(
-    PreviewRequestIdentity desiredIdentity,
-    std::shared_ptr<const ReferenceDisplayFrame> displayFrame) noexcept
+std::optional<PreparedPreviewFrame> PreparedPreviewFrame::createQualified(
+    const std::uint64_t requestGeneration,
+    std::shared_ptr<const QualifiedDisplayFrame> displayFrame) noexcept {
+    if (requestGeneration == 0 || displayFrame == nullptr ||
+        displayFrame->processFrame() == nullptr ||
+        displayFrame->identity().processFrame.plan == nullptr) {
+        return std::nullopt;
+    }
+
+    const auto& processIdentity = displayFrame->identity().processFrame;
+    const auto& plan = *processIdentity.plan;
+    if (processIdentity.output != plan.output() ||
+        displayFrame->processFrame()->identity() != processIdentity) {
+        return std::nullopt;
+    }
+
+    PreviewRequestIdentity desiredIdentity{
+        .projectId = plan.projectId(),
+        .compositionId = plan.compositionId(),
+        .sourceRevision = plan.sourceRevision(),
+        .requestGeneration = requestGeneration,
+        .time = processIdentity.time,
+        .output = PreviewOutput::Composition,
+        .resolution = processIdentity.resolution,
+        .quality = processIdentity.quality,
+        .colorIntent = processIdentity.colorIntent,
+    };
+    return PreparedPreviewFrame(desiredIdentity, DisplayFrameVariant(std::move(displayFrame)));
+}
+
+PreparedPreviewFrame::PreparedPreviewFrame(PreviewRequestIdentity desiredIdentity,
+                                           DisplayFrameVariant displayFrame) noexcept
     : desiredIdentity_(desiredIdentity), displayFrame_(std::move(displayFrame)) {}
+
+// std::visit/std::get both have a (never-actually-reachable-here, since displayFrame_ is only ever
+// constructed by create()/createQualified() and never reassigned) valueless_by_exception exception
+// path that clang-tidy's bugprone-exception-escape correctly flags inside a noexcept function.
+// Every accessor below instead uses the non-throwing std::get_if, matching this file's existing
+// precondition style (a caller violating a documented precondition, such as calling a
+// reference-only accessor on a qualified-backed envelope, gets a null-pointer dereference rather
+// than a thrown bad_variant_access -- still a loud failure, never silent misbehavior).
+using ReferencePtr = std::shared_ptr<const ReferenceDisplayFrame>;
+using QualifiedPtr = std::shared_ptr<const QualifiedDisplayFrame>;
+
+const ProcessFrameIdentity& PreparedPreviewFrame::processIdentity() const& noexcept {
+    if (const auto* reference = std::get_if<ReferencePtr>(&displayFrame_)) {
+        return (*reference)->identity().processFrame;
+    }
+    return std::get_if<QualifiedPtr>(&displayFrame_)->get()->identity().processFrame;
+}
+
+const std::shared_ptr<const ProcessFrame>& PreparedPreviewFrame::processFrame() const& noexcept {
+    if (const auto* reference = std::get_if<ReferencePtr>(&displayFrame_)) {
+        return (*reference)->processFrame();
+    }
+    return std::get_if<QualifiedPtr>(&displayFrame_)->get()->processFrame();
+}
+
+std::optional<PreviewDisplayBufferView> PreparedPreviewFrame::displayBufferView() const noexcept {
+    if (const auto* reference = std::get_if<ReferencePtr>(&displayFrame_)) {
+        const auto viewResult = (*reference)->buffer().view();
+        if (!viewResult) {
+            return std::nullopt;
+        }
+        const auto view = *viewResult.value();
+        const auto descriptorResult = view.descriptor();
+        if (!descriptorResult.has_value()) {
+            return std::nullopt;
+        }
+        return PreviewDisplayBufferView{
+            .displayWindow = descriptorResult->displayWindow(),
+            .pixelAspect = descriptorResult->pixelAspect(),
+            .layout = descriptorResult->layout(),
+            .pixels = view.pixels(),
+            .isOcioQualified = false,
+        };
+    }
+    const auto& buffer = std::get_if<QualifiedPtr>(&displayFrame_)->get()->buffer();
+    if (!buffer.isValid()) {
+        return std::nullopt;
+    }
+    return PreviewDisplayBufferView{
+        .displayWindow = buffer.displayWindow(),
+        .pixelAspect = buffer.pixelAspect(),
+        .layout = buffer.layout(),
+        .pixels = buffer.pixels(),
+        .isOcioQualified = true,
+    };
+}
+
+const std::shared_ptr<const ReferenceDisplayFrame>&
+PreparedPreviewFrame::displayFrame() const& noexcept {
+    return *std::get_if<ReferencePtr>(&displayFrame_);
+}
+
+const ReferenceDisplayFrameIdentity& PreparedPreviewFrame::displayIdentity() const& noexcept {
+    return std::get_if<ReferencePtr>(&displayFrame_)->get()->identity();
+}
+
+const render::PreparedReferenceDisplayBuffer&
+PreparedPreviewFrame::displayBuffer() const& noexcept {
+    return std::get_if<ReferencePtr>(&displayFrame_)->get()->buffer();
+}
+
+const std::shared_ptr<const QualifiedDisplayFrame>&
+PreparedPreviewFrame::qualifiedDisplayFrame() const& noexcept {
+    return *std::get_if<QualifiedPtr>(&displayFrame_);
+}
+
+const QualifiedDisplayFrameIdentity&
+PreparedPreviewFrame::qualifiedDisplayIdentity() const& noexcept {
+    return std::get_if<QualifiedPtr>(&displayFrame_)->get()->identity();
+}
 
 std::optional<PreviewPreparationResult>
 PreviewPreparationResult::prepared(std::shared_ptr<const PreparedPreviewFrame> frame) noexcept {

--- a/src/runtime/qualified_display_preparation.cpp
+++ b/src/runtime/qualified_display_preparation.cpp
@@ -1,0 +1,211 @@
+#include <bloom/runtime/qualified_display_preparation.hpp>
+
+#include <utility>
+
+namespace {
+
+using bloom::render::ImageError;
+using bloom::render::ImageErrorCode;
+using bloom::runtime::DiagnosticSeverity;
+using bloom::runtime::QualifiedDisplayDiagnostic;
+using bloom::runtime::QualifiedDisplayDiagnosticCode;
+
+[[nodiscard]] QualifiedDisplayDiagnostic diagnostic(const QualifiedDisplayDiagnosticCode code,
+                                                    std::string summary, std::string detail = {}) {
+    return {.code = code,
+            .severity = DiagnosticSeverity::Error,
+            .summary = std::move(summary),
+            .detail = std::move(detail)};
+}
+
+[[nodiscard]] QualifiedDisplayDiagnostic imageDiagnostic(const ImageError& error,
+                                                         std::string summary) {
+    auto code = QualifiedDisplayDiagnosticCode::InternalInvariant;
+    switch (error.code) {
+    case ImageErrorCode::PixelStorageBudgetExceeded:
+        code = QualifiedDisplayDiagnosticCode::PixelStorageBudgetExceeded;
+        break;
+    case ImageErrorCode::AllocationFailure:
+        code = QualifiedDisplayDiagnosticCode::AllocationFailure;
+        break;
+    case ImageErrorCode::InvalidPixel:
+    case ImageErrorCode::NonFiniteResult:
+        code = QualifiedDisplayDiagnosticCode::InvalidPixel;
+        break;
+    case ImageErrorCode::UnsupportedFloatingPointEnvironment:
+        code = QualifiedDisplayDiagnosticCode::UnsupportedFloatingPointEnvironment;
+        break;
+    case ImageErrorCode::IncompatibleImageDescriptor:
+        code = QualifiedDisplayDiagnosticCode::IncompatibleImageDescriptor;
+        break;
+    case ImageErrorCode::InvalidExtent:
+    case ImageErrorCode::InvalidWindow:
+    case ImageErrorCode::ArithmeticOverflow:
+    case ImageErrorCode::InvalidStorageSize:
+    case ImageErrorCode::CoordinateOutOfBounds:
+    case ImageErrorCode::InvalidState:
+    case ImageErrorCode::InvalidParameter:
+        break;
+    }
+
+    std::string detail;
+    if (error.requestedPixelStorageBytes.has_value()) {
+        detail += "requestedBytes=" + std::to_string(*error.requestedPixelStorageBytes);
+    }
+    if (error.pixelStorageByteLimit.has_value()) {
+        if (!detail.empty()) {
+            detail += ' ';
+        }
+        detail += "byteLimit=" + std::to_string(*error.pixelStorageByteLimit);
+    }
+    return diagnostic(code, std::move(summary), std::move(detail));
+}
+
+void reportProgress(const bloom::runtime::QualifiedDisplayProgressCallback& callback,
+                    const bloom::runtime::QualifiedDisplayProgress& progress) noexcept {
+    if (!callback) {
+        return;
+    }
+    try {
+        callback(progress);
+    } catch (...) {
+        // Monitoring is best effort and must not change display pixels.
+        return;
+    }
+}
+
+} // namespace
+
+namespace bloom::runtime {
+
+std::string_view
+qualifiedDisplayDiagnosticCodeId(const QualifiedDisplayDiagnosticCode code) noexcept {
+    switch (code) {
+    case QualifiedDisplayDiagnosticCode::InvalidRequest:
+        return "bloom.runtime.qualified-display.invalid-request";
+    case QualifiedDisplayDiagnosticCode::PixelStorageBudgetExceeded:
+        return "bloom.runtime.qualified-display.pixel-storage-budget-exceeded";
+    case QualifiedDisplayDiagnosticCode::AllocationFailure:
+        return "bloom.runtime.qualified-display.allocation-failure";
+    case QualifiedDisplayDiagnosticCode::InvalidPixel:
+        return "bloom.runtime.qualified-display.invalid-pixel";
+    case QualifiedDisplayDiagnosticCode::UnsupportedFloatingPointEnvironment:
+        return "bloom.runtime.qualified-display.unsupported-floating-point-environment";
+    case QualifiedDisplayDiagnosticCode::IncompatibleImageDescriptor:
+        return "bloom.runtime.qualified-display.incompatible-image-descriptor";
+    case QualifiedDisplayDiagnosticCode::InternalInvariant:
+        return "bloom.runtime.qualified-display.internal-invariant";
+    }
+    return "bloom.runtime.qualified-display.unknown";
+}
+
+QualifiedDisplayFrame::QualifiedDisplayFrame(QualifiedDisplayFrameIdentity identity,
+                                             std::shared_ptr<const ProcessFrame> processFrame,
+                                             color::PreparedDisplayFrame buffer) noexcept
+    : identity_(std::move(identity)), processFrame_(std::move(processFrame)),
+      buffer_(std::move(buffer)) {}
+
+QualifiedDisplayPreparationResult
+QualifiedDisplayPreparationResult::prepared(std::shared_ptr<const QualifiedDisplayFrame> frame,
+                                            std::vector<QualifiedDisplayDiagnostic> diagnostics) {
+    if (frame == nullptr) {
+        return failed(diagnostic(QualifiedDisplayDiagnosticCode::InternalInvariant,
+                                 "Qualified display preparation produced no frame"));
+    }
+    return QualifiedDisplayPreparationResult(QualifiedDisplayPreparationStatus::Prepared,
+                                             std::move(frame), std::move(diagnostics));
+}
+
+QualifiedDisplayPreparationResult
+QualifiedDisplayPreparationResult::cancelled(std::vector<QualifiedDisplayDiagnostic> diagnostics) {
+    return QualifiedDisplayPreparationResult(QualifiedDisplayPreparationStatus::Cancelled, {},
+                                             std::move(diagnostics));
+}
+
+QualifiedDisplayPreparationResult
+QualifiedDisplayPreparationResult::failed(QualifiedDisplayDiagnostic value) {
+    std::vector<QualifiedDisplayDiagnostic> diagnostics;
+    diagnostics.push_back(std::move(value));
+    return failed(std::move(diagnostics));
+}
+
+QualifiedDisplayPreparationResult
+QualifiedDisplayPreparationResult::failed(std::vector<QualifiedDisplayDiagnostic> diagnostics) {
+    return QualifiedDisplayPreparationResult(QualifiedDisplayPreparationStatus::Failed, {},
+                                             std::move(diagnostics));
+}
+
+QualifiedDisplayPreparationResult::QualifiedDisplayPreparationResult(
+    const QualifiedDisplayPreparationStatus status,
+    std::shared_ptr<const QualifiedDisplayFrame> frame,
+    std::vector<QualifiedDisplayDiagnostic> diagnostics) noexcept
+    : status_(status), frame_(std::move(frame)), diagnostics_(std::move(diagnostics)) {}
+
+QualifiedDisplayPreparationResult
+CpuQualifiedDisplayPreparer::prepare(std::shared_ptr<const ProcessFrame> processFrame,
+                                     const QualifiedDisplayPreparationRequest& request,
+                                     const CancellationToken& cancellation,
+                                     const QualifiedDisplayProgressCallback& progress) const {
+    if (cancellation.isCancellationRequested()) {
+        return QualifiedDisplayPreparationResult::cancelled();
+    }
+    reportProgress(progress,
+                   {.stage = QualifiedDisplayProgressStage::Preflight, .completed = 0, .total = 1});
+    if (handle_ == nullptr || processFrame == nullptr || processFrame->identity().plan == nullptr ||
+        request.chunkPixelCount == 0 || request.aggregatePixelStorageByteLimit == 0) {
+        return QualifiedDisplayPreparationResult::failed(
+            diagnostic(QualifiedDisplayDiagnosticCode::InvalidRequest,
+                       "Qualified display preparation request is invalid"));
+    }
+    const auto processView = processFrame->processImage().view();
+    if (!processView) {
+        return QualifiedDisplayPreparationResult::failed(
+            imageDiagnostic(*processView.error(), "Process frame image is invalid"));
+    }
+    reportProgress(progress,
+                   {.stage = QualifiedDisplayProgressStage::Preflight, .completed = 1, .total = 1});
+    if (cancellation.isCancellationRequested()) {
+        return QualifiedDisplayPreparationResult::cancelled();
+    }
+
+    reportProgress(progress,
+                   {.stage = QualifiedDisplayProgressStage::Applying, .completed = 0, .total = 0});
+    // Bridges runtime's CancellationToken to color::CancellationPredicateRef -- bloom_color_ocio
+    // stays free of a runtime dependency (see CancellationPredicateRef's own documentation): the
+    // predicate is a plain non-owning callable, and C2's own chunk loop (produceBloomNeutralDisplay
+    // Frame) already checks it between chunks and applies applyBloomNeutralDisplayChunk within one
+    // chunk, satisfying "applies the C2 chunk API with cancellation checks at chunk boundaries".
+    // Not const: color::CancellationPredicateRef's templated constructor binds a non-const F&, and
+    // this lambda has no mutable state to protect anyway (it only reads `cancellation` by
+    // reference).
+    auto isCancelled = [&cancellation]() noexcept {
+        return cancellation.isCancellationRequested();
+    };
+    auto produced = color::produceBloomNeutralDisplayFrame(
+        *handle_, *processView.value(), request.chunkPixelCount,
+        request.aggregatePixelStorageByteLimit, isCancelled);
+    if (!produced) {
+        if (cancellation.isCancellationRequested()) {
+            return QualifiedDisplayPreparationResult::cancelled();
+        }
+        return QualifiedDisplayPreparationResult::failed(
+            imageDiagnostic(*produced.error(), "Qualified display mapping could not be evaluated"));
+    }
+    if (cancellation.isCancellationRequested()) {
+        return QualifiedDisplayPreparationResult::cancelled();
+    }
+    reportProgress(progress,
+                   {.stage = QualifiedDisplayProgressStage::Applying, .completed = 1, .total = 1});
+
+    QualifiedDisplayFrameIdentity identity{
+        .processFrame = processFrame->identity(),
+        .provider = QualifiedDisplayProvider::CpuBloomNeutral,
+        .packing = QualifiedDisplayPacking::StraightRgba8,
+        .preparerSemanticsVersion = kQualifiedDisplayPreparerSemanticsVersion,
+    };
+    auto frame = std::shared_ptr<const QualifiedDisplayFrame>(new QualifiedDisplayFrame(
+        std::move(identity), std::move(processFrame), std::move(*produced.value())));
+    return QualifiedDisplayPreparationResult::prepared(std::move(frame));
+}
+
+} // namespace bloom::runtime

--- a/src/runtime/qualified_display_processor_provider.cpp
+++ b/src/runtime/qualified_display_processor_provider.cpp
@@ -1,0 +1,198 @@
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
+
+#include <bloom/color/ocio_builtin_registry.hpp>
+
+#include <new>
+#include <utility>
+
+namespace {
+
+using bloom::runtime::DiagnosticSeverity;
+using bloom::runtime::TaskDiagnostic;
+
+[[nodiscard]] TaskDiagnostic
+diagnostic(std::string code, std::string summary, std::string detail = {},
+           std::string suggestedAction = "Review the embedded Bloom Neutral display "
+                                         "configuration and rebuild.") {
+    return {.code = std::move(code),
+            .severity = DiagnosticSeverity::Error,
+            .summary = std::move(summary),
+            .detail = std::move(detail),
+            .suggestedAction = std::move(suggestedAction)};
+}
+
+[[nodiscard]] TaskDiagnostic
+registryDiagnostic(const bloom::color::OcioBuiltInResolutionResult& result) {
+    using bloom::color::OcioBuiltInInvalidReason;
+    using bloom::color::OcioBuiltInRegistryOutcome;
+    switch (result.outcome()) {
+    case OcioBuiltInRegistryOutcome::Ready:
+        break; // unreachable here; callers only invoke this on a non-Ready outcome.
+    case OcioBuiltInRegistryOutcome::Changed:
+        return diagnostic("bloom.runtime.qualified-display-processor.registry-changed",
+                          "The embedded Bloom Neutral display configuration content changed");
+    case OcioBuiltInRegistryOutcome::Missing:
+        return diagnostic("bloom.runtime.qualified-display-processor.registry-missing",
+                          "The Bloom Neutral display configuration locator could not be resolved");
+    case OcioBuiltInRegistryOutcome::LocatorKindRequiresHelper:
+        return diagnostic(
+            "bloom.runtime.qualified-display-processor.registry-requires-helper",
+            "The Bloom Neutral display configuration locator requires the supervised OCIO helper",
+            "",
+            "The supervised OCIO helper is not yet implemented; this locator kind is not "
+            "reachable for the embedded built-in.");
+    case OcioBuiltInRegistryOutcome::Invalid:
+        switch (result.invalidReason()) {
+        case OcioBuiltInInvalidReason::ParseFailed:
+            return diagnostic("bloom.runtime.qualified-display-processor.registry-parse-failed",
+                              "The embedded Bloom Neutral display configuration failed to parse");
+        case OcioBuiltInInvalidReason::ValidateFailed:
+            return diagnostic("bloom.runtime.qualified-display-processor.registry-validate-failed",
+                              "The embedded Bloom Neutral display configuration failed validation");
+        case OcioBuiltInInvalidReason::ProcessColorSpaceNotUniquelyMapped:
+            return diagnostic(
+                "bloom.runtime.qualified-display-processor.registry-process-space-ambiguous",
+                "The embedded Bloom Neutral display configuration has no unambiguous process "
+                "color space mapping");
+        case OcioBuiltInInvalidReason::OutputColorSpaceNotUniquelyMapped:
+            return diagnostic(
+                "bloom.runtime.qualified-display-processor.registry-output-space-ambiguous",
+                "The embedded Bloom Neutral display configuration has no unambiguous output "
+                "color space mapping");
+        case OcioBuiltInInvalidReason::DisplayViewNotUniquelyMapped:
+            return diagnostic(
+                "bloom.runtime.qualified-display-processor.registry-display-view-ambiguous",
+                "The embedded Bloom Neutral display configuration has no unambiguous display/"
+                "view mapping");
+        case OcioBuiltInInvalidReason::None:
+            break;
+        }
+        return diagnostic("bloom.runtime.qualified-display-processor.registry-invalid",
+                          "The embedded Bloom Neutral display configuration is invalid");
+    }
+    return diagnostic("bloom.runtime.qualified-display-processor.registry-unknown",
+                      "The Bloom Neutral display configuration could not be resolved");
+}
+
+[[nodiscard]] TaskDiagnostic buildDiagnostic(const bloom::color::OcioBuildProcessorError error) {
+    using bloom::color::OcioBuildProcessorError;
+    switch (error) {
+    case OcioBuildProcessorError::GetProcessorFailed:
+        return diagnostic("bloom.runtime.qualified-display-processor.build-get-processor-failed",
+                          "The Bloom Neutral display processor could not be built");
+    case OcioBuildProcessorError::GetCpuProcessorFailed:
+        return diagnostic(
+            "bloom.runtime.qualified-display-processor.build-get-cpu-processor-failed",
+            "The Bloom Neutral CPU display processor could not be built");
+    case OcioBuildProcessorError::IdentityConstructionFailed:
+        return diagnostic(
+            "bloom.runtime.qualified-display-processor.build-identity-construction-failed",
+            "The Bloom Neutral display processor identity could not be constructed");
+    case OcioBuildProcessorError::None:
+        break;
+    }
+    return diagnostic("bloom.runtime.qualified-display-processor.build-unknown",
+                      "The Bloom Neutral display processor could not be built");
+}
+
+} // namespace
+
+namespace bloom::runtime {
+
+QualifiedDisplayProcessorBuildResult::QualifiedDisplayProcessorBuildResult(
+    std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle) noexcept
+    : handle_(std::move(handle)) {}
+
+QualifiedDisplayProcessorBuildResult::QualifiedDisplayProcessorBuildResult(
+    TaskDiagnostic diagnostic) noexcept
+    : diagnostic_(std::move(diagnostic)) {}
+
+QualifiedDisplayProcessorBuildResult QualifiedDisplayProcessorBuildResult::ready(
+    std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle) noexcept {
+    return QualifiedDisplayProcessorBuildResult(std::move(handle));
+}
+
+QualifiedDisplayProcessorBuildResult
+QualifiedDisplayProcessorBuildResult::failed(TaskDiagnostic diagnostic) noexcept {
+    return QualifiedDisplayProcessorBuildResult(std::move(diagnostic));
+}
+
+QualifiedDisplayProcessorBuildResult buildBloomNeutralQualifiedDisplayProcessor() noexcept {
+    try {
+        auto resolution = color::resolveBloomNeutralV1BuiltIn(
+            color::OcioConfigLocatorKind::BloomBuiltIn, color::kBloomNeutralV1ConfigUri,
+            color::kBloomNeutralV1ConfigDigest);
+        if (!resolution.ready()) {
+            return QualifiedDisplayProcessorBuildResult::failed(registryDiagnostic(resolution));
+        }
+        auto resolved = std::move(resolution).takeResolved();
+        if (!resolved.has_value()) {
+            return QualifiedDisplayProcessorBuildResult::failed(
+                diagnostic("bloom.runtime.qualified-display-processor.registry-no-product",
+                           "The Bloom Neutral display configuration resolved with no product"));
+        }
+        auto built = color::buildBloomNeutralCpuDisplayProcessor(*resolved);
+        if (!built) {
+            return QualifiedDisplayProcessorBuildResult::failed(buildDiagnostic(built.error()));
+        }
+        auto handleValue = std::move(built).takeHandle();
+        if (!handleValue.has_value()) {
+            return QualifiedDisplayProcessorBuildResult::failed(
+                diagnostic("bloom.runtime.qualified-display-processor.build-no-product",
+                           "The Bloom Neutral display processor built with no product"));
+        }
+        auto shared = std::make_shared<const color::PreparedCpuDisplayProcessorHandle>(
+            std::move(*handleValue));
+        return QualifiedDisplayProcessorBuildResult::ready(std::move(shared));
+    } catch (const std::bad_alloc&) {
+        return QualifiedDisplayProcessorBuildResult::failed(
+            diagnostic("bloom.runtime.qualified-display-processor.allocation-failure",
+                       "The Bloom Neutral display processor could not be allocated"));
+    } catch (...) {
+        return QualifiedDisplayProcessorBuildResult::failed(
+            diagnostic("bloom.runtime.qualified-display-processor.unexpected-failure",
+                       "The Bloom Neutral display processor build failed unexpectedly"));
+    }
+}
+
+QualifiedDisplayProcessorReadiness QualifiedDisplayProcessorProvider::readiness() const noexcept {
+    std::lock_guard lock(mutex_);
+    return readiness_;
+}
+
+std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle>
+QualifiedDisplayProcessorProvider::handle() const noexcept {
+    std::lock_guard lock(mutex_);
+    return handle_;
+}
+
+TaskDiagnostic QualifiedDisplayProcessorProvider::failureDiagnostic() const {
+    std::lock_guard lock(mutex_);
+    return failureDiagnostic_;
+}
+
+QualifiedDisplayProcessorSnapshot QualifiedDisplayProcessorProvider::snapshot() const {
+    std::lock_guard lock(mutex_);
+    return QualifiedDisplayProcessorSnapshot{
+        .readiness = readiness_,
+        .handle = handle_,
+        .failureDiagnostic = failureDiagnostic_,
+    };
+}
+
+void QualifiedDisplayProcessorProvider::publish(
+    const QualifiedDisplayProcessorBuildResult& result) {
+    std::lock_guard lock(mutex_);
+    if (readiness_ != QualifiedDisplayProcessorReadiness::Pending) {
+        return;
+    }
+    if (result.succeeded()) {
+        handle_ = result.handle();
+        readiness_ = QualifiedDisplayProcessorReadiness::Ready;
+    } else {
+        failureDiagnostic_ = result.diagnostic();
+        readiness_ = QualifiedDisplayProcessorReadiness::Failed;
+    }
+}
+
+} // namespace bloom::runtime

--- a/src/runtime/tests/CMakeLists.txt
+++ b/src/runtime/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(bloom_runtime_snapshot_compiler_test snapshot_compiler_tests.cpp)
 add_executable(bloom_runtime_cpu_composition_evaluator_test cpu_composition_evaluator_tests.cpp)
 add_executable(bloom_runtime_animation_sampling_test animation_sampling_tests.cpp)
 add_executable(bloom_runtime_curve_compilation_test curve_compilation_tests.cpp)
+add_executable(bloom_runtime_qualified_display_preparation_test qualified_display_preparation_tests.cpp)
 
 target_link_libraries(bloom_runtime_task_test PRIVATE bloom_runtime)
 target_link_libraries(bloom_runtime_regression_test PRIVATE bloom_runtime)
@@ -21,6 +22,10 @@ target_link_libraries(
 )
 target_link_libraries(bloom_runtime_animation_sampling_test PRIVATE bloom_runtime_evaluator)
 target_link_libraries(bloom_runtime_curve_compilation_test PRIVATE bloom_runtime_compiler)
+target_link_libraries(
+    bloom_runtime_qualified_display_preparation_test
+    PRIVATE bloom_runtime_evaluator
+)
 target_include_directories(bloom_runtime_regression_test PRIVATE ..)
 target_include_directories(bloom_runtime_gpu_task_test PRIVATE ..)
 target_include_directories(bloom_runtime_snapshot_compiler_test PRIVATE ..)
@@ -32,8 +37,10 @@ bloom_enable_warnings(bloom_runtime_snapshot_compiler_test)
 bloom_enable_warnings(bloom_runtime_cpu_composition_evaluator_test)
 bloom_enable_warnings(bloom_runtime_animation_sampling_test)
 bloom_enable_warnings(bloom_runtime_curve_compilation_test)
+bloom_enable_warnings(bloom_runtime_qualified_display_preparation_test)
 bloom_enable_strict_floating_point(bloom_runtime_cpu_composition_evaluator_test)
 bloom_enable_strict_floating_point(bloom_runtime_animation_sampling_test)
+bloom_enable_strict_floating_point(bloom_runtime_qualified_display_preparation_test)
 
 include(BloomTesting)
 
@@ -90,5 +97,12 @@ bloom_add_test(
     NAME bloom.runtime.curve_compilation
     COMMAND bloom_runtime_curve_compilation_test
     LABELS runtime unit
+    TIMEOUT 30
+)
+
+bloom_add_test(
+    NAME bloom.runtime.qualified_display_preparation
+    COMMAND bloom_runtime_qualified_display_preparation_test
+    LABELS runtime unit render color
     TIMEOUT 30
 )

--- a/src/runtime/tests/qualified_display_preparation_tests.cpp
+++ b/src/runtime/tests/qualified_display_preparation_tests.cpp
@@ -1,0 +1,342 @@
+#include <bloom/runtime/qualified_display_preparation.hpp>
+
+#include <bloom/color/ocio_builtin_registry.hpp>
+#include <bloom/color/ocio_cpu_display_frame.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/document/composition_settings.hpp>
+#include <bloom/render/image_types.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+using bloom::core::RationalTime;
+using bloom::render::Rgba8;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+constexpr auto kProjectId = bloom::document::ProjectId::fromRaw(1);
+constexpr auto kCompositionId = bloom::document::CompositionId::fromRaw(2);
+constexpr auto kSolidNode = bloom::document::NodeId::fromRaw(10);
+constexpr auto kLayerNode = bloom::document::NodeId::fromRaw(11);
+constexpr auto kStackNode = bloom::document::NodeId::fromRaw(12);
+constexpr auto kOutputNode = bloom::document::NodeId::fromRaw(13);
+constexpr auto kLayer = bloom::document::LayerId::fromRaw(20);
+constexpr auto kSlot = bloom::document::LayerSlotId::fromRaw(30);
+constexpr auto kColorParam = bloom::document::ParameterId::fromRaw(40);
+constexpr auto kPositionParam = bloom::document::ParameterId::fromRaw(41);
+constexpr auto kOpacityParam = bloom::document::ParameterId::fromRaw(42);
+
+[[nodiscard]] bloom::document::CompositionFormat format(const std::uint32_t width = 4,
+                                                        const std::uint32_t height = 2) {
+    const auto value = bloom::document::CompositionFormat::create(width, height);
+    if (!value.has_value()) {
+        std::abort();
+    }
+    return *value;
+}
+
+// A one-layer opaque red solid over a small format -- the same minimal shape
+// cpu_composition_evaluator_tests.cpp's oneSolidPlan() uses, reduced to only what this file needs
+// (a real, evaluator-produced ProcessFrame; ProcessFrame's constructor is private to
+// CpuCompositionEvaluator, so it cannot be hand-built here).
+[[nodiscard]] std::shared_ptr<const bloom::runtime::CompiledCompositionPlan>
+oneSolidPlan(const bloom::document::CompositionFormat compositionFormat = format()) {
+    using namespace bloom::runtime;
+    std::vector<CompiledOperation> operations;
+    operations.emplace_back(
+        CompiledSolid{kSolidNode, kColorParam, bloom::core::Color4d{1.0, 0.0, 0.0, 1.0}});
+    operations.emplace_back(
+        CompiledLayerOutput{kLayerNode, kLayer, OperationIndex::fromRaw(0),
+                            CompiledVec2Parameter{kPositionParam, bloom::document::Vec2d{2.0, 1.0}},
+                            CompiledScalarParameter{kOpacityParam, 1.0}});
+    operations.emplace_back(
+        CompiledLayerStack{kStackNode, {{kSlot, kLayer, OperationIndex::fromRaw(1)}}});
+    operations.emplace_back(CompiledCompositionOutput{kOutputNode, OperationIndex::fromRaw(2)});
+    return std::make_shared<const CompiledCompositionPlan>(CompiledCompositionPlanDefinition{
+        bloom::document::Revision::fromRaw(7), kProjectId, kCompositionId, compositionFormat,
+        std::move(operations), OperationIndex::fromRaw(3)});
+}
+
+[[nodiscard]] bloom::runtime::EvaluationRequest
+requestFor(const bloom::runtime::CompiledCompositionPlan& plan,
+           const std::size_t budget = 1U << 20U) {
+    return {.time = RationalTime::fromInteger(0),
+            .output = plan.output(),
+            .resolution = bloom::runtime::CompositionFormatResolution{},
+            .quality = bloom::runtime::EvaluationQuality::Reference,
+            .colorIntent = bloom::runtime::EvaluationColorIntent::LinearRec709Scene,
+            .pixelStorageByteLimit = budget};
+}
+
+[[nodiscard]] std::optional<bloom::color::PreparedCpuDisplayProcessorHandle> buildNeutralHandle() {
+    auto resolution = bloom::color::resolveBloomNeutralV1BuiltIn(
+        bloom::color::OcioConfigLocatorKind::BloomBuiltIn, bloom::color::kBloomNeutralV1ConfigUri,
+        bloom::color::kBloomNeutralV1ConfigDigest);
+    if (resolution.outcome() != bloom::color::OcioBuiltInRegistryOutcome::Ready) {
+        return std::nullopt;
+    }
+    auto resolved = std::move(resolution).takeResolved();
+    if (!resolved.has_value()) {
+        return std::nullopt;
+    }
+    auto buildResult = bloom::color::buildBloomNeutralCpuDisplayProcessor(*resolved);
+    if (!buildResult) {
+        return std::nullopt;
+    }
+    return std::move(buildResult).takeHandle();
+}
+
+// The golden test: this preparer's published pixels/window must match calling C2's own
+// produceBloomNeutralDisplayFrame() directly on the identical process view, "composited per the
+// display-window rule" -- see qualified_display_preparation.hpp's own "Display-window mechanism"
+// documentation: CpuCompositionEvaluator always produces dataWindow == displayWindow (verified
+// again below), so C2's data-window-sized product already covers the full reported window with no
+// separate padding composite required to match.
+void testGoldenMatchesC2DirectOutput(Expectations& expectations) {
+    const bloom::runtime::CpuCompositionEvaluator evaluator;
+    const auto plan = oneSolidPlan();
+    const auto evaluated = evaluator.evaluate(plan, requestFor(*plan), {});
+    expectations.expect(evaluated.status() == bloom::runtime::EvaluationStatus::Evaluated &&
+                            evaluated.frame() != nullptr,
+                        "the fixture composition evaluates to a process frame");
+    if (evaluated.frame() == nullptr) {
+        return;
+    }
+    const auto* processDescriptor = evaluated.frame()->processImage().descriptor();
+    expectations.expect(processDescriptor != nullptr &&
+                            processDescriptor->dataWindow() == processDescriptor->displayWindow(),
+                        "the evaluator's process frame has no data/display window padding, "
+                        "matching this preparer's documented mechanism");
+
+    auto handle = buildNeutralHandle();
+    expectations.expect(handle.has_value(), "the Bloom Neutral processor handle builds");
+    if (!handle.has_value()) {
+        return;
+    }
+
+    const bloom::runtime::CpuQualifiedDisplayPreparer preparer(*handle);
+    const bloom::runtime::QualifiedDisplayPreparationRequest request{
+        .aggregatePixelStorageByteLimit = 1U << 20U,
+    };
+    const auto result = preparer.prepare(evaluated.frame(), request, {});
+    expectations.expect(result.status() ==
+                                bloom::runtime::QualifiedDisplayPreparationStatus::Prepared &&
+                            result.frame() != nullptr,
+                        "the qualified preparer publishes a frame for the fixture composition");
+    if (result.frame() == nullptr) {
+        return;
+    }
+
+    const auto processView = evaluated.frame()->processImage().view();
+    expectations.expect(static_cast<bool>(processView), "the process frame exposes a valid view");
+    if (!processView) {
+        return;
+    }
+    const auto direct = bloom::color::produceBloomNeutralDisplayFrame(
+        *handle, *processView.value(), request.chunkPixelCount,
+        request.aggregatePixelStorageByteLimit);
+    expectations.expect(static_cast<bool>(direct), "the direct C2 call succeeds for the fixture");
+    if (!direct) {
+        return;
+    }
+
+    const auto preparerPixels = result.frame()->buffer().pixels();
+    const auto directPixels = direct.value()->pixels();
+    expectations.expect(
+        std::vector<Rgba8>(preparerPixels.begin(), preparerPixels.end()) ==
+            std::vector<Rgba8>(directPixels.begin(), directPixels.end()),
+        "the preparer's pixels are byte-identical to calling C2's adapter directly");
+    expectations.expect(
+        result.frame()->buffer().displayWindow() == direct.value()->displayWindow() &&
+            result.frame()->buffer().displayWindow() == processDescriptor->dataWindow(),
+        "the preparer's reported window equals both C2's direct output window and "
+        "the process frame's data window (the display-window rule)");
+    expectations.expect(result.frame()->identity().processFrame == evaluated.frame()->identity(),
+                        "the qualified frame's identity retains the exact source process identity");
+    expectations.expect(result.frame()->processFrame() == evaluated.frame(),
+                        "the qualified frame retains the same shared process frame product");
+}
+
+// Cancellation at a chunk boundary: gated via a real TaskScheduler task (the only way to obtain a
+// live, cancellable CancellationToken -- see cancellation.hpp), paused at this preparer's own
+// Preflight-complete progress checkpoint (immediately before it calls into C2's chunked apply),
+// mirroring cpu_composition_evaluator_tests.cpp's CancellationGate idiom for the reference path.
+class CancellationGate final {
+  public:
+    void pauseAtPreflightComplete(const bloom::runtime::QualifiedDisplayProgress& progress) {
+        if (progress.stage != bloom::runtime::QualifiedDisplayProgressStage::Preflight ||
+            progress.completed != 1) {
+            return;
+        }
+        std::unique_lock lock(mutex_);
+        if (entered_) {
+            return;
+        }
+        entered_ = true;
+        condition_.notify_all();
+        condition_.wait(lock, [this] { return released_; });
+    }
+
+    [[nodiscard]] bool waitUntilEntered() {
+        std::unique_lock lock(mutex_);
+        return condition_.wait_for(lock, 2s, [this] { return entered_; });
+    }
+
+    void release() {
+        std::lock_guard lock(mutex_);
+        released_ = true;
+        condition_.notify_all();
+    }
+
+  private:
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    bool entered_ = false;
+    bool released_ = false;
+};
+
+void testCancellationAtChunkBoundaryPublishesNothing(Expectations& expectations) {
+    const bloom::runtime::CpuCompositionEvaluator evaluator;
+    const auto plan = oneSolidPlan();
+    const auto evaluated = evaluator.evaluate(plan, requestFor(*plan), {});
+    expectations.expect(evaluated.frame() != nullptr,
+                        "the fixture evaluates for the cancellation test");
+    if (evaluated.frame() == nullptr) {
+        return;
+    }
+    auto handle = buildNeutralHandle();
+    expectations.expect(handle.has_value(), "the handle builds for the cancellation test");
+    if (!handle.has_value()) {
+        return;
+    }
+
+    bloom::runtime::TaskSchedulerConfig config = bloom::runtime::TaskSchedulerConfig::defaults();
+    config.cpuWorkerCount = 1;
+    config.blockingIoWorkerCount = 1;
+    bloom::runtime::TaskScheduler scheduler(config);
+    CancellationGate gate;
+    std::atomic_bool preparerCancelled = false;
+    const bloom::runtime::CpuQualifiedDisplayPreparer preparer(*handle);
+    const bloom::runtime::QualifiedDisplayPreparationRequest request{
+        .aggregatePixelStorageByteLimit = 1U << 20U,
+    };
+
+    auto submission = scheduler.submit<void>(
+        bloom::runtime::TaskRequest("Qualified display cancellation fixture",
+                                    {.kind = bloom::runtime::TaskOwnerKind::Composition,
+                                     .id = bloom::runtime::TaskOwnerId::fromRaw(1)}),
+        [frame = evaluated.frame(), &preparer, &request, &gate,
+         &preparerCancelled](bloom::runtime::TaskContext& context) {
+            const auto result =
+                preparer.prepare(frame, request, context.cancellation(),
+                                 [&gate](const bloom::runtime::QualifiedDisplayProgress& progress) {
+                                     gate.pauseAtPreflightComplete(progress);
+                                 });
+            preparerCancelled.store(
+                result.status() == bloom::runtime::QualifiedDisplayPreparationStatus::Cancelled,
+                std::memory_order_release);
+            return result.status() == bloom::runtime::QualifiedDisplayPreparationStatus::Cancelled
+                       ? bloom::runtime::TaskResult<void>::cancelled()
+                       : bloom::runtime::TaskResult<void>::succeeded();
+        });
+    expectations.expect(submission.accepted() && gate.waitUntilEntered(),
+                        "the cancellation fixture reaches its progress checkpoint");
+    submission.handle.cancel();
+    gate.release();
+
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    std::optional<bloom::runtime::TaskResult<void>> taskResult;
+    while (!taskResult.has_value() && std::chrono::steady_clock::now() < deadline) {
+        taskResult = submission.handle.tryTakeResult();
+        std::this_thread::yield();
+    }
+    expectations.expect(taskResult.has_value() &&
+                            taskResult->state() == bloom::runtime::TaskState::Cancelled &&
+                            preparerCancelled.load(std::memory_order_acquire),
+                        "cancellation at the checkpoint yields the typed cancelled result and no "
+                        "product");
+
+    scheduler.beginShutdown();
+    while (!scheduler.isQuiescent() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+}
+
+void testFailurePropagationTyped(Expectations& expectations) {
+    const bloom::runtime::CpuCompositionEvaluator evaluator;
+    const auto plan = oneSolidPlan();
+    const auto evaluated = evaluator.evaluate(plan, requestFor(*plan), {});
+    expectations.expect(evaluated.frame() != nullptr, "the fixture evaluates for the failure test");
+    if (evaluated.frame() == nullptr) {
+        return;
+    }
+    auto handle = buildNeutralHandle();
+    expectations.expect(handle.has_value(), "the handle builds for the failure test");
+    if (!handle.has_value()) {
+        return;
+    }
+
+    const bloom::runtime::CpuQualifiedDisplayPreparer preparer(*handle);
+    const bloom::runtime::QualifiedDisplayPreparationRequest starvedRequest{
+        .aggregatePixelStorageByteLimit = 1,
+    };
+    const auto result = preparer.prepare(evaluated.frame(), starvedRequest, {});
+    expectations.expect(
+        result.status() == bloom::runtime::QualifiedDisplayPreparationStatus::Failed &&
+            result.frame() == nullptr && !result.diagnostics().empty() &&
+            result.diagnostics().front().code ==
+                bloom::runtime::QualifiedDisplayDiagnosticCode::PixelStorageBudgetExceeded,
+        "an impossible pixel-storage budget fails typed with no product");
+
+    const bloom::runtime::QualifiedDisplayPreparationRequest invalidRequest{
+        .aggregatePixelStorageByteLimit = 0,
+    };
+    const auto invalidResult = preparer.prepare(evaluated.frame(), invalidRequest, {});
+    expectations.expect(
+        invalidResult.status() == bloom::runtime::QualifiedDisplayPreparationStatus::Failed &&
+            invalidResult.frame() == nullptr && !invalidResult.diagnostics().empty() &&
+            invalidResult.diagnostics().front().code ==
+                bloom::runtime::QualifiedDisplayDiagnosticCode::InvalidRequest,
+        "a zero pixel-storage budget is rejected as an invalid request");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testGoldenMatchesC2DirectOutput(expectations);
+    testCancellationAtChunkBoundaryPublishesNothing(expectations);
+    testFailurePropagationTyped(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
         main_window.cpp
         node_editor.cpp
         project_host.cpp
+        qualified_display_processor_bootstrap.cpp
         task_monitor_model.cpp
         task_ui_bridge.cpp
         timeline_frame_math.cpp
@@ -35,6 +36,7 @@ target_sources(
             include/bloom/ui/main_window.hpp
             include/bloom/ui/node_editor.hpp
             include/bloom/ui/project_host.hpp
+            include/bloom/ui/qualified_display_processor_bootstrap.hpp
             include/bloom/ui/task_monitor_model.hpp
             include/bloom/ui/task_ui_bridge.hpp
             include/bloom/ui/timeline_frame_math.hpp

--- a/src/ui/composition_preview_controller.cpp
+++ b/src/ui/composition_preview_controller.cpp
@@ -451,7 +451,11 @@ void CompositionPreviewController::consumeReadyResult() {
                 next.message = tr("Preview rendering returned pixels for a different request");
                 break;
             }
-            if (!frame->displayBuffer().isValid()) {
+            // Alternative-agnostic (issue #97, task C3): frame may carry either the reference or
+            // the qualified display product (PreparedPreviewFrame's closed alternative), and
+            // displayBufferView() normalizes both to the same validity/shape check rather than
+            // assuming the reference-only displayBuffer() accessor.
+            if (!frame->displayBufferView().has_value()) {
                 next.message = tr("Preview rendering returned an invalid display buffer");
                 break;
             }

--- a/src/ui/composition_preview_pipeline.cpp
+++ b/src/ui/composition_preview_pipeline.cpp
@@ -1,6 +1,7 @@
 #include <bloom/ui/composition_preview_pipeline.hpp>
 
 #include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/qualified_display_preparation.hpp>
 #include <bloom/runtime/reference_display_preparation.hpp>
 #include <bloom/runtime/snapshot_compiler.hpp>
 
@@ -104,6 +105,21 @@ taskDiagnostics(const bloom::runtime::ReferenceDisplayPreparationResult& result)
     return diagnostics;
 }
 
+std::vector<bloom::runtime::TaskDiagnostic>
+taskDiagnostics(const bloom::runtime::QualifiedDisplayPreparationResult& result) {
+    std::vector<bloom::runtime::TaskDiagnostic> diagnostics;
+    diagnostics.reserve(result.diagnostics().size());
+    for (const auto& diagnostic : result.diagnostics()) {
+        diagnostics.push_back(
+            {.code = std::string(bloom::runtime::qualifiedDisplayDiagnosticCodeId(diagnostic.code)),
+             .severity = diagnostic.severity,
+             .summary = diagnostic.summary,
+             .detail = diagnostic.detail,
+             .suggestedAction = "Review the preview display intent and memory settings."});
+    }
+    return diagnostics;
+}
+
 bloom::runtime::TaskDiagnostic missingResultDiagnostic(std::string summary) {
     return {.code = "bloom.preview.pipeline.invalid-result",
             .severity = bloom::runtime::DiagnosticSeverity::Error,
@@ -143,15 +159,27 @@ void reportDisplayProgress(bloom::runtime::TaskContext& context,
                             .total = progress.total});
 }
 
+void reportQualifiedDisplayProgress(bloom::runtime::TaskContext& context,
+                                    const bloom::runtime::QualifiedDisplayProgress& progress) {
+    const std::string subphase =
+        progress.stage == bloom::runtime::QualifiedDisplayProgressStage::Preflight
+            ? "Validating the bounded qualified display handoff"
+            : "Applying the qualified Bloom Neutral display transform";
+    context.reportProgress({.phase = "Preparing composition preview display",
+                            .subphase = subphase,
+                            .completed = progress.completed,
+                            .total = progress.total});
+}
+
 } // namespace
 
 namespace bloom::ui {
 
-PreviewPreparationFunction
-makeCompositionPreviewPipeline(const runtime::SnapshotCompiler& compiler,
-                               const runtime::CpuCompositionEvaluator& evaluator,
-                               const runtime::CpuReferenceDisplayPreparer& displayPreparer) {
-    return [&compiler, &evaluator, &displayPreparer](
+PreviewPreparationFunction makeCompositionPreviewPipeline(
+    const runtime::SnapshotCompiler& compiler, const runtime::CpuCompositionEvaluator& evaluator,
+    const runtime::CpuReferenceDisplayPreparer& displayPreparer,
+    const runtime::QualifiedDisplayProcessorProvider& qualifiedProcessorProvider) {
+    return [&compiler, &evaluator, &displayPreparer, &qualifiedProcessorProvider](
                const document::Snapshot& snapshot,
                const runtime::PreviewRequestIdentity& desiredIdentity,
                const std::size_t pixelStorageByteLimit,
@@ -161,6 +189,22 @@ makeCompositionPreviewPipeline(const runtime::SnapshotCompiler& compiler,
 
         if (context.isCancellationRequested()) {
             return TaskResult::cancelled();
+        }
+        // One single locked read of the provider up front (see QualifiedDisplayProcessorSnapshot's
+        // documentation): readiness/handle/failureDiagnostic are used together below, and reading
+        // them as separate calls could straddle the provider's one-shot publish() and observe an
+        // inconsistent pair (Pending readiness alongside a Failed diagnostic, for example) --
+        // reading once and reusing the same snapshot for both the early fail-closed check and the
+        // later reference-vs-qualified branch makes this decision race-free.
+        const auto qualifiedSnapshot = qualifiedProcessorProvider.snapshot();
+        // Design decision 4 (fail-closed): once qualification is known to have failed, no preview
+        // request is prepared at all -- CompositionPreviewController's existing Failed handling
+        // retains its last-good frame and surfaces this diagnostic, and Bloom never auto-
+        // substitutes the reference transform for a qualified request. This is checked before any
+        // compilation/evaluation work so a permanently failed qualification does not keep spending
+        // worker time on frames nothing will ever qualify to display.
+        if (qualifiedSnapshot.readiness == runtime::QualifiedDisplayProcessorReadiness::Failed) {
+            return TaskResult::failed(qualifiedSnapshot.failureDiagnostic);
         }
         if (desiredIdentity.projectId != snapshot.project().id() ||
             snapshot.project().findComposition(desiredIdentity.compositionId) == nullptr ||
@@ -244,38 +288,80 @@ makeCompositionPreviewPipeline(const runtime::SnapshotCompiler& compiler,
             return TaskResult::failed(std::move(diagnostics));
         }
 
-        const runtime::ReferenceDisplayPreparationRequest displayRequest{
-            .intent = runtime::ReferenceDisplayIntent::LinearRec709SceneToSrgb,
-            .aggregatePixelStorageByteLimit = pixelStorageByteLimit,
-        };
-        auto displayResult = displayPreparer.prepare(
-            evaluationResult.frame(), displayRequest, context.cancellation(),
-            [&context](const runtime::ReferenceDisplayProgress& progress) {
-                reportDisplayProgress(context, progress);
-            });
-        auto displayDiagnostics = taskDiagnostics(displayResult);
-        diagnostics.insert(diagnostics.end(), std::make_move_iterator(displayDiagnostics.begin()),
-                           std::make_move_iterator(displayDiagnostics.end()));
+        // Design decision 5 (default flow after readiness): every request routes through the
+        // qualified preparer once qualifiedProcessorProvider reports Ready; the honest startup
+        // window (design decision 3) routes through the unchanged reference path otherwise -- the
+        // permanently-Failed case already returned above, before evaluation even ran.
+        std::optional<runtime::PreparedPreviewFrame> prepared;
+        if (qualifiedSnapshot.handle != nullptr) {
+            const runtime::CpuQualifiedDisplayPreparer qualifiedPreparer(*qualifiedSnapshot.handle);
+            const runtime::QualifiedDisplayPreparationRequest qualifiedRequest{
+                .aggregatePixelStorageByteLimit = pixelStorageByteLimit,
+            };
+            auto qualifiedResult = qualifiedPreparer.prepare(
+                evaluationResult.frame(), qualifiedRequest, context.cancellation(),
+                [&context](const runtime::QualifiedDisplayProgress& progress) {
+                    reportQualifiedDisplayProgress(context, progress);
+                });
+            auto qualifiedDiagnostics = taskDiagnostics(qualifiedResult);
+            diagnostics.insert(diagnostics.end(),
+                               std::make_move_iterator(qualifiedDiagnostics.begin()),
+                               std::make_move_iterator(qualifiedDiagnostics.end()));
 
-        switch (displayResult.status()) {
-        case runtime::ReferenceDisplayPreparationStatus::Cancelled:
-            return TaskResult::cancelled(std::move(diagnostics));
-        case runtime::ReferenceDisplayPreparationStatus::Failed:
-            if (diagnostics.empty()) {
-                diagnostics.push_back(
-                    missingResultDiagnostic("Reference display preparation failed"));
+            switch (qualifiedResult.status()) {
+            case runtime::QualifiedDisplayPreparationStatus::Cancelled:
+                return TaskResult::cancelled(std::move(diagnostics));
+            case runtime::QualifiedDisplayPreparationStatus::Failed:
+                if (diagnostics.empty()) {
+                    diagnostics.push_back(
+                        missingResultDiagnostic("Qualified display preparation failed"));
+                }
+                return TaskResult::failed(std::move(diagnostics));
+            case runtime::QualifiedDisplayPreparationStatus::Prepared:
+                break;
             }
-            return TaskResult::failed(std::move(diagnostics));
-        case runtime::ReferenceDisplayPreparationStatus::Prepared:
-            break;
+            if (qualifiedResult.frame() == nullptr) {
+                diagnostics.push_back(
+                    missingResultDiagnostic("Display preparation returned no immutable frame"));
+                return TaskResult::failed(std::move(diagnostics));
+            }
+            prepared = runtime::PreparedPreviewFrame::createQualified(
+                desiredIdentity.requestGeneration, qualifiedResult.frame());
+        } else {
+            const runtime::ReferenceDisplayPreparationRequest displayRequest{
+                .intent = runtime::ReferenceDisplayIntent::LinearRec709SceneToSrgb,
+                .aggregatePixelStorageByteLimit = pixelStorageByteLimit,
+            };
+            auto displayResult = displayPreparer.prepare(
+                evaluationResult.frame(), displayRequest, context.cancellation(),
+                [&context](const runtime::ReferenceDisplayProgress& progress) {
+                    reportDisplayProgress(context, progress);
+                });
+            auto displayDiagnostics = taskDiagnostics(displayResult);
+            diagnostics.insert(diagnostics.end(),
+                               std::make_move_iterator(displayDiagnostics.begin()),
+                               std::make_move_iterator(displayDiagnostics.end()));
+
+            switch (displayResult.status()) {
+            case runtime::ReferenceDisplayPreparationStatus::Cancelled:
+                return TaskResult::cancelled(std::move(diagnostics));
+            case runtime::ReferenceDisplayPreparationStatus::Failed:
+                if (diagnostics.empty()) {
+                    diagnostics.push_back(
+                        missingResultDiagnostic("Reference display preparation failed"));
+                }
+                return TaskResult::failed(std::move(diagnostics));
+            case runtime::ReferenceDisplayPreparationStatus::Prepared:
+                break;
+            }
+            if (displayResult.frame() == nullptr) {
+                diagnostics.push_back(
+                    missingResultDiagnostic("Display preparation returned no immutable frame"));
+                return TaskResult::failed(std::move(diagnostics));
+            }
+            prepared = runtime::PreparedPreviewFrame::create(desiredIdentity.requestGeneration,
+                                                             displayResult.frame());
         }
-        if (displayResult.frame() == nullptr) {
-            diagnostics.push_back(
-                missingResultDiagnostic("Display preparation returned no immutable frame"));
-            return TaskResult::failed(std::move(diagnostics));
-        }
-        auto prepared = runtime::PreparedPreviewFrame::create(desiredIdentity.requestGeneration,
-                                                              displayResult.frame());
         if (!prepared.has_value() || prepared->desiredIdentity() != desiredIdentity) {
             diagnostics.push_back(
                 missingResultDiagnostic("The prepared frame identity did not match its request"));

--- a/src/ui/include/bloom/ui/composition_preview_pipeline.hpp
+++ b/src/ui/include/bloom/ui/composition_preview_pipeline.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
 #include <bloom/ui/composition_preview_controller.hpp>
 
 namespace bloom::runtime {
@@ -10,9 +11,17 @@ class SnapshotCompiler;
 
 namespace bloom::ui {
 
-[[nodiscard]] PreviewPreparationFunction
-makeCompositionPreviewPipeline(const runtime::SnapshotCompiler& compiler,
-                               const runtime::CpuCompositionEvaluator& evaluator,
-                               const runtime::CpuReferenceDisplayPreparer& displayPreparer);
+// `qualifiedProcessorProvider` implements design decisions 3-5 (issue #97, task C3): every request
+// routes through the qualified preparer once the provider reports Ready; before that (the honest
+// startup window) it routes through `displayPreparer`, labeled unqualified exactly as it already
+// is today; once the provider reports Failed, no further preview request is prepared at all (the
+// pipeline returns a typed failure so CompositionPreviewController retains its last-good frame and
+// surfaces the diagnostic -- see composition_preview_controller.cpp's existing Failed handling,
+// unchanged) -- Bloom never auto-substitutes the reference transform for a qualified request once
+// qualification is known to have failed.
+[[nodiscard]] PreviewPreparationFunction makeCompositionPreviewPipeline(
+    const runtime::SnapshotCompiler& compiler, const runtime::CpuCompositionEvaluator& evaluator,
+    const runtime::CpuReferenceDisplayPreparer& displayPreparer,
+    const runtime::QualifiedDisplayProcessorProvider& qualifiedProcessorProvider);
 
 } // namespace bloom::ui

--- a/src/ui/include/bloom/ui/qualified_display_processor_bootstrap.hpp
+++ b/src/ui/include/bloom/ui/qualified_display_processor_bootstrap.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <QObject>
+
+// Owns the Qt-side scheduling/polling glue for the one-time blocking-stage handoff (issue #97,
+// task C3, design decision 3). Qt types stay confined to src/ui (AGENTS.md); the pure build step
+// itself lives in bloom::runtime::buildBloomNeutralQualifiedDisplayProcessor()
+// (qualified_display_processor_provider.hpp), which this class only submits and polls.
+namespace bloom::ui {
+
+class TaskUiBridge;
+
+class QualifiedDisplayProcessorBootstrap final : public QObject {
+    Q_OBJECT
+
+  public:
+    // Submits the build immediately, at construction -- design decision 3: "at pipeline/session
+    // construction, resolve Bloom Neutral through the C2 registry and build the processor". Both
+    // `scheduler` and `taskUiBridge` must outlive this object; `provider` is published into exactly
+    // once, from this object's poll handler (TaskUiBridge::snapshotsPolled), never from the
+    // submitted worker itself (the worker runs on a blocking-I/O executor thread, not the
+    // authoring/UI thread).
+    QualifiedDisplayProcessorBootstrap(runtime::TaskScheduler& scheduler,
+                                       TaskUiBridge& taskUiBridge,
+                                       runtime::QualifiedDisplayProcessorProvider& provider,
+                                       QObject* parent = nullptr);
+
+  private:
+    void pollOnce();
+
+    runtime::TaskScheduler& scheduler_;
+    runtime::QualifiedDisplayProcessorProvider& provider_;
+    runtime::TaskHandle<std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle>> handle_;
+    bool submitted_ = false;
+    bool completed_ = false;
+};
+
+} // namespace bloom::ui

--- a/src/ui/qualified_display_processor_bootstrap.cpp
+++ b/src/ui/qualified_display_processor_bootstrap.cpp
@@ -1,0 +1,84 @@
+#include <bloom/ui/qualified_display_processor_bootstrap.hpp>
+
+#include <bloom/ui/task_ui_bridge.hpp>
+
+#include <utility>
+
+namespace bloom::ui {
+
+namespace {
+
+using QualifiedHandle = std::shared_ptr<const bloom::color::PreparedCpuDisplayProcessorHandle>;
+
+} // namespace
+
+QualifiedDisplayProcessorBootstrap::QualifiedDisplayProcessorBootstrap(
+    runtime::TaskScheduler& scheduler, TaskUiBridge& taskUiBridge,
+    runtime::QualifiedDisplayProcessorProvider& provider, QObject* parent)
+    : QObject(parent), scheduler_(scheduler), provider_(provider) {
+    connect(&taskUiBridge, &TaskUiBridge::snapshotsPolled, this,
+            &QualifiedDisplayProcessorBootstrap::pollOnce);
+
+    runtime::TaskRequest request(
+        "Build the qualified Bloom Neutral display processor",
+        {.kind = runtime::TaskOwnerKind::Application, .id = runtime::TaskOwnerId::fromRaw(1)},
+        runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo);
+
+    auto submission = scheduler_.submit<QualifiedHandle>(
+        std::move(request), [](runtime::TaskContext&) -> runtime::TaskResult<QualifiedHandle> {
+            auto built = runtime::buildBloomNeutralQualifiedDisplayProcessor();
+            if (!built.succeeded()) {
+                return runtime::TaskResult<QualifiedHandle>::failed(built.diagnostic());
+            }
+            return runtime::TaskResult<QualifiedHandle>::succeeded(built.handle());
+        });
+
+    if (!submission.accepted()) {
+        provider_.publish(runtime::QualifiedDisplayProcessorBuildResult::failed(
+            {.code = "bloom.ui.qualified-display-bootstrap.submission-failed",
+             .severity = runtime::DiagnosticSeverity::Error,
+             .summary =
+                 "The qualified Bloom Neutral display processor build could not be scheduled",
+             .detail = {},
+             .suggestedAction = "Restart the application; report this if it persists."}));
+        completed_ = true;
+        return;
+    }
+    handle_ = std::move(submission.handle);
+    submitted_ = true;
+    taskUiBridge.wake();
+}
+
+void QualifiedDisplayProcessorBootstrap::pollOnce() {
+    if (completed_ || !submitted_) {
+        return;
+    }
+    auto result = handle_.tryTakeResult();
+    if (!result.has_value()) {
+        return;
+    }
+    completed_ = true;
+
+    if (result->state() == runtime::TaskState::Succeeded) {
+        const auto& value = result->value();
+        if (value.has_value() && *value != nullptr) {
+            provider_.publish(runtime::QualifiedDisplayProcessorBuildResult::ready(*value));
+            return;
+        }
+    }
+
+    const auto& diagnostics = result->diagnostics();
+    runtime::TaskDiagnostic diagnostic =
+        diagnostics.empty()
+            ? runtime::TaskDiagnostic{.code = "bloom.ui.qualified-display-bootstrap.no-diagnostic",
+                                      .severity = runtime::DiagnosticSeverity::Error,
+                                      .summary = "The qualified Bloom Neutral display processor "
+                                                 "could not be built",
+                                      .detail = {},
+                                      .suggestedAction =
+                                          "Restart the application; report this if it persists."}
+            : diagnostics.front();
+    provider_.publish(runtime::QualifiedDisplayProcessorBuildResult::failed(std::move(diagnostic)));
+}
+
+} // namespace bloom::ui

--- a/src/ui/tests/composition_preview_controller_tests.cpp
+++ b/src/ui/tests/composition_preview_controller_tests.cpp
@@ -1,12 +1,16 @@
+#include <bloom/color/ocio_builtin_registry.hpp>
+#include <bloom/color/ocio_cpu_display_processor.hpp>
 #include <bloom/commands/command_stack.hpp>
 #include <bloom/core/color.hpp>
 #include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
 #include <bloom/document/document.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/new_project.hpp>
 #include <bloom/document/project.hpp>
 #include <bloom/runtime/cpu_composition_evaluator.hpp>
 #include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
 #include <bloom/runtime/reference_display_preparation.hpp>
 #include <bloom/runtime/snapshot_compiler.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
@@ -156,6 +160,11 @@ struct PipelineFixture final {
     bloom::runtime::SnapshotCompiler compiler;
     bloom::runtime::CpuCompositionEvaluator evaluator;
     bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    // Pending by default (issue #97, task C3): a test that specifically exercises qualified-display
+    // readiness/failure builds its own provider and publishes to it directly (see
+    // testQualifiedDisplayReadinessAndFailClosed below) rather than sharing this fixture's, which
+    // every other test in this file relies on staying on the unchanged reference path.
+    bloom::runtime::QualifiedDisplayProcessorProvider qualifiedProcessorProvider;
     bloom::ui::PreviewPreparationFunction pipeline;
 
     PipelineFixture() : compiler(definitions) {
@@ -163,7 +172,8 @@ struct PipelineFixture final {
             std::abort();
         }
         definitions.freeze();
-        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer);
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                             qualifiedProcessorProvider);
     }
 };
 
@@ -786,6 +796,175 @@ void testCompositionSwitchClearsPixels(Expectations& expectations) {
     reachQuiescence(controller, bridge, scheduler, expectations);
 }
 
+// Issue #97 (task C3): before-readiness/after-readiness routing, stale rejection across the
+// qualified path, and the fail-closed contract, using the SAME PipelineFixture-shaped setup as the
+// rest of this file but with a caller-owned QualifiedDisplayProcessorProvider this test drives
+// directly (PipelineFixture's own provider is deliberately never published to for every other test
+// in this file -- see its comment).
+void testQualifiedDisplayReadinessAndFailClosed(Expectations& expectations) {
+    using namespace bloom;
+
+    // --- Part 1: Pending -> reference-labeled, then Ready -> qualified-flagged with the correct
+    // identity, and stale rejection still holds while a qualified frame is the retained one.
+    {
+        auto newProject = makeTestProject("Qualified Readiness Test");
+        const auto compositionId = newProject.initialCompositionId;
+        document::Document document(std::move(newProject.project));
+        commands::CommandStack commands(document);
+        ui::CompositionSession session(document, commands, compositionId);
+        runtime::TaskScheduler scheduler(testSchedulerConfig());
+        ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+
+        runtime::NodeDefinitionRegistry definitions;
+        expectations.expect(runtime::registerBuiltInNodeDefinitions(definitions),
+                            "readiness fixture registers built-in node definitions");
+        definitions.freeze();
+        runtime::SnapshotCompiler compiler(definitions);
+        const runtime::CpuCompositionEvaluator evaluator;
+        const runtime::CpuReferenceDisplayPreparer displayPreparer;
+        runtime::QualifiedDisplayProcessorProvider qualifiedProvider;
+        auto pipeline = ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                           qualifiedProvider);
+        ui::CompositionPreviewController controller(session, scheduler, bridge, pipeline);
+
+        expectations.expect(
+            waitUntil([&] { return isReady(controller); }),
+            "an initial frame becomes ready before the qualified processor is built");
+        expectations.expect(controller.state().frame != nullptr &&
+                                !controller.state().frame->isOcioQualified(),
+                            "a frame prepared before readiness is reference-labeled, not qualified "
+                            "-- the honest startup window, not a fallback from failure");
+        const auto referenceFrame = controller.state().frame;
+
+        auto resolution = color::resolveBloomNeutralV1BuiltIn(
+            color::OcioConfigLocatorKind::BloomBuiltIn, color::kBloomNeutralV1ConfigUri,
+            color::kBloomNeutralV1ConfigDigest);
+        expectations.expect(resolution.ready(), "the embedded Bloom Neutral built-in resolves");
+        auto resolved = std::move(resolution).takeResolved();
+        expectations.expect(resolved.has_value(), "the resolution produces a usable product");
+        if (resolved.has_value()) {
+            auto built = color::buildBloomNeutralCpuDisplayProcessor(*resolved);
+            expectations.expect(static_cast<bool>(built), "the qualified processor builds");
+            if (built) {
+                auto handleValue = std::move(built).takeHandle();
+                expectations.expect(handleValue.has_value(), "the built result carries a handle");
+                if (handleValue.has_value()) {
+                    auto shared = std::make_shared<const color::PreparedCpuDisplayProcessorHandle>(
+                        std::move(*handleValue));
+                    qualifiedProvider.publish(
+                        runtime::QualifiedDisplayProcessorBuildResult::ready(shared));
+                }
+            }
+        }
+
+        controller.requestRefresh();
+        expectations.expect(waitUntil([&] {
+                                return controller.state().activity == ui::PreviewActivity::Ready &&
+                                       controller.state().frame != referenceFrame;
+                            }),
+                            "a request after readiness produces a new frame");
+        const auto qualifiedFrame = controller.state().frame;
+        expectations.expect(qualifiedFrame != nullptr && qualifiedFrame->isOcioQualified(),
+                            "the frame prepared after readiness is qualified-flagged");
+        expectations.expect(
+            qualifiedFrame != nullptr && qualifiedFrame->qualifiedDisplayFrame() != nullptr &&
+                qualifiedFrame->qualifiedDisplayFrame()->processFrame() != nullptr &&
+                qualifiedFrame->processIdentity() ==
+                    qualifiedFrame->qualifiedDisplayFrame()->processFrame()->identity(),
+            "the qualified frame carries the correct process identity");
+        expectations.expect(controller.state().freshness == ui::FrameFreshness::Current,
+                            "the qualified frame is published as the current frame");
+
+        // Stale rejection still holds across the qualified path: a new request immediately marks
+        // the retained qualified frame Stale rather than dropping it, exactly as it would for a
+        // reference frame -- CompositionPreviewController's own freshness contract is unchanged
+        // (design decision 5).
+        controller.requestRefresh();
+        expectations.expect(controller.state().freshness == ui::FrameFreshness::Stale &&
+                                controller.state().frame == qualifiedFrame,
+                            "a newly-submitted request immediately marks the retained qualified "
+                            "frame stale rather than discarding it");
+        expectations.expect(
+            waitUntil([&] { return controller.state().activity == ui::PreviewActivity::Ready; }),
+            "the superseding request itself reaches Ready");
+        expectations.expect(controller.state().frame->isOcioQualified() &&
+                                controller.state().freshness == ui::FrameFreshness::Current,
+                            "the request that supersedes a qualified frame is itself qualified");
+
+        reachQuiescence(controller, bridge, scheduler, expectations);
+    }
+
+    // --- Part 2: fail-closed. A forced resolution failure retains last-good, surfaces a
+    // diagnostic, and never substitutes the reference transform for a qualified request.
+    {
+        auto newProject = makeTestProject("Qualified Fail-Closed Test");
+        const auto compositionId = newProject.initialCompositionId;
+        document::Document document(std::move(newProject.project));
+        commands::CommandStack commands(document);
+        ui::CompositionSession session(document, commands, compositionId);
+        runtime::TaskScheduler scheduler(testSchedulerConfig());
+        ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+
+        runtime::NodeDefinitionRegistry definitions;
+        expectations.expect(runtime::registerBuiltInNodeDefinitions(definitions),
+                            "fail-closed fixture registers built-in node definitions");
+        definitions.freeze();
+        runtime::SnapshotCompiler compiler(definitions);
+        const runtime::CpuCompositionEvaluator evaluator;
+        const runtime::CpuReferenceDisplayPreparer displayPreparer;
+        runtime::QualifiedDisplayProcessorProvider qualifiedProvider;
+        auto pipeline = ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                           qualifiedProvider);
+        ui::CompositionPreviewController controller(session, scheduler, bridge, pipeline);
+
+        expectations.expect(waitUntil([&] { return isReady(controller); }),
+                            "the honest startup window still produces a reference-labeled frame");
+        const auto lastGood = controller.state().frame;
+        expectations.expect(lastGood != nullptr && !lastGood->isOcioQualified(),
+                            "the retained last-good frame is reference-labeled");
+
+        // Design decision 4's forced-failure seam: an intentionally perturbed expected revision (an
+        // all-zero digest, guaranteed to differ from the real embedded payload's digest) through
+        // bloom::color::resolveBloomNeutralV1BuiltIn -- the registry API's own typed "Changed"
+        // outcome -- rather than fabricating a diagnostic with no real registry call behind it.
+        const auto perturbedResolution = color::resolveBloomNeutralV1BuiltIn(
+            color::OcioConfigLocatorKind::BloomBuiltIn, color::kBloomNeutralV1ConfigUri,
+            core::Sha256Digest{});
+        expectations.expect(
+            perturbedResolution.outcome() == color::OcioBuiltInRegistryOutcome::Changed,
+            "a perturbed expected revision is rejected as Changed by the registry API");
+        qualifiedProvider.publish(runtime::QualifiedDisplayProcessorBuildResult::failed(
+            {.code = "bloom.test.qualified-display.forced-failure",
+             .severity = runtime::DiagnosticSeverity::Error,
+             .summary = "The Bloom Neutral display configuration content changed",
+             .detail = {},
+             .suggestedAction = {}}));
+
+        controller.requestRefresh();
+        expectations.expect(
+            waitUntil([&] { return controller.state().activity == ui::PreviewActivity::Failed; }),
+            "a request after a forced qualification failure reaches Failed");
+        expectations.expect(controller.state().frame == lastGood &&
+                                controller.state().freshness == ui::FrameFreshness::Stale &&
+                                !controller.state().message.isEmpty(),
+                            "Failed retains the last-good frame, marks it stale, and surfaces a "
+                            "diagnostic message");
+        expectations.expect(!controller.state().frame->isOcioQualified(),
+                            "the retained frame is never silently relabeled as qualified");
+
+        // A further request never substitutes the reference transform for a qualified one either --
+        // it stays Failed with the exact same retained frame.
+        controller.requestRefresh();
+        expectations.expect(
+            waitUntil([&] { return controller.state().activity == ui::PreviewActivity::Failed; }),
+            "a subsequent request after the forced failure also reaches Failed");
+        expectations.expect(controller.state().frame == lastGood,
+                            "no later request silently substitutes a fresh reference frame");
+
+        reachQuiescence(controller, bridge, scheduler, expectations);
+    }
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -799,5 +978,6 @@ int main(int argc, char** argv) {
     testSameRevisionGenerationAndSelection(expectations);
     testLastGoodAndOutcomeMapping(expectations);
     testCompositionSwitchClearsPixels(expectations);
+    testQualifiedDisplayReadinessAndFailClosed(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/tests/composition_projection_test.cpp
+++ b/src/ui/tests/composition_projection_test.cpp
@@ -157,12 +157,16 @@ parameterForRole(const bloom::document::Composition& composition,
     runtime::SnapshotCompiler snapshotCompiler(nodeDefinitions);
     runtime::CpuCompositionEvaluator cpuEvaluator;
     runtime::CpuReferenceDisplayPreparer referenceDisplayPreparer;
+    // Never published to Ready in this test (issue #97, task C3): composition projection is
+    // unrelated to qualified-display readiness/failure, so this pipeline stays on the unchanged
+    // reference path throughout.
+    runtime::QualifiedDisplayProcessorProvider qualifiedProcessorProvider;
     runtime::TaskScheduler scheduler;
     ui::TaskUiBridge taskUiBridge(scheduler, nullptr, std::chrono::milliseconds{1});
     ui::CompositionPreviewController previewController(
         session, scheduler, taskUiBridge,
-        ui::makeCompositionPreviewPipeline(snapshotCompiler, cpuEvaluator,
-                                           referenceDisplayPreparer));
+        ui::makeCompositionPreviewPipeline(snapshotCompiler, cpuEvaluator, referenceDisplayPreparer,
+                                           qualifiedProcessorProvider));
     ui::EditorRegistry registry;
     if (!require(ui::registerFoundationEditors(registry, session, previewController),
                  "foundation editor registration succeeds") ||

--- a/src/ui/tests/direct_manipulation_tests.cpp
+++ b/src/ui/tests/direct_manipulation_tests.cpp
@@ -142,6 +142,10 @@ struct PipelineFixture final {
     bloom::runtime::SnapshotCompiler compiler;
     bloom::runtime::CpuCompositionEvaluator evaluator;
     bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    // Never published to Ready in this fixture (issue #97, task C3): direct manipulation only
+    // needs the geometry mapping, which is alternative-agnostic; keeping this pipeline on the
+    // reference path is unrelated to what this test exercises.
+    bloom::runtime::QualifiedDisplayProcessorProvider qualifiedProcessorProvider;
     bloom::ui::PreviewPreparationFunction pipeline;
 
     PipelineFixture() : compiler(definitions) {
@@ -149,7 +153,8 @@ struct PipelineFixture final {
             std::abort();
         }
         definitions.freeze();
-        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer);
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                             qualifiedProcessorProvider);
     }
 };
 

--- a/src/ui/tests/timeline_ruler_tests.cpp
+++ b/src/ui/tests/timeline_ruler_tests.cpp
@@ -111,6 +111,10 @@ struct PipelineFixture final {
     bloom::runtime::SnapshotCompiler compiler;
     bloom::runtime::CpuCompositionEvaluator evaluator;
     bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    // Never published to Ready in this fixture (issue #97, task C3): every request this pipeline
+    // prepares stays on the unchanged reference path, exactly like before this task, since nothing
+    // here exercises qualified-display readiness/failure specifically.
+    bloom::runtime::QualifiedDisplayProcessorProvider qualifiedProcessorProvider;
     bloom::ui::PreviewPreparationFunction pipeline;
 
     PipelineFixture() : compiler(definitions) {
@@ -118,7 +122,8 @@ struct PipelineFixture final {
             std::abort();
         }
         definitions.freeze();
-        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer);
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                             qualifiedProcessorProvider);
     }
 };
 

--- a/src/ui/tests/viewer_editor_tests.cpp
+++ b/src/ui/tests/viewer_editor_tests.cpp
@@ -2,17 +2,47 @@
 #include <bloom/render/image_types.hpp>
 #include <bloom/ui/viewer_editor.hpp>
 
+#include <bloom/color/ocio_builtin_registry.hpp>
+#include <bloom/color/ocio_cpu_display_processor.hpp>
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
+#include <bloom/runtime/reference_display_preparation.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_preview_pipeline.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+
 #include <QApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QImage>
 #include <QRectF>
 
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <iostream>
+#include <memory>
 #include <optional>
+#include <string>
 #include <string_view>
+#include <thread>
+#include <utility>
 
 namespace {
+
+using namespace std::chrono_literals;
 
 class Expectations final {
   public:
@@ -77,6 +107,195 @@ void testDegenerateAvailableRect(Expectations& expectations) {
     expectations.expect(fitted.isEmpty(), "empty available geometry produces no display rectangle");
 }
 
+// --- Issue #97 (task C3): "Viewer: renders the qualified frame's buffer (offscreen smoke), status
+// surface shows the color state in the failure case." The rest of this file (below) sets up a real
+// CompositionPreviewController/ViewerEditor pair to exercise that, mirroring the fixture shape in
+// composition_preview_controller_tests.cpp.
+
+bloom::document::CompositionFormat smallFormat() {
+    const auto format = bloom::document::CompositionFormat::create(4, 3);
+    if (!format.has_value()) {
+        std::abort();
+    }
+    return *format;
+}
+
+bloom::document::NewProject makeTestProject(std::string projectName) {
+    return bloom::document::makeNewProject(
+        std::move(projectName), "Main", bloom::core::RationalTime::fromInteger(10), smallFormat());
+}
+
+bloom::runtime::TaskSchedulerConfig testSchedulerConfig() {
+    return {.cpuWorkerCount = 1,
+            .blockingIoWorkerCount = 1,
+            .cpuQueueCapacity = 16,
+            .blockingIoQueueCapacity = 4,
+            .terminalHistoryCapacity = 32,
+            .diagnosticsPerTask = 8,
+            .groupRegistryCapacity = 8};
+}
+
+template <typename Predicate> bool waitUntil(Predicate predicate) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 4'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (std::invoke(predicate)) {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return std::invoke(predicate);
+}
+
+bool isReady(const bloom::ui::CompositionPreviewController& controller) {
+    return controller.state().activity == bloom::ui::PreviewActivity::Ready;
+}
+
+void reachQuiescence(bloom::ui::CompositionPreviewController& controller,
+                     bloom::ui::TaskUiBridge& bridge, bloom::runtime::TaskScheduler& scheduler,
+                     Expectations& expectations) {
+    bool quiescentSignal = false;
+    QObject::connect(&bridge, &bloom::ui::TaskUiBridge::shutdownQuiescent, &bridge,
+                     [&quiescentSignal] { quiescentSignal = true; });
+    controller.beginShutdown();
+    bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return quiescentSignal && scheduler.isQuiescent(); }),
+                        "viewer fixture reaches asynchronous scheduler quiescence");
+}
+
+// Renders the qualified frame's buffer (offscreen smoke) and confirms the corner/accessibility
+// status surface reads "Qualified display" once the qualified processor is ready -- never a silent
+// relabel of the earlier reference-labeled frame.
+void testViewerRendersQualifiedFrameAndReportsColorState(Expectations& expectations) {
+    using namespace bloom;
+
+    auto newProject = makeTestProject("Viewer Qualified Smoke Test");
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, compositionId);
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+
+    runtime::NodeDefinitionRegistry definitions;
+    expectations.expect(runtime::registerBuiltInNodeDefinitions(definitions),
+                        "viewer smoke fixture registers built-in node definitions");
+    definitions.freeze();
+    runtime::SnapshotCompiler compiler(definitions);
+    const runtime::CpuCompositionEvaluator evaluator;
+    const runtime::CpuReferenceDisplayPreparer displayPreparer;
+    runtime::QualifiedDisplayProcessorProvider qualifiedProvider;
+    auto pipeline =
+        ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer, qualifiedProvider);
+    ui::CompositionPreviewController controller(session, scheduler, bridge, pipeline);
+    ui::ViewerEditor viewer(session, controller);
+    viewer.resize(320, 240);
+
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "an initial reference-labeled frame becomes ready");
+    const QImage beforeReadiness = viewer.grab().toImage();
+    expectations.expect(!beforeReadiness.isNull(),
+                        "the viewer renders offscreen before the qualified processor is ready");
+    expectations.expect(
+        viewer.accessibleDescription().contains(QStringLiteral("Reference display")),
+        "the status surface reports the reference (unqualified) color state before "
+        "readiness");
+
+    auto resolution = color::resolveBloomNeutralV1BuiltIn(
+        color::OcioConfigLocatorKind::BloomBuiltIn, color::kBloomNeutralV1ConfigUri,
+        color::kBloomNeutralV1ConfigDigest);
+    expectations.expect(resolution.ready(), "the embedded Bloom Neutral built-in resolves");
+    auto resolved = std::move(resolution).takeResolved();
+    if (resolved.has_value()) {
+        auto built = color::buildBloomNeutralCpuDisplayProcessor(*resolved);
+        expectations.expect(static_cast<bool>(built), "the qualified processor builds");
+        if (built) {
+            auto handleValue = std::move(built).takeHandle();
+            expectations.expect(handleValue.has_value(), "the built result carries a handle");
+            if (handleValue.has_value()) {
+                auto shared = std::make_shared<const color::PreparedCpuDisplayProcessorHandle>(
+                    std::move(*handleValue));
+                qualifiedProvider.publish(
+                    runtime::QualifiedDisplayProcessorBuildResult::ready(shared));
+            }
+        }
+    }
+    controller.requestRefresh();
+    expectations.expect(waitUntil([&] {
+                            return isReady(controller) && controller.state().frame != nullptr &&
+                                   controller.state().frame->isOcioQualified();
+                        }),
+                        "a qualified frame becomes ready");
+
+    const QImage afterReadiness = viewer.grab().toImage();
+    expectations.expect(!afterReadiness.isNull(),
+                        "the viewer renders the qualified frame's buffer offscreen (smoke)");
+    expectations.expect(
+        viewer.accessibleDescription().contains(QStringLiteral("Qualified display")),
+        "the status surface reports the qualified color state once the frame is qualified");
+
+    reachQuiescence(controller, bridge, scheduler, expectations);
+}
+
+// Fail-closed: the status surface shows the color state (a diagnostic message, plus a corner label
+// that never claims "Qualified") when qualification has failed, while the viewer keeps rendering
+// its last-good pixels.
+void testViewerStatusSurfaceReflectsFailClosedColorState(Expectations& expectations) {
+    using namespace bloom;
+
+    auto newProject = makeTestProject("Viewer Fail-Closed Smoke Test");
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, compositionId);
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+
+    runtime::NodeDefinitionRegistry definitions;
+    expectations.expect(runtime::registerBuiltInNodeDefinitions(definitions),
+                        "fail-closed viewer fixture registers built-in node definitions");
+    definitions.freeze();
+    runtime::SnapshotCompiler compiler(definitions);
+    const runtime::CpuCompositionEvaluator evaluator;
+    const runtime::CpuReferenceDisplayPreparer displayPreparer;
+    runtime::QualifiedDisplayProcessorProvider qualifiedProvider;
+    auto pipeline =
+        ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer, qualifiedProvider);
+    ui::CompositionPreviewController controller(session, scheduler, bridge, pipeline);
+    ui::ViewerEditor viewer(session, controller);
+    viewer.resize(320, 240);
+
+    expectations.expect(waitUntil([&] { return isReady(controller); }),
+                        "the honest startup window still renders a reference-labeled frame");
+    const QImage lastGoodImage = viewer.grab().toImage();
+    expectations.expect(!lastGoodImage.isNull(), "the last-good frame renders offscreen");
+
+    qualifiedProvider.publish(runtime::QualifiedDisplayProcessorBuildResult::failed(
+        {.code = "bloom.test.viewer-qualified-display.forced-failure",
+         .severity = runtime::DiagnosticSeverity::Error,
+         .summary = "The Bloom Neutral display configuration could not be resolved",
+         .detail = {},
+         .suggestedAction = {}}));
+    controller.requestRefresh();
+    expectations.expect(
+        waitUntil([&] { return controller.state().activity == ui::PreviewActivity::Failed; }),
+        "a request after a forced qualification failure reaches Failed");
+
+    const QImage failedImage = viewer.grab().toImage();
+    expectations.expect(!failedImage.isNull(),
+                        "the viewer still renders its retained last-good pixels while Failed");
+    expectations.expect(
+        !viewer.accessibleDescription().contains(QStringLiteral("Qualified display")),
+        "the status surface never claims a qualified color state once qualification has failed");
+    expectations.expect(
+        viewer.accessibleDescription().contains(controller.state().message),
+        "the status surface's message reflects the controller's own fail-closed diagnostic");
+
+    reachQuiescence(controller, bridge, scheduler, expectations);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -86,5 +305,7 @@ int main(int argc, char** argv) {
     testSquarePixelFitting(expectations);
     testPixelAspectFitting(expectations);
     testDegenerateAvailableRect(expectations);
+    testViewerRendersQualifiedFrameAndReportsColorState(expectations);
+    testViewerStatusSurfaceReflectsFailClosedColorState(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/viewer_editor.cpp
+++ b/src/ui/viewer_editor.cpp
@@ -6,6 +6,7 @@
 #include <bloom/core/pixel_aspect_ratio.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/project.hpp>
+#include <bloom/render/display_buffer.hpp>
 #include <bloom/render/image_types.hpp>
 
 #include <QImage>
@@ -17,6 +18,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <optional>
 #include <variant>
 
 namespace bloom::ui {
@@ -214,40 +216,40 @@ void ViewerEditor::paintEvent(QPaintEvent* event) {
     const auto& preview = previewController_.state();
     const PreparedPreviewFrameHandle displayedFrame = preview.frame;
     bool drewPixels = false;
+    bool drewQualifiedPixels = false;
     if (displayedFrame != nullptr) {
-        const auto viewResult = displayedFrame->displayBuffer().view();
-        if (viewResult) {
-            const auto view = *viewResult.value();
-            const auto descriptorResult = view.descriptor();
-            if (descriptorResult.has_value()) {
-                const auto descriptor = *descriptorResult;
-                const auto extent = descriptor.displayWindow().extent();
-                const auto& layout = descriptor.layout();
-                if (extent.width() <= static_cast<std::uint32_t>(std::numeric_limits<int>::max()) &&
-                    extent.height() <=
-                        static_cast<std::uint32_t>(std::numeric_limits<int>::max()) &&
-                    layout.rowStrideBytes <=
-                        static_cast<std::size_t>(std::numeric_limits<qsizetype>::max())) {
-                    const auto pixels = view.pixels();
-                    // displayedFrame owns the immutable bytes for this entire paint. The const-data
-                    // QImage constructor borrows them, so presentation does not copy or convert a
-                    // full frame on the UI thread.
-                    const QImage image(
-                        reinterpret_cast<const uchar*>(pixels.data()),
-                        static_cast<int>(extent.width()), static_cast<int>(extent.height()),
-                        static_cast<qsizetype>(layout.rowStrideBytes), QImage::Format_RGBA8888);
-                    if (!image.isNull()) {
-                        const QRectF displayRect =
-                            fitDisplayRect(frame, extent, descriptor.pixelAspect());
-                        drawCheckerboard(painter, displayRect);
-                        painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
-                        painter.drawImage(displayRect, image, QRectF(image.rect()));
-                        painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
-                        painter.setPen(QPen(QColor(104, 107, 114), 1.0));
-                        painter.setBrush(Qt::NoBrush);
-                        painter.drawRect(displayRect.adjusted(0.0, 0.0, -1.0, -1.0));
-                        drewPixels = true;
-                    }
+        // displayBufferView() normalizes both display-product alternatives (reference and
+        // qualified) to the same packed-RGBA8 shape (design decision 2) -- the viewer draws
+        // pixels identically either way; isOcioQualified is the only distinguishing bit, used
+        // below only for the corner provenance label, never to change how pixels are drawn.
+        const auto bufferView = displayedFrame->displayBufferView();
+        if (bufferView.has_value()) {
+            const auto extent = bufferView->displayWindow.extent();
+            const auto& layout = bufferView->layout;
+            if (extent.width() <= static_cast<std::uint32_t>(std::numeric_limits<int>::max()) &&
+                extent.height() <= static_cast<std::uint32_t>(std::numeric_limits<int>::max()) &&
+                layout.rowStrideBytes <=
+                    static_cast<std::size_t>(std::numeric_limits<qsizetype>::max())) {
+                const auto pixels = bufferView->pixels;
+                // displayedFrame owns the immutable bytes for this entire paint. The const-data
+                // QImage constructor borrows them, so presentation does not copy or convert a
+                // full frame on the UI thread.
+                const QImage image(
+                    reinterpret_cast<const uchar*>(pixels.data()), static_cast<int>(extent.width()),
+                    static_cast<int>(extent.height()),
+                    static_cast<qsizetype>(layout.rowStrideBytes), QImage::Format_RGBA8888);
+                if (!image.isNull()) {
+                    const QRectF displayRect =
+                        fitDisplayRect(frame, extent, bufferView->pixelAspect);
+                    drawCheckerboard(painter, displayRect);
+                    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+                    painter.drawImage(displayRect, image, QRectF(image.rect()));
+                    painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
+                    painter.setPen(QPen(QColor(104, 107, 114), 1.0));
+                    painter.setBrush(Qt::NoBrush);
+                    painter.drawRect(displayRect.adjusted(0.0, 0.0, -1.0, -1.0));
+                    drewPixels = true;
+                    drewQualifiedPixels = bufferView->isOcioQualified;
                 }
             }
         }
@@ -260,8 +262,16 @@ void ViewerEditor::paintEvent(QPaintEvent* event) {
                      composition == nullptr ? tr("No composition")
                                             : QString::fromStdString(composition->name()));
     painter.setPen(QColor(169, 165, 219));
+    // Never a silent relabel: this reads the envelope's own isOcioQualified flag every paint,
+    // rather than assuming qualified once readiness is reached (design decision 2 / the "reference
+    // path is never silently relabeled as qualified" contract). A frame drawn before the qualified
+    // processor is ready -- or the last-good frame retained through a later qualification failure
+    // -- keeps reading as "Reference display (unqualified)" here for exactly as long as it is.
     painter.drawText(QRectF(frame.left(), 2.0, frame.width(), 22.0),
-                     Qt::AlignRight | Qt::AlignVCenter, tr("Reference display"));
+                     Qt::AlignRight | Qt::AlignVCenter,
+                     drewPixels ? (drewQualifiedPixels ? tr("Qualified display")
+                                                       : tr("Reference display (unqualified)"))
+                                : tr("Reference display"));
 
     if (!drewPixels) {
         painter.setPen(QColor(178, 182, 190));
@@ -306,8 +316,15 @@ void ViewerEditor::updatePreviewAccessibility() {
         frameDescription = tr("Previous composition pixels are displayed and marked out of date");
         break;
     }
+    const auto bufferView =
+        preview.frame != nullptr ? preview.frame->displayBufferView() : std::nullopt;
+    const QString colorStateDescription =
+        bufferView.has_value()
+            ? (bufferView->isOcioQualified ? tr("Qualified display.")
+                                           : tr("Reference display (unqualified)."))
+            : tr("Reference display.");
     setAccessibleDescription(
-        tr("%1. %2. Reference display.").arg(preview.message, frameDescription));
+        tr("%1. %2. %3").arg(preview.message, frameDescription, colorStateDescription));
 }
 
 std::optional<PositionInteractionMapping> ViewerEditor::currentMapping() const {
@@ -327,16 +344,24 @@ std::optional<PositionInteractionMapping> ViewerEditor::currentMapping() const {
     if (composition == nullptr) {
         return std::nullopt;
     }
-    const auto viewResult = frameHandle->displayBuffer().view();
-    if (!viewResult) {
+    // The gesture-mapping geometry is alternative-agnostic (design decision 2): a qualified frame's
+    // window/pixel-aspect maps a drag gesture exactly the way a reference frame's does. The frozen
+    // PositionInteractionMapping::displayDescriptor stays a
+    // render::ReferenceDisplayBufferDescriptor purely as a geometry/change-detection value here
+    // (extent, pixel aspect, packed layout) -- never as a claim that the underlying pixels are the
+    // unqualified reference product; a qualified frame's isOcioQualified() bit lives on
+    // PreviewDisplayBufferView above, not on this reused geometry type, and nothing reads this
+    // descriptor's own (always-false) isOcioQualified() to decide provenance.
+    const auto bufferView = frameHandle->displayBufferView();
+    if (!bufferView.has_value()) {
         return std::nullopt;
     }
-    const auto view = *viewResult.value();
-    const auto descriptorResult = view.descriptor();
-    if (!descriptorResult.has_value()) {
+    const auto descriptorResult = render::ReferenceDisplayBufferDescriptor::create(
+        bufferView->displayWindow, bufferView->pixelAspect);
+    if (!descriptorResult) {
         return std::nullopt;
     }
-    const auto descriptor = *descriptorResult;
+    const auto descriptor = *descriptorResult.value();
     const QRectF displayRect = fitDisplayRect(
         viewerFrame(*this), descriptor.displayWindow().extent(), descriptor.pixelAspect());
     if (displayRect.isEmpty()) {

--- a/tools/quality/repository_checks/repository_checks.cpp
+++ b/tools/quality/repository_checks/repository_checks.cpp
@@ -333,19 +333,19 @@ constexpr auto kKnownModules = std::to_array<std::string_view>(
      "output", "host", "scripting"});
 constexpr auto kAllowedModuleDependencies =
     std::to_array<std::pair<std::string_view, std::string_view>>({
-        {"platform", "core"},      {"document", "core"},     {"commands", "core"},
-        {"commands", "document"},  {"project", "core"},      {"project", "document"},
-        {"project", "platform"},   {"render", "core"},       {"runtime", "core"},
-        {"runtime", "document"},   {"runtime", "render"},    {"media", "core"},
-        {"media", "platform"},     {"media", "render"},      {"media", "runtime"},
-        {"color", "core"},         {"color", "platform"},    {"color", "render"},
-        {"color", "runtime"},      {"output", "color"},      {"output", "core"},
-        {"output", "document"},    {"output", "platform"},   {"output", "render"},
-        {"output", "runtime"},     {"host", "color"},        {"host", "commands"},
-        {"host", "core"},          {"host", "document"},     {"host", "output"},
-        {"host", "platform"},      {"host", "project"},      {"host", "runtime"},
-        {"scripting", "commands"}, {"scripting", "core"},    {"scripting", "document"},
-        {"scripting", "host"},     {"scripting", "runtime"},
+        {"platform", "core"},      {"document", "core"},      {"commands", "core"},
+        {"commands", "document"},  {"project", "core"},       {"project", "document"},
+        {"project", "platform"},   {"render", "core"},        {"runtime", "core"},
+        {"runtime", "document"},   {"runtime", "render"},     {"media", "core"},
+        {"media", "platform"},     {"media", "render"},       {"media", "runtime"},
+        {"color", "core"},         {"color", "platform"},     {"color", "render"},
+        {"color", "runtime"},      {"runtime", "color"},      {"output", "color"},
+        {"output", "core"},        {"output", "document"},    {"output", "platform"},
+        {"output", "render"},      {"output", "runtime"},     {"host", "color"},
+        {"host", "commands"},      {"host", "core"},          {"host", "document"},
+        {"host", "output"},        {"host", "platform"},      {"host", "project"},
+        {"host", "runtime"},       {"scripting", "commands"}, {"scripting", "core"},
+        {"scripting", "document"}, {"scripting", "host"},     {"scripting", "runtime"},
     });
 
 [[nodiscard]] constexpr auto isAllowedDependency(const std::string_view module,

--- a/tools/quality/repository_checks/repository_checks.cpp
+++ b/tools/quality/repository_checks/repository_checks.cpp
@@ -333,19 +333,19 @@ constexpr auto kKnownModules = std::to_array<std::string_view>(
      "output", "host", "scripting"});
 constexpr auto kAllowedModuleDependencies =
     std::to_array<std::pair<std::string_view, std::string_view>>({
-        {"platform", "core"},      {"document", "core"},      {"commands", "core"},
-        {"commands", "document"},  {"project", "core"},       {"project", "document"},
-        {"project", "platform"},   {"render", "core"},        {"runtime", "core"},
-        {"runtime", "document"},   {"runtime", "render"},     {"media", "core"},
-        {"media", "platform"},     {"media", "render"},       {"media", "runtime"},
-        {"color", "core"},         {"color", "platform"},     {"color", "render"},
-        {"color", "runtime"},      {"runtime", "color"},      {"output", "color"},
-        {"output", "core"},        {"output", "document"},    {"output", "platform"},
-        {"output", "render"},      {"output", "runtime"},     {"host", "color"},
-        {"host", "commands"},      {"host", "core"},          {"host", "document"},
-        {"host", "output"},        {"host", "platform"},      {"host", "project"},
-        {"host", "runtime"},       {"scripting", "commands"}, {"scripting", "core"},
-        {"scripting", "document"}, {"scripting", "host"},     {"scripting", "runtime"},
+        {"platform", "core"},      {"document", "core"},     {"commands", "core"},
+        {"commands", "document"},  {"project", "core"},      {"project", "document"},
+        {"project", "platform"},   {"render", "core"},       {"runtime", "core"},
+        {"runtime", "document"},   {"runtime", "render"},    {"media", "core"},
+        {"media", "platform"},     {"media", "render"},      {"media", "runtime"},
+        {"color", "core"},         {"color", "platform"},    {"color", "render"},
+        {"runtime", "color"},      {"output", "color"},      {"output", "core"},
+        {"output", "document"},    {"output", "platform"},   {"output", "render"},
+        {"output", "runtime"},     {"host", "color"},        {"host", "commands"},
+        {"host", "core"},          {"host", "document"},     {"host", "output"},
+        {"host", "platform"},      {"host", "project"},      {"host", "runtime"},
+        {"scripting", "commands"}, {"scripting", "core"},    {"scripting", "document"},
+        {"scripting", "host"},     {"scripting", "runtime"},
     });
 
 [[nodiscard]] constexpr auto isAllowedDependency(const std::string_view module,


### PR DESCRIPTION
Wires the qualified OCIO display path into the composition preview pipeline — the viewer now renders color-managed frames:

- **`CpuQualifiedDisplayPreparer`** (runtime, beside its reference sibling): typed results, cancellation at chunk boundaries, and a golden test proving byte-identity with the color adapter's direct output. The evaluator's data-window==display-window invariant was verified at its construction site, making the window semantics exact today with the divergent case documented as inert.
- **One-time blocking-stage processor preparation** at session construction on the shared scheduler's BlockingIo path, published once through a snapshot-consistent typed mailbox (single-lock snapshot specifically so a request can never misread a just-landed failure as still-pending). No task waits; no UI callback blocks.
- **Honest labeling end to end**: requests before readiness take the reference path and the viewer labels it unqualified; after readiness every frame is qualified-flagged; the viewer reads the flag off the actual frame in hand, never from cached readiness. Stale rejection is unchanged across both paths.
- **Fail-closed**: a resolution/build failure retains the last-good frame, marks it stale, and surfaces the color diagnostic — no silent substitution of the reference transform, pinned by tests.
- **Production bug found and fixed en route**: the preview controller's ready-path called a reference-only buffer accessor that segfaulted on qualified frames; replaced with the alternative-agnostic view accessor.
- Module boundary: runtime→color edge added; the unused reverse allowance removed so the checker cannot mask a future cycle.

Desktop 92/92 and native 78/78 (including boundary, hygiene, lock, and format checks), from a fresh dependency prefix.

Closes #97.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.