### PR TITLE
feat: publish exported EXR frames atomically

### DIFF
--- a/docs/architecture/frame-output.md
+++ b/docs/architecture/frame-output.md
@@ -6,9 +6,11 @@ Implementation status: the allocation-free Process Pixel Stream and Process-Fram
 Identity version 1 codecs, cancellable owning semantic-identity preparer, closed facet-descriptor
 grammar and validator, preset-specific owning OutputAnalysis analyzer/report, streaming analysis
 digest, preset-specific bound-analysis products, the module-private Output Semantic Identity version
-1 streaming serializer/preparer, portable golden vectors, and the flat OpenEXR adapter with its
-semantic reopen verifier and verifier-product issuance are implemented. The PNG adapter and
-end-to-end publication remain pending.
+1 streaming serializer/preparer, portable golden vectors, the flat OpenEXR adapter with its
+semantic reopen verifier and verifier-product issuance, and headless end-to-end EXR export
+publication (analysis attempt graph, immutable export request, and the shared-coordinator
+publication job) are implemented. The PNG adapter and the interactive export surface remain
+pending.
 
 Updated: 2026-08-31
 

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -5,6 +5,8 @@ target_sources(
     PRIVATE
         copy_async_io.cpp
         copy_publication.cpp
+        frame_export_publication.cpp
+        output_analysis_attempt_runner.cpp
         project_session.cpp
         publication_coordinator.cpp
         save_publication.cpp
@@ -18,6 +20,8 @@ target_sources(
             include/bloom/host/bloom_neutral_profile.hpp
             include/bloom/host/copy_async_io.hpp
             include/bloom/host/copy_publication.hpp
+            include/bloom/host/frame_export_publication.hpp
+            include/bloom/host/output_analysis_attempt_runner.hpp
             include/bloom/host/project_session.hpp
             include/bloom/host/publication_coordinator.hpp
             include/bloom/host/save_publication.hpp
@@ -49,8 +53,17 @@ target_compile_features(bloom_host PUBLIC cxx_std_20)
 # type crosses a bloom_host API boundary. bloom_color has no dependency on bloom_host (or on
 # anything that depends on bloom_host), so this introduces no cycle. The {"host", "color"} edge was
 # added to kAllowedModuleDependencies for this task.
+#
+# bloom_output is PUBLIC (task F2, issue #101): include/bloom/host/frame_export_publication.hpp
+# and include/bloom/host/output_analysis_attempt_runner.hpp declare FrameExportRequestV1/
+# executeExportPublication()/beginOutputAnalysisAttemptV1() carrying
+# bloom::output::OutputAnalysisAttemptV1/ExportResourceLedgerV1/flat-EXR-export-write types
+# directly in their own public signatures, exactly like the existing PUBLIC bloom_platform/
+# bloom_runtime dependencies above. {"host", "output"} was already present in
+# tools/quality/repository_checks/repository_checks.cpp's kAllowedModuleDependencies allowlist
+# before this task (no allowlist edit was needed).
 target_link_libraries(bloom_host PUBLIC bloom_color bloom_commands bloom_core bloom_document
-                                        bloom_project bloom_platform bloom_runtime)
+                                        bloom_output bloom_project bloom_platform bloom_runtime)
 bloom_enable_warnings(bloom_host)
 
 if(BUILD_TESTING)
@@ -168,6 +181,33 @@ if(BUILD_TESTING)
             NAME bloom.host.copy-async-io
             COMMAND bloom_host_copy_async_io_test
             LABELS unit host persistence security
+        )
+
+        # Task F2 (issue #101): drives beginOutputAnalysisAttemptV1() against a real
+        # platform::StagedArtifactCoordinator over a real bloom::runtime::TaskScheduler with real
+        # BlockingIo/Cpu workers -- gated Linux-only exactly as bloom.host.session-async-io is
+        # gated.
+        add_executable(bloom_host_output_analysis_attempt_runner_test
+                       tests/output_analysis_attempt_runner_tests.cpp)
+        target_link_libraries(bloom_host_output_analysis_attempt_runner_test PRIVATE bloom_host)
+        bloom_enable_warnings(bloom_host_output_analysis_attempt_runner_test)
+        bloom_add_test(
+            NAME bloom.host.output-analysis-attempt-runner
+            COMMAND bloom_host_output_analysis_attempt_runner_test
+            LABELS unit host output persistence
+        )
+
+        # Task F2 (issue #101): drives approveFrameExportV1()/executeExportPublication() against
+        # the same real platform::StagedArtifactCoordinator + PublicationCoordinator save/copy
+        # already prove.
+        add_executable(bloom_host_frame_export_publication_test
+                       tests/frame_export_publication_tests.cpp)
+        target_link_libraries(bloom_host_frame_export_publication_test PRIVATE bloom_host)
+        bloom_enable_warnings(bloom_host_frame_export_publication_test)
+        bloom_add_test(
+            NAME bloom.host.frame-export-publication
+            COMMAND bloom_host_frame_export_publication_test
+            LABELS unit host output persistence security
         )
     endif()
 endif()

--- a/src/host/frame_export_publication.cpp
+++ b/src/host/frame_export_publication.cpp
@@ -1,0 +1,404 @@
+#include <bloom/host/frame_export_publication.hpp>
+
+#include <bloom/core/sha256.hpp>
+#include <bloom/output/output_limits.hpp>
+
+#include <array>
+#include <atomic>
+#include <fstream>
+#include <limits>
+#include <new>
+#include <utility>
+#include <vector>
+
+namespace bloom::host {
+
+FrameExportApprovalResultV1::FrameExportApprovalResultV1(
+    const FrameExportApprovalStatusV1 status) noexcept
+    : status_(status) {}
+
+FrameExportApprovalResultV1::FrameExportApprovalResultV1(
+    std::unique_ptr<FrameExportRequestV1> request) noexcept
+    : status_(FrameExportApprovalStatusV1::Approved), request_(std::move(request)) {}
+
+FrameExportApprovalResultV1::~FrameExportApprovalResultV1() = default;
+
+std::unique_ptr<FrameExportRequestV1> FrameExportApprovalResultV1::takeRequest() && noexcept {
+    return std::move(request_);
+}
+
+FrameExportRequestV1::FrameExportRequestV1(
+    std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt, PublicationTargetClaim claim,
+    const FrameExportLimitsV1 limits) noexcept
+    : attempt_(std::move(attempt)), claim_(std::move(claim)), limits_(limits) {}
+
+FrameExportApprovalResultV1
+approveFrameExportV1(PublicationCoordinator& coordinator,
+                     std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt,
+                     const core::Sha256Digest approverDigest, const FrameExportLimitsV1 limits,
+                     PublicationAdmission* const preAdmitted) {
+    if (attempt == nullptr || !attempt->approvable()) {
+        return FrameExportApprovalResultV1(FrameExportApprovalStatusV1::NotApprovable);
+    }
+    if (!attempt->digest().has_value() || *attempt->digest() != approverDigest) {
+        return FrameExportApprovalResultV1(FrameExportApprovalStatusV1::DigestMismatch);
+    }
+
+    std::optional<PublicationAdmission> admission;
+    if (preAdmitted != nullptr) {
+        admission.emplace(std::move(*preAdmitted));
+    } else {
+        auto admissionResult = coordinator.admit();
+        if (!admissionResult) {
+            FrameExportApprovalResultV1 result(FrameExportApprovalStatusV1::AdmissionFailed);
+            result.admissionFailure_ = admissionResult.status();
+            return result;
+        }
+        admission.emplace(std::move(admissionResult).takeAdmission());
+    }
+
+    auto registrationResult =
+        coordinator.registerTarget(std::move(*admission), attempt->target().targetKey);
+    if (!registrationResult) {
+        FrameExportApprovalResultV1 result(FrameExportApprovalStatusV1::RegistrationFailed);
+        result.registrationFailure_ = registrationResult.status();
+        return result;
+    }
+    auto claim = std::move(registrationResult).takeClaim();
+
+    try {
+        auto request = std::make_unique<FrameExportRequestV1>(
+            FrameExportRequestV1(std::move(attempt), std::move(claim), limits));
+        return FrameExportApprovalResultV1(std::move(request));
+    } catch (const std::bad_alloc&) {
+        // The claim (and, transitively, its target-claim record) abandons via RAII on this path;
+        // nothing else was published or entered.
+        return FrameExportApprovalResultV1(FrameExportApprovalStatusV1::AdmissionFailed);
+    }
+}
+
+FrameExportPublicationResultV1
+FrameExportPublicationResultV1::published(platform::StagedArtifactPublicationResult publication,
+                                          const PublicationIntentId intentId,
+                                          const std::optional<core::Sha256Digest> semanticDigest,
+                                          const std::optional<core::Sha256Digest> artifactDigest,
+                                          const std::uint64_t artifactByteCount) noexcept {
+    FrameExportPublicationResultV1 result;
+    result.publication_ = publication;
+    result.intentId_ = intentId;
+    result.semanticDigest_ = semanticDigest;
+    result.artifactDigest_ = artifactDigest;
+    result.artifactByteCount_ = artifactByteCount;
+    return result;
+}
+
+FrameExportPublicationResultV1 FrameExportPublicationResultV1::failure(
+    FrameExportPublicationFailureV1 failureValue,
+    const std::optional<platform::StagedArtifactError> rejectDiagnostic) noexcept {
+    FrameExportPublicationResultV1 result;
+    result.failure_.emplace(failureValue); // trivially copyable; std::move() would be a no-op
+    result.rejectDiagnostic_ = rejectDiagnostic;
+    return result;
+}
+
+namespace {
+
+[[nodiscard]] std::filesystem::path
+uniqueScratchFilePath(const std::filesystem::path& directory) noexcept {
+    static std::atomic<std::uint64_t> counter{0};
+    const auto suffix = counter.fetch_add(1, std::memory_order_relaxed);
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    return directory /
+           (".bloom-export-scratch-" + std::to_string(now) + "-" + std::to_string(suffix) + ".exr");
+}
+
+class ScratchFileGuard final {
+  public:
+    explicit ScratchFileGuard(std::filesystem::path path) noexcept : path_(std::move(path)) {}
+    ScratchFileGuard(const ScratchFileGuard&) = delete;
+    ScratchFileGuard& operator=(const ScratchFileGuard&) = delete;
+    ~ScratchFileGuard() {
+        std::error_code errorCode;
+        std::filesystem::remove(path_, errorCode);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+[[nodiscard]] FrameExportPublicationResultV1
+cancelledResult(const FrameExportPublicationStageV1 /*lastStage*/) noexcept {
+    // The stage a cancellation checkpoint was observed at is not separately distinguished --
+    // mirrors SavePublicationStage::Cancelled's identical established rationale (every checkpoint
+    // here never calls lease.publish(), so the caller-observable contract, "no replacement
+    // occurred", is identical at all of them).
+    return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+        FrameExportPublicationStageV1::Cancelled, std::monostate{}));
+}
+
+} // namespace
+
+FrameExportPublicationResultV1 executeExportPublication(
+    runtime::TaskContext& context, platform::StagedArtifactCoordinator& artifacts,
+    FrameExportRequestV1 request, const std::filesystem::path& scratchDirectory,
+    output::OutputExportClockV1 clock, output::OutputExportProgressCallbackV1 progress) noexcept {
+    if (!clock) {
+        clock = output::systemOutputExportClockV1();
+    }
+    const auto start = clock();
+    auto lastProgress = start;
+    const auto& limits = request.limits();
+
+    const auto deadlineExceeded = [&](const std::chrono::steady_clock::time_point now) noexcept {
+        return now - start > limits.totalDeadline;
+    };
+    const auto noProgressExceeded = [&](const std::chrono::steady_clock::time_point now) noexcept {
+        return now - lastProgress > limits.noProgressInterval;
+    };
+
+    if (context.isCancellationRequested()) {
+        return cancelledResult(FrameExportPublicationStageV1::Preflight);
+    }
+
+    const auto& attempt = *request.attempt();
+    const auto& target = attempt.target();
+
+    // --- Preflight (design decision 4 node 1: "CPU output preflight validates the retained
+    // attempt/request binding and checked aggregate resources without reevaluating the
+    // composition or rehashing the process frame") -- revalidates the SAME platform preflight the
+    // attempt's own Resolving stage already ran, reusing artifacts.preflight() rather than
+    // reimplementing any of the checks it owns.
+    auto preflightResult = artifacts.preflight({.targetPath = target.targetPath,
+                                                .overwritePolicy = target.overwritePolicy,
+                                                .expectedTarget = target.observation});
+    if (!preflightResult) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::Preflight, preflightResult.error()));
+    }
+    auto platformTarget = std::move(preflightResult).takeTarget();
+    if (platformTarget.targetKey() != target.targetKey) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::Preflight, FrameExportUnexpectedFailureV1{}));
+    }
+
+    // Approved-job admission transactionally expands the SAME reservation the attempt already
+    // holds (design decision 5: "Approved-job admission transactionally expands that reservation
+    // to the checked peak ... it neither double-charges shared retained storage") -- the checked
+    // peak here is the retained bytes already charged plus one streaming chunk of encoder/
+    // verifier/copy scratch (EXR exposes retained rows directly; there is no separate prepared
+    // display/output buffer to add).
+    const auto currentCharge = attempt.resources()->chargedBytes();
+    constexpr auto chunkBound =
+        static_cast<std::uint64_t>(output::kOutputAdapterMaximumStreamingChunkBytesV1);
+    const auto peak = currentCharge > std::numeric_limits<std::uint64_t>::max() - chunkBound
+                          ? std::numeric_limits<std::uint64_t>::max()
+                          : currentCharge + chunkBound;
+    if (attempt.resources()->expand(peak) != output::ExportResourceAdmissionStatusV1::Reserved) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::Preflight, FrameExportResourceExhaustedV1{}));
+    }
+
+    if (context.isCancellationRequested()) {
+        return cancelledResult(FrameExportPublicationStageV1::Preflight);
+    }
+
+    // --- Staging.
+    auto stageResult = artifacts.stage(std::move(platformTarget));
+    if (!stageResult) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::Staging, stageResult.error()));
+    }
+    auto lease = std::move(stageResult).takeLease();
+
+    if (context.isCancellationRequested()) {
+        return cancelledResult(FrameExportPublicationStageV1::Staging);
+    }
+
+    // --- Writing + Verifying (design decision 4 node 3's first half): F1's writer/verifier
+    // against a caller-owned scratch path bridging their path-based OpenEXR API to the lease's
+    // byte-oriented staging (see bloom/output/flat_exr_export_write.hpp's own namespace comment
+    // for the full rationale). The bridging progress callback also resets the no-progress clock;
+    // a mid-call deadline/no-progress violation can only be detected once F1's own (synchronous,
+    // uninterruptible from here) call returns -- runtime::CancellationToken exposes no
+    // caller-side "request my own cancellation" seam, and changing task_scheduler.hpp is out of
+    // this task's scope. See the implementor's report for the full limitation.
+    const ScratchFileGuard scratch(uniqueScratchFilePath(scratchDirectory));
+    const output::FlatExrExportWriterV1 writer;
+    const auto writeVerifyResult = writer.run(
+        attempt, scratch.path(), context.cancellation(),
+        [&](const output::OutputExportProgressV1& stageProgress) {
+            lastProgress = clock();
+            context.reportProgress(
+                {.phase = stageProgress.stage == output::OutputExportStageV1::Writing
+                              ? "Writing"
+                              : (stageProgress.stage == output::OutputExportStageV1::Verifying
+                                     ? "Verifying"
+                                     : "Publishing"),
+                 .subphase = "",
+                 .completed = stageProgress.completed,
+                 .total = stageProgress.total});
+            if (progress) {
+                progress(stageProgress);
+            }
+        });
+
+    const auto afterWriteVerify = clock();
+    if (deadlineExceeded(afterWriteVerify)) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::Writing, FrameExportDeadlineExceededV1{}));
+    }
+    if (noProgressExceeded(afterWriteVerify)) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::Writing, FrameExportNoProgressExceededV1{}));
+    }
+    if (writeVerifyResult.status() == output::FlatExrExportWriteStatusV1::Cancelled) {
+        return cancelledResult(FrameExportPublicationStageV1::Writing);
+    }
+    if (writeVerifyResult.status() != output::FlatExrExportWriteStatusV1::Written) {
+        const auto stage =
+            writeVerifyResult.error() == output::FlatExrExportWriteErrorCodeV1::WriteFailed
+                ? FrameExportPublicationStageV1::Writing
+                : FrameExportPublicationStageV1::Verifying;
+        return FrameExportPublicationResultV1::failure(
+            FrameExportPublicationFailureV1(stage, writeVerifyResult.error()));
+    }
+
+    // --- Artifact copy (design decision 4 node 3's "artifact SHA-256 + flush"): stream the
+    // verified scratch bytes into the lease's own exclusive staged file, checking cancellation
+    // and this stage's deadline/no-progress interval BETWEEN chunks -- the one segment of this
+    // pipeline this code fully owns and can therefore genuinely preempt.
+    {
+        std::ifstream scratchStream(scratch.path(), std::ios::binary);
+        if (!scratchStream) {
+            return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                FrameExportPublicationStageV1::ArtifactCopy, FrameExportUnexpectedFailureV1{}));
+        }
+        std::vector<std::byte> buffer(output::kOutputAdapterMaximumStreamingChunkBytesV1);
+        while (scratchStream) {
+            const auto now = clock();
+            if (context.isCancellationRequested()) {
+                return cancelledResult(FrameExportPublicationStageV1::ArtifactCopy);
+            }
+            if (deadlineExceeded(now)) {
+                return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                    FrameExportPublicationStageV1::ArtifactCopy, FrameExportDeadlineExceededV1{}));
+            }
+            if (noProgressExceeded(now)) {
+                return FrameExportPublicationResultV1::failure(
+                    FrameExportPublicationFailureV1(FrameExportPublicationStageV1::ArtifactCopy,
+                                                    FrameExportNoProgressExceededV1{}));
+            }
+            scratchStream.read(reinterpret_cast<char*>(buffer.data()),
+                               static_cast<std::streamsize>(buffer.size()));
+            const auto readCount = static_cast<std::size_t>(scratchStream.gcount());
+            if (readCount == 0) {
+                break;
+            }
+            const auto writeResult = lease.write(std::span(buffer).first(readCount));
+            if (!writeResult) {
+                return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                    FrameExportPublicationStageV1::ArtifactCopy, writeResult.error));
+            }
+            lastProgress = clock();
+        }
+        if (scratchStream.bad()) {
+            return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                FrameExportPublicationStageV1::ArtifactCopy, FrameExportUnexpectedFailureV1{}));
+        }
+    }
+
+    const auto finishResult = lease.finishWriting();
+    if (!finishResult) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::ArtifactCopy, finishResult.error));
+    }
+
+    // Read the lease's own staged bytes back and recompute their SHA-256, proving the exclusive
+    // staged file the coordinator will atomically publish is byte-identical to what F1 verified --
+    // "F1 verifier on the staged identity (Verifying)" extended to the file that is actually
+    // published, not only the bridging scratch copy.
+    {
+        core::Sha256Hasher rehasher;
+        std::vector<std::byte> buffer(output::kOutputAdapterMaximumStreamingChunkBytesV1);
+        std::uint64_t offset = 0;
+        while (true) {
+            const auto now = clock();
+            if (context.isCancellationRequested()) {
+                static_cast<void>(lease.rejectVerification());
+                return cancelledResult(FrameExportPublicationStageV1::ArtifactCopy);
+            }
+            if (deadlineExceeded(now) || noProgressExceeded(now)) {
+                static_cast<void>(lease.rejectVerification());
+                return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                    FrameExportPublicationStageV1::ArtifactCopy,
+                    deadlineExceeded(now)
+                        ? FrameExportPublicationFailurePayloadV1(FrameExportDeadlineExceededV1{})
+                        : FrameExportPublicationFailurePayloadV1(
+                              FrameExportNoProgressExceededV1{})));
+            }
+            const auto readResult = lease.readForVerification(offset, std::span(buffer));
+            if (!readResult) {
+                static_cast<void>(lease.rejectVerification());
+                return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                    FrameExportPublicationStageV1::ArtifactCopy, readResult.error));
+            }
+            if (readResult.bytesRead > 0 && !rehasher.update(std::span(buffer).first(
+                                                static_cast<std::size_t>(readResult.bytesRead)))) {
+                static_cast<void>(lease.rejectVerification());
+                return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                    FrameExportPublicationStageV1::ArtifactCopy, FrameExportUnexpectedFailureV1{}));
+            }
+            offset += readResult.bytesRead;
+            lastProgress = clock();
+            if (readResult.endOfFile) {
+                break;
+            }
+        }
+        if (rehasher.finalize() != writeVerifyResult.artifactDigest()) {
+            static_cast<void>(lease.rejectVerification());
+            return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                FrameExportPublicationStageV1::ArtifactCopy, FrameExportUnexpectedFailureV1{}));
+        }
+    }
+
+    const auto acceptResult = lease.acceptVerification();
+    if (!acceptResult) {
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::ArtifactCopy, acceptResult.error));
+    }
+
+    if (context.isCancellationRequested()) {
+        return cancelledResult(FrameExportPublicationStageV1::Guard);
+    }
+
+    // --- Guard + Publishing: identical composition to executeCopyPublication()'s own final
+    // switch (see its declaration comment for the full unreachability argument for
+    // InvalidClaim/TargetBusy/AlreadyEntered in a single-executor composition).
+    auto& claim = FrameExportRequestAccessV1::claim(request);
+    auto guardResult = claim.tryEnterPublication();
+    const auto intentId = claim.intentId();
+    switch (guardResult.status()) {
+    case PublicationGuardStatus::Entered: {
+        auto guard = std::move(guardResult).takeGuard();
+        auto publication = lease.publish(platform::PublicationDisposition::Proceed);
+        return FrameExportPublicationResultV1::published(
+            publication, intentId, writeVerifyResult.semanticDigest(),
+            writeVerifyResult.artifactDigest(), writeVerifyResult.artifactByteCount());
+    }
+    case PublicationGuardStatus::Superseded:
+        return FrameExportPublicationResultV1::published(
+            lease.publish(platform::PublicationDisposition::Superseded), intentId, std::nullopt,
+            std::nullopt, 0);
+    case PublicationGuardStatus::InvalidClaim:
+    case PublicationGuardStatus::TargetBusy:
+    case PublicationGuardStatus::AlreadyEntered:
+        return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+            FrameExportPublicationStageV1::Guard, guardResult.status()));
+    }
+    return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+        FrameExportPublicationStageV1::Guard, guardResult.status()));
+}
+
+} // namespace bloom::host

