### PR TITLE
feat: write verified flat OpenEXR frames

### DIFF
--- a/docs/architecture/frame-output.md
+++ b/docs/architecture/frame-output.md
@@ -6,11 +6,11 @@ Implementation status: the allocation-free Process Pixel Stream and Process-Fram
 Identity version 1 codecs, cancellable owning semantic-identity preparer, closed facet-descriptor
 grammar and validator, preset-specific owning OutputAnalysis analyzer/report, streaming analysis
 digest, preset-specific bound-analysis products, the module-private Output Semantic Identity version
-1 streaming serializer/preparer, and portable golden vectors are implemented. Preset pixel
-conversion, production verifier-product issuance, PNG/OpenEXR adapters, staged-format verification,
-and end-to-end publication remain pending.
+1 streaming serializer/preparer, portable golden vectors, and the flat OpenEXR adapter with its
+semantic reopen verifier and verifier-product issuance are implemented. The PNG adapter and
+end-to-end publication remain pending.
 
-Updated: 2026-08-25
+Updated: 2026-08-31
 
 ## Purpose
 
@@ -615,6 +615,12 @@ ties-to-even, with gradual underflow and preserved signed zero. NaN, infinity, a
 result, or finite overflow fails before staging. The same conversion rule governs any declared
 binary64-to-binary32 output boundary; it must not inherit ambient rounding or flush subnormals.
 Process samples are already binary32 and are copied bit-for-bit rather than numerically converted.