--- a/src/host/include/bloom/host/frame_export_publication.hpp
+++ b/src/host/include/bloom/host/frame_export_publication.hpp
@@ -1,0 +1,276 @@
+#pragma once
+
+#include <bloom/core/sha256.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/output/flat_exr_export_write.hpp>
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/output/output_export_resource_ledger.hpp>
+#include <bloom/output/output_export_stage.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <variant>
+
+// docs/architecture/frame-output.md "Approval", "Immutable Export Request", "Non-Blocking
+// Execution", and "Atomic Publication": the host-owned composition binding
+// bloom::output::OutputAnalysisAttemptV1 (design decision 2) to the application-wide
+// PublicationCoordinator + platform StagedArtifactCoordinator, mirroring
+// bloom/host/copy_publication.hpp's admission -> preflight -> registerTarget -> stage -> guard ->
+// publish(disposition) composition (design decision 1) -- the closest established shape: like Save
+// Copy, an export publishes from already-retained products (the attempt's frame/report), not a
+// freshly-evaluated document.
+//
+// Two temporal halves, per design decision 3 ("assign PublicationIntentId (host, via the
+// coordinator, at APPROVAL time per the atomic-publication section) and freeze the immutable
+// request"):
+//   - approveFrameExportV1() runs ENTIRELY on the calling (authoring) thread: no evaluation,
+//     hashing, color work, or filesystem access (frame-output.md "Non-Blocking Execution":
+//     "Approval itself performs no evaluation, hashing, color work, or filesystem access"). It
+//     checks byte-equality against the retained attempt's own digest, then performs the SAME
+//     coordinator.admit()+registerTarget() pair copy_publication.hpp's executeCopyPublication()
+//     performs internally -- just earlier in time, before a job is ever submitted -- producing a
+//     move-only FrameExportRequestV1 that owns the resulting PublicationTargetClaim.
+//   - executeExportPublication() is the approved job's own blocking-I/O publication stage (design
+//     decision 4's node 3). It runs INSIDE a real bloom::runtime::TaskContext (TaskExecutor::
+//     BlockingIo) rather than as a free synchronous function taking a raw cancellation flag like
+//     executeSavePublication()/executeCopyPublication() do: bloom::output's F1 writer/verifier and
+//     ProcessFrameSemanticIdentityV1Preparer all require a genuine runtime::CancellationToken,
+//     which only a real TaskContext can mint (its constructor is private, friended only to
+//     TaskContext) -- see the implementor's report for the full rationale. Design decision 4's
+//     node 1 ("CPU output preflight") and node 2 ("EXR exposes retained rows directly, no
+//     PreparingOutput work") are folded into the START of this ONE task's synchronous stage
+//     sequence, exactly like executeSavePublication() folds its own Admission/Preflight/
+//     Registration/Staging stages into one synchronous call on one executor -- "mirror the
+//     established save/copy publication composition rather than inventing coordinator variants".
+namespace bloom::host {
+
+struct FrameExportLimitsV1 final {
+    std::chrono::steady_clock::duration totalDeadline = std::chrono::hours(24);
+    std::chrono::steady_clock::duration noProgressInterval = std::chrono::seconds(120);
+};
+
+enum class FrameExportApprovalStatusV1 : std::uint8_t {
+    Approved,
+    NotApprovable,
+    DigestMismatch,
+    AdmissionFailed,
+    RegistrationFailed,
+};
+
+class FrameExportRequestV1;
+
+class [[nodiscard]] FrameExportApprovalResultV1 final {
+  public:
+    FrameExportApprovalResultV1(FrameExportApprovalResultV1&&) noexcept = default;
+    FrameExportApprovalResultV1& operator=(FrameExportApprovalResultV1&&) noexcept = default;
+    FrameExportApprovalResultV1(const FrameExportApprovalResultV1&) = delete;
+    FrameExportApprovalResultV1& operator=(const FrameExportApprovalResultV1&) = delete;
+    ~FrameExportApprovalResultV1();
+
+    [[nodiscard]] FrameExportApprovalStatusV1 status() const noexcept { return status_; }
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return status_ == FrameExportApprovalStatusV1::Approved;
+    }
+    // Valid, and non-null, only when *this is true. Moves the request out (single-use, mirroring
+    // every other takeX()&& idiom in this module family).
+    [[nodiscard]] std::unique_ptr<FrameExportRequestV1> takeRequest() && noexcept;
+    [[nodiscard]] std::optional<PublicationAdmissionStatus> admissionFailure() const noexcept {
+        return admissionFailure_;
+    }
+    [[nodiscard]] std::optional<PublicationRegistrationStatus>
+    registrationFailure() const noexcept {
+        return registrationFailure_;
+    }
+
+  private:
+    friend FrameExportApprovalResultV1
+    approveFrameExportV1(PublicationCoordinator&,
+                         std::shared_ptr<const output::OutputAnalysisAttemptV1>, core::Sha256Digest,
+                         FrameExportLimitsV1, PublicationAdmission*);
+
+    explicit FrameExportApprovalResultV1(FrameExportApprovalStatusV1 status) noexcept;
+    explicit FrameExportApprovalResultV1(std::unique_ptr<FrameExportRequestV1> request) noexcept;
+
+    FrameExportApprovalStatusV1 status_;
+    std::unique_ptr<FrameExportRequestV1> request_;
+    std::optional<PublicationAdmissionStatus> admissionFailure_;
+    std::optional<PublicationRegistrationStatus> registrationFailure_;
+};
+
+// Compares `approverDigest` byte-for-byte against `attempt->digest()` (frame-output.md: "Approval
+// requires both that digest and all eleven derived permission bits" -- a caller cannot reduce this
+// to `acceptLoss = true`). On an exact match, assigns the PublicationIntentId (coordinator.admit(),
+// or takes ownership of `*preAdmitted` when non-null -- the identical seam
+// SavePublicationRequest::preAdmitted documents) and registers it for the attempt's own retained
+// target key, then freezes the immutable FrameExportRequestV1: no mutator, no re-evaluation path,
+// export uses the retained frame/identity/report directly.
+[[nodiscard]] FrameExportApprovalResultV1
+approveFrameExportV1(PublicationCoordinator& coordinator,
+                     std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt,
+                     core::Sha256Digest approverDigest, FrameExportLimitsV1 limits = {},
+                     PublicationAdmission* preAdmitted = nullptr);
+
+// The immutable, move-only frozen request design decision 3 names: retains the completed attempt
+// (and, through it, its resource reservation) and the PublicationTargetClaim approval registered.
+// No accessor exposes a mutator; the only way to consume it is executeExportPublication(), which
+// takes it by value.
+class FrameExportRequestV1 final {
+  public:
+    FrameExportRequestV1(const FrameExportRequestV1&) = delete;
+    FrameExportRequestV1& operator=(const FrameExportRequestV1&) = delete;
+    FrameExportRequestV1(FrameExportRequestV1&&) noexcept = default;
+    FrameExportRequestV1& operator=(FrameExportRequestV1&&) noexcept = default;
+    ~FrameExportRequestV1() = default;
+
+    [[nodiscard]] const std::shared_ptr<const output::OutputAnalysisAttemptV1>&
+    attempt() const& noexcept {
+        return attempt_;
+    }
+    [[nodiscard]] const std::shared_ptr<const output::OutputAnalysisAttemptV1>&
+    attempt() const&& = delete;
+    [[nodiscard]] PublicationIntentId intentId() const noexcept { return claim_.intentId(); }
+    [[nodiscard]] const FrameExportLimitsV1& limits() const noexcept { return limits_; }
+
+  private:
+    friend FrameExportApprovalResultV1
+    approveFrameExportV1(PublicationCoordinator&,
+                         std::shared_ptr<const output::OutputAnalysisAttemptV1>, core::Sha256Digest,
+                         FrameExportLimitsV1, PublicationAdmission*);
+    friend class FrameExportRequestAccessV1;
+
+    FrameExportRequestV1(std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt,
+                         PublicationTargetClaim claim, FrameExportLimitsV1 limits) noexcept;
+
+    std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt_;
+    PublicationTargetClaim claim_;
+    FrameExportLimitsV1 limits_;
+};
+
+// Test/executor-only accessor: executeExportPublication() needs to consume `claim_` by value
+// (tryEnterPublication() below); kept as a dedicated friend accessor type (rather than a public
+// method) so nothing outside this module's own executor can reach the claim.
+class FrameExportRequestAccessV1 final {
+  public:
+    [[nodiscard]] static PublicationTargetClaim& claim(FrameExportRequestV1& request) noexcept {
+        return request.claim_;
+    }
+};
+
+enum class FrameExportPublicationStageV1 : std::uint8_t {
+    Preflight,
+    Staging,
+    Writing,
+    Verifying,
+    ArtifactCopy,
+    Guard,
+    Cancelled,
+};
+
+struct FrameExportDeadlineExceededV1 final {};
+struct FrameExportNoProgressExceededV1 final {};
+struct FrameExportResourceExhaustedV1 final {};
+struct FrameExportUnexpectedFailureV1 final {};
+
+using FrameExportPublicationFailurePayloadV1 =
+    std::variant<std::monostate, platform::StagedArtifactError,
+                 output::FlatExrExportWriteErrorCodeV1, PublicationGuardStatus,
+                 FrameExportDeadlineExceededV1, FrameExportNoProgressExceededV1,
+                 FrameExportResourceExhaustedV1, FrameExportUnexpectedFailureV1>;
+
+class FrameExportPublicationFailureV1 final {
+  public:
+    FrameExportPublicationFailureV1() = default;
+    template <typename Payload>
+    FrameExportPublicationFailureV1(const FrameExportPublicationStageV1 stage, Payload payload)
+        : stage_(stage), payload_(std::move(payload)) {}
+
+    [[nodiscard]] FrameExportPublicationStageV1 stage() const noexcept { return stage_; }
+    [[nodiscard]] const FrameExportPublicationFailurePayloadV1& payload() const noexcept {
+        return payload_;
+    }
+    template <typename Payload> [[nodiscard]] const Payload* payloadAs() const noexcept {
+        return std::get_if<Payload>(&payload_);
+    }
+
+  private:
+    FrameExportPublicationStageV1 stage_ = FrameExportPublicationStageV1::Preflight;
+    FrameExportPublicationFailurePayloadV1 payload_;
+};
+
+// Mirrors SavePublicationResult/CopyPublicationResult exactly: `publication()` is set only when
+// the pipeline actually reached `lease.publish()`. On a Published/PublishedWithDurabilityWarning
+// outcome, `semanticDigest()`/`artifactDigest()`/`artifactByteCount()` are also set (design
+// decision 4's "artifact SHA-256 + flush"; "artifact digest surfaced" test requirement).
+class [[nodiscard]] FrameExportPublicationResultV1 final {
+  public:
+    FrameExportPublicationResultV1(FrameExportPublicationResultV1&&) noexcept = default;
+    FrameExportPublicationResultV1& operator=(FrameExportPublicationResultV1&&) noexcept = default;
+    FrameExportPublicationResultV1(const FrameExportPublicationResultV1&) = delete;
+    FrameExportPublicationResultV1& operator=(const FrameExportPublicationResultV1&) = delete;
+    ~FrameExportPublicationResultV1() = default;
+
+    [[nodiscard]] static FrameExportPublicationResultV1
+    published(platform::StagedArtifactPublicationResult publication, PublicationIntentId intentId,
+              std::optional<core::Sha256Digest> semanticDigest,
+              std::optional<core::Sha256Digest> artifactDigest,
+              std::uint64_t artifactByteCount) noexcept;
+    [[nodiscard]] static FrameExportPublicationResultV1
+    failure(FrameExportPublicationFailureV1 failure,
+            std::optional<platform::StagedArtifactError> rejectDiagnostic = std::nullopt) noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return !failure_.has_value(); }
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const& noexcept {
+        return publication_.has_value() ? &*publication_ : nullptr;
+    }
+    [[nodiscard]] const platform::StagedArtifactPublicationResult* publication() const&& = delete;
+    [[nodiscard]] std::optional<PublicationIntentId> intentId() const noexcept { return intentId_; }
+    [[nodiscard]] std::optional<core::Sha256Digest> semanticDigest() const noexcept {
+        return semanticDigest_;
+    }
+    [[nodiscard]] std::optional<core::Sha256Digest> artifactDigest() const noexcept {
+        return artifactDigest_;
+    }
+    [[nodiscard]] std::uint64_t artifactByteCount() const noexcept { return artifactByteCount_; }
+    [[nodiscard]] const FrameExportPublicationFailureV1* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const FrameExportPublicationFailureV1* failure() const&& = delete;
+    [[nodiscard]] std::optional<platform::StagedArtifactError> rejectDiagnostic() const noexcept {
+        return rejectDiagnostic_;
+    }
+
+  private:
+    FrameExportPublicationResultV1() = default;
+
+    std::optional<platform::StagedArtifactPublicationResult> publication_;
+    std::optional<PublicationIntentId> intentId_;
+    std::optional<core::Sha256Digest> semanticDigest_;
+    std::optional<core::Sha256Digest> artifactDigest_;
+    std::uint64_t artifactByteCount_ = 0;
+    std::optional<FrameExportPublicationFailureV1> failure_;
+    std::optional<platform::StagedArtifactError> rejectDiagnostic_;
+};
+
+// Runs the approved export job's blocking-I/O publication stage. See the namespace-level comment
+// above for why this takes a real runtime::TaskContext& (F1/identity-preparer cancellation) rather
+// than a raw atomic flag, and for how design decision 4's preflight/PreparingOutput nodes fold into
+// this one stage sequence. `scratchDirectory` is a caller-owned directory (never the real
+// destination's parent, never tracked by StagedArtifactCoordinator) this call uses for its
+// bridging Writing/Verifying scratch file (bloom/output/flat_exr_export_write.hpp); the scratch
+// file is always removed before this call returns, on every path. `clock` is design decision 5's
+// injectable monotonic clock (defaults to the task system's own std::chrono::steady_clock source).
+// Approved-job resource admission (design decision 5) transactionally expands the SAME
+// output::ExportResourceReservationV1 the attempt already owns (reached through
+// `request.attempt()->resources()`); no separate ExportResourceLedgerV1 reference is needed here.
+[[nodiscard]] FrameExportPublicationResultV1 executeExportPublication(
+    runtime::TaskContext& context, platform::StagedArtifactCoordinator& artifacts,
+    FrameExportRequestV1 request, const std::filesystem::path& scratchDirectory,
+    output::OutputExportClockV1 clock = output::systemOutputExportClockV1(),
+    output::OutputExportProgressCallbackV1 progress = {}) noexcept;
+
+} // namespace bloom::host

--- a/src/host/include/bloom/host/output_analysis_attempt_runner.hpp
+++ b/src/host/include/bloom/host/output_analysis_attempt_runner.hpp
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <bloom/output/output_analysis_analyzer.hpp>
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/output/output_export_resource_ledger.hpp>
+#include <bloom/output/process_frame_semantic_identity.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/evaluation.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <variant>
+
+// docs/architecture/frame-output.md "Pre-Approval Output Analysis Attempt": "The application
+// controller submits each dependent stage only after consuming its predecessor's typed result; a
+// worker never waits on another task or on the UI." Design decision 2 names the exact stage order
+// (Resolving -> Evaluating -> Identifying -> Analyzing) and the "established mailbox idiom".
+//
+// This is bloom::host's binding of bloom::output's Qt-free stage functions/products
+// (output_analysis_attempt.hpp) to the real bloom::runtime::TaskScheduler and
+// bloom::platform::StagedArtifactCoordinator (design decision 1's module split), generalizing
+// bloom/host/session_async_io.hpp's single-task AsyncSessionSave pattern to TWO chained tasks that
+// cross an executor boundary the way this attempt graph's own stages do:
+//   - Resolving is cheap blocking-I/O target preflight (platform::StagedArtifactCoordinator::
+//     preflight()) -- submitted as one TaskExecutor::BlockingIo task. Only the plain-data outcome
+//     (ArtifactTargetKey + ArtifactTargetObservation) is retained; the live
+//     platform::StagedArtifactTarget handle this task obtains is deliberately let go out of scope
+//     at the end of the task body (releasing the platform's active-target admission immediately)
+//     rather than held open for the lifetime of a pending artist decision -- the job graph
+//     revalidates via a second, real StagedArtifactCoordinator::preflight() call at publish time
+//     (bloom/host/frame_export_publication.hpp), reusing the identical platform call rather than
+//     inventing a way to keep the first live handle alive indefinitely.
+//   - Evaluating, Identifying, and Analyzing are pure CPU work sharing one TaskExecutor::Cpu task
+//     (runtime::CpuCompositionEvaluator, output::ProcessFrameSemanticIdentityV1Preparer,
+//     output::analyzeFlatExrRgba32fLinRec709SceneV1, output::buildOutputAnalysisAttemptV1 in
+//     sequence, each with its own between-stage cancellation checkpoint and TaskProgress phase) --
+//     bundled into one task because none of the three cross an executor boundary from one another
+///    and each has a hard data dependency on the one before it; "a worker never waits on another
+//     task" is satisfied trivially (this task never touches a TaskHandle at all) while the
+//     BlockingIo/Cpu executor split -- the concrete reason two SEPARATE tasks exist in this graph
+//     -- is honored exactly. See the implementor's report for the full rationale.
+//
+// The controller itself (this file) never touches a runtime::CancellationToken or F1/analyzer/
+// evaluator type directly inside a worker closure's cross-task synchronization; each task's own
+// TaskContext is the only place a stage observes cancellation or reports progress, and the
+// controller only ever calls TaskHandle<...>::tryTakeResult()/TaskScheduler::snapshot() from the
+// authoring thread between submissions -- the "established mailbox idiom" the doc names,
+// generalized from bloom/host/session_async_io.hpp's own single-stage use of it.
+namespace bloom::host {
+
+struct OutputAnalysisAttemptRequestV1 final {
+    std::shared_ptr<const runtime::CompiledCompositionPlan> plan;
+    runtime::EvaluationRequest evaluation;
+    std::filesystem::path targetPath;
+    platform::ArtifactOverwritePolicy overwritePolicy =
+        platform::ArtifactOverwritePolicy::CreateOrReplace;
+    runtime::TaskOwner owner{.kind = runtime::TaskOwnerKind::Export, .id = {}};
+};
+
+enum class OutputAnalysisAttemptStageV1 : std::uint8_t {
+    Resolving,
+    Evaluating,
+    Identifying,
+    Analyzing,
+};
+
+// Mirrors bloom/host/save_publication.hpp's SavePublicationFailurePayload shape: exactly one
+// alternative is meaningful per `stage()`. std::monostate covers submission refusal and
+// cancellation (no per-stage diagnostic payload beyond "which stage was current").
+using OutputAnalysisAttemptFailurePayloadV1 =
+    std::variant<std::monostate, runtime::TaskSubmissionStatus, platform::StagedArtifactError,
+                 runtime::EvaluationDiagnosticCode, output::ProcessFrameSemanticIdentityErrorCode,
+                 output::OutputAnalysisAnalyzerErrorCodeV1,
+                 output::OutputAnalysisAttemptErrorCodeV1>;
+
+class OutputAnalysisAttemptFailureV1 final {
+  public:
+    OutputAnalysisAttemptFailureV1() = default;
+    template <typename Payload>
+    OutputAnalysisAttemptFailureV1(const OutputAnalysisAttemptStageV1 stage, const bool cancelled,
+                                   Payload payload)
+        : stage_(stage), cancelled_(cancelled), payload_(std::move(payload)) {}
+
+    [[nodiscard]] OutputAnalysisAttemptStageV1 stage() const noexcept { return stage_; }
+    [[nodiscard]] bool cancelled() const noexcept { return cancelled_; }
+    [[nodiscard]] const OutputAnalysisAttemptFailurePayloadV1& payload() const noexcept {
+        return payload_;
+    }
+    template <typename Payload> [[nodiscard]] const Payload* payloadAs() const noexcept {
+        return std::get_if<Payload>(&payload_);
+    }
+
+  private:
+    OutputAnalysisAttemptStageV1 stage_ = OutputAnalysisAttemptStageV1::Resolving;
+    bool cancelled_ = false;
+    OutputAnalysisAttemptFailurePayloadV1 payload_;
+};
+
+class [[nodiscard]] OutputAnalysisAttemptOutcomeV1 final {
+  public:
+    [[nodiscard]] static OutputAnalysisAttemptOutcomeV1
+    completed(std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt) noexcept;
+    [[nodiscard]] static OutputAnalysisAttemptOutcomeV1
+    failure(OutputAnalysisAttemptFailureV1 failure) noexcept;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return attempt_ != nullptr; }
+    [[nodiscard]] const std::shared_ptr<const output::OutputAnalysisAttemptV1>&
+    attempt() const& noexcept {
+        return attempt_;
+    }
+    [[nodiscard]] const std::shared_ptr<const output::OutputAnalysisAttemptV1>&
+    attempt() const&& = delete;
+    [[nodiscard]] const OutputAnalysisAttemptFailureV1* failure() const& noexcept {
+        return failure_.has_value() ? &*failure_ : nullptr;
+    }
+    [[nodiscard]] const OutputAnalysisAttemptFailureV1* failure() const&& = delete;
+
+  private:
+    std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt_;
+    std::optional<OutputAnalysisAttemptFailureV1> failure_;
+};
+
+namespace detail {
+struct OutputAnalysisAttemptRunnerState;
+}
+
+class OutputAnalysisAttemptRunnerResultV1;
+
+class OutputAnalysisAttemptRunnerV1 final {
+  public:
+    // Defined (= default) in the .cpp, where detail::OutputAnalysisAttemptRunnerState is a complete
+    // type -- std::unique_ptr<Incomplete>'s move-assignment operator requires completeness to
+    // destroy the previously owned object, so these cannot be defaulted inline here (the same
+    // pimpl idiom bloom::platform::StagedArtifactCoordinator's own move operations already use).
+    OutputAnalysisAttemptRunnerV1(OutputAnalysisAttemptRunnerV1&&) noexcept;
+    OutputAnalysisAttemptRunnerV1& operator=(OutputAnalysisAttemptRunnerV1&&) noexcept;
+    OutputAnalysisAttemptRunnerV1(const OutputAnalysisAttemptRunnerV1&) = delete;
+    OutputAnalysisAttemptRunnerV1& operator=(const OutputAnalysisAttemptRunnerV1&) = delete;
+    // Same typed-abandonment contract as ~AsyncSessionSave(): requests cancellation of whichever
+    // task is currently in flight, then drops the handle. Releases the target admission the
+    // Resolving task briefly held and, if the Cpu stage already built an attempt before this
+    // destructor runs, its resource reservation once the last reference drops.
+    ~OutputAnalysisAttemptRunnerV1();
+
+    // Non-blocking, non-consuming poll of whichever task is currently active. See
+    // bloom/host/session_async_io.hpp's identical "Readiness" documentation.
+    [[nodiscard]] bool isReady() const noexcept;
+    // May be called from any thread at any time, exactly like AsyncSessionSave::
+    // requestCancellation().
+    void requestCancellation() noexcept;
+    // Advances the internal state machine: while the active task is not yet terminal, returns
+    // nullopt. When Resolving completes successfully, this call submits the Cpu stage and returns
+    // nullopt again (still running). Only once the LAST stage reaches a scheduler-terminal state
+    // does this return the full typed outcome, exactly once.
+    [[nodiscard]] std::optional<OutputAnalysisAttemptOutcomeV1> tryComplete();
+
+  private:
+    friend class OutputAnalysisAttemptRunnerResultV1;
+    friend OutputAnalysisAttemptRunnerResultV1
+    beginOutputAnalysisAttemptV1(runtime::TaskScheduler&, platform::StagedArtifactCoordinator&,
+                                 output::ExportResourceLedgerV1&, OutputAnalysisAttemptRequestV1);
+
+    explicit OutputAnalysisAttemptRunnerV1(
+        std::unique_ptr<detail::OutputAnalysisAttemptRunnerState> state) noexcept;
+
+    std::unique_ptr<detail::OutputAnalysisAttemptRunnerState> state_;
+};
+
+class [[nodiscard]] OutputAnalysisAttemptRunnerResultV1 final {
+  public:
+    OutputAnalysisAttemptRunnerResultV1(OutputAnalysisAttemptRunnerResultV1&&) noexcept = default;
+    OutputAnalysisAttemptRunnerResultV1&
+    operator=(OutputAnalysisAttemptRunnerResultV1&&) noexcept = default;
+    OutputAnalysisAttemptRunnerResultV1(const OutputAnalysisAttemptRunnerResultV1&) = delete;
+    OutputAnalysisAttemptRunnerResultV1&
+    operator=(const OutputAnalysisAttemptRunnerResultV1&) = delete;
+    ~OutputAnalysisAttemptRunnerResultV1() = default;
+
+    [[nodiscard]] explicit operator bool() const noexcept { return handle_.has_value(); }
+    [[nodiscard]] std::optional<runtime::TaskSubmissionStatus> submissionFailure() const noexcept {
+        return submissionFailure_;
+    }
+    [[nodiscard]] OutputAnalysisAttemptRunnerV1 takeHandle() && noexcept;
+
+  private:
+    friend OutputAnalysisAttemptRunnerResultV1
+    beginOutputAnalysisAttemptV1(runtime::TaskScheduler&, platform::StagedArtifactCoordinator&,
+                                 output::ExportResourceLedgerV1&, OutputAnalysisAttemptRequestV1);
+
+    explicit OutputAnalysisAttemptRunnerResultV1(runtime::TaskSubmissionStatus status) noexcept;
+    explicit OutputAnalysisAttemptRunnerResultV1(OutputAnalysisAttemptRunnerV1 handle) noexcept;
+
+    std::optional<runtime::TaskSubmissionStatus> submissionFailure_;
+    std::optional<OutputAnalysisAttemptRunnerV1> handle_;
+};
+
+// Submits the Resolving task. `scheduler`, `artifacts`, and `ledger` must outlive the whole
+// asynchronous operation (identical threading rule to AsyncSessionSave's captured references).
+[[nodiscard]] OutputAnalysisAttemptRunnerResultV1 beginOutputAnalysisAttemptV1(
+    runtime::TaskScheduler& scheduler, platform::StagedArtifactCoordinator& artifacts,
+    output::ExportResourceLedgerV1& ledger, OutputAnalysisAttemptRequestV1 request);
+
+} // namespace bloom::host

--- a/src/host/output_analysis_attempt_runner.cpp
+++ b/src/host/output_analysis_attempt_runner.cpp
@@ -1,0 +1,360 @@
+#include <bloom/host/output_analysis_attempt_runner.hpp>
+
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace bloom::host {
+
+namespace {
+
+struct ResolvingOutcomeV1 final {
+    bool succeeded = false;
+    platform::StagedArtifactError error = platform::StagedArtifactError::None;
+    std::shared_ptr<const output::OutputAnalysisAttemptTargetV1> target = nullptr;
+};
+static_assert(runtime::TaskResultValue<ResolvingOutcomeV1>);
+
+enum class BuildFailureKindV1 : std::uint8_t {
+    None,
+    Evaluation,
+    Identity,
+    Analyzer,
+    AttemptBuild,
+};
+
+struct BuildOutcomeV1 final {
+    bool succeeded = false;
+    BuildFailureKindV1 failureKind = BuildFailureKindV1::None;
+    std::uint8_t rawCode = 0;
+    std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt = nullptr;
+};
+static_assert(runtime::TaskResultValue<BuildOutcomeV1>);
+
+[[nodiscard]] OutputAnalysisAttemptFailureV1
+translateBuildFailure(const BuildOutcomeV1& outcome) noexcept {
+    switch (outcome.failureKind) {
+    case BuildFailureKindV1::Evaluation:
+        return {OutputAnalysisAttemptStageV1::Evaluating, false,
+                static_cast<runtime::EvaluationDiagnosticCode>(outcome.rawCode)};
+    case BuildFailureKindV1::Identity:
+        return {OutputAnalysisAttemptStageV1::Identifying, false,
+                static_cast<output::ProcessFrameSemanticIdentityErrorCode>(outcome.rawCode)};
+    case BuildFailureKindV1::Analyzer:
+        return {OutputAnalysisAttemptStageV1::Analyzing, false,
+                static_cast<output::OutputAnalysisAnalyzerErrorCodeV1>(outcome.rawCode)};
+    case BuildFailureKindV1::AttemptBuild:
+        return {OutputAnalysisAttemptStageV1::Analyzing, false,
+                static_cast<output::OutputAnalysisAttemptErrorCodeV1>(outcome.rawCode)};
+    case BuildFailureKindV1::None:
+        break;
+    }
+    return {OutputAnalysisAttemptStageV1::Analyzing, false, std::monostate{}};
+}
+
+[[nodiscard]] runtime::TaskOwner attemptOwner(const runtime::TaskOwner requested) noexcept {
+    return requested.isValid() ? requested
+                               : runtime::TaskOwner{.kind = runtime::TaskOwnerKind::Export,
+                                                    .id = runtime::TaskOwnerId::fromRaw(1)};
+}
+
+} // namespace
+
+OutputAnalysisAttemptOutcomeV1 OutputAnalysisAttemptOutcomeV1::completed(
+    std::shared_ptr<const output::OutputAnalysisAttemptV1> attempt) noexcept {
+    OutputAnalysisAttemptOutcomeV1 outcome;
+    outcome.attempt_ = std::move(attempt);
+    return outcome;
+}
+
+OutputAnalysisAttemptOutcomeV1
+OutputAnalysisAttemptOutcomeV1::failure(OutputAnalysisAttemptFailureV1 failureValue) noexcept {
+    OutputAnalysisAttemptOutcomeV1 outcome;
+    outcome.failure_.emplace(failureValue); // trivially copyable; std::move() would be a no-op
+    return outcome;
+}
+
+namespace detail {
+
+struct OutputAnalysisAttemptRunnerState final {
+    runtime::TaskScheduler* scheduler = nullptr;
+    platform::StagedArtifactCoordinator* artifacts = nullptr;
+    output::ExportResourceLedgerV1* ledger = nullptr;
+    OutputAnalysisAttemptRequestV1 request;
+    OutputAnalysisAttemptStageV1 stage = OutputAnalysisAttemptStageV1::Resolving;
+    runtime::TaskHandle<ResolvingOutcomeV1> resolvingHandle;
+    std::optional<runtime::TaskHandle<BuildOutcomeV1>> buildHandle;
+    bool completed = false;
+};
+
+} // namespace detail
+
+OutputAnalysisAttemptRunnerV1::OutputAnalysisAttemptRunnerV1(
+    OutputAnalysisAttemptRunnerV1&&) noexcept = default;
+OutputAnalysisAttemptRunnerV1&
+OutputAnalysisAttemptRunnerV1::operator=(OutputAnalysisAttemptRunnerV1&&) noexcept = default;
+
+OutputAnalysisAttemptRunnerV1::OutputAnalysisAttemptRunnerV1(
+    std::unique_ptr<detail::OutputAnalysisAttemptRunnerState> state) noexcept
+    : state_(std::move(state)) {}
+
+OutputAnalysisAttemptRunnerV1::~OutputAnalysisAttemptRunnerV1() {
+    if (state_ && !state_->completed) {
+        requestCancellation();
+    }
+}
+
+bool OutputAnalysisAttemptRunnerV1::isReady() const noexcept {
+    if (!state_ || state_->completed || state_->scheduler == nullptr) {
+        return false;
+    }
+    const auto id =
+        state_->buildHandle.has_value() ? state_->buildHandle->id() : state_->resolvingHandle.id();
+    const auto snapshot = state_->scheduler->snapshot(id);
+    return snapshot.has_value() && runtime::isTerminal(snapshot->state);
+}
+
+void OutputAnalysisAttemptRunnerV1::requestCancellation() noexcept {
+    if (!state_) {
+        return;
+    }
+    if (state_->buildHandle.has_value()) {
+        state_->buildHandle->cancel();
+    } else {
+        state_->resolvingHandle.cancel();
+    }
+}
+
+std::optional<OutputAnalysisAttemptOutcomeV1> OutputAnalysisAttemptRunnerV1::tryComplete() {
+    if (!state_ || state_->completed) {
+        return std::nullopt;
+    }
+
+    if (!state_->buildHandle.has_value()) {
+        // Still waiting on / just reached the Resolving stage.
+        auto taken = state_->resolvingHandle.tryTakeResult();
+        if (!taken.has_value()) {
+            return std::nullopt;
+        }
+        if (taken->state() == runtime::TaskState::Cancelled) {
+            state_->completed = true;
+            return OutputAnalysisAttemptOutcomeV1::failure(
+                {OutputAnalysisAttemptStageV1::Resolving, true, std::monostate{}});
+        }
+        if (taken->state() != runtime::TaskState::Succeeded || !taken->value().has_value() ||
+            !taken->value()->succeeded) {
+            state_->completed = true;
+            const auto error = taken->value().has_value() ? taken->value()->error
+                                                          : platform::StagedArtifactError::None;
+            return OutputAnalysisAttemptOutcomeV1::failure(
+                {OutputAnalysisAttemptStageV1::Resolving, false, error});
+        }
+
+        // Resolving succeeded: submit the Cpu stage, consuming its typed result (the retained
+        // target) directly into the next task's closure -- never a wait/get/join.
+        auto resolvedTarget = taken->value()->target;
+        auto* ledger = state_->ledger;
+        auto plan = state_->request.plan;
+        auto evaluation = state_->request.evaluation;
+
+        runtime::TaskRequest cpuRequest(
+            "Analyze a frame export attempt", attemptOwner(state_->request.owner),
+            runtime::TaskPriority::Foreground, runtime::TaskExecutor::Cpu);
+        auto submission = state_->scheduler->submit<BuildOutcomeV1>(
+            std::move(cpuRequest),
+            [plan = std::move(plan), evaluation, resolvedTarget,
+             ledger](runtime::TaskContext& context) -> runtime::TaskResult<BuildOutcomeV1> {
+                if (context.isCancellationRequested()) {
+                    return runtime::TaskResult<BuildOutcomeV1>::cancelled();
+                }
+
+                context.reportProgress(
+                    {.phase = "Evaluating", .subphase = "", .completed = 0, .total = std::nullopt});
+                const runtime::CpuCompositionEvaluator evaluator;
+                auto evalResult = evaluator.evaluate(plan, evaluation, context.cancellation());
+                if (evalResult.status() == runtime::EvaluationStatus::Cancelled) {
+                    return runtime::TaskResult<BuildOutcomeV1>::cancelled();
+                }
+                if (evalResult.status() != runtime::EvaluationStatus::Evaluated ||
+                    evalResult.frame() == nullptr) {
+                    const auto code = evalResult.diagnostics().empty()
+                                          ? runtime::EvaluationDiagnosticCode::InternalInvariant
+                                          : evalResult.diagnostics().front().code;
+                    return runtime::TaskResult<BuildOutcomeV1>::succeeded(
+                        {.succeeded = false,
+                         .failureKind = BuildFailureKindV1::Evaluation,
+                         .rawCode = static_cast<std::uint8_t>(code)});
+                }
+                if (context.isCancellationRequested()) {
+                    return runtime::TaskResult<BuildOutcomeV1>::cancelled();
+                }
+
+                context.reportProgress({.phase = "Identifying",
+                                        .subphase = "",
+                                        .completed = 0,
+                                        .total = std::nullopt});
+                const output::ProcessFrameSemanticIdentityV1Preparer identityPreparer;
+                auto identityResult =
+                    identityPreparer.prepare(evalResult.frame(), context.cancellation());
+                if (identityResult.status() ==
+                    output::ProcessFrameSemanticIdentityPreparationStatus::Cancelled) {
+                    return runtime::TaskResult<BuildOutcomeV1>::cancelled();
+                }
+                if (identityResult.status() !=
+                        output::ProcessFrameSemanticIdentityPreparationStatus::Prepared ||
+                    identityResult.identity() == nullptr) {
+                    return runtime::TaskResult<BuildOutcomeV1>::succeeded(
+                        {.succeeded = false,
+                         .failureKind = BuildFailureKindV1::Identity,
+                         .rawCode = static_cast<std::uint8_t>(identityResult.error())});
+                }
+                if (context.isCancellationRequested()) {
+                    return runtime::TaskResult<BuildOutcomeV1>::cancelled();
+                }
+
+                context.reportProgress(
+                    {.phase = "Analyzing", .subphase = "", .completed = 0, .total = std::nullopt});
+                auto analyzed = output::analyzeFlatExrRgba32fLinRec709SceneV1(
+                    {.process = {.state = output::OutputAnalysisProcessSourceStateV1::Ready,
+                                 .readyIdentity = identityResult.identity(),
+                                 .missingDescriptor = std::nullopt}});
+                if (!analyzed.hasReport()) {
+                    return runtime::TaskResult<BuildOutcomeV1>::succeeded(
+                        {.succeeded = false,
+                         .failureKind = BuildFailureKindV1::Analyzer,
+                         .rawCode = static_cast<std::uint8_t>(analyzed.error())});
+                }
+                if (context.isCancellationRequested()) {
+                    return runtime::TaskResult<BuildOutcomeV1>::cancelled();
+                }
+
+                auto buildResult = output::buildOutputAnalysisAttemptV1(
+                    {.frame = evalResult.frame(),
+                     .processIdentity = identityResult.identity(),
+                     .report = analyzed.report(),
+                     .target = *resolvedTarget},
+                    *ledger);
+                if (!buildResult) {
+                    return runtime::TaskResult<BuildOutcomeV1>::succeeded(
+                        {.succeeded = false,
+                         .failureKind = BuildFailureKindV1::AttemptBuild,
+                         .rawCode = static_cast<std::uint8_t>(buildResult.error())});
+                }
+                return runtime::TaskResult<BuildOutcomeV1>::succeeded(
+                    {.succeeded = true, .attempt = buildResult.attempt()});
+            });
+
+        if (!submission.accepted()) {
+            state_->completed = true;
+            return OutputAnalysisAttemptOutcomeV1::failure(
+                {OutputAnalysisAttemptStageV1::Evaluating, false, submission.status});
+        }
+        state_->buildHandle.emplace(std::move(submission.handle));
+        return std::nullopt;
+    }
+
+    auto taken = state_->buildHandle->tryTakeResult();
+    if (!taken.has_value()) {
+        return std::nullopt;
+    }
+    state_->completed = true;
+    if (taken->state() == runtime::TaskState::Cancelled) {
+        return OutputAnalysisAttemptOutcomeV1::failure(
+            {OutputAnalysisAttemptStageV1::Evaluating, true, std::monostate{}});
+    }
+    if (taken->state() != runtime::TaskState::Succeeded || !taken->value().has_value() ||
+        !taken->value()->succeeded || taken->value()->attempt == nullptr) {
+        if (taken->value().has_value()) {
+            return OutputAnalysisAttemptOutcomeV1::failure(translateBuildFailure(*taken->value()));
+        }
+        return OutputAnalysisAttemptOutcomeV1::failure(
+            {OutputAnalysisAttemptStageV1::Analyzing, false, std::monostate{}});
+    }
+    return OutputAnalysisAttemptOutcomeV1::completed(taken->value()->attempt);
+}
+
+OutputAnalysisAttemptRunnerResultV1::OutputAnalysisAttemptRunnerResultV1(
+    const runtime::TaskSubmissionStatus status) noexcept
+    : submissionFailure_(status) {}
+
+OutputAnalysisAttemptRunnerResultV1::OutputAnalysisAttemptRunnerResultV1(
+    OutputAnalysisAttemptRunnerV1 handle) noexcept
+    : handle_(std::move(handle)) {}
+
+OutputAnalysisAttemptRunnerV1 OutputAnalysisAttemptRunnerResultV1::takeHandle() && noexcept {
+    if (!handle_.has_value()) {
+        std::terminate();
+    }
+    return std::move(*handle_);
+}
+
+OutputAnalysisAttemptRunnerResultV1 beginOutputAnalysisAttemptV1(
+    runtime::TaskScheduler& scheduler, platform::StagedArtifactCoordinator& artifacts,
+    output::ExportResourceLedgerV1& ledger, OutputAnalysisAttemptRequestV1 request) {
+    const auto targetPath = request.targetPath;
+    const auto overwritePolicy = request.overwritePolicy;
+    // Direct aggregate-brace construction (never T's own implicit default constructor, which
+    // std::make_unique<T>() would call with zero arguments): OutputAnalysisAttemptRequestV1 has no
+    // default constructor of its own (runtime::EvaluationRequest's OperationIndex member has none
+    // either), so `request` -- the one field with no usable default -- must be supplied inline
+    // here rather than default-constructed then assigned.
+    auto state = std::unique_ptr<detail::OutputAnalysisAttemptRunnerState>(
+        new detail::OutputAnalysisAttemptRunnerState{
+            .scheduler = &scheduler,
+            .artifacts = &artifacts,
+            .ledger = &ledger,
+            .request = std::move(request),
+            .stage = OutputAnalysisAttemptStageV1::Resolving,
+            .resolvingHandle = {},
+            .buildHandle = std::nullopt,
+            .completed = false,
+        });
+
+    runtime::TaskRequest resolvingRequest(
+        "Resolve an export target", attemptOwner(state->request.owner),
+        runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo);
+    auto submission = scheduler.submit<ResolvingOutcomeV1>(
+        std::move(resolvingRequest),
+        [&artifacts, targetPath, overwritePolicy](
+            runtime::TaskContext& context) -> runtime::TaskResult<ResolvingOutcomeV1> {
+            if (context.isCancellationRequested()) {
+                return runtime::TaskResult<ResolvingOutcomeV1>::cancelled();
+            }
+            auto preflightResult = artifacts.preflight({.targetPath = targetPath,
+                                                        .overwritePolicy = overwritePolicy,
+                                                        .expectedTarget = std::nullopt});
+            if (!preflightResult) {
+                return runtime::TaskResult<ResolvingOutcomeV1>::succeeded(
+                    {.succeeded = false, .error = preflightResult.error()});
+            }
+            auto target = std::move(preflightResult).takeTarget();
+            const auto targetKey = target.targetKey();
+            const auto observation = target.observation();
+            // `target` goes out of scope here: the live platform active-target admission it holds
+            // is released immediately rather than kept open for the duration of a pending artist
+            // decision (see this file's own header-level rationale comment).
+            std::shared_ptr<const output::OutputAnalysisAttemptTargetV1> retained;
+            try {
+                retained = std::make_shared<const output::OutputAnalysisAttemptTargetV1>(
+                    output::OutputAnalysisAttemptTargetV1{.targetKey = targetKey,
+                                                          .observation = observation,
+                                                          .targetPath = targetPath,
+                                                          .overwritePolicy = overwritePolicy});
+            } catch (const std::bad_alloc&) {
+                return runtime::TaskResult<ResolvingOutcomeV1>::succeeded(
+                    {.succeeded = false,
+                     .error = platform::StagedArtifactError::ResourceUnavailable});
+            }
+            return runtime::TaskResult<ResolvingOutcomeV1>::succeeded(
+                {.succeeded = true, .target = std::move(retained)});
+        });
+
+    if (!submission.accepted()) {
+        return OutputAnalysisAttemptRunnerResultV1(submission.status);
+    }
+    state->resolvingHandle = std::move(submission.handle);
+    return OutputAnalysisAttemptRunnerResultV1(OutputAnalysisAttemptRunnerV1(std::move(state)));
+}
+
+} // namespace bloom::host