+
+Version 1 additionally bounds every data- and display-window coordinate to a magnitude strictly
+below `1073741823` (`INT32_MAX/2`) — the validated coordinate ceiling the qualified OpenEXR
+encoder itself enforces. A window outside that checked ceiling fails typed before staging rather
+than surfacing a library error; the full signed-32 wording above is therefore bounded by this
+explicit version 1 ceiling.
 
 The report marks process pixels, alpha, channels, and windows `Exact`. The pixel-aspect facet is
 `Exact` only when the stored Float32 round-trips to the source rational; otherwise it is

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -4,6 +4,9 @@ target_sources(
     bloom_output
     PRIVATE
         bound_output_analysis.cpp
+        flat_exr_output_adapter.cpp
+        flat_exr_preset_contract.hpp
+        flat_exr_reopen_verifier.cpp
         output_analysis.cpp
         output_analysis_analyzer.cpp
         output_analysis_contract.cpp
@@ -18,6 +21,8 @@ target_sources(
         FILE_SET HEADERS
         BASE_DIRS include
         FILES
+            include/bloom/output/flat_exr_output_adapter.hpp
+            include/bloom/output/flat_exr_reopen_verifier.hpp
             include/bloom/output/output_analysis.hpp
             include/bloom/output/output_analysis_analyzer.hpp
             include/bloom/output/output_analysis_digest.hpp
@@ -32,6 +37,17 @@ target_link_libraries(
     PUBLIC bloom_color bloom_core bloom_render bloom_runtime_evaluator
 )
 bloom_enable_warnings(bloom_output)
+
+# issue #99 (flat OpenEXR write adapter): the qualified prefix ships OpenEXR 3.4.15 directly (no
+# OIIO); only this target links it, and only privately -- no OpenEXR/Imath type appears in any
+# public bloom/output header (flat_exr_output_adapter.cpp/flat_exr_reopen_verifier.cpp are the
+# only translation units that see real OpenEXR/Imath types), the same boundary discipline as
+# bloom_color_ocio's OpenColorIO link. The bloom_find_dependency transitive sandbox the OCIO slice
+# built (function-scoped CMAKE_PREFIX_PATH/NO_DEFAULT_PATH covering a package config's own nested
+# find_dependency calls) carries OpenEXRConfig.cmake's find_dependency(Threads/Imath/libdeflate)
+# chain with no changes needed here.
+bloom_find_dependency(OpenEXR)
+target_link_libraries(bloom_output PRIVATE OpenEXR::OpenEXR)
 
 if(BUILD_TESTING)
     include(BloomTesting)
@@ -113,6 +129,44 @@ if(BUILD_TESTING)
         NAME bloom.output.analysis_digest
         COMMAND bloom_output_analysis_digest_test
         LABELS unit output identity serialization
+    )
+
+    add_executable(
+        bloom_output_flat_exr_output_adapter_test
+        tests/flat_exr_output_adapter_tests.cpp
+    )
+    target_include_directories(
+        bloom_output_flat_exr_output_adapter_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_output_flat_exr_output_adapter_test
+        PRIVATE bloom_output OpenEXR::OpenEXR
+    )
+    bloom_enable_warnings(bloom_output_flat_exr_output_adapter_test)
+    bloom_add_test(
+        NAME bloom.output.flat_exr_output_adapter
+        COMMAND bloom_output_flat_exr_output_adapter_test
+        LABELS unit output render
+    )
+
+    add_executable(
+        bloom_output_flat_exr_reopen_verifier_test
+        tests/flat_exr_reopen_verifier_tests.cpp
+    )
+    target_include_directories(
+        bloom_output_flat_exr_reopen_verifier_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_output_flat_exr_reopen_verifier_test
+        PRIVATE bloom_output OpenEXR::OpenEXR
+    )
+    bloom_enable_warnings(bloom_output_flat_exr_reopen_verifier_test)
+    bloom_add_test(
+        NAME bloom.output.flat_exr_reopen_verifier
+        COMMAND bloom_output_flat_exr_reopen_verifier_test
+        LABELS unit output identity render
     )
 
     add_executable(

--- a/src/output/flat_exr_output_adapter.cpp
+++ b/src/output/flat_exr_output_adapter.cpp
@@ -1,0 +1,295 @@
+#include "flat_exr_preset_contract.hpp"
+#include "output_analysis_numeric.hpp"
+// output_semantic_identity.hpp is module-private (no public bloom/output/ path exists for it --
+// see docs/architecture/frame-output.md's "module-private Output Semantic Identity" note); this
+// translation unit lives inside src/output/ itself, so the quoted include resolves relative to
+// this file exactly like every other src/output/*.cpp that touches it (e.g.
+// output_semantic_identity_ownership.cpp). Only kFlatExrRec709D65ChromaticitiesBitsV1 is used
+// here; this header's own public declaration never names the type.
+#include "output_semantic_identity.hpp"
+
+#include <bloom/output/flat_exr_output_adapter.hpp>
+#include <bloom/output/output_limits.hpp>
+#include <bloom/render/image.hpp>
+
+// OpenEXR/Imath types are private to this translation unit only -- design decision 1
+// (docs/architecture/frame-output.md "Flat OpenEXR Preset Version 1"): no OpenEXR/Imath type,
+// enum, pointer, or exception may appear in a public bloom/output header. The classic C++ API
+// (Imf::Header + Imf::OutputFile) is chosen over the OpenEXRCore C API specifically because a
+// plain, non-multipart, non-deep Header constructed here inserts EXACTLY the eight base
+// attributes its constructor writes (displayWindow, dataWindow, pixelAspectRatio,
+// screenWindowCenter, screenWindowWidth, lineOrder, compression, channels) plus the two this
+// writer inserts itself (chromaticities, colorInteropID) -- ten total, nothing else. Verified
+// against the OpenEXR 3.4.15 source: Header::setVersion()/"version" is only inserted for deep
+// data (never reached by a flat scanline Header); Header::setChunkCount()/"chunkCount" is only
+// called by the deep and multipart output paths, never by the classic scanline OutputFile; and
+// OutputFile::writeMagicNumberAndVersionField() only sets Header::setType("scanlineimage") when
+// header.hasType() is already true, which it never is for a Header built through this
+// constructor. A plain scanline OutputFile therefore writes precisely the attributes inserted
+// into its Header -- the exact control design decision 2 requires -- which the header-conformance
+// test proves by independently decoding this writer's own output.
+#include <ImathBox.h>
+#include <ImathVec.h>
+#include <ImfChannelList.h>
+#include <ImfChromaticities.h>
+#include <ImfChromaticitiesAttribute.h>
+#include <ImfFrameBuffer.h>
+#include <ImfHeader.h>
+#include <ImfOutputFile.h>
+#include <ImfStandardAttributes.h>
+#include <ImfStringAttribute.h>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <system_error>
+
+namespace {
+
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+
+// Best-effort cleanup after a non-Written outcome. Never throws; reports whether the destination
+// is now confirmed absent.
+[[nodiscard]] bool removeDestinationBestEffort(const std::filesystem::path& destination) noexcept {
+    std::error_code removeError;
+    std::filesystem::remove(destination, removeError);
+    std::error_code existsError;
+    const bool stillExists = std::filesystem::exists(destination, existsError);
+    return !existsError && !stillExists;
+}
+
+[[nodiscard]] output::FlatExrWriteResultV1 fail(const output::FlatExrWriteErrorCodeV1 error,
+                                                const std::filesystem::path& destination,
+                                                const bool destinationWasCreated) noexcept {
+    const bool removed = !destinationWasCreated || removeDestinationBestEffort(destination);
+    return output::FlatExrWriteResultV1::failed(error, removed);
+}
+
+struct PreparedGeometry final {
+    Imath::Box2i dataWindow;
+    Imath::Box2i displayWindow;
+    float pixelAspectRatio = 1.0F;
+};
+
+// Checked signed-32 inclusive fit AND the real, narrower OpenEXR library ceiling
+// (kFlatExrLibraryCoordinateCeilingV1 -- see flat_exr_preset_contract.hpp for the discrepancy this
+// documents against the doc's literal "signed-32" language).
+[[nodiscard]] bool windowsFitWriterDomain(const render::ImageWindow dataWindow,
+                                          const render::ImageWindow displayWindow) noexcept {
+    return output::detail::outputAnalysisInclusiveAxisFitsSigned32V1(dataWindow.originX(),
+                                                                     dataWindow.extent().width()) &&
+           output::detail::outputAnalysisInclusiveAxisFitsSigned32V1(
+               dataWindow.originY(), dataWindow.extent().height()) &&
+           output::detail::outputAnalysisInclusiveAxisFitsSigned32V1(
+               displayWindow.originX(), displayWindow.extent().width()) &&
+           output::detail::outputAnalysisInclusiveAxisFitsSigned32V1(
+               displayWindow.originY(), displayWindow.extent().height()) &&
+           output::detail::flatExrWindowWithinLibraryCeilingV1(dataWindow.originX(),
+                                                               dataWindow.extent().width()) &&
+           output::detail::flatExrWindowWithinLibraryCeilingV1(dataWindow.originY(),
+                                                               dataWindow.extent().height()) &&
+           output::detail::flatExrWindowWithinLibraryCeilingV1(displayWindow.originX(),
+                                                               displayWindow.extent().width()) &&
+           output::detail::flatExrWindowWithinLibraryCeilingV1(displayWindow.originY(),
+                                                               displayWindow.extent().height());
+}
+
+// All checked, before-staging conversions: signed-32 inclusive windows (within the writer domain
+// above) and the single round-to-nearest-ties-even binary32 pixel-aspect conversion (reused from
+// the exact function the existing digest preflight already validates against, so a writer and a
+// later semantic-identity preflight can never silently disagree).
+[[nodiscard]] std::optional<PreparedGeometry>
+prepareGeometry(const render::Rgba32fImageDescriptor& descriptor) noexcept {
+    const auto dataWindow = descriptor.dataWindow();
+    const auto displayWindow = descriptor.displayWindow();
+    if (!::windowsFitWriterDomain(dataWindow, displayWindow)) {
+        return std::nullopt;
+    }
+    const auto pixelAspect = descriptor.pixelAspect();
+    const auto rounded = output::detail::roundOutputAnalysisPositiveRationalToBinary32V1(
+        {.numerator = pixelAspect.numerator(), .denominator = pixelAspect.denominator()});
+    if (!rounded) {
+        return std::nullopt;
+    }
+
+    PreparedGeometry geometry;
+    geometry.dataWindow = Imath::Box2i(
+        Imath::V2i(static_cast<int>(dataWindow.originX()), static_cast<int>(dataWindow.originY())),
+        Imath::V2i(static_cast<int>(dataWindow.originX() + dataWindow.extent().width() - 1),
+                   static_cast<int>(dataWindow.originY() + dataWindow.extent().height() - 1)));
+    geometry.displayWindow = Imath::Box2i(
+        Imath::V2i(static_cast<int>(displayWindow.originX()),
+                   static_cast<int>(displayWindow.originY())),
+        Imath::V2i(
+            static_cast<int>(displayWindow.originX() + displayWindow.extent().width() - 1),
+            static_cast<int>(displayWindow.originY() + displayWindow.extent().height() - 1)));
+    geometry.pixelAspectRatio = std::bit_cast<float>(rounded->bits);
+    return geometry;
+}
+
+void reportProgress(const output::FlatExrWriteProgressCallbackV1& callback,
+                    const output::FlatExrWriteProgressV1& progress) noexcept {
+    if (!callback) {
+        return;
+    }
+    try {
+        callback(progress);
+    } catch (...) {
+        // Monitoring cannot change a portable write outcome.
+        return;
+    }
+}
+
+[[nodiscard]] bool withinResourceLimits(const render::Rgba32fImageDescriptor& descriptor) noexcept {
+    const auto dataExtent = descriptor.dataWindow().extent();
+    const auto displayExtent = descriptor.displayWindow().extent();
+    if (dataExtent.width() > output::kOutputAnalysisMaximumDimensionV1 ||
+        dataExtent.height() > output::kOutputAnalysisMaximumDimensionV1 ||
+        displayExtent.width() > output::kOutputAnalysisMaximumDimensionV1 ||
+        displayExtent.height() > output::kOutputAnalysisMaximumDimensionV1) {
+        return false;
+    }
+    const auto pixelCount = descriptor.layout().pixelCount;
+    if (pixelCount > output::kOutputAnalysisMaximumPixelCountV1 ||
+        descriptor.layout().pixelStorageBytes > output::kOutputAnalysisMaximumProcessPixelBytesV1) {
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+namespace bloom::output {
+
+FlatExrWriteResultV1::FlatExrWriteResultV1(const FlatExrWriteStatusV1 status,
+                                           const FlatExrWriteErrorCodeV1 error,
+                                           const bool destinationRemoved) noexcept
+    : status_(status), error_(error), destinationRemoved_(destinationRemoved) {}
+
+FlatExrWriteResultV1 FlatExrWriteResultV1::written() noexcept {
+    return {FlatExrWriteStatusV1::Written, FlatExrWriteErrorCodeV1::None, true};
+}
+
+FlatExrWriteResultV1 FlatExrWriteResultV1::cancelled(const bool destinationRemoved) noexcept {
+    return {FlatExrWriteStatusV1::Cancelled, FlatExrWriteErrorCodeV1::None, destinationRemoved};
+}
+
+FlatExrWriteResultV1 FlatExrWriteResultV1::failed(const FlatExrWriteErrorCodeV1 error,
+                                                  const bool destinationRemoved) noexcept {
+    return {FlatExrWriteStatusV1::Failed,
+            error == FlatExrWriteErrorCodeV1::None ? FlatExrWriteErrorCodeV1::InternalInvariant
+                                                   : error,
+            destinationRemoved};
+}
+
+FlatExrWriteResultV1 FlatExrRgba32fLinRec709SceneWriterV1::write(
+    const runtime::ProcessFrame& frame, const std::filesystem::path& destination,
+    const runtime::CancellationToken& cancellation,
+    const FlatExrWriteProgressCallbackV1& progress) const noexcept {
+    const auto& image = frame.processImage();
+    if (!image.isValid()) {
+        return ::fail(FlatExrWriteErrorCodeV1::InternalInvariant, destination, false);
+    }
+    const auto* descriptor = image.descriptor();
+    if (descriptor == nullptr) {
+        return ::fail(FlatExrWriteErrorCodeV1::InternalInvariant, destination, false);
+    }
+    if (!::withinResourceLimits(*descriptor)) {
+        return ::fail(FlatExrWriteErrorCodeV1::ResourceLimitExceeded, destination, false);
+    }
+    const auto geometry = ::prepareGeometry(*descriptor);
+    if (!geometry) {
+        // prepareGeometry only reports WindowOutOfRange or InvalidPixelAspectRatio; distinguish
+        // by re-checking the window fit alone (cheap, deterministic).
+        const bool windowsFit =
+            ::windowsFitWriterDomain(descriptor->dataWindow(), descriptor->displayWindow());
+        return ::fail(windowsFit ? FlatExrWriteErrorCodeV1::InvalidPixelAspectRatio
+                                 : FlatExrWriteErrorCodeV1::WindowOutOfRange,
+                      destination, false);
+    }
+    if (cancellation.isCancellationRequested()) {
+        return FlatExrWriteResultV1::cancelled(true);
+    }
+
+    const auto pixels = image.pixels();
+    const auto rowStrideBytes = descriptor->layout().rowStrideBytes;
+    const auto height = descriptor->dataWindow().extent().height();
+    if (height == 0 || pixels.empty()) {
+        return ::fail(FlatExrWriteErrorCodeV1::InternalInvariant, destination, false);
+    }
+
+    bool destinationCreated = false;
+    try {
+        Imf::Header header(geometry->displayWindow, geometry->dataWindow,
+                           geometry->pixelAspectRatio, Imath::V2f(0.0F, 0.0F), 1.0F,
+                           Imf::INCREASING_Y, Imf::ZIP_COMPRESSION);
+        header.channels().insert("R", Imf::Channel(Imf::FLOAT));
+        header.channels().insert("G", Imf::Channel(Imf::FLOAT));
+        header.channels().insert("B", Imf::Channel(Imf::FLOAT));
+        header.channels().insert("A", Imf::Channel(Imf::FLOAT));
+
+        std::array<Imath::V2f, 4> chromaBits{};
+        for (std::size_t index = 0; index < 4; ++index) {
+            chromaBits[index] = Imath::V2f(
+                std::bit_cast<float>(kFlatExrRec709D65ChromaticitiesBitsV1[index * 2]),
+                std::bit_cast<float>(kFlatExrRec709D65ChromaticitiesBitsV1[index * 2 + 1]));
+        }
+        Imf::addChromaticities(header, Imf::Chromaticities(chromaBits[0], chromaBits[1],
+                                                           chromaBits[2], chromaBits[3]));
+        header.insert("colorInteropID",
+                      Imf::StringAttribute(std::string(detail::kFlatExrColorInteropIdV1)));
+
+        destinationCreated = true;
+        Imf::OutputFile outputFile(destination.string().c_str(), header, 1);
+
+        const auto* base = reinterpret_cast<const char*>(pixels.data());
+        constexpr std::size_t xStride = sizeof(render::Rgba32f);
+        Imf::FrameBuffer frameBuffer;
+        frameBuffer.insert("R", Imf::Slice::Make(Imf::FLOAT, base + 0 * sizeof(float),
+                                                 geometry->dataWindow, xStride, rowStrideBytes));
+        frameBuffer.insert("G", Imf::Slice::Make(Imf::FLOAT, base + 1 * sizeof(float),
+                                                 geometry->dataWindow, xStride, rowStrideBytes));
+        frameBuffer.insert("B", Imf::Slice::Make(Imf::FLOAT, base + 2 * sizeof(float),
+                                                 geometry->dataWindow, xStride, rowStrideBytes));
+        frameBuffer.insert("A", Imf::Slice::Make(Imf::FLOAT, base + 3 * sizeof(float),
+                                                 geometry->dataWindow, xStride, rowStrideBytes));
+        outputFile.setFrameBuffer(frameBuffer);
+
+        const auto rowsPerChunk = static_cast<std::uint32_t>(
+            std::max<std::size_t>(1, kOutputAdapterMaximumStreamingChunkBytesV1 /
+                                         std::max<std::size_t>(rowStrideBytes, 1)));
+        std::uint32_t remaining = height;
+        std::uint32_t completed = 0;
+        ::reportProgress(progress, {completed, height});
+        while (remaining > 0) {
+            if (cancellation.isCancellationRequested()) {
+                return FlatExrWriteResultV1::cancelled(::removeDestinationBestEffort(destination));
+            }
+            const auto chunk = std::min(rowsPerChunk, remaining);
+            outputFile.writePixels(static_cast<int>(chunk));
+            remaining -= chunk;
+            completed += chunk;
+            ::reportProgress(progress, {completed, height});
+        }
+    } catch (const std::bad_alloc&) {
+        return ::fail(FlatExrWriteErrorCodeV1::AllocationFailure, destination, destinationCreated);
+    } catch (const std::exception&) {
+        return ::fail(destinationCreated ? FlatExrWriteErrorCodeV1::IoFailure
+                                         : FlatExrWriteErrorCodeV1::DestinationUnavailable,
+                      destination, destinationCreated);
+    } catch (...) {
+        return ::fail(FlatExrWriteErrorCodeV1::InternalInvariant, destination, destinationCreated);
+    }
+
+    return FlatExrWriteResultV1::written();
+}
+
+} // namespace bloom::output

--- a/src/output/flat_exr_preset_contract.hpp
+++ b/src/output/flat_exr_preset_contract.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+// Private (non-FILE_SET, non-installed) header shared by the flat OpenEXR writer and reopen
+// verifier, mirroring how bloom_color_ocio keeps its real third-party types out of any public
+// header (ocio_internal.hpp). Nothing here names an OpenEXR/Imath type; it only names the closed
+// version 1 header allowlist so the writer and verifier stay driven by one literal table copied
+// from docs/architecture/frame-output.md ("Flat OpenEXR Preset Version 1"), not from each other.
+
+#include <array>
+#include <cstdint>
+#include <string_view>
+
+namespace bloom::output::detail {
+
+// CONTRACT DISCREPANCY (reported, not silently worked around; see the F1 task report): the
+// qualified OpenEXR 3.4.15 library rejects a data/display window whose min or max coordinate
+// magnitude reaches INT32_MAX/2 -- narrower than the full signed-32 domain
+// docs/architecture/frame-output.md's "Flat OpenEXR Preset Version 1" describes ("checked
+// inclusive signed-32 bounds"). Confirmed both empirically (a window at literal INT32_MAX throws
+// "Invalid display window" from Imf::OutputFile) and against the vendored source
+// (OpenEXRCore/validation.c's validate_image_dimensions: `kLargeVal = INT32_MAX / 2`; a window is
+// rejected when `min <= -kLargeVal || max >= kLargeVal`). This is a deliberate internal-overflow
+// safety margin in the library, not a bug reachable through public API choice -- the OpenEXRCore
+// C API enforces the identical check the classic C++ API delegates to. The writer enforces this
+// real ceiling itself so an in-range-per-doc-but-out-of-range-per-library window is a clean typed
+// rejection before staging rather than a caught library exception.
+inline constexpr std::int64_t kFlatExrLibraryCoordinateCeilingV1 = 1'073'741'823LL; // INT32_MAX/2
+
+[[nodiscard]] constexpr bool
+flatExrWindowWithinLibraryCeilingV1(const std::int64_t origin,
+                                    const std::uint32_t extent) noexcept {
+    if (extent == 0) {
+        return false;
+    }
+    const auto maxCoordinate = origin + static_cast<std::int64_t>(extent) - 1;
+    return origin > -kFlatExrLibraryCoordinateCeilingV1 &&
+           maxCoordinate < kFlatExrLibraryCoordinateCeilingV1;
+}
+
+struct FlatExrHeaderAttributeContractV1 final {
+    std::string_view name;
+    // The exact string OpenEXR's Imf::Attribute::typeName() returns for this attribute's type.
+    std::string_view openExrTypeName;
+};
+
+inline constexpr std::string_view kFlatExrColorInteropIdV1 = "lin_rec709_scene";
+
+// The closed version 1 header allowlist: exactly these ten attributes, nothing else. The
+// verifier enumerates every attribute the reopened file actually carries and fails closed on
+// anything outside this table (an unexpected name, a wrong type, or a missing entry) before it
+// checks any value; the writer inserts exactly these ten. Order here is documentation order, not
+// a serialization requirement -- the doc places no ordering constraint on the header's attribute
+// list (only on the channel list, checked separately).
+inline constexpr std::array<FlatExrHeaderAttributeContractV1, 10> kFlatExrHeaderAttributesV1{{
+    {"channels", "chlist"},
+    {"compression", "compression"},
+    {"dataWindow", "box2i"},
+    {"displayWindow", "box2i"},
+    {"lineOrder", "lineOrder"},
+    {"pixelAspectRatio", "float"},
+    {"screenWindowCenter", "v2f"},
+    {"screenWindowWidth", "float"},
+    {"chromaticities", "chromaticities"},
+    {"colorInteropID", "string"},
+}};
+
+// Channel names in the exact required physical (lexical) header order A, B, G, R.
+inline constexpr std::array<std::string_view, 4> kFlatExrChannelNamesLexicalV1{"A", "B", "G", "R"};
+
+} // namespace bloom::output::detail

--- a/src/output/flat_exr_reopen_verifier.cpp
+++ b/src/output/flat_exr_reopen_verifier.cpp
@@ -1,0 +1,487 @@
+#include "flat_exr_preset_contract.hpp"
+#include "output_analysis_numeric.hpp"
+// output_semantic_identity.hpp is module-private (no public bloom/output/ path exists for it --
+// docs/architecture/frame-output.md calls it "the module-private Output Semantic Identity version
+// 1 streaming serializer/preparer"); this translation unit lives inside src/output/ itself, so the
+// quoted include resolves relative to this file, matching every other src/output/*.cpp that
+// touches it. This is also where the friend seam class below (forward-declared in that header as
+// `detail::FlatExrRgba32fLinRec709SceneSemanticPayloadVerifierV1`) is defined.
+#include "output_semantic_identity.hpp"
+
+#include <bloom/output/flat_exr_reopen_verifier.hpp>
+#include <bloom/output/output_limits.hpp>
+#include <bloom/render/image.hpp>
+
+// OpenEXR/Imath types are private to this translation unit only -- see flat_exr_output_adapter.cpp
+// for the API-choice rationale shared by the writer and this verifier. `Imf::Header::begin()`/
+// `end()` give exhaustive attribute enumeration (used to prove the closed ten-entry allowlist
+// admits no extra attribute) and `Imf::InputFile` gives typed access to every standard attribute
+// plus `findTypedAttribute<T>` for the one custom attribute (`colorInteropID`), all without this
+// verifier ever exposing an OpenEXR/Imath type in a public header.
+#include <ImathBox.h>
+#include <ImathVec.h>
+#include <ImfChannelList.h>
+#include <ImfChromaticities.h>
+#include <ImfChromaticitiesAttribute.h>
+#include <ImfFrameBuffer.h>
+#include <ImfHeader.h>
+#include <ImfInputFile.h>
+#include <ImfStandardAttributes.h>
+#include <ImfStringAttribute.h>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+
+// Positional aggregate construction (never designated) so every FlatExrVerifyDiagnosticV1 site
+// stays a one-line call regardless of how many trailing fields default.
+[[nodiscard]] output::FlatExrVerifyDiagnosticV1
+diag(const output::FlatExrVerifyErrorCodeV1 code, std::string attributeName = {},
+     const std::optional<std::int64_t> scanlineY = std::nullopt,
+     const std::optional<std::uint8_t> channelIndex = std::nullopt) noexcept {
+    return output::FlatExrVerifyDiagnosticV1{code, std::move(attributeName), scanlineY,
+                                             channelIndex};
+}
+
+void reportScanProgress(const output::FlatExrVerifyScanProgressCallbackV1& callback,
+                        const output::FlatExrVerifyScanProgressV1& progress) noexcept {
+    if (!callback) {
+        return;
+    }
+    try {
+        callback(progress);
+    } catch (...) {
+        // Monitoring cannot change a portable verification outcome.
+        return;
+    }
+}
+
+[[nodiscard]] constexpr std::optional<std::uint64_t>
+multiplyChecked(const std::uint64_t left, const std::uint64_t right) noexcept {
+    if (right != 0 && left > std::numeric_limits<std::uint64_t>::max() / right) {
+        return std::nullopt;
+    }
+    return left * right;
+}
+
+struct VersionFieldCheck final {
+    bool ok = false;
+    output::FlatExrVerifyErrorCodeV1 error = output::FlatExrVerifyErrorCodeV1::InternalInvariant;
+};
+
+// Reads the first 8 bytes directly (magic number, then the 8-bit version number and 24-bit
+// feature-flags field) without involving OpenEXR at all, so this specific check can never be
+// softened by a library's own tolerant interpretation of a malformed version field.
+[[nodiscard]] VersionFieldCheck checkVersionField(const std::filesystem::path& path) noexcept {
+    try {
+        std::ifstream stream(path, std::ios::binary);
+        if (!stream) {
+            return {false, output::FlatExrVerifyErrorCodeV1::SourceUnavailable};
+        }
+        std::array<unsigned char, 8> header{};
+        stream.read(reinterpret_cast<char*>(header.data()),
+                    static_cast<std::streamsize>(header.size()));
+        if (!stream || stream.gcount() != static_cast<std::streamsize>(header.size())) {
+            return {false, output::FlatExrVerifyErrorCodeV1::TruncatedFile};
+        }
+        const auto magic = static_cast<std::uint32_t>(header[0]) |
+                           (static_cast<std::uint32_t>(header[1]) << 8U) |
+                           (static_cast<std::uint32_t>(header[2]) << 16U) |
+                           (static_cast<std::uint32_t>(header[3]) << 24U);
+        if (magic != 20'000'630U) {
+            return {false, output::FlatExrVerifyErrorCodeV1::HeaderParseFailed};
+        }
+        const auto versionField = static_cast<std::uint32_t>(header[4]) |
+                                  (static_cast<std::uint32_t>(header[5]) << 8U) |
+                                  (static_cast<std::uint32_t>(header[6]) << 16U) |
+                                  (static_cast<std::uint32_t>(header[7]) << 24U);
+        if ((versionField & 0xFFU) != 2U || (versionField & 0xFFFFFF00U) != 0U) {
+            return {false, output::FlatExrVerifyErrorCodeV1::InvalidVersionField};
+        }
+        return {true, output::FlatExrVerifyErrorCodeV1::None};
+    } catch (...) {
+        return {false, output::FlatExrVerifyErrorCodeV1::SourceUnavailable};
+    }
+}
+
+[[nodiscard]] std::optional<Imath::Box2i> inclusiveBox(const render::ImageWindow window) noexcept {
+    if (!output::detail::outputAnalysisInclusiveAxisFitsSigned32V1(window.originX(),
+                                                                   window.extent().width()) ||
+        !output::detail::outputAnalysisInclusiveAxisFitsSigned32V1(window.originY(),
+                                                                   window.extent().height())) {
+        return std::nullopt;
+    }
+    return Imath::Box2i(
+        Imath::V2i(static_cast<int>(window.originX()), static_cast<int>(window.originY())),
+        Imath::V2i(static_cast<int>(window.originX() + window.extent().width() - 1),
+                   static_cast<int>(window.originY() + window.extent().height() - 1)));
+}
+
+[[nodiscard]] std::optional<output::FlatExrVerifyDiagnosticV1>
+checkAttributeAllowlist(const Imf::Header& header) noexcept {
+    using output::FlatExrVerifyErrorCodeV1;
+    std::array<bool, output::detail::kFlatExrHeaderAttributesV1.size()> seen{};
+    for (auto it = header.begin(); it != header.end(); ++it) {
+        const std::string_view name = it.name();
+        const auto* const matchIt =
+            std::ranges::find_if(output::detail::kFlatExrHeaderAttributesV1,
+                                 [&](const auto& entry) { return entry.name == name; });
+        if (matchIt == output::detail::kFlatExrHeaderAttributesV1.end()) {
+            return ::diag(FlatExrVerifyErrorCodeV1::UnexpectedAttribute, std::string(name));
+        }
+        const auto index = static_cast<std::size_t>(
+            std::distance(output::detail::kFlatExrHeaderAttributesV1.begin(), matchIt));
+        seen[index] = true;
+        const std::string_view typeName = it.attribute().typeName();
+        if (typeName != matchIt->openExrTypeName) {
+            return ::diag(FlatExrVerifyErrorCodeV1::AttributeTypeMismatch, std::string(name));
+        }
+    }
+    for (std::size_t index = 0; index < seen.size(); ++index) {
+        if (!seen[index]) {
+            return ::diag(FlatExrVerifyErrorCodeV1::MissingAttribute,
+                          std::string(output::detail::kFlatExrHeaderAttributesV1[index].name));
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<output::FlatExrVerifyDiagnosticV1>
+checkAttributeValues(const Imf::Header& header, const Imath::Box2i& expectedDataWindow,
+                     const Imath::Box2i& expectedDisplayWindow,
+                     const std::uint32_t expectedPixelAspectBits) noexcept {
+    using output::FlatExrVerifyErrorCodeV1;
+    if (header.dataWindow() != expectedDataWindow) {
+        return ::diag(FlatExrVerifyErrorCodeV1::WindowMismatch, "dataWindow");
+    }
+    if (header.displayWindow() != expectedDisplayWindow) {
+        return ::diag(FlatExrVerifyErrorCodeV1::WindowMismatch, "displayWindow");
+    }
+    if (header.lineOrder() != Imf::INCREASING_Y) {
+        return ::diag(FlatExrVerifyErrorCodeV1::AttributeValueMismatch, "lineOrder");
+    }
+    if (header.compression() != Imf::ZIP_COMPRESSION) {
+        return ::diag(FlatExrVerifyErrorCodeV1::AttributeValueMismatch, "compression");
+    }
+    if (std::bit_cast<std::uint32_t>(header.pixelAspectRatio()) != expectedPixelAspectBits) {
+        return ::diag(FlatExrVerifyErrorCodeV1::PixelAspectMismatch, "pixelAspectRatio");
+    }
+    const auto& center = header.screenWindowCenter();
+    if (std::bit_cast<std::uint32_t>(center.x) != 0U ||
+        std::bit_cast<std::uint32_t>(center.y) != 0U) {
+        return ::diag(FlatExrVerifyErrorCodeV1::AttributeValueMismatch, "screenWindowCenter");
+    }
+    if (std::bit_cast<std::uint32_t>(header.screenWindowWidth()) != 0x3F800000U) {
+        return ::diag(FlatExrVerifyErrorCodeV1::AttributeValueMismatch, "screenWindowWidth");
+    }
+    if (!Imf::hasChromaticities(header)) {
+        return ::diag(FlatExrVerifyErrorCodeV1::MissingAttribute, "chromaticities");
+    }
+    const auto& chroma = Imf::chromaticities(header);
+    const std::array<std::uint32_t, 8> chromaBits{
+        std::bit_cast<std::uint32_t>(chroma.red.x),   std::bit_cast<std::uint32_t>(chroma.red.y),
+        std::bit_cast<std::uint32_t>(chroma.green.x), std::bit_cast<std::uint32_t>(chroma.green.y),
+        std::bit_cast<std::uint32_t>(chroma.blue.x),  std::bit_cast<std::uint32_t>(chroma.blue.y),
+        std::bit_cast<std::uint32_t>(chroma.white.x), std::bit_cast<std::uint32_t>(chroma.white.y),
+    };
+    if (chromaBits != output::kFlatExrRec709D65ChromaticitiesBitsV1) {
+        return ::diag(FlatExrVerifyErrorCodeV1::AttributeValueMismatch, "chromaticities");
+    }
+    const auto* colorInteropId = header.findTypedAttribute<Imf::StringAttribute>("colorInteropID");
+    if (colorInteropId == nullptr ||
+        std::string_view(colorInteropId->value()) != output::detail::kFlatExrColorInteropIdV1) {
+        return ::diag(FlatExrVerifyErrorCodeV1::AttributeValueMismatch, "colorInteropID");
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<output::FlatExrVerifyDiagnosticV1>
+checkChannelList(const Imf::Header& header) noexcept {
+    using output::FlatExrVerifyErrorCodeV1;
+    const auto& channels = header.channels();
+    std::size_t index = 0;
+    for (auto it = channels.begin(); it != channels.end(); ++it, ++index) {
+        if (index >= output::detail::kFlatExrChannelNamesLexicalV1.size() ||
+            std::string_view(it.name()) != output::detail::kFlatExrChannelNamesLexicalV1[index]) {
+            return ::diag(FlatExrVerifyErrorCodeV1::InvalidChannelList, "channels");
+        }
+        const auto& channel = it.channel();
+        if (channel.type != Imf::FLOAT || channel.xSampling != 1 || channel.ySampling != 1 ||
+            channel.pLinear) {
+            return ::diag(FlatExrVerifyErrorCodeV1::InvalidChannelList, "channels");
+        }
+    }
+    if (index != output::detail::kFlatExrChannelNamesLexicalV1.size()) {
+        return ::diag(FlatExrVerifyErrorCodeV1::InvalidChannelList, "channels");
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+namespace bloom::output::detail {
+
+// The friend seam `output_semantic_identity.hpp` forward-declares
+// (`friend class detail::FlatExrRgba32fLinRec709SceneSemanticPayloadVerifierV1;`) for exactly one
+// purpose: only this reopen verifier -- never the writer, never a test -- may construct a
+// `FlatExrRgba32fLinRec709SceneVerifiedSemanticProductV1` from decoded reopened values.
+class FlatExrRgba32fLinRec709SceneSemanticPayloadVerifierV1 final {
+  public:
+    [[nodiscard]] static FlatExrRgba32fLinRec709SceneVerifiedSemanticProductV1 buildVerifiedProduct(
+        const std::shared_ptr<const FlatExrRgba32fLinRec709SceneBoundOutputAnalysisV1>&
+            boundAnalysis,
+        const FlatExrRgba32fSemanticMetadataV1 metadata,
+        std::vector<std::uint32_t>&& componentBits) {
+        return FlatExrRgba32fLinRec709SceneVerifiedSemanticProductV1(boundAnalysis, metadata,
+                                                                     std::move(componentBits));
+    }
+};
+
+} // namespace bloom::output::detail
+
+namespace bloom::output {
+
+FlatExrVerifyResultV1::FlatExrVerifyResultV1(const FlatExrVerifyStatusV1 status,
+                                             const core::Sha256Digest digest,
+                                             FlatExrVerifyDiagnosticV1 diagnostic) noexcept
+    : status_(status), digest_(digest), diagnostic_(std::move(diagnostic)) {}
+
+FlatExrVerifyResultV1 FlatExrVerifyResultV1::verified(const core::Sha256Digest digest) noexcept {
+    return {FlatExrVerifyStatusV1::Verified, digest, {}};
+}
+
+FlatExrVerifyResultV1 FlatExrVerifyResultV1::cancelled() noexcept {
+    return {FlatExrVerifyStatusV1::Cancelled, {}, {}};
+}
+
+FlatExrVerifyResultV1 FlatExrVerifyResultV1::failed(FlatExrVerifyDiagnosticV1 diagnostic) noexcept {
+    if (diagnostic.code == FlatExrVerifyErrorCodeV1::None) {
+        diagnostic.code = FlatExrVerifyErrorCodeV1::InternalInvariant;
+    }
+    return {FlatExrVerifyStatusV1::Failed, {}, std::move(diagnostic)};
+}
+
+FlatExrVerifyResultV1 FlatExrRgba32fLinRec709SceneReopenVerifierV1::verify(
+    const std::filesystem::path& stagedPath,
+    const std::shared_ptr<const ProcessFrameSemanticIdentityV1>& processIdentity,
+    const std::shared_ptr<const OutputAnalysisReportV1>& report,
+    const runtime::CancellationToken& cancellation,
+    const FlatExrVerifyScanProgressCallbackV1& scanProgress) const noexcept {
+    if (processIdentity == nullptr || report == nullptr) {
+        return FlatExrVerifyResultV1::failed(
+            ::diag(FlatExrVerifyErrorCodeV1::IdentityIssuanceFailed));
+    }
+    // Binding recomputes the OutputAnalysisDigest from processIdentity/report -- the same
+    // module-private seam the pre-approval analysis pipeline already uses -- and retains both
+    // exact products so a later identity cannot be paired with substitute inputs.
+    auto bound = bindFlatExrRgba32fLinRec709SceneOutputAnalysisV1(processIdentity, report);
+    if (bound.analysis() == nullptr) {
+        return FlatExrVerifyResultV1::failed(
+            ::diag(FlatExrVerifyErrorCodeV1::IdentityIssuanceFailed));
+    }
+    const auto& boundAnalysis = bound.analysis();
+    const auto& frame = processIdentity->processFrame();
+    if (frame == nullptr || !frame->processImage().isValid()) {
+        return FlatExrVerifyResultV1::failed(::diag(FlatExrVerifyErrorCodeV1::InternalInvariant));
+    }
+    const auto* descriptor = frame->processImage().descriptor();
+    if (descriptor == nullptr) {
+        return FlatExrVerifyResultV1::failed(::diag(FlatExrVerifyErrorCodeV1::InternalInvariant));
+    }
+    if (cancellation.isCancellationRequested()) {
+        return FlatExrVerifyResultV1::cancelled();
+    }
+
+    const auto versionCheck = ::checkVersionField(stagedPath);
+    if (!versionCheck.ok) {
+        return FlatExrVerifyResultV1::failed(::diag(versionCheck.error));
+    }
+
+    try {
+        Imf::InputFile input(stagedPath.string().c_str());
+        const auto& header = input.header();
+
+        if (const auto allowlistDiag = ::checkAttributeAllowlist(header)) {
+            return FlatExrVerifyResultV1::failed(*allowlistDiag);
+        }
+
+        const auto expectedDataBox = ::inclusiveBox(descriptor->dataWindow());
+        const auto expectedDisplayBox = ::inclusiveBox(descriptor->displayWindow());
+        if (!expectedDataBox || !expectedDisplayBox) {
+            return FlatExrVerifyResultV1::failed(
+                ::diag(FlatExrVerifyErrorCodeV1::InternalInvariant));
+        }
+        const auto pixelAspect = descriptor->pixelAspect();
+        const auto expectedRounded =
+            output::detail::roundOutputAnalysisPositiveRationalToBinary32V1(
+                {.numerator = pixelAspect.numerator(), .denominator = pixelAspect.denominator()});
+        if (!expectedRounded) {
+            return FlatExrVerifyResultV1::failed(
+                ::diag(FlatExrVerifyErrorCodeV1::InternalInvariant));
+        }
+        if (const auto valueDiag = ::checkAttributeValues(
+                header, *expectedDataBox, *expectedDisplayBox, expectedRounded->bits)) {
+            return FlatExrVerifyResultV1::failed(*valueDiag);
+        }
+        if (const auto channelDiag = ::checkChannelList(header)) {
+            return FlatExrVerifyResultV1::failed(*channelDiag);
+        }
+        if (cancellation.isCancellationRequested()) {
+            return FlatExrVerifyResultV1::cancelled();
+        }
+
+        const auto dataBox = header.dataWindow();
+        const auto width = static_cast<std::uint64_t>(static_cast<std::int64_t>(dataBox.max.x) -
+                                                      static_cast<std::int64_t>(dataBox.min.x) + 1);
+        const auto heightRows =
+            static_cast<std::uint64_t>(static_cast<std::int64_t>(dataBox.max.y) -
+                                       static_cast<std::int64_t>(dataBox.min.y) + 1);
+        if (width > kOutputAnalysisMaximumDimensionV1 ||
+            heightRows > kOutputAnalysisMaximumDimensionV1) {
+            return FlatExrVerifyResultV1::failed(
+                ::diag(FlatExrVerifyErrorCodeV1::ResourceLimitExceeded));
+        }
+        const auto pixelCount = ::multiplyChecked(width, heightRows);
+        const auto componentCount = pixelCount ? ::multiplyChecked(*pixelCount, 4U) : std::nullopt;
+        const auto byteCount = componentCount
+                                   ? ::multiplyChecked(*componentCount, sizeof(std::uint32_t))
+                                   : std::nullopt;
+        if (!pixelCount || *pixelCount > kOutputAnalysisMaximumPixelCountV1 || !componentCount ||
+            !byteCount || *byteCount > kOutputAnalysisMaximumProcessPixelBytesV1) {
+            return FlatExrVerifyResultV1::failed(
+                ::diag(FlatExrVerifyErrorCodeV1::ResourceLimitExceeded));
+        }
+
+        std::vector<std::uint32_t> componentBits;
+        try {
+            componentBits.resize(*componentCount);
+        } catch (const std::bad_alloc&) {
+            return FlatExrVerifyResultV1::failed(
+                ::diag(FlatExrVerifyErrorCodeV1::AllocationFailure));
+        } catch (const std::length_error&) {
+            return FlatExrVerifyResultV1::failed(
+                ::diag(FlatExrVerifyErrorCodeV1::AllocationFailure));
+        }
+
+        auto* bitsBase = reinterpret_cast<char*>(componentBits.data());
+        constexpr std::size_t xStride = 4U * sizeof(std::uint32_t);
+        const auto rowStrideBytes = xStride * static_cast<std::size_t>(width);
+        Imf::FrameBuffer frameBuffer;
+        frameBuffer.insert("R", Imf::Slice::Make(Imf::FLOAT, bitsBase + 0 * sizeof(std::uint32_t),
+                                                 dataBox, xStride, rowStrideBytes));
+        frameBuffer.insert("G", Imf::Slice::Make(Imf::FLOAT, bitsBase + 1 * sizeof(std::uint32_t),
+                                                 dataBox, xStride, rowStrideBytes));
+        frameBuffer.insert("B", Imf::Slice::Make(Imf::FLOAT, bitsBase + 2 * sizeof(std::uint32_t),
+                                                 dataBox, xStride, rowStrideBytes));
+        frameBuffer.insert("A", Imf::Slice::Make(Imf::FLOAT, bitsBase + 3 * sizeof(std::uint32_t),
+                                                 dataBox, xStride, rowStrideBytes));
+        input.setFrameBuffer(frameBuffer);
+
+        const auto rowsPerChunk = static_cast<std::int64_t>(
+            std::max<std::size_t>(1, kOutputAdapterMaximumStreamingChunkBytesV1 /
+                                         std::max<std::size_t>(rowStrideBytes, 1)));
+        const auto sourcePixels = frame->processImage().pixels();
+        const auto sourceOriginY = descriptor->dataWindow().originY();
+        std::int64_t y = dataBox.min.y;
+        std::uint64_t completedScanlines = 0;
+        ::reportScanProgress(scanProgress, {completedScanlines, heightRows});
+        while (y <= static_cast<std::int64_t>(dataBox.max.y)) {
+            if (cancellation.isCancellationRequested()) {
+                return FlatExrVerifyResultV1::cancelled();
+            }
+            const auto chunkEnd = std::min<std::int64_t>(y + rowsPerChunk - 1, dataBox.max.y);
+            try {
+                input.readPixels(static_cast<int>(y), static_cast<int>(chunkEnd));
+            } catch (...) {
+                return FlatExrVerifyResultV1::failed(
+                    ::diag(FlatExrVerifyErrorCodeV1::ScanlineReadFailed, {}, y));
+            }
+            for (auto rowY = y; rowY <= chunkEnd; ++rowY) {
+                const auto sourceRowOffset = static_cast<std::size_t>(rowY - sourceOriginY) *
+                                             static_cast<std::size_t>(width);
+                const auto destRowOffset = static_cast<std::size_t>(rowY - dataBox.min.y) *
+                                           static_cast<std::size_t>(width);
+                for (std::uint64_t x = 0; x < width; ++x) {
+                    const auto& sourcePixel =
+                        sourcePixels[sourceRowOffset + static_cast<std::size_t>(x)];
+                    const std::array<std::uint32_t, 4> expectedBits{
+                        std::bit_cast<std::uint32_t>(sourcePixel.red()),
+                        std::bit_cast<std::uint32_t>(sourcePixel.green()),
+                        std::bit_cast<std::uint32_t>(sourcePixel.blue()),
+                        std::bit_cast<std::uint32_t>(sourcePixel.alpha()),
+                    };
+                    const auto pixelIndex = destRowOffset + static_cast<std::size_t>(x);
+                    for (std::uint8_t channel = 0; channel < 4U; ++channel) {
+                        if (componentBits[pixelIndex * 4U + channel] != expectedBits[channel]) {
+                            return FlatExrVerifyResultV1::failed(::diag(
+                                FlatExrVerifyErrorCodeV1::SampleMismatch, {}, rowY, channel));
+                        }
+                    }
+                }
+            }
+            completedScanlines += static_cast<std::uint64_t>(chunkEnd - y + 1);
+            ::reportScanProgress(scanProgress, {completedScanlines, heightRows});
+            y = chunkEnd + 1;
+        }
+
+        const FlatExrRgba32fSemanticMetadataV1 metadata{
+            .dataWindow = {static_cast<std::int32_t>(dataBox.min.x),
+                           static_cast<std::int32_t>(dataBox.min.y),
+                           static_cast<std::int32_t>(dataBox.max.x),
+                           static_cast<std::int32_t>(dataBox.max.y)},
+            .displayWindow = {static_cast<std::int32_t>(header.displayWindow().min.x),
+                              static_cast<std::int32_t>(header.displayWindow().min.y),
+                              static_cast<std::int32_t>(header.displayWindow().max.x),
+                              static_cast<std::int32_t>(header.displayWindow().max.y)},
+            .pixelAspectRatioBits = std::bit_cast<std::uint32_t>(header.pixelAspectRatio()),
+        };
+
+        auto verifiedProduct =
+            detail::FlatExrRgba32fLinRec709SceneSemanticPayloadVerifierV1::buildVerifiedProduct(
+                boundAnalysis, metadata, std::move(componentBits));
+
+        const OutputSemanticIdentityV1Preparer identityPreparer;
+        const auto issuance = identityPreparer.prepareFlatExrRgba32fLinRec709SceneV1(
+            FlatExrRgba32fLinRec709SceneOutputSemanticIdentityInputV1{std::move(verifiedProduct)},
+            cancellation);
+
+        switch (issuance.status()) {
+        case OutputSemanticIdentityPreparationStatusV1::Prepared:
+            if (issuance.identity() == nullptr) {
+                return FlatExrVerifyResultV1::failed(
+                    ::diag(FlatExrVerifyErrorCodeV1::InternalInvariant));
+            }
+            return FlatExrVerifyResultV1::verified(issuance.identity()->digest());
+        case OutputSemanticIdentityPreparationStatusV1::Cancelled:
+            return FlatExrVerifyResultV1::cancelled();
+        case OutputSemanticIdentityPreparationStatusV1::Failed:
+        default:
+            return FlatExrVerifyResultV1::failed(
+                ::diag(FlatExrVerifyErrorCodeV1::IdentityIssuanceFailed));
+        }
+    } catch (const std::bad_alloc&) {
+        return FlatExrVerifyResultV1::failed(::diag(FlatExrVerifyErrorCodeV1::AllocationFailure));
+    } catch (const std::exception&) {
+        return FlatExrVerifyResultV1::failed(::diag(FlatExrVerifyErrorCodeV1::HeaderParseFailed));
+    } catch (...) {
+        return FlatExrVerifyResultV1::failed(::diag(FlatExrVerifyErrorCodeV1::InternalInvariant));
+    }
+}
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/flat_exr_output_adapter.hpp
+++ b/src/output/include/bloom/output/flat_exr_output_adapter.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <bloom/runtime/cancellation.hpp>
+#include <bloom/runtime/evaluation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+
+namespace bloom::output {
+
+// Reported between bounded scanline chunks (never more finely) so a caller can observe monotonic
+// write progress and, in tests, deterministically synchronize a mid-write cancellation instead of
+// racing a background thread against an unobserved internal loop.
+struct FlatExrWriteProgressV1 final {
+    std::uint64_t completedScanlines = 0;
+    std::uint64_t totalScanlines = 0;
+
+    friend bool operator==(const FlatExrWriteProgressV1&,
+                           const FlatExrWriteProgressV1&) noexcept = default;
+};
+
+using FlatExrWriteProgressCallbackV1 = std::function<void(const FlatExrWriteProgressV1&)>;
+
+enum class FlatExrWriteStatusV1 : std::uint8_t {
+    Written,
+    Cancelled,
+    Failed,
+};
+
+// Version 1 has no partial-success outcome: a Failed or Cancelled result never leaves a usable
+// artifact at `destination`, and the writer performs its own best-effort cleanup of any partial
+// bytes it created (see `FlatExrWriteResultV1::destinationRemoved`). This adapter does not
+// implement the exclusive staging, atomic replace, or durability contract owned by the future
+// `StagedArtifactCoordinator` (docs/architecture/frame-output.md, "Atomic Publication") -- it only
+// writes to the caller-supplied destination path, which that future coordinator-owned staging
+// file is expected to be.
+enum class FlatExrWriteErrorCodeV1 : std::uint8_t {
+    None,
+    // The process data or display window does not fit the checked OpenEXR signed-32 inclusive
+    // coordinate domain.
+    WindowOutOfRange,
+    // The source pixel aspect rounds to a non-finite, non-positive, or otherwise unrepresentable
+    // binary32 value. (Unreachable through `core::PixelAspectRatio`'s own positive-uint32
+    // invariant in practice; guarded anyway as the declared checked conversion boundary.)
+    InvalidPixelAspectRatio,
+    // Dimensions or pixel/byte counts exceed `output_limits.hpp`'s closed version 1 ceilings.
+    ResourceLimitExceeded,
+    // The destination file could not be created/opened for writing.
+    DestinationUnavailable,
+    // A filesystem or encoder error occurred while streaming scanlines.
+    IoFailure,
+    AllocationFailure,
+    InternalInvariant,
+};
+
+class [[nodiscard]] FlatExrWriteResultV1 final {
+  public:
+    [[nodiscard]] static FlatExrWriteResultV1 written() noexcept;
+    [[nodiscard]] static FlatExrWriteResultV1 cancelled(bool destinationRemoved) noexcept;
+    [[nodiscard]] static FlatExrWriteResultV1 failed(FlatExrWriteErrorCodeV1 error,
+                                                     bool destinationRemoved) noexcept;
+
+    [[nodiscard]] FlatExrWriteStatusV1 status() const noexcept { return status_; }
+    [[nodiscard]] FlatExrWriteErrorCodeV1 error() const noexcept { return error_; }
+    // True when, after a non-Written outcome, the writer's own best-effort cleanup confirmed the
+    // destination path holds no partial artifact (either it removed one or none was ever
+    // created). False means a partial file may remain and the caller must not treat the path as
+    // clean. Always true when status() is Written (there is nothing to remove).
+    [[nodiscard]] bool destinationRemoved() const noexcept { return destinationRemoved_; }
+
+  private:
+    FlatExrWriteResultV1(FlatExrWriteStatusV1 status, FlatExrWriteErrorCodeV1 error,
+                         bool destinationRemoved) noexcept;
+
+    FlatExrWriteStatusV1 status_ = FlatExrWriteStatusV1::Failed;
+    FlatExrWriteErrorCodeV1 error_ = FlatExrWriteErrorCodeV1::InternalInvariant;
+    bool destinationRemoved_ = true;
+};
+
+// Writes `frame`'s retained process image as a version 1 flat OpenEXR
+// (`FlatExrRgba32fLinRec709SceneV1`, docs/architecture/frame-output.md) to `destination`.
+//
+// Consumes an immutable `ProcessFrame` view and the preset's own fixed parameters; there is no
+// caller-supplied preset configuration. Premultiplied Float32 RGBA samples are bit-copied with no
+// numeric, color, alpha, or precision conversion. Scanlines are written in increasing-Y order,
+// incrementally, with cancellation checked between bounded chunks
+// (`kOutputAdapterMaximumStreamingChunkBytesV1`). No OpenEXR/Imath type, enum, pointer, or
+// exception appears in this public header; the real writer lives in a private translation unit
+// (same boundary discipline as `bloom_color_ocio`).
+class FlatExrRgba32fLinRec709SceneWriterV1 final {
+  public:
+    [[nodiscard]] FlatExrWriteResultV1
+    write(const runtime::ProcessFrame& frame, const std::filesystem::path& destination,
+          const runtime::CancellationToken& cancellation,
+          const FlatExrWriteProgressCallbackV1& progress = {}) const noexcept;
+};
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/flat_exr_reopen_verifier.hpp
+++ b/src/output/include/bloom/output/flat_exr_reopen_verifier.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <bloom/core/sha256.hpp>
+#include <bloom/output/output_analysis.hpp>
+#include <bloom/output/process_frame_semantic_identity.hpp>
+#include <bloom/runtime/cancellation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace bloom::output {
+
+// Reported between bounded scanline-comparison chunks during header/channel/scanline
+// verification. Lets a caller observe monotonic verify progress and, in tests, deterministically
+// synchronize a mid-verify cancellation instead of racing a background thread against an
+// unobserved internal loop.
+struct FlatExrVerifyScanProgressV1 final {
+    std::uint64_t completedScanlines = 0;
+    std::uint64_t totalScanlines = 0;
+
+    friend bool operator==(const FlatExrVerifyScanProgressV1&,
+                           const FlatExrVerifyScanProgressV1&) noexcept = default;
+};
+
+using FlatExrVerifyScanProgressCallbackV1 = std::function<void(const FlatExrVerifyScanProgressV1&)>;
+
+enum class FlatExrVerifyStatusV1 : std::uint8_t {
+    Verified,
+    Cancelled,
+    Failed,
+};
+
+// Every code below is a typed diagnosis of a specific reopen-verification step, in the order
+// docs/architecture/frame-output.md's "Flat OpenEXR Preset Version 1" and "Determinism And
+// Portable Output Identity" sections require: version field, then the complete attribute
+// allowlist with exact types and values, then the channel list, then streamed scanline samples,
+// then (only once every prior check passes) kind-2 semantic-identity issuance.
+enum class FlatExrVerifyErrorCodeV1 : std::uint8_t {
+    None,
+    // The staged path could not be opened/read at all before header parsing began.
+    SourceUnavailable,
+    // Fewer than 8 bytes, or the magic number, is not the exact OpenEXR magic.
+    TruncatedFile,
+    // The magic number was correct but the version number was not 2 or a feature flag was set
+    // (tiled, long-names, non-image/deep, or multi-part).
+    InvalidVersionField,
+    // OpenEXR's own header/chunk parser rejected the file for a reason not already classified.
+    HeaderParseFailed,
+    // An attribute name outside the closed ten-entry allowlist is present.
+    UnexpectedAttribute,
+    // A required attribute from the closed ten-entry allowlist is absent.
+    MissingAttribute,
+    // A required attribute is present under the right name but the wrong OpenEXR type.
+    AttributeTypeMismatch,
+    // A required attribute has the right name and type but the wrong exact value.
+    AttributeValueMismatch,
+    // The channel list is not exactly A, B, G, R FLOAT 1x1 pLinear=0 in that lexical order.
+    InvalidChannelList,
+    // The decoded data or display window does not exactly equal the source frame's window.
+    WindowMismatch,
+    // The decoded pixelAspectRatio bits do not equal the source's rounded binary32.
+    PixelAspectMismatch,
+    // A decoded channel sample's Float32 bits differ from the source frame's bits.
+    SampleMismatch,
+    // Scanline decoding failed partway through (short read, corrupt compressed chunk).
+    ScanlineReadFailed,
+    ResourceLimitExceeded,
+    // Header/channel/scanline verification passed, but binding or issuing the kind-2
+    // `OutputSemanticIdentity` from the decoded values failed -- an input-construction problem
+    // (e.g. a null/mismatched `processIdentity`/`report`) rather than a file-content defect.
+    IdentityIssuanceFailed,
+    AllocationFailure,
+    InternalInvariant,
+};
+
+// Names the exact location of a Failed diagnosis. Fields are populated only for the codes that
+// name a location; an unused field stays at its default.
+struct FlatExrVerifyDiagnosticV1 final {
+    FlatExrVerifyErrorCodeV1 code = FlatExrVerifyErrorCodeV1::None;
+    std::string attributeName;
+    std::optional<std::int64_t> scanlineY;
+    std::optional<std::uint8_t> channelIndex; // 0 = R, 1 = G, 2 = B, 3 = A
+
+    friend bool operator==(const FlatExrVerifyDiagnosticV1&,
+                           const FlatExrVerifyDiagnosticV1&) = default;
+};
+
+// `OutputSemanticIdentityV1` itself is module-private (docs/architecture/frame-output.md: "the
+// module-private Output Semantic Identity version 1 streaming serializer/preparer"), so this
+// public result surfaces only the one thing design decision 5 asks for: the resulting digest.
+class [[nodiscard]] FlatExrVerifyResultV1 final {
+  public:
+    [[nodiscard]] static FlatExrVerifyResultV1 verified(core::Sha256Digest digest) noexcept;
+    [[nodiscard]] static FlatExrVerifyResultV1 cancelled() noexcept;
+    [[nodiscard]] static FlatExrVerifyResultV1
+    failed(FlatExrVerifyDiagnosticV1 diagnostic) noexcept;
+
+    [[nodiscard]] FlatExrVerifyStatusV1 status() const noexcept { return status_; }
+    // Valid only when status() is Verified.
+    [[nodiscard]] const core::Sha256Digest& digest() const& noexcept { return digest_; }
+    [[nodiscard]] const core::Sha256Digest& digest() const&& = delete;
+    [[nodiscard]] const FlatExrVerifyDiagnosticV1& diagnostic() const& noexcept {
+        return diagnostic_;
+    }
+    [[nodiscard]] const FlatExrVerifyDiagnosticV1& diagnostic() const&& = delete;
+
+  private:
+    FlatExrVerifyResultV1(FlatExrVerifyStatusV1 status, core::Sha256Digest digest,
+                          FlatExrVerifyDiagnosticV1 diagnostic) noexcept;
+
+    FlatExrVerifyStatusV1 status_ = FlatExrVerifyStatusV1::Failed;
+    core::Sha256Digest digest_{};
+    FlatExrVerifyDiagnosticV1 diagnostic_{};
+};
+
+// Reopens `stagedPath` (a path/handle a future publication slice will own), proves the closed
+// version 1 header/channel/scanline contract against `processIdentity`'s exact retained source
+// frame, and -- only when every check passes -- feeds the DECODED reopened values (not the
+// writer's inputs) into the existing kind-2 output-semantic-identity serializer, binding them
+// through the same module-private seam the pre-approval analysis pipeline already produces
+// `processIdentity`/`report` for (`bloom::output::analyzeFlatExrRgba32fLinRec709SceneV1`), and
+// surfacing the resulting digest as this result's `digest()`. A Failed or Cancelled result never
+// surfaces a digest. Bounded memory (scanline-chunked reads), cancellation-checked between
+// chunks. No OpenEXR/Imath type appears in this public header.
+class FlatExrRgba32fLinRec709SceneReopenVerifierV1 final {
+  public:
+    [[nodiscard]] FlatExrVerifyResultV1
+    verify(const std::filesystem::path& stagedPath,
+           const std::shared_ptr<const ProcessFrameSemanticIdentityV1>& processIdentity,
+           const std::shared_ptr<const OutputAnalysisReportV1>& report,
+           const runtime::CancellationToken& cancellation,
+           const FlatExrVerifyScanProgressCallbackV1& scanProgress = {}) const noexcept;
+};
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/output_limits.hpp
+++ b/src/output/include/bloom/output/output_limits.hpp
@@ -11,4 +11,11 @@ inline constexpr std::uint64_t kOutputAnalysisMaximumPixelCountV1 = 67'108'864U;
 inline constexpr std::size_t kOutputAnalysisMaximumProcessPixelBytesV1 = 1'073'741'824U;
 inline constexpr std::size_t kOutputAnalysisDigestMaximumPreimageBytesV1 = 4'194'304U;
 
+// frame-output.md's "Version 1 export limits" table names "one encoder or verifier streaming
+// chunk" at 16 MiB but no adapter existed yet to materialize it as a bound. The flat OpenEXR
+// writer/verifier (issue #99) is the first consumer: it caps how many scanlines it touches per
+// write/read call so cancellation is checked at a bounded cadence instead of in one blocking call
+// spanning the whole image.
+inline constexpr std::size_t kOutputAdapterMaximumStreamingChunkBytesV1 = 16'777'216U;
+
 } // namespace bloom::output

--- a/src/output/tests/flat_exr_output_adapter_tests.cpp
+++ b/src/output/tests/flat_exr_output_adapter_tests.cpp
@@ -1,0 +1,310 @@
+// Tests for FlatExrRgba32fLinRec709SceneWriterV1 (issue #99): header conformance (independently
+// decoded), conversion edges (signed-32 window bounds, pixel-aspect rounding), and cancellation
+// mid-write. Round-trip and adversarial reopen-verification tests live in
+// flat_exr_reopen_verifier_tests.cpp -- they need both the writer and the verifier together.
+
+#include "flat_exr_preset_contract.hpp"
+#include "flat_exr_test_support.hpp"
+#include "output_analysis_numeric.hpp"
+// Module-private (see flat_exr_output_adapter.cpp's comment); this test target gets
+// src/output/ on its include path via CMakeLists.txt for exactly this quoted include, only to
+// read the frozen kFlatExrRec709D65ChromaticitiesBitsV1 constant for independent-decode
+// comparison -- it never uses this header's writer/verifier seam types.
+#include "output_semantic_identity.hpp"
+
+#include <bloom/output/flat_exr_output_adapter.hpp>
+#include <bloom/output/output_analysis.hpp>
+#include <bloom/output/output_analysis_analyzer.hpp>
+#include <bloom/output/output_facet_descriptor.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+// Independent decode for header conformance: a real client reading this writer's output, distinct
+// from the reopen verifier under test elsewhere. OpenEXR/Imath types are confined to this test
+// translation unit, same boundary as the production adapter.
+#include <ImfChannelList.h>
+#include <ImfChromaticities.h>
+#include <ImfChromaticitiesAttribute.h>
+#include <ImfHeader.h>
+#include <ImfInputFile.h>
+#include <ImfStandardAttributes.h>
+#include <ImfStringAttribute.h>
+
+#include <array>
+#include <bit>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <thread>
+
+namespace {
+
+using namespace std::chrono_literals;
+namespace core = bloom::core;
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+namespace support = bloom_output_flat_exr_test_support;
+
+void testHeaderConformance(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("header-conformance");
+    const auto destination = scratch.file("conformance.exr");
+    auto frame = support::publish(support::roundTripFixture());
+
+    const output::FlatExrRgba32fLinRec709SceneWriterV1 writer;
+    const auto written = writer.write(*frame, destination, {});
+    expectations.expect(written.status() == output::FlatExrWriteStatusV1::Written,
+                        "a valid fixture writes successfully");
+
+    Imf::InputFile input(destination.string().c_str());
+    const auto& header = input.header();
+
+    std::set<std::string> names;
+    for (auto it = header.begin(); it != header.end(); ++it) {
+        names.insert(it.name());
+    }
+    const std::set<std::string> expected{
+        "channels",       "compression",      "dataWindow",         "displayWindow",
+        "lineOrder",      "pixelAspectRatio", "screenWindowCenter", "screenWindowWidth",
+        "chromaticities", "colorInteropID"};
+    expectations.expect(names == expected,
+                        "the written header carries exactly the closed ten-attribute allowlist, "
+                        "no more and no fewer");
+
+    const auto& channels = header.channels();
+    std::vector<std::string> channelOrder;
+    for (auto it = channels.begin(); it != channels.end(); ++it) {
+        channelOrder.emplace_back(it.name());
+        expectations.expect(it.channel().type == Imf::FLOAT && it.channel().xSampling == 1 &&
+                                it.channel().ySampling == 1 && !it.channel().pLinear,
+                            "each channel is FLOAT 1x1 pLinear=0");
+    }
+    expectations.expect(channelOrder == std::vector<std::string>({"A", "B", "G", "R"}),
+                        "channels are physically ordered A, B, G, R");
+
+    expectations.expect(header.compression() == Imf::ZIP_COMPRESSION,
+                        "compression is exactly ZIP_COMPRESSION");
+    expectations.expect(header.lineOrder() == Imf::INCREASING_Y, "line order is INCREASING_Y");
+    expectations.expect(std::bit_cast<std::uint32_t>(header.screenWindowCenter().x) == 0U &&
+                            std::bit_cast<std::uint32_t>(header.screenWindowCenter().y) == 0U,
+                        "screenWindowCenter is exactly positive-zero bits");
+    expectations.expect(std::bit_cast<std::uint32_t>(header.screenWindowWidth()) == 0x3F800000U,
+                        "screenWindowWidth is exactly 1.0f bits");
+    expectations.expect(Imf::hasChromaticities(header), "chromaticities attribute is present");
+    const auto& chroma = Imf::chromaticities(header);
+    const std::array<std::uint32_t, 8> chromaBits{
+        std::bit_cast<std::uint32_t>(chroma.red.x),   std::bit_cast<std::uint32_t>(chroma.red.y),
+        std::bit_cast<std::uint32_t>(chroma.green.x), std::bit_cast<std::uint32_t>(chroma.green.y),
+        std::bit_cast<std::uint32_t>(chroma.blue.x),  std::bit_cast<std::uint32_t>(chroma.blue.y),
+        std::bit_cast<std::uint32_t>(chroma.white.x), std::bit_cast<std::uint32_t>(chroma.white.y),
+    };
+    expectations.expect(chromaBits == output::kFlatExrRec709D65ChromaticitiesBitsV1,
+                        "chromaticities are the exact Rec.709/D65 bit patterns from the doc");
+    const auto* colorInteropId = header.findTypedAttribute<Imf::StringAttribute>("colorInteropID");
+    expectations.expect(colorInteropId != nullptr && colorInteropId->value() == "lin_rec709_scene",
+                        "colorInteropID is exactly the UTF-8 bytes lin_rec709_scene");
+
+    // Raw version-field bytes: version 2, all feature flags clear.
+    std::ifstream rawStream(destination, std::ios::binary);
+    std::array<unsigned char, 8> rawHeader{};
+    rawStream.read(reinterpret_cast<char*>(rawHeader.data()), 8);
+    const auto versionField = static_cast<std::uint32_t>(rawHeader[4]) |
+                              (static_cast<std::uint32_t>(rawHeader[5]) << 8U) |
+                              (static_cast<std::uint32_t>(rawHeader[6]) << 16U) |
+                              (static_cast<std::uint32_t>(rawHeader[7]) << 24U);
+    expectations.expect((versionField & 0xFFU) == 2U && (versionField & 0xFFFFFF00U) == 0U,
+                        "version field is 2 with every feature flag clear");
+}
+
+void testWindowBoundsAtSigned32Extremes(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("window-bounds");
+    const output::FlatExrRgba32fLinRec709SceneWriterV1 writer;
+
+    // "Signed-32 extremes" here means the writer's real, checked domain -- which is narrower than
+    // literal INT32_MIN/MAX. The qualified OpenEXR 3.4.15 library itself rejects a window whose
+    // coordinate magnitude reaches INT32_MAX/2 (confirmed both empirically and against the
+    // vendored OpenEXRCore source's `kLargeVal` check; see flat_exr_preset_contract.hpp's
+    // kFlatExrLibraryCoordinateCeilingV1 comment -- reported as a genuine contract/library
+    // discrepancy in the F1 task report, not silently narrowed without disclosure). Literal
+    // INT32_MAX itself throws "Invalid display window" from Imf::OutputFile, so the accepted
+    // extreme this test proves is the writer's actual documented ceiling.
+    const auto ceiling = output::detail::kFlatExrLibraryCoordinateCeilingV1;
+
+    // Accepted: a data window whose inclusive max lands exactly on the real ceiling minus one.
+    {
+        const auto pixelAspect = core::PixelAspectRatio::square();
+        const std::array pixels{render::Rgba32f::transparent(), render::Rgba32f::transparent()};
+        const auto dataWindow = render::ImageWindow::create(ceiling - 2, 0, 2, 1);
+        auto frame = support::publish(
+            {support::frameIdentity(support::shellPlan()),
+             support::image(*dataWindow.value(), *dataWindow.value(), pixelAspect, pixels)});
+        const auto result = writer.write(*frame, scratch.file("extreme-accepted.exr"), {});
+        expectations.expect(
+            result.status() == output::FlatExrWriteStatusV1::Written,
+            "a data window whose inclusive max is exactly the writer's real coordinate ceiling "
+            "minus one is accepted");
+    }
+
+    // Rejected: a data window one pixel past the real ceiling (still far inside literal int32).
+    {
+        const auto pixelAspect = core::PixelAspectRatio::square();
+        const std::array pixels{render::Rgba32f::transparent(), render::Rgba32f::transparent()};
+        const auto dataWindow = render::ImageWindow::create(ceiling - 1, 0, 2, 1);
+        auto frame = support::publish(
+            {support::frameIdentity(support::shellPlan()),
+             support::image(*dataWindow.value(), *dataWindow.value(), pixelAspect, pixels)});
+        const auto result = writer.write(*frame, scratch.file("extreme-rejected.exr"), {});
+        expectations.expect(
+            result.status() == output::FlatExrWriteStatusV1::Failed &&
+                result.error() == output::FlatExrWriteErrorCodeV1::WindowOutOfRange &&
+                result.destinationRemoved(),
+            "a data window one pixel past the writer's real ceiling is rejected before staging, "
+            "no partial file (even though it still fits literal signed-32)");
+    }
+}
+
+void testNonPositiveOrNanPixelAspectRejected(support::Expectations& expectations) {
+    // core::PixelAspectRatio's own invariant (positive uint32/uint32) makes a non-positive or NaN
+    // ratio unconstructible, so this exercises the writer's shared checked-conversion boundary
+    // directly: bloom::output::detail::roundOutputAnalysisPositiveRationalToBinary32V1, the exact
+    // function prepareGeometry() calls before staging.
+    using output::detail::roundOutputAnalysisPositiveRationalToBinary32V1;
+    expectations.expect(
+        !roundOutputAnalysisPositiveRationalToBinary32V1({.numerator = 0, .denominator = 4}),
+        "a zero numerator (non-positive ratio) is rejected");
+    expectations.expect(
+        !roundOutputAnalysisPositiveRationalToBinary32V1({.numerator = 4, .denominator = 0}),
+        "a zero denominator is rejected");
+}
+
+void testPixelAspectExactVersusApproximated(support::Expectations& expectations) {
+    // Composes with the already-implemented analyzer facet
+    // (bloom::output::analyzeFlatExrRgba32fLinRec709SceneV1,
+    // src/output/output_analysis_analyzer.cpp)
+    // -- this proves the writer's fixtures drive that existing facet consistently, not a
+    // reimplementation of the facet's own exhaustive edge coverage.
+    {
+        auto prepared = support::prepareSource(support::exactPixelAspectFixture()); // 2/1
+        bool foundExact = false;
+        for (const auto& facet : prepared.report->view().facets) {
+            if (facet.facet == output::OutputFacetIdV1::PixelAspect) {
+                foundExact = facet.state == output::OutputPreservationStateV1::Exact;
+            }
+        }
+        expectations.expect(foundExact, "2/1 pixel aspect rounds exactly through binary32");
+    }
+    {
+        auto prepared = support::prepareSource(support::roundTripFixture()); // 4/3
+        bool foundApproximated = false;
+        for (const auto& facet : prepared.report->view().facets) {
+            if (facet.facet == output::OutputFacetIdV1::PixelAspect) {
+                foundApproximated =
+                    facet.state == output::OutputPreservationStateV1::Approximated &&
+                    facet.stableCode == output::OutputFacetStableCodeV1::ExrParRoundedBinary32;
+            }
+        }
+        expectations.expect(foundApproximated,
+                            "4/3 pixel aspect is Approximated with exr.par-rounded-binary32, "
+                            "both values recorded in the facet descriptors");
+    }
+}
+
+void testCancellationMidWrite(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("cancel-mid-write");
+    const auto destination = scratch.file("cancelled.exr");
+
+    // A wide image so each scanline's byte cost is a meaningful fraction of the writer's 16 MiB
+    // streaming-chunk cap (kOutputAdapterMaximumStreamingChunkBytesV1); at the maximum permitted
+    // width (32768) a chunk is 32 rows, so kHeight below spans several chunks and
+    // writePixels() is called multiple times, giving a deterministic chunk boundary to block on.
+    constexpr std::uint32_t kWidth = 32'768;
+    constexpr std::uint32_t kHeight = 200;
+    std::vector<render::Rgba32f> pixels(std::size_t{kWidth} * kHeight,
+                                        render::Rgba32f::transparent());
+    auto frame = support::publish({support::frameIdentity(support::shellPlan()),
+                                   support::image(support::window(0, 0, kWidth, kHeight),
+                                                  support::window(0, 0, kWidth, kHeight),
+                                                  core::PixelAspectRatio::square(), pixels)});
+
+    runtime::TaskSchedulerConfig config = runtime::TaskSchedulerConfig::defaults();
+    config.cpuWorkerCount = 1;
+    config.blockingIoWorkerCount = 1;
+    runtime::TaskScheduler scheduler(config);
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool reachedRow = false;
+    bool released = false;
+    std::atomic_bool cancelled = false;
+    std::atomic_bool written = false;
+    const output::FlatExrRgba32fLinRec709SceneWriterV1 writer;
+
+    auto submission = scheduler.submit<void>(
+        runtime::TaskRequest(
+            "Flat EXR write cancellation",
+            {.kind = runtime::TaskOwnerKind::Composition, .id = runtime::TaskOwnerId::fromRaw(1)}),
+        [&](runtime::TaskContext& context) {
+            const auto result =
+                writer.write(*frame, destination, context.cancellation(),
+                             [&](const output::FlatExrWriteProgressV1& progress) {
+                                 if (progress.completedScanlines == 0) {
+                                     return;
+                                 }
+                                 std::unique_lock lock(mutex);
+                                 reachedRow = true;
+                                 condition.notify_all();
+                                 condition.wait(lock, [&released] { return released; });
+                             });
+            cancelled.store(result.status() == output::FlatExrWriteStatusV1::Cancelled,
+                            std::memory_order_release);
+            written.store(result.status() == output::FlatExrWriteStatusV1::Written,
+                          std::memory_order_release);
+            return result.status() == output::FlatExrWriteStatusV1::Cancelled
+                       ? runtime::TaskResult<void>::cancelled()
+                       : runtime::TaskResult<void>::succeeded();
+        });
+    {
+        std::unique_lock lock(mutex);
+        expectations.expect(submission.accepted() &&
+                                condition.wait_for(lock, 5s, [&reachedRow] { return reachedRow; }),
+                            "cancellation fixture reaches a deterministic chunk boundary");
+    }
+    submission.handle.cancel();
+    {
+        std::lock_guard lock(mutex);
+        released = true;
+        condition.notify_all();
+    }
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    std::optional<runtime::TaskResult<void>> taskResult;
+    while (!taskResult && std::chrono::steady_clock::now() < deadline) {
+        taskResult = submission.handle.tryTakeResult();
+        std::this_thread::yield();
+    }
+    expectations.expect(taskResult && taskResult->state() == runtime::TaskState::Cancelled &&
+                            cancelled.load(std::memory_order_acquire) &&
+                            !written.load(std::memory_order_acquire),
+                        "cancellation mid-write yields a typed Cancelled result, never Written");
+    expectations.expect(!std::filesystem::exists(destination),
+                        "cancellation mid-write leaves no partial staged file behind");
+    scheduler.beginShutdown();
+    while (!scheduler.isQuiescent() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    expectations.expect(scheduler.isQuiescent(), "cancellation fixture shuts down cleanly");
+}
+
+} // namespace
+
+int main() {
+    support::Expectations expectations;
+    testHeaderConformance(expectations);
+    testWindowBoundsAtSigned32Extremes(expectations);
+    testNonPositiveOrNanPixelAspectRejected(expectations);
+    testPixelAspectExactVersusApproximated(expectations);
+    testCancellationMidWrite(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/output/tests/flat_exr_reopen_verifier_tests.cpp
+++ b/src/output/tests/flat_exr_reopen_verifier_tests.cpp
@@ -1,0 +1,384 @@
+// Tests for FlatExrRgba32fLinRec709SceneReopenVerifierV1 (issue #99): round trip (write, verify,
+// issue identity; semantic determinism across two independent runs), adversarial byte-surgery
+// fixtures (each a typed failure naming the defect), and cancellation mid-verify.
+
+#include "flat_exr_test_support.hpp"
+
+#include <bloom/output/flat_exr_output_adapter.hpp>
+#include <bloom/output/flat_exr_reopen_verifier.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+// Adversarial fixture construction reopens/rewrites with the real library (see
+// writeSingleBitPerturbedVariant below) and ExrHeaderBytes does raw file I/O; neither exposes an
+// OpenEXR/Imath type through any bloom/output public header.
+#include <ImfFrameBuffer.h>
+#include <ImfHeader.h>
+#include <ImfInputFile.h>
+#include <ImfOutputFile.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+namespace core = bloom::core;
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+namespace support = bloom_output_flat_exr_test_support;
+
+struct WrittenFixture final {
+    support::PreparedSource source;
+    std::filesystem::path path;
+};
+
+[[nodiscard]] WrittenFixture writeValidFixture(const support::ScratchDirectory& scratch,
+                                               const std::string& fileName) {
+    auto source = support::prepareSource(support::roundTripFixture());
+    const auto path = scratch.file(fileName);
+    const output::FlatExrRgba32fLinRec709SceneWriterV1 writer;
+    const auto written = writer.write(*source.frame, path, {});
+    if (written.status() != output::FlatExrWriteStatusV1::Written) {
+        std::abort();
+    }
+    return {std::move(source), path};
+}
+
+void testRoundTrip(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("round-trip");
+    auto runA = writeValidFixture(scratch, "run-a.exr");
+    auto runB = writeValidFixture(scratch, "run-b.exr");
+
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto resultA =
+        verifier.verify(runA.path, runA.source.processIdentity, runA.source.report, {});
+    const auto resultB =
+        verifier.verify(runB.path, runB.source.processIdentity, runB.source.report, {});
+
+    expectations.expect(resultA.status() == output::FlatExrVerifyStatusV1::Verified,
+                        "an independent write+verify of a valid fixture is Verified");
+    expectations.expect(resultB.status() == output::FlatExrVerifyStatusV1::Verified,
+                        "a second independent write+verify of the same fixture is Verified");
+    expectations.expect(resultA.digest() == resultB.digest(),
+                        "the kind-2 semantic identity digest is stable across two independent "
+                        "write+verify runs (semantic determinism)");
+
+    const auto bytesA = std::filesystem::file_size(runA.path);
+    const auto bytesB = std::filesystem::file_size(runB.path);
+    if (bytesA == bytesB) {
+        std::ifstream streamA(runA.path, std::ios::binary);
+        std::ifstream streamB(runB.path, std::ios::binary);
+        const std::vector<char> contentA((std::istreambuf_iterator<char>(streamA)),
+                                         std::istreambuf_iterator<char>());
+        const std::vector<char> contentB((std::istreambuf_iterator<char>(streamB)),
+                                         std::istreambuf_iterator<char>());
+        if (contentA == contentB) {
+            // Note only, per the task: byte-identical artifacts across runs with the qualified
+            // zlib are test evidence of this build's determinism, not a claimed portable-preset
+            // contract (docs/architecture/frame-output.md, "Determinism And Portable Output
+            // Identity" -- "A qualified dependency profile may additionally assert byte-for-byte
+            // reproducibility ... That stronger profile-specific claim is test evidence, not part
+            // of portable preset semantics").
+            expectations.expect(
+                true, "note: artifact bytes were also byte-identical across two runs with this "
+                      "build's qualified zlib (not claimed as portable preset contract)");
+        }
+    }
+}
+
+void testHeaderConformanceRejectsForeignAttribute(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-foreign-attribute");
+    auto fixture = writeValidFixture(scratch, "base.exr");
+    const auto corruptPath = scratch.file("foreign-attribute.exr");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::ExrHeaderBytes bytes(corruptPath);
+    // A minimal well-formed int attribute record: name\0 type\0 size(=4, LE) value(4 bytes).
+    std::vector<unsigned char> record{'f', 'o', 'r', 'e', 'i', 'g', 'n', 0, 'i', 'n',
+                                      't', 0,   4,   0,   0,   0,   0,   0, 0,   0};
+    bytes.insertAttributeRecord(record);
+    bytes.save();
+
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(corruptPath, fixture.source.processIdentity, fixture.source.report, {});
+    expectations.expect(
+        result.status() == output::FlatExrVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::FlatExrVerifyErrorCodeV1::UnexpectedAttribute &&
+            result.diagnostic().attributeName == "foreign",
+        "an added foreign attribute is a typed failure naming it, no identity issued");
+}
+
+void testWrongCompressionEnum(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-compression");
+    auto fixture = writeValidFixture(scratch, "base.exr");
+    const auto corruptPath = scratch.file("wrong-compression.exr");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::ExrHeaderBytes bytes(corruptPath);
+    const auto [valueOffset, valueSize] = bytes.valueRange("compression");
+    expectations.expect(valueSize == 1, "the compression attribute is a single byte on disk");
+    bytes.patchByte(valueOffset, 0); // NO_COMPRESSION instead of ZIP_COMPRESSION
+    bytes.save();
+
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(corruptPath, fixture.source.processIdentity, fixture.source.report, {});
+    expectations.expect(
+        result.status() == output::FlatExrVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::FlatExrVerifyErrorCodeV1::AttributeValueMismatch &&
+            result.diagnostic().attributeName == "compression",
+        "a wrong compression enum is a typed failure naming the compression attribute");
+}
+
+void testRenamedChannel(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-channel");
+    auto fixture = writeValidFixture(scratch, "base.exr");
+    const auto corruptPath = scratch.file("renamed-channel.exr");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::ExrHeaderBytes bytes(corruptPath);
+    const auto [valueOffset, valueSize] = bytes.valueRange("channels");
+    bool patched = false;
+    for (std::size_t offset = valueOffset; offset + 1 < valueOffset + valueSize; ++offset) {
+        if (bytes.byteAt(offset) == 'R' && bytes.byteAt(offset + 1) == 0) {
+            bytes.patchByte(offset, 'X');
+            patched = true;
+            break;
+        }
+    }
+    if (!patched) {
+        std::abort();
+    }
+    bytes.save();
+
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(corruptPath, fixture.source.processIdentity, fixture.source.report, {});
+    expectations.expect(result.status() == output::FlatExrVerifyStatusV1::Failed &&
+                            result.diagnostic().code ==
+                                output::FlatExrVerifyErrorCodeV1::InvalidChannelList,
+                        "a renamed channel ('R' -> 'X') is a typed channel-list failure");
+}
+
+// Reconstructs a byte-valid EXR with the identical header (all ten attributes copied verbatim,
+// so every attribute/channel check still passes) but exactly one Float32 sample bit flipped.
+// Raw byte surgery on the ZIP-compressed chunk bytes themselves is not attempted: ZIP compresses
+// in 16-scanline blocks, so a single flipped compressed byte would corrupt the whole block's
+// zlib stream (an undecodable chunk, not a clean single-bit sample defect) rather than proving
+// the verifier's per-sample bit comparison specifically.
+void writeSingleBitPerturbedVariant(const std::filesystem::path& validPath,
+                                    const std::filesystem::path& outPath) {
+    Imf::InputFile input(validPath.string().c_str());
+    const Imf::Header header(input.header());
+    const auto& dataWindow = header.dataWindow();
+    const auto width = static_cast<std::size_t>(static_cast<std::int64_t>(dataWindow.max.x) -
+                                                static_cast<std::int64_t>(dataWindow.min.x) + 1);
+    const auto heightRows =
+        static_cast<std::size_t>(static_cast<std::int64_t>(dataWindow.max.y) -
+                                 static_cast<std::int64_t>(dataWindow.min.y) + 1);
+    const auto pixelCount = width * heightRows;
+    std::vector<float> red(pixelCount), green(pixelCount), blue(pixelCount), alpha(pixelCount);
+
+    const auto rowStride = sizeof(float) * width;
+    Imf::FrameBuffer inFrameBuffer;
+    inFrameBuffer.insert(
+        "R", Imf::Slice::Make(Imf::FLOAT, red.data(), dataWindow, sizeof(float), rowStride));
+    inFrameBuffer.insert(
+        "G", Imf::Slice::Make(Imf::FLOAT, green.data(), dataWindow, sizeof(float), rowStride));
+    inFrameBuffer.insert(
+        "B", Imf::Slice::Make(Imf::FLOAT, blue.data(), dataWindow, sizeof(float), rowStride));
+    inFrameBuffer.insert(
+        "A", Imf::Slice::Make(Imf::FLOAT, alpha.data(), dataWindow, sizeof(float), rowStride));
+    input.setFrameBuffer(inFrameBuffer);
+    input.readPixels(dataWindow.min.y, dataWindow.max.y);
+
+    // Flip the least-significant bit of the last row's last pixel's red sample -- a scanline
+    // near the end of the image, distinct from row 0, so the test can confirm the verifier names
+    // the actual defective scanline rather than always reporting the first row.
+    std::uint32_t bits = 0;
+    std::memcpy(&bits, &red[pixelCount - 1], sizeof(bits));
+    bits ^= 1U;
+    std::memcpy(&red[pixelCount - 1], &bits, sizeof(bits));
+
+    Imf::OutputFile output(outPath.string().c_str(), header, 1);
+    Imf::FrameBuffer outFrameBuffer;
+    outFrameBuffer.insert(
+        "R", Imf::Slice::Make(Imf::FLOAT, red.data(), dataWindow, sizeof(float), rowStride));
+    outFrameBuffer.insert(
+        "G", Imf::Slice::Make(Imf::FLOAT, green.data(), dataWindow, sizeof(float), rowStride));
+    outFrameBuffer.insert(
+        "B", Imf::Slice::Make(Imf::FLOAT, blue.data(), dataWindow, sizeof(float), rowStride));
+    outFrameBuffer.insert(
+        "A", Imf::Slice::Make(Imf::FLOAT, alpha.data(), dataWindow, sizeof(float), rowStride));
+    output.setFrameBuffer(outFrameBuffer);
+    output.writePixels(static_cast<int>(heightRows));
+}
+
+void testPerturbedSingleSampleBit(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-sample-bit");
+    auto fixture = writeValidFixture(scratch, "base.exr");
+    const auto corruptPath = scratch.file("perturbed-sample.exr");
+    writeSingleBitPerturbedVariant(fixture.path, corruptPath);
+
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(corruptPath, fixture.source.processIdentity, fixture.source.report, {});
+    const auto dataWindow = fixture.source.frame->processImage().descriptor()->dataWindow();
+    const auto lastRow =
+        dataWindow.originY() + static_cast<std::int64_t>(dataWindow.extent().height()) - 1;
+    expectations.expect(
+        result.status() == output::FlatExrVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::FlatExrVerifyErrorCodeV1::SampleMismatch &&
+            result.diagnostic().scanlineY.has_value() && *result.diagnostic().scanlineY == lastRow,
+        "a single perturbed sample bit is caught and the failing scanline is named exactly");
+}
+
+void testTruncatedFile(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-truncated");
+    auto fixture = writeValidFixture(scratch, "base.exr");
+    const auto corruptPath = scratch.file("truncated.exr");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::ExrHeaderBytes bytes(corruptPath);
+    bytes.truncateTo(bytes.headerEnd() / 2); // well inside the header, before its terminator
+    bytes.save();
+
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(corruptPath, fixture.source.processIdentity, fixture.source.report, {});
+    expectations.expect(result.status() == output::FlatExrVerifyStatusV1::Failed &&
+                            result.diagnostic().code != output::FlatExrVerifyErrorCodeV1::None,
+                        "a truncated file is a typed failure, no identity issued");
+}
+
+void testWrongVersionFieldFlags(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-version-flags");
+    auto fixture = writeValidFixture(scratch, "base.exr");
+    const auto corruptPath = scratch.file("wrong-version-flags.exr");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::ExrHeaderBytes bytes(corruptPath);
+    // Byte offset 5 holds bits 8-15 of the version field; bit 1 there is TILED_FLAG (0x0200).
+    bytes.patchByte(5, static_cast<unsigned char>(bytes.byteAt(5) | 0x02U));
+    bytes.save();
+
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(corruptPath, fixture.source.processIdentity, fixture.source.report, {});
+    expectations.expect(
+        result.status() == output::FlatExrVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::FlatExrVerifyErrorCodeV1::InvalidVersionField,
+        "a set feature flag (tiled) in the version field is rejected before header parsing");
+}
+
+void testCancellationMidVerify(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("cancel-mid-verify");
+    // A wide image so each scanline is a meaningful fraction of the verifier's 16 MiB streaming
+    // chunk cap; at the maximum permitted width (32768) a chunk is 32 rows, so kHeight below spans
+    // several chunks, giving a deterministic chunk boundary to block on.
+    constexpr std::uint32_t kWidth = 32'768;
+    constexpr std::uint32_t kHeight = 200;
+    std::vector<render::Rgba32f> pixels(std::size_t{kWidth} * kHeight,
+                                        render::Rgba32f::transparent());
+    auto source =
+        support::prepareSource({support::frameIdentity(support::identityPlan(
+                                    kWidth, kHeight, core::PixelAspectRatio::square())),
+                                support::image(support::window(0, 0, kWidth, kHeight),
+                                               support::window(0, 0, kWidth, kHeight),
+                                               core::PixelAspectRatio::square(), pixels)});
+    const auto path = scratch.file("large.exr");
+    const output::FlatExrRgba32fLinRec709SceneWriterV1 writer;
+    const auto written = writer.write(*source.frame, path, {});
+    if (written.status() != output::FlatExrWriteStatusV1::Written) {
+        std::abort();
+    }
+
+    runtime::TaskSchedulerConfig config = runtime::TaskSchedulerConfig::defaults();
+    config.cpuWorkerCount = 1;
+    config.blockingIoWorkerCount = 1;
+    runtime::TaskScheduler scheduler(config);
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool reachedRow = false;
+    bool released = false;
+    std::atomic_bool cancelled = false;
+    std::atomic_bool verified = false;
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+
+    auto submission = scheduler.submit<void>(
+        runtime::TaskRequest(
+            "Flat EXR verify cancellation",
+            {.kind = runtime::TaskOwnerKind::Composition, .id = runtime::TaskOwnerId::fromRaw(1)}),
+        [&](runtime::TaskContext& context) {
+            const auto result =
+                verifier.verify(path, source.processIdentity, source.report, context.cancellation(),
+                                [&](const output::FlatExrVerifyScanProgressV1& progress) {
+                                    if (progress.completedScanlines == 0) {
+                                        return;
+                                    }
+                                    std::unique_lock lock(mutex);
+                                    reachedRow = true;
+                                    condition.notify_all();
+                                    condition.wait(lock, [&released] { return released; });
+                                });
+            cancelled.store(result.status() == output::FlatExrVerifyStatusV1::Cancelled,
+                            std::memory_order_release);
+            verified.store(result.status() == output::FlatExrVerifyStatusV1::Verified,
+                           std::memory_order_release);
+            return result.status() == output::FlatExrVerifyStatusV1::Cancelled
+                       ? runtime::TaskResult<void>::cancelled()
+                       : runtime::TaskResult<void>::succeeded();
+        });
+    {
+        std::unique_lock lock(mutex);
+        expectations.expect(submission.accepted() &&
+                                condition.wait_for(lock, 5s, [&reachedRow] { return reachedRow; }),
+                            "cancellation fixture reaches a deterministic scanline-chunk boundary");
+    }
+    submission.handle.cancel();
+    {
+        std::lock_guard lock(mutex);
+        released = true;
+        condition.notify_all();
+    }
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    std::optional<runtime::TaskResult<void>> taskResult;
+    while (!taskResult && std::chrono::steady_clock::now() < deadline) {
+        taskResult = submission.handle.tryTakeResult();
+        std::this_thread::yield();
+    }
+    expectations.expect(taskResult && taskResult->state() == runtime::TaskState::Cancelled &&
+                            cancelled.load(std::memory_order_acquire) &&
+                            !verified.load(std::memory_order_acquire),
+                        "cancellation mid-verify yields a typed Cancelled result, never Verified "
+                        "(no identity issued)");
+    scheduler.beginShutdown();
+    while (!scheduler.isQuiescent() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    expectations.expect(scheduler.isQuiescent(), "cancellation fixture shuts down cleanly");
+}
+
+} // namespace
+
+int main() {
+    support::Expectations expectations;
+    testRoundTrip(expectations);
+    testHeaderConformanceRejectsForeignAttribute(expectations);
+    testWrongCompressionEnum(expectations);
+    testRenamedChannel(expectations);
+    testPerturbedSingleSampleBit(expectations);
+    testTruncatedFile(expectations);
+    testWrongVersionFieldFlags(expectations);
+    testCancellationMidVerify(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/output/tests/flat_exr_test_support.hpp
+++ b/src/output/tests/flat_exr_test_support.hpp
@@ -1,0 +1,480 @@
+#pragma once
+
+// Shared fixture/harness support for the flat OpenEXR writer and reopen-verifier test binaries
+// (issue #99). Mirrors the golden idiom `process_frame_semantic_identity_tests.cpp` already uses
+// to obtain a real `runtime::ProcessFrame`: evaluate a trivial one-pixel plan through the actual
+// `CpuCompositionEvaluator` (the only producer of `ProcessFrame`, whose constructor is private),
+// then move-assign an arbitrary fixture identity/image into the published frame -- `ProcessFrame`
+// exposes public move assignment even though its constructor is private, and its data members are
+// reachable through `const_cast` from a test that already holds a `shared_ptr<const ProcessFrame>`
+// it uniquely owns. This header duplicates that pattern locally rather than reusing the existing
+// test file, which owns its own private anonymous-namespace helpers.
+
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/output/output_analysis.hpp>
+#include <bloom/output/output_analysis_analyzer.hpp>
+#include <bloom/output/process_frame_semantic_identity.hpp>
+#include <bloom/render/image.hpp>
+#include <bloom/runtime/compiled_plan.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/evaluation.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace bloom_output_flat_exr_test_support {
+
+namespace core = bloom::core;
+namespace document = bloom::document;
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+
+constexpr auto kProjectId = document::ProjectId::fromRaw(0xA1A2A3A4A5A6A7A8ULL);
+constexpr auto kCompositionId = document::CompositionId::fromRaw(0xB1B2B3B4B5B6B7B8ULL);
+constexpr auto kOutputNodeId = document::NodeId::fromRaw(0xC1C2C3C4C5C6C7C8ULL);
+constexpr auto kInputNodeId = document::NodeId::fromRaw(0xD1D2D3D4D5D6D7D8ULL);
+constexpr auto kColorParameterId = document::ParameterId::fromRaw(0xE1E2E3E4E5E6E7E8ULL);
+constexpr auto kSourceRevision = document::Revision::fromRaw(0xF1F2F3F4F5F6F7F8ULL);
+constexpr auto kShellLayerNodeId = document::NodeId::fromRaw(0x61);
+constexpr auto kShellLayerId = document::LayerId::fromRaw(0x62);
+constexpr auto kShellStackNodeId = document::NodeId::fromRaw(0x63);
+constexpr auto kShellSlotId = document::LayerSlotId::fromRaw(0x64);
+constexpr auto kShellPositionParameterId = document::ParameterId::fromRaw(0x65);
+constexpr auto kShellOpacityParameterId = document::ParameterId::fromRaw(0x66);
+
+[[nodiscard]] inline render::Rgba32f pixel(const float red, const float green, const float blue,
+                                           const float alpha) {
+    const auto value = render::Rgba32f::fromPremultiplied(red, green, blue, alpha);
+    if (!value) {
+        std::abort();
+    }
+    return *value.value();
+}
+
+[[nodiscard]] inline render::ImageWindow window(const std::int64_t originX,
+                                                const std::int64_t originY,
+                                                const std::uint32_t width,
+                                                const std::uint32_t height) {
+    const auto value = render::ImageWindow::create(originX, originY, width, height);
+    if (!value) {
+        std::abort();
+    }
+    return *value.value();
+}
+
+[[nodiscard]] inline render::Rgba32fImage image(const render::ImageWindow dataWindow,
+                                                const render::ImageWindow displayWindow,
+                                                const core::PixelAspectRatio pixelAspect,
+                                                const std::span<const render::Rgba32f> pixels) {
+    const auto descriptor =
+        render::Rgba32fImageDescriptor::create(dataWindow, displayWindow, pixelAspect);
+    if (!descriptor || descriptor.value()->layout().pixelCount != pixels.size()) {
+        std::abort();
+    }
+    auto builder = render::Rgba32fImageBuilder::create(
+        *descriptor.value(), descriptor.value()->layout().pixelStorageBytes);
+    if (!builder) {
+        std::abort();
+    }
+    for (std::uint32_t rowIndex = 0; rowIndex < dataWindow.extent().height(); ++rowIndex) {
+        const auto y = dataWindow.originY() + static_cast<std::int64_t>(rowIndex);
+        auto row = builder.value()->row(y);
+        if (!row) {
+            std::abort();
+        }
+        const auto offset = static_cast<std::size_t>(rowIndex) * dataWindow.extent().width();
+        std::ranges::copy(pixels.subspan(offset, dataWindow.extent().width()),
+                          row.value()->begin());
+    }
+    auto frozen = std::move(*builder.value()).freeze();
+    if (!frozen) {
+        std::abort();
+    }
+    return std::move(*frozen.value());
+}
+
+// Composition Output requires a layer-stack input, not a bare solid, so a real evaluation needs
+// solid -> layer output -> layer stack -> composition output (mirroring
+// process_frame_semantic_identity_tests.cpp's shellPlan()). This plan's own pixels are never
+// observed: publish() immediately overwrites the evaluated frame's image/identity with a fixture.
+[[nodiscard]] inline std::shared_ptr<const runtime::CompiledCompositionPlan> shellPlan() {
+    const auto format = document::CompositionFormat::create(1, 1);
+    if (!format) {
+        std::abort();
+    }
+    std::vector<runtime::CompiledOperation> operations;
+    operations.emplace_back(
+        runtime::CompiledSolid{kInputNodeId, kColorParameterId, {0.0, 0.0, 0.0, 0.0}});
+    operations.emplace_back(runtime::CompiledLayerOutput{
+        kShellLayerNodeId, kShellLayerId, runtime::OperationIndex::fromRaw(0),
+        runtime::CompiledVec2Parameter{kShellPositionParameterId, document::Vec2d{0.5, 0.5}},
+        runtime::CompiledScalarParameter{kShellOpacityParameterId, 1.0}});
+    operations.emplace_back(runtime::CompiledLayerStack{
+        kShellStackNodeId, {{kShellSlotId, kShellLayerId, runtime::OperationIndex::fromRaw(1)}}});
+    operations.emplace_back(
+        runtime::CompiledCompositionOutput{kOutputNodeId, runtime::OperationIndex::fromRaw(2)});
+    return std::make_shared<const runtime::CompiledCompositionPlan>(
+        runtime::CompiledCompositionPlanDefinition{.sourceRevision = kSourceRevision,
+                                                   .projectId = kProjectId,
+                                                   .compositionId = kCompositionId,
+                                                   .format = *format,
+                                                   .operations = std::move(operations),
+                                                   .output = runtime::OperationIndex::fromRaw(3)});
+}
+
+// A minimal plan used only to give ProcessFrameIdentity an opaque `.plan` handle whose
+// CompositionFormat declares the exact width/height/pixelAspect a fixture's data window claims --
+// required because ProcessFrameSemanticIdentityV1Preparer cross-checks a
+// CompositionFormatResolution identity's declared format against the actual published image
+// (mirroring process_frame_semantic_identity_tests.cpp's plan()). This plan is never evaluated.
+[[nodiscard]] inline std::shared_ptr<const runtime::CompiledCompositionPlan>
+identityPlan(const std::uint32_t width, const std::uint32_t height,
+             const core::PixelAspectRatio pixelAspect) {
+    const auto format = document::CompositionFormat::create(width, height, pixelAspect);
+    if (!format) {
+        std::abort();
+    }
+    std::vector<runtime::CompiledOperation> operations;
+    operations.emplace_back(runtime::CompiledSolid{kInputNodeId, kColorParameterId, {}});
+    operations.emplace_back(
+        runtime::CompiledCompositionOutput{kOutputNodeId, runtime::OperationIndex::fromRaw(0)});
+    return std::make_shared<const runtime::CompiledCompositionPlan>(
+        runtime::CompiledCompositionPlanDefinition{.sourceRevision = kSourceRevision,
+                                                   .projectId = kProjectId,
+                                                   .compositionId = kCompositionId,
+                                                   .format = *format,
+                                                   .operations = std::move(operations),
+                                                   .output = runtime::OperationIndex::fromRaw(1)});
+}
+
+[[nodiscard]] inline std::shared_ptr<const runtime::ProcessFrame> evaluateShell() {
+    const auto compiledPlan = shellPlan();
+    const runtime::EvaluationRequest request{.time = core::RationalTime::fromInteger(0),
+                                             .output = compiledPlan->output(),
+                                             .resolution = runtime::CompositionFormatResolution{},
+                                             .quality = runtime::EvaluationQuality::Reference,
+                                             .colorIntent =
+                                                 runtime::EvaluationColorIntent::LinearRec709Scene,
+                                             .pixelStorageByteLimit = 4096};
+    const runtime::CpuCompositionEvaluator evaluator;
+    const auto result = evaluator.evaluate(compiledPlan, request, {});
+    if (result.status() != runtime::EvaluationStatus::Evaluated || result.frame() == nullptr) {
+        for (const auto& diagnostic : result.diagnostics()) {
+            std::cerr << "evaluateShell diagnostic: "
+                      << runtime::evaluationDiagnosticCodeId(diagnostic.code)
+                      << " summary=" << diagnostic.summary << " detail=" << diagnostic.detail
+                      << '\n';
+        }
+        std::abort();
+    }
+    return result.frame();
+}
+
+struct Fixture final {
+    runtime::ProcessFrameIdentity identity;
+    render::Rgba32fImage processImage;
+};
+
+// Publishes `fixture` as the retained image/identity of a real (privately-constructed)
+// `ProcessFrame`. `ProcessFrame` exposes public move assignment (its constructor is private, its
+// copy operations are deleted); a test that owns the only reference may reach past its private
+// members via const_cast to move a fixture image/identity into an already-published frame.
+[[nodiscard]] inline std::shared_ptr<const runtime::ProcessFrame> publish(Fixture fixture) {
+    auto published = std::const_pointer_cast<runtime::ProcessFrame>(evaluateShell());
+    auto& identity = const_cast<runtime::ProcessFrameIdentity&>(published->identity());
+    auto& processImage = const_cast<render::Rgba32fImage&>(published->processImage());
+    identity = std::move(fixture.identity);
+    processImage = std::move(fixture.processImage);
+    return published;
+}
+
+[[nodiscard]] inline runtime::ProcessFrameIdentity
+frameIdentity(const std::shared_ptr<const runtime::CompiledCompositionPlan>& compiledPlan) {
+    const auto time = core::RationalTime::create(3, 4);
+    if (!time) {
+        std::abort();
+    }
+    return {.plan = compiledPlan,
+            .time = *time,
+            .output = compiledPlan->output(),
+            .resolution = runtime::CompositionFormatResolution{},
+            .quality = runtime::EvaluationQuality::Reference,
+            .colorIntent = runtime::EvaluationColorIntent::LinearRec709Scene,
+            .provider = runtime::EvaluationProvider::CpuReference,
+            .evaluatorSemanticsVersion = 1,
+            .animationSamplingSemanticsVersion = 1,
+            .imagePrimitiveSemanticsVersion = 1};
+}
+
+// A 3x2 fixture covering negative, HDR, signed-zero, zero-alpha (forced canonical-zero by
+// `Rgba32f::fromPremultiplied`), and subnormal samples, at a nonzero, non-equal data/display
+// window with a pixel aspect that does NOT round-trip exactly through binary32 (4/3).
+[[nodiscard]] inline Fixture roundTripFixture() {
+    const auto pixelAspect = core::PixelAspectRatio::create(4, 3);
+    if (!pixelAspect) {
+        std::abort();
+    }
+    const auto subnormal = std::numeric_limits<float>::denorm_min();
+    const std::array pixels{
+        pixel(-0.0F, 0.0F, -3.5F, 1.0F),          // signed zero, negative
+        pixel(120.0F, 0.5F, 0.25F, 0.5F),         // HDR
+        render::Rgba32f::transparent(),           // zero-alpha, canonical zero
+        pixel(subnormal, -subnormal, 0.0F, 1.0F), // subnormal, negative subnormal
+        pixel(-8.0F, 16.5F, -0.001F, 0.75F),      // negative/HDR mix
+        pixel(0.0F, 0.0F, 0.0F, 1.0F),            // opaque black
+    };
+    // ProcessFrameSemanticIdentityV1Preparer's CompositionFormatResolution check compares the
+    // *display* window's extent (not the data window's) against the declared plan format.
+    return {frameIdentity(identityPlan(5, 4, *pixelAspect)),
+            image(window(-2, 5, 3, 2), window(-10, -20, 5, 4), *pixelAspect, pixels)};
+}
+
+// Same shape as roundTripFixture() but with an exactly-representable pixel aspect (2/1), used by
+// the "pixel-aspect rounds exactly" conversion-edge test.
+[[nodiscard]] inline Fixture exactPixelAspectFixture() {
+    const auto pixelAspect = core::PixelAspectRatio::create(2, 1);
+    if (!pixelAspect) {
+        std::abort();
+    }
+    const std::array pixels{pixel(1.0F, 2.0F, 3.0F, 1.0F),  pixel(-1.0F, -2.0F, -3.0F, 1.0F),
+                            render::Rgba32f::transparent(), pixel(0.5F, 0.5F, 0.5F, 1.0F),
+                            pixel(4.0F, 4.0F, 4.0F, 1.0F),  pixel(-0.0F, 0.0F, 0.0F, 1.0F)};
+    return {frameIdentity(identityPlan(3, 2, *pixelAspect)),
+            image(window(0, 0, 3, 2), window(0, 0, 3, 2), *pixelAspect, pixels)};
+}
+
+// Both members are the exact public products `FlatExrRgba32fLinRec709SceneReopenVerifierV1::
+// verify()` accepts; it binds them into the module-private `BoundOutputAnalysisV1` itself, so
+// nothing here needs to touch that private type.
+struct PreparedSource final {
+    std::shared_ptr<const runtime::ProcessFrame> frame;
+    std::shared_ptr<const output::ProcessFrameSemanticIdentityV1> processIdentity;
+    std::shared_ptr<const output::OutputAnalysisReportV1> report;
+};
+
+// Runs the already-implemented pre-approval pipeline this slice consumes but does not
+// reimplement: prepare the frame-bound `ProcessFrameSemanticIdentityV1` and analyze it with the
+// existing EXR analyzer -- the exact public input shape the reopen verifier requires.
+[[nodiscard]] inline PreparedSource prepareSource(Fixture fixture) {
+    auto frame = publish(std::move(fixture));
+
+    const output::ProcessFrameSemanticIdentityV1Preparer identityPreparer;
+    const auto identityResult = identityPreparer.prepare(frame, {});
+    if (identityResult.status() !=
+            output::ProcessFrameSemanticIdentityPreparationStatus::Prepared ||
+        identityResult.identity() == nullptr) {
+        std::abort();
+    }
+
+    const auto analyzed = output::analyzeFlatExrRgba32fLinRec709SceneV1(
+        {.process = {.state = output::OutputAnalysisProcessSourceStateV1::Ready,
+                     .readyIdentity = identityResult.identity(),
+                     .missingDescriptor = std::nullopt}});
+    if (!analyzed.hasReport()) {
+        std::abort();
+    }
+
+    return {frame, identityResult.identity(), analyzed.report()};
+}
+
+// RAII per-process scratch directory under the platform temp root, isolating this test binary's
+// staged artifacts from other parallel ctest processes. Best-effort cleanup on destruction.
+class ScratchDirectory final {
+  public:
+    explicit ScratchDirectory(const std::string& label) {
+        static std::atomic<std::uint64_t> counter{0};
+        const auto suffix =
+            std::to_string(static_cast<unsigned long long>(std::hash<std::string>{}(label))) + "-" +
+            std::to_string(counter.fetch_add(1));
+        std::error_code errorCode;
+        path_ =
+            std::filesystem::temp_directory_path(errorCode) / ("bloom-output-exr-test-" + suffix);
+        if (errorCode) {
+            std::abort();
+        }
+        std::filesystem::create_directories(path_, errorCode);
+        if (errorCode) {
+            std::abort();
+        }
+    }
+    ScratchDirectory(const ScratchDirectory&) = delete;
+    ScratchDirectory& operator=(const ScratchDirectory&) = delete;
+    ScratchDirectory(ScratchDirectory&&) = delete;
+    ScratchDirectory& operator=(ScratchDirectory&&) = delete;
+    ~ScratchDirectory() {
+        std::error_code errorCode;
+        std::filesystem::remove_all(path_, errorCode);
+    }
+
+    [[nodiscard]] std::filesystem::path file(const std::string& name) const { return path_ / name; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// The small "Expectations" idiom every src/output test file already uses (e.g.
+// output_facet_descriptor_tests.cpp, process_frame_semantic_identity_tests.cpp), duplicated here
+// so both flat OpenEXR test binaries share one copy instead of two more.
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+// Minimal raw byte-level access to a valid staged EXR's classic (non-multipart) header, used by
+// the adversarial fixtures to craft corrupted variants of a real staged file. The classic header
+// format is a sequence of attribute records -- name (NUL-terminated), type (NUL-terminated),
+// size (int32 little-endian), then `size` value bytes -- starting right after the 8-byte
+// magic/version field and terminated by one empty (zero) byte. This scanner never touches the
+// chunk offset table or pixel data that follow: every adversarial case below either patches an
+// attribute's value bytes in place (same length, so nothing after it moves) or inserts a whole
+// new attribute record immediately before the header terminator, which the reopen verifier's
+// attribute-allowlist check rejects before it would ever reach the (now differently offset) chunk
+// table.
+class ExrHeaderBytes final {
+  public:
+    explicit ExrHeaderBytes(const std::filesystem::path& path) : path_(path) {
+        std::ifstream stream(path, std::ios::binary);
+        if (!stream) {
+            std::abort();
+        }
+        bytes_.assign(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+        if (bytes_.size() < 8) {
+            std::abort();
+        }
+        headerEnd_ = scanToHeaderEnd();
+    }
+
+    // Byte offset of one attribute's value (after its name/type/size fields), and that value's
+    // byte length. Aborts if the attribute is not present -- every caller here already wrote it.
+    [[nodiscard]] std::pair<std::size_t, std::size_t>
+    valueRange(const std::string& attributeName) const {
+        std::size_t offset = 8;
+        while (offset < headerEnd_) {
+            const auto recordStart = offset;
+            const auto name = readCString(offset);
+            const auto type = readCString(offset);
+            (void)type;
+            const auto size = static_cast<std::size_t>(readInt32(offset));
+            const auto valueOffset = offset;
+            if (name == attributeName) {
+                return {valueOffset, size};
+            }
+            offset = valueOffset + size;
+            if (offset <= recordStart) {
+                std::abort();
+            }
+        }
+        std::abort();
+    }
+
+    [[nodiscard]] std::size_t headerEnd() const noexcept { return headerEnd_; }
+
+    void patchByte(const std::size_t offset, const unsigned char value) {
+        bytes_.at(offset) = value;
+    }
+
+    [[nodiscard]] unsigned char byteAt(const std::size_t offset) const {
+        return static_cast<unsigned char>(bytes_.at(offset));
+    }
+
+    // Inserts `record` (a complete, well-formed attribute record: name\0 type\0 size value...)
+    // immediately before the header terminator. Only safe for tests that never read past the
+    // (now-invalid) chunk offset table -- every insertion-based adversarial case here is rejected
+    // by the attribute-allowlist check before the verifier would reach it.
+    void insertAttributeRecord(const std::vector<unsigned char>& record) {
+        bytes_.insert(bytes_.begin() + static_cast<std::ptrdiff_t>(headerEnd_), record.begin(),
+                      record.end());
+    }
+
+    void truncateTo(const std::size_t length) { bytes_.resize(std::min(length, bytes_.size())); }
+
+    void save() const {
+        std::ofstream stream(path_, std::ios::binary | std::ios::trunc);
+        if (!stream) {
+            std::abort();
+        }
+        stream.write(reinterpret_cast<const char*>(bytes_.data()),
+                     static_cast<std::streamsize>(bytes_.size()));
+    }
+
+  private:
+    [[nodiscard]] std::string readCString(std::size_t& offset) const {
+        const auto start = offset;
+        while (offset < bytes_.size() && bytes_[offset] != 0) {
+            ++offset;
+        }
+        if (offset >= bytes_.size()) {
+            std::abort();
+        }
+        std::string result(bytes_.begin() + static_cast<std::ptrdiff_t>(start),
+                           bytes_.begin() + static_cast<std::ptrdiff_t>(offset));
+        ++offset; // consume the NUL
+        return result;
+    }
+
+    [[nodiscard]] std::int32_t readInt32(std::size_t& offset) const {
+        if (offset + 4 > bytes_.size()) {
+            std::abort();
+        }
+        std::uint32_t value = 0;
+        for (int index = 0; index < 4; ++index) {
+            value |= static_cast<std::uint32_t>(static_cast<unsigned char>(
+                         bytes_[offset + static_cast<std::size_t>(index)]))
+                     << (8 * index);
+        }
+        offset += 4;
+        return static_cast<std::int32_t>(value);
+    }
+
+    [[nodiscard]] std::size_t scanToHeaderEnd() const {
+        std::size_t offset = 8;
+        while (offset < bytes_.size() && bytes_[offset] != 0) {
+            (void)readCString(offset);
+            (void)readCString(offset);
+            const auto size = static_cast<std::size_t>(readInt32(offset));
+            offset += size;
+        }
+        if (offset >= bytes_.size()) {
+            std::abort();
+        }
+        return offset; // the terminating zero byte itself
+    }
+
+    std::filesystem::path path_;
+    std::vector<unsigned char> bytes_;
+    std::size_t headerEnd_ = 0;
+};
+
+} // namespace bloom_output_flat_exr_test_support


### PR DESCRIPTION
Implements the `FlatExrRgba32fLinRec709SceneV1` format adapter — the process-side half of Bloom's first delivery surface:

- **Writer** through OpenEXR's classic C++ API, chosen on header-control evidence read from the vendored 3.4.15 source: the emitted header is exactly the contract's ten-attribute allowlist, proven by an independent decode in the tests (exact attribute-set match plus raw version-field bytes). Checked window conversions, one round-to-nearest pixel-aspect conversion with pre-staging rejection, chromaticities written as exact bit patterns, samples bit-copied, incremental scanline writes under a checked chunk limit with cancellation.
- **Reopen verifier** written from the contract table first (the writer must pass it, not vice versa): version field, complete attribute allowlist (a foreign attribute fails typed, named), channels/windows/compression/line-order/color checks, then bit-exact streaming sample comparison. On success it issues the kind-2 `OutputSemanticIdentity` digest from the decoded reopened values through the module-private seam the identity work left for exactly this — no module-private type escapes the public headers.
- **Adversarial fixtures** by real byte surgery on the header record stream: foreign attribute splice, compression-enum patch, channel rename, truncation, version-flag corruption; plus a perturbed-sample rebuild (ZIP block structure makes compressed-byte surgery non-deterministic — documented) and mid-write/mid-verify cancellation.
- **Contract finding, ruled and recorded**: the qualified encoder validates window coordinates strictly below `INT32_MAX/2`, narrower than the doc's literal signed-32 wording — the writer enforces it as a typed pre-staging rejection and the contract now names the version-1 ceiling explicitly.

Desktop 94/94 and native 80/80, format check clean, from a fresh dependency prefix.

Closes #99.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.