--- a/src/host/tests/frame_export_publication_tests.cpp
+++ b/src/host/tests/frame_export_publication_tests.cpp
@@ -1,0 +1,875 @@
+#include <bloom/host/frame_export_publication.hpp>
+
+#include <bloom/host/output_analysis_attempt_runner.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/output/flat_exr_reopen_verifier.hpp>
+
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
+#include <bloom/document/ids.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/compiled_plan.hpp>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+// Task F2 (issue #101): drives approveFrameExportV1()/executeExportPublication() against a real
+// platform::StagedArtifactCoordinator + PublicationCoordinator, mirroring bloom/host/tests/
+// save_publication_tests.cpp / copy_publication_tests.cpp's own top-of-file rationale for doing so.
+namespace {
+
+namespace document = bloom::document;
+namespace host = bloom::host;
+namespace output = bloom::output;
+namespace platform = bloom::platform;
+namespace runtime = bloom::runtime;
+
+using namespace std::chrono_literals;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+// The one place this file dereferences a std::optional (or a std::optional-shaped result type)
+// without a directly-adjacent has_value()/operator bool() check: it performs that check right
+// here and returns a raw pointer, so every call site below works with a plain (possibly-null)
+// pointer instead -- clang-tidy's bugprone-unchecked-optional-access only tracks std::optional
+// itself, so converting to a pointer once, in one place, is the established way to avoid repeating
+// an unprovable-at-a-distance check at dozens of call sites.
+template <typename Optional>
+[[nodiscard]] auto require(Optional& value, Expectations& expectations,
+                           const std::string_view message) -> decltype(&*value) {
+    expectations.expect(static_cast<bool>(value), message);
+    if (!value) {
+        return nullptr;
+    }
+    return &*value; // NOLINT(bugprone-unchecked-optional-access) -- guarded immediately above.
+}
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-frame-export-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (!path_.empty()) {
+            std::error_code errorCode;
+            std::filesystem::remove_all(path_, errorCode);
+        }
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+constexpr auto kProjectId = document::ProjectId::fromRaw(0x2001);
+constexpr auto kCompositionId = document::CompositionId::fromRaw(0x2002);
+constexpr auto kSolidNodeId = document::NodeId::fromRaw(0x2003);
+constexpr auto kOutputNodeId = document::NodeId::fromRaw(0x2004);
+constexpr auto kColorParameterId = document::ParameterId::fromRaw(0x2005);
+constexpr auto kRevision = document::Revision::fromRaw(0x2006);
+constexpr auto kLayerNodeId = document::NodeId::fromRaw(0x2007);
+constexpr auto kLayerId = document::LayerId::fromRaw(0x2008);
+constexpr auto kStackNodeId = document::NodeId::fromRaw(0x2009);
+constexpr auto kSlotId = document::LayerSlotId::fromRaw(0x200a);
+constexpr auto kPositionParameterId = document::ParameterId::fromRaw(0x200b);
+constexpr auto kOpacityParameterId = document::ParameterId::fromRaw(0x200c);
+
+[[nodiscard]] std::shared_ptr<const runtime::CompiledCompositionPlan> smallSolidPlan() {
+    const auto format = document::CompositionFormat::create(2, 2);
+    if (!format) {
+        std::abort();
+    }
+    std::vector<runtime::CompiledOperation> operations;
+    operations.emplace_back(runtime::CompiledSolid{kSolidNodeId, kColorParameterId,
+                                                   bloom::core::Color4d{0.1, 0.2, 0.3, 1.0}});
+    // CompiledCompositionOutput requires a layer-stack input, not a bare solid (mirrors
+    // bloom/output/tests/flat_exr_test_support.hpp's shellPlan()): solid -> layer output -> layer
+    // stack -> composition output.
+    operations.emplace_back(runtime::CompiledLayerOutput{
+        kLayerNodeId, kLayerId, runtime::OperationIndex::fromRaw(0),
+        runtime::CompiledVec2Parameter{kPositionParameterId, document::Vec2d{0.5, 0.5}},
+        runtime::CompiledScalarParameter{kOpacityParameterId, 1.0}});
+    operations.emplace_back(runtime::CompiledLayerStack{
+        kStackNodeId, {{kSlotId, kLayerId, runtime::OperationIndex::fromRaw(1)}}});
+    operations.emplace_back(
+        runtime::CompiledCompositionOutput{kOutputNodeId, runtime::OperationIndex::fromRaw(2)});
+    return std::make_shared<const runtime::CompiledCompositionPlan>(
+        runtime::CompiledCompositionPlanDefinition{.sourceRevision = kRevision,
+                                                   .projectId = kProjectId,
+                                                   .compositionId = kCompositionId,
+                                                   .format = *format,
+                                                   .operations = std::move(operations),
+                                                   .output = runtime::OperationIndex::fromRaw(3)});
+}
+
+[[nodiscard]] host::OutputAnalysisAttemptRequestV1
+attemptRequestFor(const std::filesystem::path& target) {
+    const auto plan = smallSolidPlan();
+    return {
+        .plan = plan,
+        .evaluation = {.time = bloom::core::RationalTime::fromInteger(0),
+                       .output = plan->output(),
+                       .resolution = runtime::CompositionFormatResolution{},
+                       .quality = runtime::EvaluationQuality::Reference,
+                       .colorIntent = runtime::EvaluationColorIntent::LinearRec709Scene,
+                       .pixelStorageByteLimit = 4096},
+        .targetPath = target,
+        .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
+        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)}};
+}
+
+// Owns a real TaskScheduler/StagedArtifactCoordinator/PublicationCoordinator/ExportResourceLedgerV1
+// fixture set. TaskScheduler is non-movable (its move constructor/assignment are explicitly
+// deleted) and StagedArtifactCoordinator/PublicationCoordinator are only constructible through
+// their own ::create() factories, so every member is held in-place inside a std::optional and
+// populated by setUp() -- the accessor methods below are the ONE place each member's optional is
+// dereferenced (guarded by setUp()'s own already-checked success), rather than repeating an
+// unprovable-at-a-distance dereference at every one of this file's many call sites.
+class ExportFixture final {
+  public:
+    [[nodiscard]] bool setUp(Expectations& expectations, const std::string_view context) {
+        auto artifactsResult = platform::StagedArtifactCoordinator::create({});
+        auto coordinatorResult = host::PublicationCoordinator::create();
+        const bool ok =
+            directory_.isValid() && artifactsResult.succeeded() && coordinatorResult.has_value();
+        expectations.expect(ok, context);
+        if (!ok) {
+            return false;
+        }
+        scheduler_.emplace();
+        artifacts_.emplace(std::move(artifactsResult).takeCoordinator());
+        coordinator_.emplace(
+            std::move(*coordinatorResult)); // NOLINT(bugprone-unchecked-optional-access)
+        ledger_.emplace();
+        return true;
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return directory_.path(); }
+    [[nodiscard]] runtime::TaskScheduler& scheduler() noexcept {
+        return *scheduler_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed by setUp().
+    }
+    [[nodiscard]] platform::StagedArtifactCoordinator& artifacts() noexcept {
+        return *artifacts_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed by setUp().
+    }
+    [[nodiscard]] host::PublicationCoordinator& coordinator() noexcept {
+        return *coordinator_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed by
+                              // setUp().
+    }
+    [[nodiscard]] output::ExportResourceLedgerV1& ledger() noexcept {
+        return *ledger_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed by setUp().
+    }
+
+  private:
+    TempDirectory directory_;
+    std::optional<runtime::TaskScheduler> scheduler_;
+    std::optional<platform::StagedArtifactCoordinator> artifacts_;
+    std::optional<host::PublicationCoordinator> coordinator_;
+    std::optional<output::ExportResourceLedgerV1> ledger_;
+};
+
+// Runs beginOutputAnalysisAttemptV1() to a completed, approvable attempt over `target`. Every test
+// fixture below needs a real attempt (frame + identity + report + digest), not a hand-built one --
+// approveFrameExportV1() cannot be exercised meaningfully without one.
+[[nodiscard]] std::shared_ptr<const output::OutputAnalysisAttemptV1>
+buildApprovableAttempt(Expectations& expectations, runtime::TaskScheduler& scheduler,
+                       platform::StagedArtifactCoordinator& artifacts,
+                       output::ExportResourceLedgerV1& ledger,
+                       const std::filesystem::path& target) {
+    auto begin =
+        host::beginOutputAnalysisAttemptV1(scheduler, artifacts, ledger, attemptRequestFor(target));
+    expectations.expect(static_cast<bool>(begin),
+                        "attempt fixture: begin submits the Resolving task");
+    if (!begin) {
+        return nullptr;
+    }
+    auto runner = std::move(begin).takeHandle();
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto outcome = runner.tryComplete();
+        if (!outcome.has_value()) {
+            std::this_thread::sleep_for(1ms);
+            continue;
+        }
+        const auto& outcomeValue = *outcome; // NOLINT(bugprone-unchecked-optional-access)
+        expectations.expect(static_cast<bool>(outcomeValue),
+                            "attempt fixture: the attempt completes");
+        return static_cast<bool>(outcomeValue) ? outcomeValue.attempt() : nullptr;
+    }
+    expectations.expect(false, "attempt fixture: the attempt reaches a terminal outcome in time");
+    return nullptr;
+}
+
+// Retrieves attempt->digest() with an immediately-adjacent has_value() check (attempt->digest()
+// is a fresh temporary each call, so no earlier check anywhere else in the caller can cover it).
+[[nodiscard]] bloom::core::Sha256Digest
+requireDigest(const std::shared_ptr<const output::OutputAnalysisAttemptV1>& attempt,
+              Expectations& expectations) {
+    const auto digest = attempt->digest();
+    expectations.expect(digest.has_value(), "the attempt fixture is approvable with a digest");
+    if (!digest.has_value()) {
+        return {};
+    }
+    return *digest; // NOLINT(bugprone-unchecked-optional-access) -- guarded immediately above.
+}
+
+struct ExportRun final {
+    runtime::TaskHandle<void> handle;
+    std::shared_ptr<std::optional<host::FrameExportPublicationResultV1>> result;
+};
+
+[[nodiscard]] std::optional<ExportRun>
+beginExportRun(runtime::TaskScheduler& scheduler, platform::StagedArtifactCoordinator& artifacts,
+               std::unique_ptr<host::FrameExportRequestV1> request,
+               const std::filesystem::path& scratchDir,
+               const output::OutputExportClockV1& clock = {}) {
+    auto shared = std::make_shared<std::optional<host::FrameExportPublicationResultV1>>();
+    auto sharedRequest = std::shared_ptr<host::FrameExportRequestV1>(std::move(request));
+    auto submission = scheduler.submit<void>(
+        runtime::TaskRequest("export-publication-test",
+                             runtime::TaskOwner{.kind = runtime::TaskOwnerKind::Export,
+                                                .id = runtime::TaskOwnerId::fromRaw(2)},
+                             runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo),
+        [&artifacts, sharedRequest, shared, scratchDir, clock](runtime::TaskContext& context) {
+            auto result = host::executeExportPublication(
+                context, artifacts, std::move(*sharedRequest), scratchDir, clock);
+            shared->emplace(std::move(result));
+            return runtime::TaskResult<void>::succeeded();
+        });
+    if (!submission.accepted()) {
+        return std::nullopt;
+    }
+    return ExportRun{std::move(submission.handle), shared};
+}
+
+// Polls handle.tryTakeResult() to terminality, then returns the worker's own recorded outcome.
+[[nodiscard]] std::optional<host::FrameExportPublicationResultV1> awaitExportRun(ExportRun& run) {
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (run.handle.tryTakeResult().has_value()) {
+            break;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return std::move(*run.result);
+}
+
+// -------------------------------------------------------------------------------------------
+// Approval
+// -------------------------------------------------------------------------------------------
+
+void testDigestMismatchRejected(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "digest mismatch: fixture is available")) {
+        return;
+    }
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                          fixture.ledger(), fixture.path() / "mismatch.exr");
+    if (attempt == nullptr) {
+        return;
+    }
+
+    const auto goodDigest = requireDigest(attempt, expectations);
+    auto mutableBytes = bloom::core::Sha256Digest::Bytes{};
+    std::ranges::copy(goodDigest.bytes(), mutableBytes.begin());
+    mutableBytes[0] = static_cast<std::uint8_t>(mutableBytes[0] ^ 0xFFU);
+    const auto flipped = bloom::core::Sha256Digest::fromBytes(mutableBytes);
+
+    auto result = host::approveFrameExportV1(fixture.coordinator(), attempt, flipped);
+    expectations.expect(
+        result.status() == host::FrameExportApprovalStatusV1::DigestMismatch,
+        "an approver digest that does not byte-equal the attempt's own digest is rejected");
+    expectations.expect(!result, "a rejected approval carries no request");
+}
+
+void testIntentRegisteredExactlyOnce(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "intent-once: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "intent-once.exr";
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                          fixture.ledger(), target);
+    if (attempt == nullptr) {
+        return;
+    }
+    const auto targetKey = attempt->target().targetKey;
+
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval),
+                        "approval with the exact retained digest succeeds");
+    if (!approval) {
+        return;
+    }
+    auto snapshot = fixture.coordinator().targetSnapshot(targetKey);
+    expectations.expect(static_cast<bool>(snapshot) &&
+                            snapshot.snapshot().activeTargetClaimCount == 1,
+                        "approval registers exactly one active target claim for this target");
+}
+
+// -------------------------------------------------------------------------------------------
+// Job execution
+// -------------------------------------------------------------------------------------------
+
+void testEndToEndExportPublished(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "end to end: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "published.exr";
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                          fixture.ledger(), target);
+    if (attempt == nullptr) {
+        return;
+    }
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval), "end to end: approval succeeds");
+    if (!approval) {
+        return;
+    }
+
+    auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                              std::move(approval).takeRequest(), fixture.path());
+    auto* runValue = require(run, expectations, "end to end: the export job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result =
+        require(resultOpt, expectations, "end to end: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*result) && result->publication() != nullptr &&
+                            result->publication()->outcome ==
+                                platform::StagedArtifactPublicationOutcome::Published,
+                        "end to end: the export publishes");
+    expectations.expect(std::filesystem::exists(target), "end to end: the target file now exists");
+    const auto semanticDigest = result->semanticDigest();
+    expectations.expect(semanticDigest.has_value() && result->artifactDigest().has_value(),
+                        "end to end: both the semantic and artifact digests are surfaced");
+    if (!semanticDigest.has_value()) {
+        return;
+    }
+
+    // "reopened file passes the F1 verifier independently".
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 independentVerifier;
+    const auto verifyResult =
+        independentVerifier.verify(target, attempt->processIdentity(), attempt->report(), {});
+    expectations.expect(
+        verifyResult.status() == output::FlatExrVerifyStatusV1::Verified &&
+            verifyResult.digest() == *semanticDigest, // NOLINT(bugprone-unchecked-optional-access)
+        "the published target independently reopen-verifies to the surfaced digest");
+}
+
+void testSupersessionOlderPublishesSecond(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "supersession: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "superseded.exr";
+
+    auto attemptA = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                           fixture.ledger(), target);
+    auto attemptB = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                           fixture.ledger(), target);
+    if (attemptA == nullptr || attemptB == nullptr) {
+        return;
+    }
+    auto approvalA = host::approveFrameExportV1(fixture.coordinator(), attemptA,
+                                                requireDigest(attemptA, expectations));
+    auto approvalB = host::approveFrameExportV1(fixture.coordinator(), attemptB,
+                                                requireDigest(attemptB, expectations));
+    expectations.expect(static_cast<bool>(approvalA) && static_cast<bool>(approvalB),
+                        "supersession: both intents approve for the same target");
+    if (!approvalA || !approvalB) {
+        return;
+    }
+    auto requestA = std::move(approvalA).takeRequest();
+    auto requestB = std::move(approvalB).takeRequest();
+    const auto olderIntent = requestA->intentId();
+    const auto newerIntent = requestB->intentId();
+    expectations.expect(olderIntent.value() < newerIntent.value(),
+                        "supersession: the first-approved intent is numerically older");
+
+    // The older intent's job runs FULLY to completion first, while the target is still untouched
+    // (the newer intent has not published yet): its own preflight/writing/verifying all succeed
+    // against the still-absent target, so only its final Guard step observes that a newer
+    // same-target intent already exists.
+    auto runA = beginExportRun(fixture.scheduler(), fixture.artifacts(), std::move(requestA),
+                               fixture.path());
+    auto* runAValue = require(runA, expectations, "supersession: the older job is submitted");
+    if (runAValue == nullptr) {
+        return;
+    }
+    auto resultAOpt = awaitExportRun(*runAValue);
+    const auto* resultA =
+        require(resultAOpt, expectations, "supersession: the older job reaches a terminal state");
+    if (resultA == nullptr) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*resultA) && resultA->publication() != nullptr &&
+                            resultA->publication()->outcome ==
+                                platform::StagedArtifactPublicationOutcome::Superseded,
+                        "the older intent's own publish observes Superseded");
+    expectations.expect(!std::filesystem::exists(target),
+                        "a superseded older intent leaves the target untouched");
+
+    auto runB = beginExportRun(fixture.scheduler(), fixture.artifacts(), std::move(requestB),
+                               fixture.path());
+    auto* runBValue = require(runB, expectations, "supersession: the newer job is submitted");
+    if (runBValue == nullptr) {
+        return;
+    }
+    auto resultBOpt = awaitExportRun(*runBValue);
+    const auto* resultB =
+        require(resultBOpt, expectations, "supersession: the newer job reaches a terminal state");
+    if (resultB == nullptr) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*resultB) && resultB->publication() != nullptr &&
+                            resultB->publication()->outcome ==
+                                platform::StagedArtifactPublicationOutcome::Published,
+                        "the newer intent publishes normally");
+    expectations.expect(std::filesystem::exists(target), "the newer intent's file is intact");
+}
+
+void testExternalModificationConflict(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "external conflict: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "conflict.exr";
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                          fixture.ledger(), target);
+    if (attempt == nullptr) {
+        return;
+    }
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval), "external conflict: approval succeeds");
+    if (!approval) {
+        return;
+    }
+
+    // An out-of-band write between approval and publish -- the attempt observed an absent target,
+    // but by the time the job runs a file now exists there.
+    {
+        std::ofstream external(target, std::ios::binary);
+        external << "not a bloom export";
+    }
+
+    auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                              std::move(approval).takeRequest(), fixture.path());
+    auto* runValue = require(run, expectations, "external conflict: the job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result =
+        require(resultOpt, expectations, "external conflict: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    const auto* failure = result->failure();
+    expectations.expect(failure != nullptr &&
+                            failure->payloadAs<platform::StagedArtifactError>() != nullptr &&
+                            *failure->payloadAs<platform::StagedArtifactError>() ==
+                                platform::StagedArtifactError::ExternalModificationConflict,
+                        "an externally-modified target between approval and publish is a typed "
+                        "conflict, not a crash");
+    std::ifstream reopened(target);
+    std::string contents((std::istreambuf_iterator<char>(reopened)),
+                         std::istreambuf_iterator<char>());
+    expectations.expect(contents == "not a bloom export",
+                        "the externally-written target is left exactly as it was");
+}
+
+[[nodiscard]] host::OutputAnalysisAttemptRequestV1
+attemptRequestWithPolicy(const std::filesystem::path& target,
+                         const platform::ArtifactOverwritePolicy policy) {
+    auto request = attemptRequestFor(target);
+    request.overwritePolicy = policy;
+    return request;
+}
+
+void testOverwritePolicyCreateOnlyDeniesExisting(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "overwrite create-only: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "create-only.exr";
+    {
+        std::ofstream existing(target, std::ios::binary);
+        existing << "already here";
+    }
+    auto begin = host::beginOutputAnalysisAttemptV1(
+        fixture.scheduler(), fixture.artifacts(), fixture.ledger(),
+        attemptRequestWithPolicy(target, platform::ArtifactOverwritePolicy::CreateOnly));
+    expectations.expect(static_cast<bool>(begin),
+                        "overwrite create-only: begin submits the Resolving task");
+    if (!begin) {
+        return;
+    }
+    auto runner = std::move(begin).takeHandle();
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    std::optional<host::OutputAnalysisAttemptOutcomeV1> outcome;
+    while (std::chrono::steady_clock::now() < deadline) {
+        outcome = runner.tryComplete();
+        if (outcome.has_value()) {
+            break;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    const auto* outcomeValue = require(
+        outcome, expectations, "overwrite create-only: the attempt reaches a terminal outcome");
+    if (outcomeValue == nullptr) {
+        return;
+    }
+    expectations.expect(
+        !*outcomeValue,
+        "CreateOnly against an existing target fails the attempt's own Resolving preflight");
+}
+
+void testOverwritePolicyReplaceExistingSucceeds(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "overwrite replace-existing: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "replace-existing.exr";
+    {
+        std::ofstream existing(target, std::ios::binary);
+        existing << "already here";
+    }
+    auto begin = host::beginOutputAnalysisAttemptV1(
+        fixture.scheduler(), fixture.artifacts(), fixture.ledger(),
+        attemptRequestWithPolicy(target, platform::ArtifactOverwritePolicy::ReplaceExisting));
+    expectations.expect(static_cast<bool>(begin),
+                        "overwrite replace-existing: begin submits the Resolving task");
+    if (!begin) {
+        return;
+    }
+    auto runner = std::move(begin).takeHandle();
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    std::optional<host::OutputAnalysisAttemptOutcomeV1> outcome;
+    while (std::chrono::steady_clock::now() < deadline) {
+        outcome = runner.tryComplete();
+        if (outcome.has_value()) {
+            break;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    const auto* outcomeValue =
+        require(outcome, expectations,
+                "overwrite replace-existing: the attempt reaches a terminal outcome");
+    if (outcomeValue == nullptr) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*outcomeValue),
+                        "ReplaceExisting against an existing target completes the attempt");
+    if (!*outcomeValue) {
+        return;
+    }
+    auto attempt = outcomeValue->attempt();
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval),
+                        "overwrite replace-existing: approval succeeds");
+    if (!approval) {
+        return;
+    }
+    auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                              std::move(approval).takeRequest(), fixture.path());
+    auto* runValue = require(run, expectations, "overwrite replace-existing: the job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result = require(resultOpt, expectations,
+                                 "overwrite replace-existing: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*result) && result->publication() != nullptr &&
+                            result->publication()->targetWasPublished(),
+                        "ReplaceExisting overwrites the pre-existing target with the export");
+}
+
+void testDurabilityWarningViaFaultInjection(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "durability warning: fixture is available")) {
+        return;
+    }
+    // A test seam the platform surface already exposes (bloom/platform/staged_artifact.hpp's
+    // StagedArtifactFaultPlan): a fresh coordinator configured to inject a ParentDurability
+    // failure at the parent-directory fsync step so the publish outcome is deterministically
+    // PublishedWithDurabilityWarning rather than depending on an unreliable real filesystem/host
+    // condition.
+    auto injectedArtifacts = platform::StagedArtifactCoordinator::create(
+        {.faults = {.point = platform::StagedArtifactFaultPoint::ParentDurability,
+                    .occurrence = 1}});
+    expectations.expect(injectedArtifacts.succeeded(),
+                        "durability warning: the fault-injecting coordinator is created");
+    if (!injectedArtifacts) {
+        return;
+    }
+    auto artifacts = std::move(injectedArtifacts).takeCoordinator();
+    const auto target = fixture.path() / "durability.exr";
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), artifacts,
+                                          fixture.ledger(), target);
+    if (attempt == nullptr) {
+        return;
+    }
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval), "durability warning: approval succeeds");
+    if (!approval) {
+        return;
+    }
+    auto run = beginExportRun(fixture.scheduler(), artifacts, std::move(approval).takeRequest(),
+                              fixture.path());
+    auto* runValue = require(run, expectations, "durability warning: the job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result =
+        require(resultOpt, expectations, "durability warning: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    expectations.expect(
+        static_cast<bool>(*result) && result->publication() != nullptr &&
+            result->publication()->outcome ==
+                platform::StagedArtifactPublicationOutcome::PublishedWithDurabilityWarning,
+        "an injected parent-durability fault yields PublishedWithDurabilityWarning");
+    expectations.expect(std::filesystem::exists(target),
+                        "the target is visible despite the durability warning");
+}
+
+void testCancellationBeforeStagingLeavesTargetIntact(Expectations& expectations) {
+    // "Cancellation mid-Writing and mid-Verifying" -- see the implementor's report for why the
+    // frozen runtime::CancellationToken API cannot preempt a single synchronous F1 writer/verifier
+    // call from outside it (no self-cancellation seam exists); this exercises the closest
+    // deterministic equivalent this pipeline can offer: cancellation observed at the stage
+    // boundary immediately before Writing/Verifying begins, with the identical caller-observable
+    // contract ("previous target intact, typed outcome").
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "cancellation: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "cancelled.exr";
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                          fixture.ledger(), target);
+    if (attempt == nullptr) {
+        return;
+    }
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval), "cancellation: approval succeeds");
+    if (!approval) {
+        return;
+    }
+
+    auto shared = std::make_shared<std::optional<host::FrameExportPublicationResultV1>>();
+    auto sharedRequest =
+        std::shared_ptr<host::FrameExportRequestV1>(std::move(approval).takeRequest());
+    auto scratchDir = fixture.path();
+    auto submission = fixture.scheduler().submit<void>(
+        runtime::TaskRequest("export-publication-cancel-test",
+                             runtime::TaskOwner{.kind = runtime::TaskOwnerKind::Export,
+                                                .id = runtime::TaskOwnerId::fromRaw(3)},
+                             runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo),
+        [&artifacts = fixture.artifacts(), sharedRequest, shared,
+         scratchDir](runtime::TaskContext& context) {
+            while (!context.isCancellationRequested()) {
+            }
+            auto result = host::executeExportPublication(context, artifacts,
+                                                         std::move(*sharedRequest), scratchDir);
+            shared->emplace(std::move(result));
+            return runtime::TaskResult<void>::succeeded();
+        });
+    expectations.expect(submission.accepted(), "cancellation: the job is submitted");
+    if (!submission.accepted()) {
+        return;
+    }
+    submission.handle.cancel();
+    ExportRun run{std::move(submission.handle), shared};
+    // Two legitimate outcomes race here, both correct: the scheduler may cancel the task before
+    // ever invoking this closure (shared stays unpopulated -- awaitExportRun() then returns
+    // nullopt), or the closure starts, observes cancellation at its very first checkpoint, and
+    // returns a typed CancelledResult. Either way nothing is published.
+    auto resultOpt = awaitExportRun(run);
+    if (resultOpt.has_value()) {
+        expectations.expect(!*resultOpt, // NOLINT(bugprone-unchecked-optional-access)
+                            "cancellation: an early-cancelled job never reaches publish()");
+    }
+    expectations.expect(!std::filesystem::exists(target),
+                        "cancellation before staging leaves the (nonexistent) target untouched");
+}
+
+// A deterministic fake clock (design decision 5's injectable clock seam): the first two calls
+// establish `start`/`lastProgress`; every call after that jumps `jump` ahead, tripping the
+// relevant deadline/no-progress limit without depending on real elapsed wall time.
+[[nodiscard]] output::OutputExportClockV1
+jumpingClock(const std::chrono::steady_clock::duration jump) {
+    auto calls = std::make_shared<int>(0);
+    return [calls, jump]() noexcept {
+        ++*calls;
+        if (*calls <= 2) {
+            return std::chrono::steady_clock::time_point{};
+        }
+        return std::chrono::steady_clock::time_point{} + jump;
+    };
+}
+
+void testDeadlineExpiryViaInjectedClock(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "deadline expiry: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "deadline.exr";
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                          fixture.ledger(), target);
+    if (attempt == nullptr) {
+        return;
+    }
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval), "deadline expiry: approval succeeds");
+    if (!approval) {
+        return;
+    }
+
+    // Jumps 25 hours ahead, past the default 24-hour deadline.
+    auto run =
+        beginExportRun(fixture.scheduler(), fixture.artifacts(), std::move(approval).takeRequest(),
+                       fixture.path(), jumpingClock(std::chrono::hours(25)));
+    auto* runValue = require(run, expectations, "deadline expiry: the job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result =
+        require(resultOpt, expectations, "deadline expiry: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    const auto* failure = result->failure();
+    expectations.expect(
+        failure != nullptr && failure->payloadAs<host::FrameExportDeadlineExceededV1>() != nullptr,
+        "the injected clock jump is diagnosed as a typed deadline-exceeded resource failure");
+    expectations.expect(!std::filesystem::exists(target), "deadline expiry publishes nothing");
+}
+
+void testNoProgressExpiryViaInjectedClock(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "no-progress expiry: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "no-progress.exr";
+    auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                          fixture.ledger(), target);
+    if (attempt == nullptr) {
+        return;
+    }
+    // A 1-nanosecond no-progress interval (design decision 5's injectable-limits half of the same
+    // seam: "a request may lower but not raise" the closed version 1 limits) trips
+    // deterministically on the real system clock's very first between-stage gap, regardless of
+    // exactly how many times F1's own writer/verifier progress callback fires for this fixture's
+    // tiny image -- a fake clock jump landing precisely between a no-progress "check" call and the
+    // immediately preceding progress-driven "reset" call would otherwise be sensitive to that
+    // internal, implementation-owned call cadence (see testDeadlineExpiryViaInjectedClock for the
+    // sibling case where a fake clock jump IS safely deterministic: total-deadline is checked
+    // against a fixed `start`, never reset mid-flight).
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations),
+                                               {.totalDeadline = std::chrono::hours(24),
+                                                .noProgressInterval = std::chrono::nanoseconds(1)});
+    expectations.expect(static_cast<bool>(approval), "no-progress expiry: approval succeeds");
+    if (!approval) {
+        return;
+    }
+
+    auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                              std::move(approval).takeRequest(), fixture.path());
+    auto* runValue = require(run, expectations, "no-progress expiry: the job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result =
+        require(resultOpt, expectations, "no-progress expiry: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    const auto* failure = result->failure();
+    expectations.expect(
+        failure != nullptr &&
+            failure->payloadAs<host::FrameExportNoProgressExceededV1>() != nullptr,
+        "the injected clock jump is diagnosed as a typed no-progress resource failure");
+    expectations.expect(!std::filesystem::exists(target), "no-progress expiry publishes nothing");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    try {
+        testDigestMismatchRejected(expectations);
+        testIntentRegisteredExactlyOnce(expectations);
+        testEndToEndExportPublished(expectations);
+        testSupersessionOlderPublishesSecond(expectations);
+        testExternalModificationConflict(expectations);
+        testOverwritePolicyCreateOnlyDeniesExisting(expectations);
+        testOverwritePolicyReplaceExistingSucceeds(expectations);
+        testDurabilityWarningViaFaultInjection(expectations);
+        testCancellationBeforeStagingLeavesTargetIntact(expectations);
+        testDeadlineExpiryViaInjectedClock(expectations);
+        testNoProgressExpiryViaInjectedClock(expectations);
+    } catch (const std::exception& error) {
+        std::cerr << "unexpected exception: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/host/tests/output_analysis_attempt_runner_tests.cpp
+++ b/src/host/tests/output_analysis_attempt_runner_tests.cpp
@@ -1,0 +1,297 @@
+#include <bloom/host/output_analysis_attempt_runner.hpp>
+
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/document/composition_settings.hpp>
+#include <bloom/document/ids.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/compiled_plan.hpp>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+// Task F2 (issue #101): drives beginOutputAnalysisAttemptV1() -- the Resolving (BlockingIo) ->
+// Evaluating/Identifying/Analyzing (Cpu) two-task chain -- against a REAL bloom::runtime::
+// TaskScheduler with real BlockingIo/Cpu workers and a REAL platform::StagedArtifactCoordinator,
+// exactly mirroring bloom/host/tests/session_async_io_tests.cpp's own top-of-file rationale for
+// doing so.
+namespace {
+
+namespace document = bloom::document;
+namespace host = bloom::host;
+namespace output = bloom::output;
+namespace platform = bloom::platform;
+namespace runtime = bloom::runtime;
+
+using namespace std::chrono_literals;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-attempt-runner-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (!path_.empty()) {
+            std::error_code errorCode;
+            std::filesystem::remove_all(path_, errorCode);
+        }
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+constexpr auto kProjectId = document::ProjectId::fromRaw(0x1001);
+constexpr auto kCompositionId = document::CompositionId::fromRaw(0x1002);
+constexpr auto kSolidNodeId = document::NodeId::fromRaw(0x1003);
+constexpr auto kOutputNodeId = document::NodeId::fromRaw(0x1004);
+constexpr auto kColorParameterId = document::ParameterId::fromRaw(0x1005);
+constexpr auto kRevision = document::Revision::fromRaw(0x1006);
+constexpr auto kLayerNodeId = document::NodeId::fromRaw(0x1007);
+constexpr auto kLayerId = document::LayerId::fromRaw(0x1008);
+constexpr auto kStackNodeId = document::NodeId::fromRaw(0x1009);
+constexpr auto kSlotId = document::LayerSlotId::fromRaw(0x100a);
+constexpr auto kPositionParameterId = document::ParameterId::fromRaw(0x100b);
+constexpr auto kOpacityParameterId = document::ParameterId::fromRaw(0x100c);
+
+// A trivial one-node (solid -> composition output) plan: a real, directly evaluable composition,
+// unlike bloom/output/tests/flat_exr_test_support.hpp's shellPlan() (which evaluates a plan only
+// to immediately overwrite the result with a fixture). This test exercises the real
+// runtime::CpuCompositionEvaluator through beginOutputAnalysisAttemptV1()'s own Cpu stage.
+[[nodiscard]] std::shared_ptr<const runtime::CompiledCompositionPlan> smallSolidPlan() {
+    const auto format = document::CompositionFormat::create(2, 2);
+    if (!format) {
+        std::abort();
+    }
+    std::vector<runtime::CompiledOperation> operations;
+    operations.emplace_back(runtime::CompiledSolid{kSolidNodeId, kColorParameterId,
+                                                   bloom::core::Color4d{0.25, 0.5, 0.75, 1.0}});
+    // CompiledCompositionOutput requires a layer-stack input, not a bare solid (mirrors
+    // bloom/output/tests/flat_exr_test_support.hpp's shellPlan()): solid -> layer output -> layer
+    // stack -> composition output.
+    operations.emplace_back(runtime::CompiledLayerOutput{
+        kLayerNodeId, kLayerId, runtime::OperationIndex::fromRaw(0),
+        runtime::CompiledVec2Parameter{kPositionParameterId, document::Vec2d{0.5, 0.5}},
+        runtime::CompiledScalarParameter{kOpacityParameterId, 1.0}});
+    operations.emplace_back(runtime::CompiledLayerStack{
+        kStackNodeId, {{kSlotId, kLayerId, runtime::OperationIndex::fromRaw(1)}}});
+    operations.emplace_back(
+        runtime::CompiledCompositionOutput{kOutputNodeId, runtime::OperationIndex::fromRaw(2)});
+    return std::make_shared<const runtime::CompiledCompositionPlan>(
+        runtime::CompiledCompositionPlanDefinition{.sourceRevision = kRevision,
+                                                   .projectId = kProjectId,
+                                                   .compositionId = kCompositionId,
+                                                   .format = *format,
+                                                   .operations = std::move(operations),
+                                                   .output = runtime::OperationIndex::fromRaw(3)});
+}
+
+[[nodiscard]] host::OutputAnalysisAttemptRequestV1
+requestFor(const std::filesystem::path& targetPath) {
+    const auto plan = smallSolidPlan();
+    return {
+        .plan = plan,
+        .evaluation = {.time = bloom::core::RationalTime::fromInteger(0),
+                       .output = plan->output(),
+                       .resolution = runtime::CompositionFormatResolution{},
+                       .quality = runtime::EvaluationQuality::Reference,
+                       .colorIntent = runtime::EvaluationColorIntent::LinearRec709Scene,
+                       .pixelStorageByteLimit = 4096},
+        .targetPath = targetPath,
+        .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
+        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)}};
+}
+
+[[nodiscard]] std::optional<host::OutputAnalysisAttemptOutcomeV1>
+pumpUntilComplete(host::OutputAnalysisAttemptRunnerV1& runner) {
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (auto outcome = runner.tryComplete()) {
+            return outcome;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return std::nullopt;
+}
+
+void testFullGraphProducesStableDigestAcrossTwoRuns(Expectations& expectations) {
+    TempDirectory directory;
+    expectations.expect(directory.isValid(), "full graph: temp directory is available");
+    if (!directory.isValid()) {
+        return;
+    }
+    runtime::TaskScheduler scheduler;
+    auto artifacts = platform::StagedArtifactCoordinator::create({});
+    expectations.expect(artifacts.succeeded(),
+                        "full graph: staged-artifact coordinator is created");
+    if (!artifacts) {
+        return;
+    }
+    auto coordinator = std::move(artifacts).takeCoordinator();
+    output::ExportResourceLedgerV1 ledger;
+
+    std::optional<bloom::core::Sha256Digest> firstDigest;
+    for (int run = 0; run < 2; ++run) {
+        auto begin = host::beginOutputAnalysisAttemptV1(
+            scheduler, coordinator, ledger,
+            requestFor(directory.path() / ("attempt-" + std::to_string(run) + ".exr")));
+        expectations.expect(static_cast<bool>(begin),
+                            "full graph: begin submits the Resolving task");
+        if (!begin) {
+            continue;
+        }
+        auto runner = std::move(begin).takeHandle();
+        auto outcome = pumpUntilComplete(runner);
+        expectations.expect(outcome.has_value(),
+                            "full graph: the attempt reaches a terminal outcome");
+        if (!outcome.has_value()) {
+            continue;
+        }
+        expectations.expect(static_cast<bool>(*outcome),
+                            "full graph: Resolving -> Evaluating -> Identifying -> Analyzing "
+                            "completes successfully");
+        if (!*outcome) {
+            continue;
+        }
+        expectations.expect((*outcome).attempt()->approvable() &&
+                                (*outcome).attempt()->digest().has_value(),
+                            "full graph: the completed attempt is approvable with a digest");
+        if (run == 0) {
+            firstDigest = (*outcome).attempt()->digest();
+        } else {
+            expectations.expect(firstDigest.has_value() &&
+                                    (*outcome).attempt()->digest() == firstDigest,
+                                "full graph: the digest is stable across two independent runs "
+                                "over the identical fixture");
+        }
+    }
+}
+
+void testCancellationBeforeResolvingCompletes(Expectations& expectations) {
+    TempDirectory directory;
+    expectations.expect(directory.isValid(), "cancel: temp directory is available");
+    if (!directory.isValid()) {
+        return;
+    }
+    runtime::TaskScheduler scheduler;
+    auto artifacts = platform::StagedArtifactCoordinator::create({});
+    expectations.expect(artifacts.succeeded(), "cancel: staged-artifact coordinator is created");
+    if (!artifacts) {
+        return;
+    }
+    auto coordinator = std::move(artifacts).takeCoordinator();
+    output::ExportResourceLedgerV1 ledger;
+
+    auto begin = host::beginOutputAnalysisAttemptV1(scheduler, coordinator, ledger,
+                                                    requestFor(directory.path() / "cancelled.exr"));
+    expectations.expect(static_cast<bool>(begin), "cancel: begin submits the Resolving task");
+    if (!begin) {
+        return;
+    }
+    auto runner = std::move(begin).takeHandle();
+    runner.requestCancellation();
+    auto outcome = pumpUntilComplete(runner);
+    expectations.expect(outcome.has_value(), "cancel: the attempt reaches a terminal outcome");
+    if (!outcome.has_value()) {
+        return;
+    }
+    expectations.expect(!*outcome, "cancel: an immediately-cancelled attempt does not complete");
+    const auto* failure = outcome->failure();
+    expectations.expect(failure != nullptr && failure->cancelled(),
+                        "cancel: the typed failure is marked cancelled");
+}
+
+void testResourceExhaustionIsTypedWithZeroLeak(Expectations& expectations) {
+    TempDirectory directory;
+    expectations.expect(directory.isValid(), "resource exhaustion: temp directory is available");
+    if (!directory.isValid()) {
+        return;
+    }
+    runtime::TaskScheduler scheduler;
+    auto artifacts = platform::StagedArtifactCoordinator::create({});
+    expectations.expect(artifacts.succeeded(),
+                        "resource exhaustion: staged-artifact coordinator is created");
+    if (!artifacts) {
+        return;
+    }
+    auto coordinator = std::move(artifacts).takeCoordinator();
+    output::ExportResourceLedgerV1 ledger(/*concurrentAllowance=*/1);
+
+    auto begin = host::beginOutputAnalysisAttemptV1(scheduler, coordinator, ledger,
+                                                    requestFor(directory.path() / "exhausted.exr"));
+    expectations.expect(static_cast<bool>(begin),
+                        "resource exhaustion: begin submits the Resolving task");
+    if (!begin) {
+        return;
+    }
+    auto runner = std::move(begin).takeHandle();
+    auto outcome = pumpUntilComplete(runner);
+    expectations.expect(outcome.has_value(),
+                        "resource exhaustion: the attempt reaches a terminal outcome");
+    if (!outcome.has_value()) {
+        return;
+    }
+    expectations.expect(!*outcome,
+                        "resource exhaustion: a 1-byte ledger cannot admit a real evaluated frame");
+    const auto* failure = outcome->failure();
+    expectations.expect(failure != nullptr &&
+                            failure->payloadAs<output::OutputAnalysisAttemptErrorCodeV1>() !=
+                                nullptr &&
+                            *failure->payloadAs<output::OutputAnalysisAttemptErrorCodeV1>() ==
+                                output::OutputAnalysisAttemptErrorCodeV1::ResourceReservationFailed,
+                        "resource exhaustion: the failure is a typed ResourceReservationFailed at "
+                        "the Analyzing stage");
+    expectations.expect(ledger.chargedBytes() == 0,
+                        "resource exhaustion: a refused attempt charges nothing (zero leak)");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testFullGraphProducesStableDigestAcrossTwoRuns(expectations);
+    testCancellationBeforeResolvingCompletes(expectations);
+    testResourceExhaustionIsTypedWithZeroLeak(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -4,13 +4,16 @@ target_sources(
     bloom_output
     PRIVATE
         bound_output_analysis.cpp
+        flat_exr_export_write.cpp
         flat_exr_output_adapter.cpp
         flat_exr_preset_contract.hpp
         flat_exr_reopen_verifier.cpp
         output_analysis.cpp
         output_analysis_analyzer.cpp
+        output_analysis_attempt.cpp
         output_analysis_contract.cpp
         output_analysis_digest.cpp
+        output_export_resource_ledger.cpp
         output_facet_descriptor.cpp
         output_analysis_numeric.cpp
         output_semantic_identity.cpp
@@ -21,11 +24,15 @@ target_sources(
         FILE_SET HEADERS
         BASE_DIRS include
         FILES
+            include/bloom/output/flat_exr_export_write.hpp
             include/bloom/output/flat_exr_output_adapter.hpp
             include/bloom/output/flat_exr_reopen_verifier.hpp
             include/bloom/output/output_analysis.hpp
             include/bloom/output/output_analysis_analyzer.hpp
+            include/bloom/output/output_analysis_attempt.hpp
             include/bloom/output/output_analysis_digest.hpp
+            include/bloom/output/output_export_resource_ledger.hpp
+            include/bloom/output/output_export_stage.hpp
             include/bloom/output/output_facet_descriptor.hpp
             include/bloom/output/output_limits.hpp
             include/bloom/output/process_frame_semantic_identity.hpp
@@ -34,7 +41,14 @@ target_sources(
 target_compile_features(bloom_output PUBLIC cxx_std_20)
 target_link_libraries(
     bloom_output
-    PUBLIC bloom_color bloom_core bloom_render bloom_runtime_evaluator
+    # bloom_platform is PUBLIC: bloom/output/output_analysis_attempt.hpp's
+    # OutputAnalysisAttemptTargetV1 carries bloom::platform::ArtifactTargetObservation/
+    # ArtifactOverwritePolicy value types (the plain-data OUTCOME of a platform preflight call, not
+    # a live StagedArtifactCoordinator/Target/Lease handle -- design decision 1's module split; see
+    # output_analysis_attempt.hpp's own namespace comment). {"output", "platform"} was already
+    # present in tools/quality/repository_checks/repository_checks.cpp's kAllowedModuleDependencies
+    # allowlist before this task (no allowlist edit was needed).
+    PUBLIC bloom_color bloom_core bloom_platform bloom_render bloom_runtime_evaluator
 )
 bloom_enable_warnings(bloom_output)
 
@@ -186,5 +200,59 @@ if(BUILD_TESTING)
         NAME bloom.output.semantic_identity
         COMMAND bloom_output_semantic_identity_test
         LABELS unit output identity serialization
+    )
+
+    # Task F2 (issue #101): the export-attempt/job orchestration library's own Qt-free pieces.
+    add_executable(
+        bloom_output_export_resource_ledger_test
+        tests/output_export_resource_ledger_tests.cpp
+    )
+    target_link_libraries(
+        bloom_output_export_resource_ledger_test
+        PRIVATE bloom_output
+    )
+    bloom_enable_warnings(bloom_output_export_resource_ledger_test)
+    bloom_add_test(
+        NAME bloom.output.export_resource_ledger
+        COMMAND bloom_output_export_resource_ledger_test
+        LABELS unit output
+    )
+
+    add_executable(
+        bloom_output_analysis_attempt_test
+        tests/output_analysis_attempt_tests.cpp
+    )
+    target_include_directories(
+        bloom_output_analysis_attempt_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_output_analysis_attempt_test
+        PRIVATE bloom_output
+    )
+    bloom_enable_warnings(bloom_output_analysis_attempt_test)
+    bloom_add_test(
+        NAME bloom.output.analysis_attempt
+        COMMAND bloom_output_analysis_attempt_test
+        LABELS unit output identity render
+    )
+
+    add_executable(
+        bloom_output_flat_exr_export_write_test
+        tests/flat_exr_export_write_tests.cpp
+    )
+    target_include_directories(
+        bloom_output_flat_exr_export_write_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_output_flat_exr_export_write_test
+        PRIVATE bloom_output OpenEXR::OpenEXR
+    )
+    bloom_enable_warnings(bloom_output_flat_exr_export_write_test)
+    bloom_add_test(
+        NAME bloom.output.flat_exr_export_write
+        COMMAND bloom_output_flat_exr_export_write_test
+        LABELS unit output identity render
     )
 endif()

--- a/src/output/flat_exr_export_write.cpp
+++ b/src/output/flat_exr_export_write.cpp
@@ -1,0 +1,162 @@
+#include <bloom/output/flat_exr_export_write.hpp>
+
+#include <bloom/output/output_limits.hpp>
+
+#include <array>
+#include <fstream>
+#include <vector>
+
+namespace bloom::output {
+
+FlatExrExportWriteResultV1
+FlatExrExportWriteResultV1::written(const core::Sha256Digest semanticDigest,
+                                    const core::Sha256Digest artifactDigest,
+                                    const std::uint64_t artifactByteCount) noexcept {
+    FlatExrExportWriteResultV1 result;
+    result.status_ = FlatExrExportWriteStatusV1::Written;
+    result.error_ = FlatExrExportWriteErrorCodeV1::None;
+    result.semanticDigest_ = semanticDigest;
+    result.artifactDigest_ = artifactDigest;
+    result.artifactByteCount_ = artifactByteCount;
+    return result;
+}
+
+FlatExrExportWriteResultV1 FlatExrExportWriteResultV1::cancelled() noexcept {
+    FlatExrExportWriteResultV1 result;
+    result.status_ = FlatExrExportWriteStatusV1::Cancelled;
+    result.error_ = FlatExrExportWriteErrorCodeV1::None;
+    return result;
+}
+
+FlatExrExportWriteResultV1
+FlatExrExportWriteResultV1::failed(const FlatExrExportWriteErrorCodeV1 error,
+                                   const FlatExrWriteErrorCodeV1 writeError,
+                                   const FlatExrVerifyDiagnosticV1& verifyDiagnostic) noexcept {
+    FlatExrExportWriteResultV1 result;
+    result.status_ = FlatExrExportWriteStatusV1::Failed;
+    result.error_ = error == FlatExrExportWriteErrorCodeV1::None
+                        ? FlatExrExportWriteErrorCodeV1::InternalInvariant
+                        : error;
+    result.writeError_ = writeError;
+    result.verifyDiagnostic_ = verifyDiagnostic;
+    return result;
+}
+
+namespace {
+
+void reportProgress(const OutputExportProgressCallbackV1& callback,
+                    const OutputExportProgressV1& progress) noexcept {
+    if (!callback) {
+        return;
+    }
+    try {
+        callback(progress);
+    } catch (...) {
+        return;
+    }
+}
+
+// Streams `path`'s complete raw bytes in bounded chunks, computing their SHA-256. Returns
+// nullopt on I/O failure, allocation failure, or cancellation.
+[[nodiscard]] std::optional<core::Sha256Digest>
+hashArtifactFile(const std::filesystem::path& path, const runtime::CancellationToken& cancellation,
+                 const OutputExportProgressCallbackV1& progress,
+                 std::uint64_t& byteCountOut) noexcept {
+    try {
+        std::ifstream stream(path, std::ios::binary);
+        if (!stream) {
+            return std::nullopt;
+        }
+        std::vector<std::byte> buffer(kOutputAdapterMaximumStreamingChunkBytesV1);
+        core::Sha256Hasher hasher;
+        std::uint64_t total = 0;
+        reportProgress(progress,
+                       {.stage = OutputExportStageV1::Publishing, .completed = 0, .total = 0});
+        while (stream) {
+            if (cancellation.isCancellationRequested()) {
+                return std::nullopt;
+            }
+            stream.read(reinterpret_cast<char*>(buffer.data()),
+                        static_cast<std::streamsize>(buffer.size()));
+            const auto readCount = static_cast<std::size_t>(stream.gcount());
+            if (readCount == 0) {
+                break;
+            }
+            if (!hasher.update(std::span(buffer).first(readCount))) {
+                return std::nullopt;
+            }
+            total += readCount;
+            reportProgress(
+                progress,
+                {.stage = OutputExportStageV1::Publishing, .completed = total, .total = total});
+        }
+        if (stream.bad()) {
+            return std::nullopt;
+        }
+        byteCountOut = total;
+        return hasher.finalize();
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+} // namespace
+
+FlatExrExportWriteResultV1
+FlatExrExportWriterV1::run(const OutputAnalysisAttemptV1& attempt,
+                           const std::filesystem::path& scratchPath,
+                           const runtime::CancellationToken& cancellation,
+                           const OutputExportProgressCallbackV1& progress) const noexcept {
+    if (attempt.frame() == nullptr || attempt.processIdentity() == nullptr ||
+        attempt.report() == nullptr) {
+        return FlatExrExportWriteResultV1::failed(FlatExrExportWriteErrorCodeV1::InternalInvariant);
+    }
+
+    const FlatExrRgba32fLinRec709SceneWriterV1 writer;
+    const auto writeResult =
+        writer.write(*attempt.frame(), scratchPath, cancellation,
+                     [&progress](const FlatExrWriteProgressV1& writeProgress) {
+                         reportProgress(progress, {.stage = OutputExportStageV1::Writing,
+                                                   .completed = writeProgress.completedScanlines,
+                                                   .total = writeProgress.totalScanlines});
+                     });
+    if (writeResult.status() == FlatExrWriteStatusV1::Cancelled) {
+        return FlatExrExportWriteResultV1::cancelled();
+    }
+    if (writeResult.status() != FlatExrWriteStatusV1::Written) {
+        return FlatExrExportWriteResultV1::failed(FlatExrExportWriteErrorCodeV1::WriteFailed,
+                                                  writeResult.error());
+    }
+
+    const FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+    const auto verifyResult = verifier.verify(
+        scratchPath, attempt.processIdentity(), attempt.report(), cancellation,
+        [&progress](const FlatExrVerifyScanProgressV1& verifyProgress) {
+            reportProgress(progress, {.stage = OutputExportStageV1::Verifying,
+                                      .completed = verifyProgress.completedScanlines,
+                                      .total = verifyProgress.totalScanlines});
+        });
+    if (verifyResult.status() == FlatExrVerifyStatusV1::Cancelled) {
+        return FlatExrExportWriteResultV1::cancelled();
+    }
+    if (verifyResult.status() != FlatExrVerifyStatusV1::Verified) {
+        return FlatExrExportWriteResultV1::failed(FlatExrExportWriteErrorCodeV1::VerifyFailed, {},
+                                                  verifyResult.diagnostic());
+    }
+
+    std::uint64_t artifactByteCount = 0;
+    const auto artifactDigest =
+        hashArtifactFile(scratchPath, cancellation, progress, artifactByteCount);
+    if (!artifactDigest.has_value()) {
+        if (cancellation.isCancellationRequested()) {
+            return FlatExrExportWriteResultV1::cancelled();
+        }
+        return FlatExrExportWriteResultV1::failed(
+            FlatExrExportWriteErrorCodeV1::ArtifactHashFailed);
+    }
+
+    return FlatExrExportWriteResultV1::written(verifyResult.digest(), *artifactDigest,
+                                               artifactByteCount);
+}
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/flat_exr_export_write.hpp
+++ b/src/output/include/bloom/output/flat_exr_export_write.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <bloom/core/sha256.hpp>
+#include <bloom/output/flat_exr_output_adapter.hpp>
+
+// output_analysis_analyzer.hpp (which declares the real OutputAnalysisReportV1 class) must be
+// visible before flat_exr_reopen_verifier.hpp's own header: that F1 header uses
+// std::shared_ptr<const OutputAnalysisReportV1> in verify()'s public signature without including
+// or forward-declaring it itself (out of scope to change -- "no changes to F1 adapter/verifier").
+// A blank-line-separated include block (this codebase's .clang-format uses the default
+// IncludeBlocks: Preserve, which sorts alphabetically only WITHIN a block, never across one) keeps
+// this header strictly first regardless of clang-format's usual alphabetical reordering.
+#include <bloom/output/output_analysis_analyzer.hpp>
+
+#include <bloom/output/flat_exr_reopen_verifier.hpp>
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/output/output_export_stage.hpp>
+#include <bloom/runtime/cancellation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+
+// Bridges F1's path-based OpenEXR adapter/verifier (bloom/output/flat_exr_output_adapter.hpp,
+// bloom/output/flat_exr_reopen_verifier.hpp -- OpenEXR's classic API opens a real filesystem path,
+// it has no in-memory-buffer or byte-sink overload) to a caller that ultimately publishes through
+// bloom::platform::StagedArtifactLease, whose own exclusive staged file is reached only through its
+// byte-oriented write()/finishWriting()/readForVerification() API and never exposes a filesystem
+// path (see the implementor's report's "interpretations/deviations" for the full rationale this
+// documents). This writer therefore targets a caller-owned SCRATCH path outside the lease's own
+// staging file -- not a second "private staging" artifact in project-format.md's atomic-publication
+// sense (design decision 1: "format adapters cannot implement private staging"): this scratch file
+// is never published, never atomically replaces anything, and is not tracked by
+// StagedArtifactCoordinator at all. The caller (bloom::host::executeExportPublication) streams its
+// bytes into the real lease afterward and discards it. Composes ONLY F1's existing public writer/
+// verifier -- no OpenEXR/Imath type appears here either.
+namespace bloom::output {
+
+enum class FlatExrExportWriteStatusV1 : std::uint8_t {
+    Written,
+    Cancelled,
+    Failed,
+};
+
+enum class FlatExrExportWriteErrorCodeV1 : std::uint8_t {
+    None,
+    WriteFailed,
+    VerifyFailed,
+    ArtifactHashFailed,
+    InternalInvariant,
+};
+
+class [[nodiscard]] FlatExrExportWriteResultV1 final {
+  public:
+    [[nodiscard]] static FlatExrExportWriteResultV1
+    written(core::Sha256Digest semanticDigest, core::Sha256Digest artifactDigest,
+            std::uint64_t artifactByteCount) noexcept;
+    [[nodiscard]] static FlatExrExportWriteResultV1 cancelled() noexcept;
+    [[nodiscard]] static FlatExrExportWriteResultV1
+    failed(FlatExrExportWriteErrorCodeV1 error, FlatExrWriteErrorCodeV1 writeError = {},
+           const FlatExrVerifyDiagnosticV1& verifyDiagnostic = {}) noexcept;
+
+    [[nodiscard]] FlatExrExportWriteStatusV1 status() const noexcept { return status_; }
+    [[nodiscard]] FlatExrExportWriteErrorCodeV1 error() const noexcept { return error_; }
+    [[nodiscard]] FlatExrWriteErrorCodeV1 writeError() const noexcept { return writeError_; }
+    [[nodiscard]] const FlatExrVerifyDiagnosticV1& verifyDiagnostic() const& noexcept {
+        return verifyDiagnostic_;
+    }
+    [[nodiscard]] const FlatExrVerifyDiagnosticV1& verifyDiagnostic() const&& = delete;
+    // Valid only when status() is Written: the kind-2 OutputSemanticIdentity digest F1's verifier
+    // issued from the DECODED reopened scratch file, and the artifact SHA-256 of the scratch file's
+    // complete raw bytes (frame-output.md "Atomic Publication" step 5: "compute the artifact
+    // SHA-256"), plus its byte count.
+    [[nodiscard]] const core::Sha256Digest& semanticDigest() const& noexcept {
+        return semanticDigest_;
+    }
+    [[nodiscard]] const core::Sha256Digest& semanticDigest() const&& = delete;
+    [[nodiscard]] const core::Sha256Digest& artifactDigest() const& noexcept {
+        return artifactDigest_;
+    }
+    [[nodiscard]] const core::Sha256Digest& artifactDigest() const&& = delete;
+    [[nodiscard]] std::uint64_t artifactByteCount() const noexcept { return artifactByteCount_; }
+
+  private:
+    FlatExrExportWriteResultV1() = default;
+
+    FlatExrExportWriteStatusV1 status_ = FlatExrExportWriteStatusV1::Failed;
+    FlatExrExportWriteErrorCodeV1 error_ = FlatExrExportWriteErrorCodeV1::InternalInvariant;
+    FlatExrWriteErrorCodeV1 writeError_ = FlatExrWriteErrorCodeV1::None;
+    FlatExrVerifyDiagnosticV1 verifyDiagnostic_;
+    core::Sha256Digest semanticDigest_;
+    core::Sha256Digest artifactDigest_;
+    std::uint64_t artifactByteCount_ = 0;
+};
+
+class FlatExrExportWriterV1 final {
+  public:
+    // Writes `attempt.frame()` to `scratchPath` (F1's writer -- progress-stage `Writing`), reopens
+    // and semantically verifies it against `attempt.processIdentity()`/`attempt.report()` (F1's
+    // verifier -- progress-stage `Verifying`), then streams `scratchPath`'s raw bytes back in
+    // `kOutputAdapterMaximumStreamingChunkBytesV1`-bounded chunks to compute the artifact SHA-256,
+    // checking `cancellation` between chunks at every stage. `scratchPath` must not already exist;
+    // this call creates it. On any non-Written outcome the caller owns removing whatever partial
+    // bytes exist at `scratchPath` (mirroring FlatExrWriteResultV1::destinationRemoved()'s own
+    // caller-visible contract) -- this class does not delete the caller's scratch path itself,
+    // consistent with the caller (not this bridge) owning the scratch directory's lifetime.
+    [[nodiscard]] FlatExrExportWriteResultV1
+    run(const OutputAnalysisAttemptV1& attempt, const std::filesystem::path& scratchPath,
+        const runtime::CancellationToken& cancellation,
+        const OutputExportProgressCallbackV1& progress = {}) const noexcept;
+};
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/output_analysis_attempt.hpp
+++ b/src/output/include/bloom/output/output_analysis_attempt.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <bloom/core/artifact_target_key.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/output/output_analysis_analyzer.hpp>
+#include <bloom/output/output_export_resource_ledger.hpp>
+#include <bloom/output/process_frame_semantic_identity.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/evaluation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+
+// docs/architecture/frame-output.md "Pre-Approval Output Analysis Attempt" and "Immutable Export
+// Request": the immutable, owning product a completed OutputAnalysisAttempt graph publishes.
+// Design decision 2: "The completed attempt RETAINS everything the doc's 'Immutable Export
+// Request' bullet list names (snapshot + revision, identities, frame, report, preset/profile,
+// canonical target preflight -- reuse the platform preflight/ArtifactTargetKey machinery)."
+//
+// This type is pure/Qt-free (no platform::StagedArtifactCoordinator, no
+// bloom::runtime::TaskScheduler): it only RETAINS the plain-data outcome of a platform preflight
+// call (ArtifactTargetKey + ArtifactTargetObservation, both value types), never a live
+// platform::StagedArtifactTarget/Lease handle. bloom::host owns making the actual
+// StagedArtifactCoordinator::preflight() call (the "Resolving" task) and the multi-task attempt
+// controller that drives Resolving -> Evaluating -> Identifying -> Analyzing and then calls
+// buildOutputAnalysisAttemptV1() with this file's inputs (bloom/host/
+// output_analysis_attempt_runner.hpp) -- design decision 1's module split ("src/output owns the
+// Qt-free attempt/job orchestration library ... src/host owns executeExportPublication that binds
+// the output orchestration to the application-wide PublicationCoordinator + platform
+// StagedArtifactCoordinator").
+namespace bloom::output {
+
+// Version 1 ships EXR only (design decision 3's task package scope); PNG's additional retained
+// display-processor identity is future preset breadth, not represented here.
+struct OutputAnalysisAttemptTargetV1 final {
+    core::ArtifactTargetKey targetKey;
+    platform::ArtifactTargetObservation observation = platform::ArtifactTargetObservation::absent();
+    std::filesystem::path targetPath;
+    platform::ArtifactOverwritePolicy overwritePolicy =
+        platform::ArtifactOverwritePolicy::CreateOrReplace;
+
+    [[nodiscard]] bool isValid() const noexcept { return targetKey.isValid(); }
+};
+
+enum class OutputAnalysisAttemptErrorCodeV1 : std::uint8_t {
+    None,
+    InvalidTarget,
+    InvalidFrame,
+    InvalidIdentity,
+    InvalidReport,
+    DigestFailed,
+    ResourceReservationFailed,
+    InternalInvariant,
+};
+
+class OutputAnalysisAttemptV1;
+
+struct OutputAnalysisAttemptBuildInputsV1 final {
+    std::shared_ptr<const runtime::ProcessFrame> frame;
+    std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity;
+    std::shared_ptr<const OutputAnalysisReportV1> report;
+    OutputAnalysisAttemptTargetV1 target;
+};
+
+class [[nodiscard]] OutputAnalysisAttemptBuildResultV1 final {
+  public:
+    [[nodiscard]] bool hasAttempt() const noexcept { return attempt_ != nullptr; }
+    [[nodiscard]] explicit operator bool() const noexcept { return hasAttempt(); }
+    [[nodiscard]] const std::shared_ptr<const OutputAnalysisAttemptV1>& attempt() const& noexcept {
+        return attempt_;
+    }
+    [[nodiscard]] const std::shared_ptr<const OutputAnalysisAttemptV1>& attempt() const&& = delete;
+    [[nodiscard]] OutputAnalysisAttemptErrorCodeV1 error() const noexcept { return error_; }
+
+    [[nodiscard]] static OutputAnalysisAttemptBuildResultV1
+    success(std::shared_ptr<const OutputAnalysisAttemptV1> attempt) noexcept;
+    [[nodiscard]] static OutputAnalysisAttemptBuildResultV1
+    failure(OutputAnalysisAttemptErrorCodeV1 error) noexcept;
+
+  private:
+    std::shared_ptr<const OutputAnalysisAttemptV1> attempt_;
+    OutputAnalysisAttemptErrorCodeV1 error_ = OutputAnalysisAttemptErrorCodeV1::InternalInvariant;
+};
+
+// Retains, as one inseparable immutable product: the evaluated ProcessFrame (which itself retains
+// the document snapshot/revision and project/composition/output/time identity through its own
+// ProcessFrameIdentity), the frame-bound ProcessFrameSemanticIdentityV1, the owning
+// OutputAnalysisReportV1, the approval OutputAnalysisDigest (present only when the report is
+// approvable -- frame-output.md: "OutputAnalysisDigest becomes available only when a validated
+// frame-bound process identity exists ... Approval requires both that digest and all eleven
+// derived permission bits"), the canonical target preflight, and its own resource reservation
+// (released when the last shared_ptr to this attempt, or to a FrameExportRequestV1 that still
+// retains it, is dropped -- "Dismissal or supersession cancels unfinished work and releases the
+// completed attempt and its reservations when no admitted export retains them").
+class OutputAnalysisAttemptV1 final {
+  public:
+    OutputAnalysisAttemptV1(const OutputAnalysisAttemptV1&) = delete;
+    OutputAnalysisAttemptV1& operator=(const OutputAnalysisAttemptV1&) = delete;
+    OutputAnalysisAttemptV1(OutputAnalysisAttemptV1&&) = delete;
+    OutputAnalysisAttemptV1& operator=(OutputAnalysisAttemptV1&&) = delete;
+    ~OutputAnalysisAttemptV1() = default;
+
+    [[nodiscard]] const std::shared_ptr<const runtime::ProcessFrame>& frame() const& noexcept {
+        return frame_;
+    }
+    [[nodiscard]] const std::shared_ptr<const runtime::ProcessFrame>& frame() const&& = delete;
+    [[nodiscard]] const std::shared_ptr<const ProcessFrameSemanticIdentityV1>&
+    processIdentity() const& noexcept {
+        return processIdentity_;
+    }
+    [[nodiscard]] const std::shared_ptr<const ProcessFrameSemanticIdentityV1>&
+    processIdentity() const&& = delete;
+    [[nodiscard]] const std::shared_ptr<const OutputAnalysisReportV1>& report() const& noexcept {
+        return report_;
+    }
+    [[nodiscard]] const std::shared_ptr<const OutputAnalysisReportV1>& report() const&& = delete;
+    [[nodiscard]] bool approvable() const noexcept { return digest_.has_value(); }
+    [[nodiscard]] std::optional<core::Sha256Digest> digest() const noexcept { return digest_; }
+    [[nodiscard]] const OutputAnalysisAttemptTargetV1& target() const noexcept { return target_; }
+    [[nodiscard]] const std::shared_ptr<ExportResourceReservationV1>& resources() const& noexcept {
+        return reservation_;
+    }
+    [[nodiscard]] const std::shared_ptr<ExportResourceReservationV1>& resources() const&& = delete;
+
+  private:
+    friend OutputAnalysisAttemptBuildResultV1
+    buildOutputAnalysisAttemptV1(OutputAnalysisAttemptBuildInputsV1 inputs,
+                                 ExportResourceLedgerV1& ledger) noexcept;
+
+    OutputAnalysisAttemptV1(std::shared_ptr<const runtime::ProcessFrame> frame,
+                            std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity,
+                            std::shared_ptr<const OutputAnalysisReportV1> report,
+                            std::optional<core::Sha256Digest> digest,
+                            OutputAnalysisAttemptTargetV1 target,
+                            std::shared_ptr<ExportResourceReservationV1> reservation) noexcept;
+
+    std::shared_ptr<const runtime::ProcessFrame> frame_;
+    std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity_;
+    std::shared_ptr<const OutputAnalysisReportV1> report_;
+    std::optional<core::Sha256Digest> digest_;
+    OutputAnalysisAttemptTargetV1 target_;
+    std::shared_ptr<ExportResourceReservationV1> reservation_;
+};
+
+// The Analyzing stage's typed successor: computes the OutputAnalysisDigest (when approvable),
+// reserves the checked retained bytes against `ledger` (process-pixel bytes + report descriptor
+// bytes + the closed digest-preimage bound), and publishes the immutable attempt only after every
+// check succeeds -- "Cancellation, allocation failure, a resource-limit failure, or any invariant
+// failure publishes no partial identity" extended here to "no partial attempt".
+[[nodiscard]] OutputAnalysisAttemptBuildResultV1
+buildOutputAnalysisAttemptV1(OutputAnalysisAttemptBuildInputsV1 inputs,
+                             ExportResourceLedgerV1& ledger) noexcept;
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/output_export_resource_ledger.hpp
+++ b/src/output/include/bloom/output/output_export_resource_ledger.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+// docs/architecture/frame-output.md "Non-Blocking Execution": "Attempt resource admission computes
+// and reserves the checked retained bytes needed through the approval decision ... Approved-job
+// admission transactionally expands that reservation to the checked peak across retained attempt
+// products, prepared display/output pixels, encoder scratch, and verification chunks; it neither
+// double-charges shared retained storage nor grants display mapping a hidden second allowance ...
+// Admission reserves from the service allowance before work starts and releases on every terminal
+// path." and the version 1 export-limits table's "one export job's aggregate Bloom-host resident
+// allowance" (2 GiB) and "all concurrent export jobs' aggregate ... allowance" (4 GiB).
+//
+// bloom::output::ExportResourceLedgerV1 is the shared service-wide allowance (one instance owned by
+// the application/test caller, analogous to bloom::host::PublicationCoordinator/
+// bloom::platform::StagedArtifactCoordinator being shared singletons). bloom::output::
+// ExportResourceReservationV1 is one export's own checked-bytes charge against it: created at
+// attempt-admission time with the retained-product bytes, transactionally expand()ed at job-
+// admission time to the checked peak, and released (in full) exactly once, on destruction --
+// whichever terminal path (dismissal, supersession, cancellation, failure, or successful
+// publication) drops the last shared_ptr to it. Reservation state lives in a heap block reached
+// through a shared_ptr so a caller can hold a `const ExportResourceReservationV1&`/
+// `std::shared_ptr<const ...>` (as OutputAnalysisAttemptV1 does) while still calling expand()
+// through the pointee's own non-const method -- only the pointer, not the pointee, is const.
+namespace bloom::output {
+
+inline constexpr std::uint64_t kOutputExportJobResidentAllowanceV1 = 2'147'483'648ULL;
+inline constexpr std::uint64_t kOutputExportConcurrentResidentAllowanceV1 = 4'294'967'296ULL;
+
+enum class ExportResourceAdmissionStatusV1 : std::uint8_t {
+    Reserved,
+    ArithmeticOverflow,
+    JobAllowanceExceeded,
+    ServiceAllowanceExceeded,
+};
+
+namespace detail {
+struct ExportResourceLedgerState;
+}
+
+class ExportResourceReservationV1;
+
+// The shared service-wide allowance. Move-only (holds the shared counter state); a caller keeps
+// one instance alive for the lifetime of the application/test and passes it by reference to every
+// attempt/job admission call.
+class ExportResourceLedgerV1 final {
+  public:
+    explicit ExportResourceLedgerV1(
+        std::uint64_t concurrentAllowance = kOutputExportConcurrentResidentAllowanceV1) noexcept;
+    ExportResourceLedgerV1(const ExportResourceLedgerV1&) = delete;
+    ExportResourceLedgerV1& operator=(const ExportResourceLedgerV1&) = delete;
+    ExportResourceLedgerV1(ExportResourceLedgerV1&&) = delete;
+    ExportResourceLedgerV1& operator=(ExportResourceLedgerV1&&) = delete;
+    ~ExportResourceLedgerV1() = default;
+
+    // Reserves `bytes` against both the per-job cap (`kOutputExportJobResidentAllowanceV1` unless
+    // overridden) and this ledger's shared concurrent cap. Returns a live reservation on success;
+    // nullptr and a status on refusal (nothing is charged on refusal).
+    [[nodiscard]] std::shared_ptr<ExportResourceReservationV1>
+    reserve(std::uint64_t bytes, ExportResourceAdmissionStatusV1& status,
+            std::uint64_t jobAllowance = kOutputExportJobResidentAllowanceV1) noexcept;
+
+    [[nodiscard]] std::uint64_t chargedBytes() const noexcept;
+    [[nodiscard]] std::uint64_t concurrentAllowance() const noexcept;
+
+  private:
+    friend class ExportResourceReservationV1;
+
+    std::shared_ptr<detail::ExportResourceLedgerState> state_;
+};
+
+class ExportResourceReservationV1 final {
+  public:
+    ~ExportResourceReservationV1();
+
+    [[nodiscard]] std::uint64_t chargedBytes() const noexcept { return chargedBytes_; }
+    [[nodiscard]] std::uint64_t jobAllowance() const noexcept { return jobAllowance_; }
+
+    // Transactionally raises this reservation's own charge to `newTotalBytes` (never lowers it;
+    // a `newTotalBytes` at or below the current charge is a no-op success -- "neither
+    // double-charges shared retained storage"). Checks the same per-job and shared-ledger caps the
+    // initial reserve() did, charging (and refunding on refusal) only the incremental delta.
+    [[nodiscard]] ExportResourceAdmissionStatusV1 expand(std::uint64_t newTotalBytes) noexcept;
+
+  private:
+    friend class ExportResourceLedgerV1;
+
+    ExportResourceReservationV1(std::shared_ptr<detail::ExportResourceLedgerState> ledger,
+                                std::uint64_t initialBytes, std::uint64_t jobAllowance) noexcept;
+
+    std::shared_ptr<detail::ExportResourceLedgerState> ledger_;
+    std::uint64_t chargedBytes_ = 0;
+    std::uint64_t jobAllowance_ = 0;
+};
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/output_export_stage.hpp
+++ b/src/output/include/bloom/output/output_export_stage.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+
+// docs/architecture/frame-output.md "Non-Blocking Execution": "Attempt and export progress are
+// monotonic within each stage and use the ordered stage vocabulary Resolving, Evaluating,
+// Identifying, ColorPreparing, Analyzing, PreparingOutput, Writing, Verifying, Publishing. EXR
+// skips ColorPreparing". This header is the one closed enum shared by both the pre-approval
+// OutputAnalysisAttempt graph (bloom::output::OutputAnalysisAttemptV1,
+// bloom::host::beginOutputAnalysisAttemptV1) and the approved export job graph
+// (bloom::host::executeExportPublication) -- design decision 1's "stage-progress vocabulary as a
+// closed enum" living in src/output alongside the other Qt-free orchestration types.
+namespace bloom::output {
+
+// EXR never emits ColorPreparing or PreparingOutput (design decision 1/4: EXR has no display
+// processor and exposes retained rows directly), but both enumerators stay in the closed
+// vocabulary so a caller can format/compare stages from either preset without a preset-specific
+// enum, exactly as the doc names all nine stages as one ordered list.
+enum class OutputExportStageV1 : std::uint8_t {
+    Resolving,
+    Evaluating,
+    Identifying,
+    ColorPreparing,
+    Analyzing,
+    PreparingOutput,
+    Writing,
+    Verifying,
+    Publishing,
+};
+
+struct OutputExportProgressV1 final {
+    OutputExportStageV1 stage = OutputExportStageV1::Resolving;
+    std::uint64_t completed = 0;
+    std::uint64_t total = 0;
+
+    friend bool operator==(const OutputExportProgressV1&,
+                           const OutputExportProgressV1&) noexcept = default;
+};
+
+using OutputExportProgressCallbackV1 = std::function<void(const OutputExportProgressV1&)>;
+
+// Design decision 5's injectable monotonic clock: "the 24-hour total deadline and 120-second
+// no-progress interval enforced against an INJECTABLE monotonic clock (tests drive it; production
+// uses the task system's existing clock source)". bloom::runtime::TaskSnapshot already timestamps
+// queuedAt/startedAt/finishedAt with std::chrono::steady_clock::time_point (task_types.hpp) -- that
+// IS the task system's existing clock source, so the production default below reuses it directly.
+// A test supplies a deterministic substitute instead of sleeping in real time.
+using OutputExportClockV1 = std::function<std::chrono::steady_clock::time_point()>;
+
+[[nodiscard]] inline OutputExportClockV1 systemOutputExportClockV1() noexcept {
+    return []() noexcept { return std::chrono::steady_clock::now(); };
+}
+
+} // namespace bloom::output

--- a/src/output/output_analysis_attempt.cpp
+++ b/src/output/output_analysis_attempt.cpp
@@ -1,0 +1,127 @@
+#include <bloom/output/output_analysis_attempt.hpp>
+
+#include <bloom/output/output_analysis_digest.hpp>
+#include <bloom/output/output_limits.hpp>
+#include <bloom/render/image.hpp>
+
+#include <limits>
+#include <utility>
+
+namespace bloom::output {
+
+OutputAnalysisAttemptBuildResultV1 OutputAnalysisAttemptBuildResultV1::success(
+    std::shared_ptr<const OutputAnalysisAttemptV1> attempt) noexcept {
+    OutputAnalysisAttemptBuildResultV1 result;
+    result.attempt_ = std::move(attempt);
+    result.error_ = OutputAnalysisAttemptErrorCodeV1::None;
+    return result;
+}
+
+OutputAnalysisAttemptBuildResultV1
+OutputAnalysisAttemptBuildResultV1::failure(const OutputAnalysisAttemptErrorCodeV1 error) noexcept {
+    OutputAnalysisAttemptBuildResultV1 result;
+    result.error_ = error == OutputAnalysisAttemptErrorCodeV1::None
+                        ? OutputAnalysisAttemptErrorCodeV1::InternalInvariant
+                        : error;
+    return result;
+}
+
+OutputAnalysisAttemptV1::OutputAnalysisAttemptV1(
+    std::shared_ptr<const runtime::ProcessFrame> frame,
+    std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity,
+    std::shared_ptr<const OutputAnalysisReportV1> report,
+    const std::optional<core::Sha256Digest> digest, OutputAnalysisAttemptTargetV1 target,
+    std::shared_ptr<ExportResourceReservationV1> reservation) noexcept
+    : frame_(std::move(frame)), processIdentity_(std::move(processIdentity)),
+      report_(std::move(report)), digest_(digest), target_(std::move(target)),
+      reservation_(std::move(reservation)) {}
+
+namespace {
+
+// Checked sum of the retained-product bytes the completed attempt charges through the approval
+// decision: the retained process-pixel bytes, the report's bounded descriptor storage, and a fixed
+// bound for the digest's own bounded streaming preimage (never allocated in full --
+// output_analysis_digest.hpp streams it -- but charged conservatively at its closed cap anyway, so
+// this reservation is never an under-count of what Analyzing/digesting can touch).
+[[nodiscard]] std::optional<std::uint64_t>
+checkedAttemptRetainedBytes(const render::Rgba32fImageDescriptor& descriptor,
+                            const OutputAnalysisReportV1& report) noexcept {
+    constexpr auto maximum = std::numeric_limits<std::uint64_t>::max();
+    std::uint64_t total = descriptor.layout().pixelStorageBytes;
+    const auto descriptorBytes = static_cast<std::uint64_t>(report.descriptorByteCount());
+    if (descriptorBytes > maximum - total) {
+        return std::nullopt;
+    }
+    total += descriptorBytes;
+    constexpr auto digestPreimageBound =
+        static_cast<std::uint64_t>(kOutputAnalysisDigestMaximumPreimageBytesV1);
+    if (digestPreimageBound > maximum - total) {
+        return std::nullopt;
+    }
+    total += digestPreimageBound;
+    return total;
+}
+
+} // namespace
+
+OutputAnalysisAttemptBuildResultV1
+buildOutputAnalysisAttemptV1(OutputAnalysisAttemptBuildInputsV1 inputs,
+                             ExportResourceLedgerV1& ledger) noexcept {
+    if (!inputs.target.isValid()) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::InvalidTarget);
+    }
+    if (inputs.frame == nullptr || !inputs.frame->processImage().isValid() ||
+        inputs.frame->processImage().descriptor() == nullptr) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::InvalidFrame);
+    }
+    if (inputs.processIdentity == nullptr) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::InvalidIdentity);
+    }
+    if (inputs.report == nullptr) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::InvalidReport);
+    }
+
+    // A nonapprovable report is still a successful, completed attempt (frame-output.md: "A
+    // nonapprovable but valid report is a successful analysis attempt"); only an approvable report
+    // gets a digest at all.
+    std::optional<core::Sha256Digest> digest;
+    if (inputs.report->approvable()) {
+        const auto digestResult =
+            computeOutputAnalysisDigestV1(*inputs.processIdentity, inputs.report->view(), {});
+        if (!digestResult) {
+            return OutputAnalysisAttemptBuildResultV1::failure(
+                OutputAnalysisAttemptErrorCodeV1::DigestFailed);
+        }
+        digest = *digestResult.digest();
+    }
+
+    const auto* descriptor = inputs.frame->processImage().descriptor();
+    const auto retainedBytes = checkedAttemptRetainedBytes(*descriptor, *inputs.report);
+    if (!retainedBytes.has_value()) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::ResourceReservationFailed);
+    }
+
+    ExportResourceAdmissionStatusV1 admissionStatus = ExportResourceAdmissionStatusV1::Reserved;
+    auto reservation = ledger.reserve(*retainedBytes, admissionStatus);
+    if (reservation == nullptr) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::ResourceReservationFailed);
+    }
+
+    try {
+        auto attempt = std::shared_ptr<OutputAnalysisAttemptV1>(new OutputAnalysisAttemptV1(
+            std::move(inputs.frame), std::move(inputs.processIdentity), std::move(inputs.report),
+            digest, std::move(inputs.target), std::move(reservation)));
+        return OutputAnalysisAttemptBuildResultV1::success(std::move(attempt));
+    } catch (const std::bad_alloc&) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::ResourceReservationFailed);
+    }
+}
+
+} // namespace bloom::output

--- a/src/output/output_export_resource_ledger.cpp
+++ b/src/output/output_export_resource_ledger.cpp
@@ -1,0 +1,104 @@
+#include <bloom/output/output_export_resource_ledger.hpp>
+
+#include <limits>
+#include <mutex>
+#include <utility>
+
+namespace bloom::output::detail {
+
+struct ExportResourceLedgerState final {
+    explicit ExportResourceLedgerState(const std::uint64_t allowance) noexcept
+        : concurrentAllowance(allowance) {}
+
+    std::mutex mutex;
+    std::uint64_t concurrentAllowance = 0;
+    std::uint64_t chargedBytes = 0;
+
+    // Returns true and charges `delta` on success. Checked against overflow and both caps.
+    [[nodiscard]] bool chargeLocked(const std::uint64_t delta) noexcept {
+        if (delta > std::numeric_limits<std::uint64_t>::max() - chargedBytes) {
+            return false;
+        }
+        if (chargedBytes + delta > concurrentAllowance) {
+            return false;
+        }
+        chargedBytes += delta;
+        return true;
+    }
+
+    void releaseLocked(const std::uint64_t delta) noexcept { chargedBytes -= delta; }
+};
+
+} // namespace bloom::output::detail
+
+namespace bloom::output {
+
+ExportResourceLedgerV1::ExportResourceLedgerV1(const std::uint64_t concurrentAllowance) noexcept
+    : state_(std::make_shared<detail::ExportResourceLedgerState>(concurrentAllowance)) {}
+
+std::shared_ptr<ExportResourceReservationV1>
+ExportResourceLedgerV1::reserve(const std::uint64_t bytes, ExportResourceAdmissionStatusV1& status,
+                                const std::uint64_t jobAllowance) noexcept {
+    if (bytes > jobAllowance) {
+        status = ExportResourceAdmissionStatusV1::JobAllowanceExceeded;
+        return nullptr;
+    }
+    {
+        std::lock_guard lock(state_->mutex);
+        if (!state_->chargeLocked(bytes)) {
+            status = ExportResourceAdmissionStatusV1::ServiceAllowanceExceeded;
+            return nullptr;
+        }
+    }
+    status = ExportResourceAdmissionStatusV1::Reserved;
+    try {
+        return std::shared_ptr<ExportResourceReservationV1>(
+            new ExportResourceReservationV1(state_, bytes, jobAllowance));
+    } catch (const std::bad_alloc&) {
+        std::lock_guard lock(state_->mutex);
+        state_->releaseLocked(bytes);
+        status = ExportResourceAdmissionStatusV1::ServiceAllowanceExceeded;
+        return nullptr;
+    }
+}
+
+std::uint64_t ExportResourceLedgerV1::chargedBytes() const noexcept {
+    std::lock_guard lock(state_->mutex);
+    return state_->chargedBytes;
+}
+
+std::uint64_t ExportResourceLedgerV1::concurrentAllowance() const noexcept {
+    return state_->concurrentAllowance;
+}
+
+ExportResourceReservationV1::ExportResourceReservationV1(
+    std::shared_ptr<detail::ExportResourceLedgerState> ledger, const std::uint64_t initialBytes,
+    const std::uint64_t jobAllowance) noexcept
+    : ledger_(std::move(ledger)), chargedBytes_(initialBytes), jobAllowance_(jobAllowance) {}
+
+ExportResourceReservationV1::~ExportResourceReservationV1() {
+    if (ledger_ == nullptr) {
+        return;
+    }
+    std::lock_guard lock(ledger_->mutex);
+    ledger_->releaseLocked(chargedBytes_);
+}
+
+ExportResourceAdmissionStatusV1
+ExportResourceReservationV1::expand(const std::uint64_t newTotalBytes) noexcept {
+    if (newTotalBytes <= chargedBytes_) {
+        return ExportResourceAdmissionStatusV1::Reserved;
+    }
+    if (newTotalBytes > jobAllowance_) {
+        return ExportResourceAdmissionStatusV1::JobAllowanceExceeded;
+    }
+    const auto delta = newTotalBytes - chargedBytes_;
+    std::lock_guard lock(ledger_->mutex);
+    if (!ledger_->chargeLocked(delta)) {
+        return ExportResourceAdmissionStatusV1::ServiceAllowanceExceeded;
+    }
+    chargedBytes_ = newTotalBytes;
+    return ExportResourceAdmissionStatusV1::Reserved;
+}
+
+} // namespace bloom::output

--- a/src/output/tests/flat_exr_export_write_tests.cpp
+++ b/src/output/tests/flat_exr_export_write_tests.cpp
@@ -1,0 +1,140 @@
+#include <bloom/output/flat_exr_export_write.hpp>
+
+#include "flat_exr_test_support.hpp"
+
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <source_location>
+#include <string_view>
+#include <thread>
+
+namespace {
+
+namespace output = bloom::output;
+namespace platform = bloom::platform;
+namespace runtime = bloom::runtime;
+namespace support = bloom_output_flat_exr_test_support;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] std::shared_ptr<const output::OutputAnalysisAttemptV1>
+buildAttempt(output::ExportResourceLedgerV1& ledger, support::Fixture fixture) {
+    auto source = support::prepareSource(std::move(fixture));
+    auto result = output::buildOutputAnalysisAttemptV1(
+        {.frame = source.frame,
+         .processIdentity = source.processIdentity,
+         .report = source.report,
+         .target = {.targetKey = bloom::core::ArtifactTargetKey::fromRaw(1),
+                    .observation = platform::ArtifactTargetObservation::absent(),
+                    .targetPath = "/tmp/ignored.exr",
+                    .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace}},
+        ledger);
+    if (!result) {
+        std::abort();
+    }
+    return result.attempt();
+}
+
+void testWrittenAndIndependentlyVerifiable(Expectations& expectations) {
+    output::ExportResourceLedgerV1 ledger;
+    auto attempt = buildAttempt(ledger, support::roundTripFixture());
+    support::ScratchDirectory scratch("flat-exr-export-write");
+    const auto scratchPath = scratch.file("attempt.exr");
+
+    const output::FlatExrExportWriterV1 writer;
+    const auto result = writer.run(*attempt, scratchPath, {});
+    expectations.expect(result.status() == output::FlatExrExportWriteStatusV1::Written,
+                        "writing and verifying a valid attempt succeeds");
+    if (result.status() != output::FlatExrExportWriteStatusV1::Written) {
+        return;
+    }
+    expectations.expect(std::filesystem::exists(scratchPath),
+                        "the scratch file exists after a Written result");
+
+    // Independent reopen-verification: the same F1 verifier this bridge already used, run again
+    // from scratch against the same staged bytes -- "reopened file passes the F1 verifier
+    // independently".
+    const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 independentVerifier;
+    const auto independentResult =
+        independentVerifier.verify(scratchPath, attempt->processIdentity(), attempt->report(), {});
+    expectations.expect(independentResult.status() == output::FlatExrVerifyStatusV1::Verified &&
+                            independentResult.digest() == result.semanticDigest(),
+                        "an independent reopen-verify pass reproduces the same semantic digest");
+}
+
+void testCancellationBeforeWritingProducesNoArtifact(Expectations& expectations) {
+    output::ExportResourceLedgerV1 ledger;
+    auto attempt = buildAttempt(ledger, support::roundTripFixture());
+    support::ScratchDirectory scratch("flat-exr-export-write-cancel");
+    const auto scratchPath = scratch.file("cancelled.exr");
+
+    runtime::TaskScheduler scheduler;
+    auto submission = scheduler.submit<output::FlatExrExportWriteStatusV1>(
+        runtime::TaskRequest("cancel-before-writing",
+                             runtime::TaskOwner{.kind = runtime::TaskOwnerKind::Export,
+                                                .id = runtime::TaskOwnerId::fromRaw(1)},
+                             runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo),
+        [&attempt, &scratchPath](runtime::TaskContext& context) {
+            // The task cancels itself immediately at entry (deterministic, no background race):
+            // isCancellationRequested() observes the handle's own cancel() below only after the
+            // scheduler has actually delivered it, so this task synchronously spins until it
+            // observes its own requested cancellation before ever calling the writer.
+            while (!context.isCancellationRequested()) {
+            }
+            const output::FlatExrExportWriterV1 writer;
+            const auto result = writer.run(*attempt, scratchPath, context.cancellation());
+            return runtime::TaskResult<output::FlatExrExportWriteStatusV1>::succeeded(
+                result.status());
+        });
+    expectations.expect(submission.accepted(), "the cancellation-race task is accepted");
+    if (!submission.accepted()) {
+        return;
+    }
+    submission.handle.cancel();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    std::optional<runtime::TaskResult<output::FlatExrExportWriteStatusV1>> taken;
+    while (std::chrono::steady_clock::now() < deadline) {
+        taken = submission.handle.tryTakeResult();
+        if (taken.has_value()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    expectations.expect(taken.has_value(), "the task reaches a terminal state");
+    if (taken.has_value() && taken->value().has_value()) {
+        expectations.expect(*taken->value() == output::FlatExrExportWriteStatusV1::Cancelled,
+                            "cancellation observed before writing yields Cancelled, not Written");
+    }
+    expectations.expect(!std::filesystem::exists(scratchPath),
+                        "cancellation before writing publishes no artifact at the scratch path");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testWrittenAndIndependentlyVerifiable(expectations);
+    testCancellationBeforeWritingProducesNoArtifact(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/output/tests/output_analysis_attempt_tests.cpp
+++ b/src/output/tests/output_analysis_attempt_tests.cpp
@@ -1,0 +1,131 @@
+#include <bloom/output/output_analysis_attempt.hpp>
+
+#include "flat_exr_test_support.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string_view>
+
+namespace {
+
+namespace output = bloom::output;
+namespace platform = bloom::platform;
+namespace support = bloom_output_flat_exr_test_support;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] output::OutputAnalysisAttemptTargetV1 fixtureTarget() {
+    return {.targetKey = bloom::core::ArtifactTargetKey::fromRaw(7),
+            .observation = platform::ArtifactTargetObservation::absent(),
+            .targetPath = "/tmp/does-not-matter.exr",
+            .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace};
+}
+
+void testBuildSucceedsAndRetainsProducts(Expectations& expectations) {
+    auto source = support::prepareSource(support::roundTripFixture());
+    output::ExportResourceLedgerV1 ledger;
+    auto result = output::buildOutputAnalysisAttemptV1({.frame = source.frame,
+                                                        .processIdentity = source.processIdentity,
+                                                        .report = source.report,
+                                                        .target = fixtureTarget()},
+                                                       ledger);
+    expectations.expect(static_cast<bool>(result),
+                        "a valid ready EXR source builds a completed attempt");
+    if (!result) {
+        return;
+    }
+    const auto& attempt = *result.attempt();
+    expectations.expect(attempt.frame() == source.frame,
+                        "the attempt retains the exact evaluated frame");
+    expectations.expect(attempt.processIdentity() == source.processIdentity,
+                        "the attempt retains the exact process identity");
+    expectations.expect(attempt.report() == source.report, "the attempt retains the exact report");
+    expectations.expect(attempt.approvable() && attempt.digest().has_value(),
+                        "a nominal EXR report is approvable and carries a digest");
+    expectations.expect(attempt.target().targetKey == fixtureTarget().targetKey,
+                        "the attempt retains the canonical target preflight");
+    expectations.expect(attempt.resources() != nullptr && attempt.resources()->chargedBytes() > 0,
+                        "the attempt reserves nonzero retained bytes");
+}
+
+void testDigestIsStableAcrossTwoBuilds(Expectations& expectations) {
+    auto sourceA = support::prepareSource(support::roundTripFixture());
+    auto sourceB = support::prepareSource(support::roundTripFixture());
+    output::ExportResourceLedgerV1 ledger;
+    auto resultA = output::buildOutputAnalysisAttemptV1({.frame = sourceA.frame,
+                                                         .processIdentity = sourceA.processIdentity,
+                                                         .report = sourceA.report,
+                                                         .target = fixtureTarget()},
+                                                        ledger);
+    auto resultB = output::buildOutputAnalysisAttemptV1({.frame = sourceB.frame,
+                                                         .processIdentity = sourceB.processIdentity,
+                                                         .report = sourceB.report,
+                                                         .target = fixtureTarget()},
+                                                        ledger);
+    expectations.expect(static_cast<bool>(resultA) && static_cast<bool>(resultB),
+                        "both identical-fixture builds succeed");
+    if (!resultA || !resultB) {
+        return;
+    }
+    expectations.expect(resultA.attempt()->digest().has_value() &&
+                            resultB.attempt()->digest().has_value() &&
+                            *resultA.attempt()->digest() == *resultB.attempt()->digest(),
+                        "the approval digest is stable across two runs over the same fixture");
+}
+
+void testInvalidTargetIsRejected(Expectations& expectations) {
+    auto source = support::prepareSource(support::roundTripFixture());
+    output::ExportResourceLedgerV1 ledger;
+    auto result = output::buildOutputAnalysisAttemptV1(
+        {.frame = source.frame,
+         .processIdentity = source.processIdentity,
+         .report = source.report,
+         .target = {}}, // default-constructed target has an invalid ArtifactTargetKey
+        ledger);
+    expectations.expect(!result && result.error() ==
+                                       output::OutputAnalysisAttemptErrorCodeV1::InvalidTarget,
+                        "an invalid (never-preflighted) target is a typed InvalidTarget failure");
+}
+
+void testResourceExhaustionIsTypedWithZeroLeak(Expectations& expectations) {
+    auto source = support::prepareSource(support::roundTripFixture());
+    output::ExportResourceLedgerV1 ledger(/*concurrentAllowance=*/1);
+    auto result = output::buildOutputAnalysisAttemptV1({.frame = source.frame,
+                                                        .processIdentity = source.processIdentity,
+                                                        .report = source.report,
+                                                        .target = fixtureTarget()},
+                                                       ledger);
+    expectations.expect(
+        !result &&
+            result.error() == output::OutputAnalysisAttemptErrorCodeV1::ResourceReservationFailed,
+        "a ledger too small for the retained bytes is a typed ResourceReservationFailed failure");
+    expectations.expect(ledger.chargedBytes() == 0,
+                        "a refused attempt build charges nothing against the ledger (zero leak)");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testBuildSucceedsAndRetainsProducts(expectations);
+    testDigestIsStableAcrossTwoBuilds(expectations);
+    testInvalidTargetIsRejected(expectations);
+    testResourceExhaustionIsTypedWithZeroLeak(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/output/tests/output_export_resource_ledger_tests.cpp
+++ b/src/output/tests/output_export_resource_ledger_tests.cpp
@@ -1,0 +1,117 @@
+#include <bloom/output/output_export_resource_ledger.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string_view>
+
+namespace {
+
+namespace output = bloom::output;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+void testReserveWithinCapSucceeds(Expectations& expectations) {
+    output::ExportResourceLedgerV1 ledger(1024);
+    output::ExportResourceAdmissionStatusV1 status{};
+    auto reservation = ledger.reserve(100, status, /*jobAllowance=*/512);
+    expectations.expect(reservation != nullptr &&
+                            status == output::ExportResourceAdmissionStatusV1::Reserved,
+                        "reserve within both caps succeeds");
+    expectations.expect(ledger.chargedBytes() == 100,
+                        "the ledger charges exactly the reserved bytes");
+    expectations.expect(reservation->chargedBytes() == 100,
+                        "the reservation reports its own charged bytes");
+}
+
+void testReserveExceedingJobAllowanceFails(Expectations& expectations) {
+    output::ExportResourceLedgerV1 ledger(1024);
+    output::ExportResourceAdmissionStatusV1 status{};
+    auto reservation = ledger.reserve(600, status, /*jobAllowance=*/512);
+    expectations.expect(reservation == nullptr &&
+                            status == output::ExportResourceAdmissionStatusV1::JobAllowanceExceeded,
+                        "a reservation over the per-job cap is refused and charges nothing");
+    expectations.expect(ledger.chargedBytes() == 0, "a refused reservation charges zero bytes");
+}
+
+void testReserveExceedingServiceAllowanceFails(Expectations& expectations) {
+    output::ExportResourceLedgerV1 ledger(100);
+    output::ExportResourceAdmissionStatusV1 firstStatus{};
+    auto first = ledger.reserve(80, firstStatus, /*jobAllowance=*/1000);
+    expectations.expect(first != nullptr, "the first reservation fits the shared allowance");
+
+    output::ExportResourceAdmissionStatusV1 secondStatus{};
+    auto second = ledger.reserve(30, secondStatus, /*jobAllowance=*/1000);
+    expectations.expect(
+        second == nullptr &&
+            secondStatus == output::ExportResourceAdmissionStatusV1::ServiceAllowanceExceeded,
+        "a second reservation that would exceed the shared concurrent allowance is refused");
+    expectations.expect(ledger.chargedBytes() == 80,
+                        "a refused second reservation leaves the first charge untouched");
+}
+
+void testReleaseOnDestructionIsZeroLeak(Expectations& expectations) {
+    output::ExportResourceLedgerV1 ledger(1024);
+    {
+        output::ExportResourceAdmissionStatusV1 status{};
+        auto reservation = ledger.reserve(500, status);
+        expectations.expect(reservation != nullptr, "the reservation is granted");
+        expectations.expect(ledger.chargedBytes() == 500, "the ledger reflects the live charge");
+    }
+    expectations.expect(ledger.chargedBytes() == 0,
+                        "dropping the reservation releases every charged byte (zero leak)");
+}
+
+void testExpandGrowsAndRefusesOverCap(Expectations& expectations) {
+    output::ExportResourceLedgerV1 ledger(1024);
+    output::ExportResourceAdmissionStatusV1 status{};
+    auto reservation = ledger.reserve(100, status, /*jobAllowance=*/300);
+    expectations.expect(reservation != nullptr, "the initial reservation is granted");
+
+    expectations.expect(reservation->expand(250) ==
+                            output::ExportResourceAdmissionStatusV1::Reserved,
+                        "expand() to a higher total within the job cap succeeds");
+    expectations.expect(reservation->chargedBytes() == 250,
+                        "expand() raises the reservation's own charge to the new total");
+    expectations.expect(ledger.chargedBytes() == 250,
+                        "expand() charges only the incremental delta against the shared ledger");
+
+    expectations.expect(reservation->expand(200) ==
+                            output::ExportResourceAdmissionStatusV1::Reserved,
+                        "expand() to a lower total than already charged is a no-op success");
+    expectations.expect(reservation->chargedBytes() == 250,
+                        "expand() never lowers the charge (no double-charging, no shrink either)");
+
+    expectations.expect(reservation->expand(400) ==
+                            output::ExportResourceAdmissionStatusV1::JobAllowanceExceeded,
+                        "expand() beyond the per-job cap is refused");
+    expectations.expect(reservation->chargedBytes() == 250,
+                        "a refused expand() leaves the prior charge intact");
+}
+
+} // namespace
+
+int main() {
+    Expectations expectations;
+    testReserveWithinCapSucceeds(expectations);
+    testReserveExceedingJobAllowanceFails(expectations);
+    testReserveExceedingServiceAllowanceFails(expectations);
+    testReleaseOnDestructionIsZeroLeak(expectations);
+    testExpandGrowsAndRefusesOverCap(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Closes the export loop at the host level — Bloom can now take a composition frame from analysis to a verified, atomically-published EXR file, headless-capable:

- **Analysis attempt graph** (Resolving → Evaluating → Identifying → Analyzing over real task stages with the mailbox discipline; EXR skips ColorPreparing): produces the retained, immutable `OutputAnalysisAttemptV1` — frame, semantic identity, owning report, approval digest, canonical target preflight — with checked resource admission on a shared export ledger.
- **Approval** verifies digest byte-equality, admits and registers the publication intent (the same per-target generation policy saves use), and freezes the immutable `FrameExportRequestV1`; every retained product and reservation releases automatically on any terminal path.
- **Publication job** mirrors the copy-publication composition through the shared `StagedArtifactCoordinator`: F1 writes and semantically verifies against a caller-owned scratch path (the lease is byte-oriented; verification transfers to the staged bytes by artifact-digest equality re-proven from `readForVerification()`), then the short non-cancellable publish section with the full outcome vocabulary — Published, durability warning, Superseded, ExternalModificationConflict, cancelled/failed-before-publication — all pinned by tests including fault-plan durability and injected-clock deadline/no-progress expiry.
- Version 1 export limits enforced with checked arithmetic; transactional reservation expansion at job admission never double-charges retained bytes.

Desktop 99/99 and native 85/85, format check clean.

Closes #101.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.