### PR TITLE
feat: export frames from the File menu

### DIFF
--- a/apps/bloom/main.cpp
+++ b/apps/bloom/main.cpp
@@ -9,6 +9,7 @@
 #include <bloom/ui/composition_preview_pipeline.hpp>
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/frame_export_controller.hpp>
 #include <bloom/ui/jobs_editor.hpp>
 #include <bloom/ui/main_window.hpp>
 #include <bloom/ui/project_host.hpp>
@@ -89,6 +90,15 @@ int main(int argc, char* argv[]) {
     application.installEventFilter(&shutdownCoordinator);
     bloom::ui::TaskMonitorModel taskMonitor(taskUiBridge);
 
+    // "File -> Export Frame..." (task F3, issue #103): binds to the SAME application-wide
+    // PublicationCoordinator/StagedArtifactCoordinator ProjectHost already owns (docs/architecture/
+    // frame-output.md, "Capability Boundary": saves and exports share one coordinator pair for
+    // correct same-target ordering/supersession), and to the SAME SnapshotCompiler/TaskScheduler/
+    // TaskUiBridge the preview pipeline above already uses.
+    bloom::ui::FrameExportController frameExportController(
+        compositionSession, taskScheduler, taskUiBridge, snapshotCompiler,
+        projectHost.publicationCoordinator(), projectHost.artifactCoordinator());
+
     bloom::ui::EditorRegistry editorRegistry;
     const bool editorsRegistered = bloom::ui::registerFoundationEditors(
                                        editorRegistry, compositionSession, previewController) &&
@@ -107,7 +117,8 @@ int main(int argc, char* argv[]) {
 
     application.setQuitOnLastWindowClosed(false);
     QSettings settings;
-    bloom::ui::MainWindow window(editorRegistry, compositionSession, projectHost);
+    bloom::ui::MainWindow window(editorRegistry, compositionSession, projectHost,
+                                 frameExportController);
     (void)window.restoreApplicationState(settings);
     QObject::connect(&shutdownCoordinator,
                      &bloom::ui::ApplicationShutdownCoordinator::shutdownStarted, &window,

--- a/docs/architecture/frame-output.md
+++ b/docs/architecture/frame-output.md
@@ -9,8 +9,8 @@ digest, preset-specific bound-analysis products, the module-private Output Seman
 1 streaming serializer/preparer, portable golden vectors, the flat OpenEXR adapter with its
 semantic reopen verifier and verifier-product issuance, and headless end-to-end EXR export
 publication (analysis attempt graph, immutable export request, and the shared-coordinator
-publication job) are implemented. The PNG adapter and the interactive export surface remain
-pending.
+publication job), and the interactive frame-export command with explicit digest approval are
+implemented. The PNG adapter remains pending.
 
 Updated: 2026-08-31
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
         composition_session.cpp
         editor_area.cpp
         editor_registry.cpp
+        frame_export_controller.cpp
         jobs_editor.cpp
         main_window.cpp
         node_editor.cpp
@@ -32,6 +33,7 @@ target_sources(
             include/bloom/ui/composition_session.hpp
             include/bloom/ui/editor_area.hpp
             include/bloom/ui/editor_registry.hpp
+            include/bloom/ui/frame_export_controller.hpp
             include/bloom/ui/jobs_editor.hpp
             include/bloom/ui/main_window.hpp
             include/bloom/ui/node_editor.hpp

--- a/src/ui/frame_export_controller.cpp
+++ b/src/ui/frame_export_controller.cpp
@@ -1,0 +1,723 @@
+#include <bloom/ui/frame_export_controller.hpp>
+
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+
+#include <bloom/document/project.hpp>
+#include <bloom/render/image.hpp>
+
+#include <QDir>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QStandardPaths>
+
+#include <system_error>
+#include <utility>
+
+namespace bloom::ui {
+
+namespace {
+
+// Design decision 4: "an app-private temp location — find/establish the app's existing convention
+// for transient files; justify the choice." No such convention existed anywhere in src/host,
+// src/platform, or src/ui before this task (verified: grep found nothing), so this establishes one:
+// QStandardPaths::TempLocation is Qt's own portable per-user temp root (XDG runtime/cache-adjacent
+// /tmp on Linux, NSTemporaryDirectory() on macOS, %TEMP% on Windows -- exactly the kind of
+// platform-appropriate transient location AGENTS.md's "treat Linux/macOS/Windows as first class"
+// rule calls for); "Bloom/export-scratch" underneath it is a directory this application owns,
+// distinct from any artist-chosen destination directory and never tracked by
+// platform::StagedArtifactCoordinator, matching frame_export_publication.hpp's `scratchDirectory`
+// contract ("a caller-owned directory ... never the real destination's parent, never tracked by
+// StagedArtifactCoordinator").
+[[nodiscard]] std::filesystem::path defaultExportScratchDirectory() {
+    auto base = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+    if (base.isEmpty()) {
+        base = QDir::tempPath();
+    }
+    return std::filesystem::path(base.toStdString()) / "Bloom" / "export-scratch";
+}
+
+[[nodiscard]] QString
+firstDiagnosticSummary(const std::vector<runtime::TaskDiagnostic>& diagnostics, QString fallback) {
+    if (diagnostics.empty() || diagnostics.front().summary.empty()) {
+        return fallback;
+    }
+    return QString::fromStdString(diagnostics.front().summary);
+}
+
+[[nodiscard]] QString facetDisplayName(const output::OutputFacetIdV1 facet) {
+    switch (facet) {
+    case output::OutputFacetIdV1::Pixels:
+        return FrameExportController::tr("Pixels");
+    case output::OutputFacetIdV1::Precision:
+        return FrameExportController::tr("Precision");
+    case output::OutputFacetIdV1::Color:
+        return FrameExportController::tr("Color");
+    case output::OutputFacetIdV1::AlphaAssociation:
+        return FrameExportController::tr("Alpha Association");
+    case output::OutputFacetIdV1::Channels:
+        return FrameExportController::tr("Channels");
+    case output::OutputFacetIdV1::DataWindow:
+        return FrameExportController::tr("Data Window");
+    case output::OutputFacetIdV1::DisplayWindow:
+        return FrameExportController::tr("Display Window");
+    case output::OutputFacetIdV1::PixelAspect:
+        return FrameExportController::tr("Pixel Aspect");
+    case output::OutputFacetIdV1::Compression:
+        return FrameExportController::tr("Compression");
+    case output::OutputFacetIdV1::Metadata:
+        return FrameExportController::tr("Metadata");
+    case output::OutputFacetIdV1::ExternalDependencies:
+        return FrameExportController::tr("External Dependencies");
+    }
+    return FrameExportController::tr("Unknown facet");
+}
+
+[[nodiscard]] FrameExportFacetSummary
+summarizeFacets(const output::OutputAnalysisReportV1View& view) {
+    FrameExportFacetSummary summary;
+    for (const auto& facet : view.facets) {
+        if (facet.state == output::OutputPreservationStateV1::Exact) {
+            ++summary.exactFacetCount;
+        } else {
+            ++summary.nonExactFacetCount;
+            summary.nonExactFacetNames << facetDisplayName(facet.facet);
+        }
+    }
+    return summary;
+}
+
+[[nodiscard]] QString stageName(const host::OutputAnalysisAttemptStageV1 stage) {
+    switch (stage) {
+    case host::OutputAnalysisAttemptStageV1::Resolving:
+        return FrameExportController::tr("resolving the destination");
+    case host::OutputAnalysisAttemptStageV1::Evaluating:
+        return FrameExportController::tr("evaluating the composition");
+    case host::OutputAnalysisAttemptStageV1::Identifying:
+        return FrameExportController::tr("computing the frame identity");
+    case host::OutputAnalysisAttemptStageV1::Analyzing:
+        return FrameExportController::tr("analyzing preservation");
+    }
+    return FrameExportController::tr("preparing the export");
+}
+
+[[nodiscard]] QString jobStageName(const host::FrameExportPublicationStageV1 stage) {
+    switch (stage) {
+    case host::FrameExportPublicationStageV1::Preflight:
+        return FrameExportController::tr("preflight");
+    case host::FrameExportPublicationStageV1::Staging:
+        return FrameExportController::tr("staging");
+    case host::FrameExportPublicationStageV1::Writing:
+        return FrameExportController::tr("writing");
+    case host::FrameExportPublicationStageV1::Verifying:
+        return FrameExportController::tr("verifying");
+    case host::FrameExportPublicationStageV1::ArtifactCopy:
+        return FrameExportController::tr("copying the artifact");
+    case host::FrameExportPublicationStageV1::Guard:
+        return FrameExportController::tr("the final publish guard");
+    case host::FrameExportPublicationStageV1::Cancelled:
+        return FrameExportController::tr("cancellation");
+    }
+    return FrameExportController::tr("publication");
+}
+
+// docs/architecture/frame-output.md, "Non-Blocking Execution": the closed stage vocabulary
+// Resolving/Evaluating/Identifying/ColorPreparing/Analyzing/PreparingOutput/Writing/Verifying/
+// Publishing. This maps the approved job's own bloom::output::OutputExportProgressCallbackV1 into
+// the existing bloom::runtime::TaskContext::reportProgress() plumbing (design decision 4: "smallest
+// honest wiring, no new progress framework") -- the pre-approval attempt's Resolving/Evaluating/
+// Identifying/Analyzing stages already report through the identical mechanism inside
+// beginOutputAnalysisAttemptV1() itself (src/host/output_analysis_attempt_runner.cpp), so nothing
+// extra is needed for that half.
+[[nodiscard]] std::string outputExportStagePhase(const output::OutputExportStageV1 stage) {
+    switch (stage) {
+    case output::OutputExportStageV1::Resolving:
+        return "Resolving";
+    case output::OutputExportStageV1::Evaluating:
+        return "Evaluating";
+    case output::OutputExportStageV1::Identifying:
+        return "Identifying";
+    case output::OutputExportStageV1::ColorPreparing:
+        return "ColorPreparing";
+    case output::OutputExportStageV1::Analyzing:
+        return "Analyzing";
+    case output::OutputExportStageV1::PreparingOutput:
+        return "PreparingOutput";
+    case output::OutputExportStageV1::Writing:
+        return "Writing";
+    case output::OutputExportStageV1::Verifying:
+        return "Verifying";
+    case output::OutputExportStageV1::Publishing:
+        return "Publishing";
+    }
+    return "Publishing";
+}
+
+[[nodiscard]] FrameExportOutcome
+exportFailureOutcome(const host::FrameExportPublicationFailureV1* failure) {
+    if (failure != nullptr && failure->stage() == host::FrameExportPublicationStageV1::Cancelled) {
+        return FrameExportOutcome::Cancelled;
+    }
+    return FrameExportOutcome::Failed;
+}
+
+} // namespace
+
+FrameExportController::FrameExportController(
+    CompositionSession& session, runtime::TaskScheduler& scheduler, TaskUiBridge& taskUiBridge,
+    const runtime::SnapshotCompiler& compiler, host::PublicationCoordinator& publicationCoordinator,
+    platform::StagedArtifactCoordinator& artifactCoordinator,
+    std::filesystem::path scratchDirectory, QObject* parent)
+    : QObject(parent), session_(session), scheduler_(scheduler), taskUiBridge_(taskUiBridge),
+      compiler_(compiler), publicationCoordinator_(publicationCoordinator),
+      artifactCoordinator_(artifactCoordinator),
+      scratchDirectory_(scratchDirectory.empty() ? defaultExportScratchDirectory()
+                                                 : std::move(scratchDirectory)) {
+    std::error_code error;
+    std::filesystem::create_directories(scratchDirectory_, error);
+
+    connect(&taskUiBridge_, &TaskUiBridge::snapshotsPolled, this, &FrameExportController::pollOnce);
+
+    destinationProvider_ = []() -> std::optional<std::filesystem::path> {
+        const auto chosen =
+            QFileDialog::getSaveFileName(nullptr, tr("Export Frame"), {}, tr("OpenEXR (*.exr)"));
+        if (chosen.isEmpty()) {
+            return std::nullopt;
+        }
+        return std::filesystem::path(chosen.toStdString());
+    };
+
+    approvalDecisionProvider_ = [](const FrameExportApprovalPrompt& prompt) {
+        QMessageBox box;
+        box.setWindowTitle(tr("Export Frame"));
+        box.setText(tr("Export this frame to %1?")
+                        .arg(QString::fromStdString(prompt.destination.filename().string())));
+        QStringList lines;
+        lines << tr("Destination: %1").arg(QString::fromStdString(prompt.destination.string()));
+        lines << tr("Resolution: %1 x %2").arg(prompt.width).arg(prompt.height);
+        lines << tr("Preset: %1").arg(prompt.presetName);
+        lines << tr("Preserved exactly: %1 of %2 facets")
+                     .arg(prompt.facets.exactFacetCount)
+                     .arg(prompt.facets.exactFacetCount + prompt.facets.nonExactFacetCount);
+        if (!prompt.facets.nonExactFacetNames.isEmpty()) {
+            lines << tr("Not exact: %1").arg(prompt.facets.nonExactFacetNames.join(", "));
+        }
+        lines << tr("Digest: %1…").arg(prompt.digestShortForm);
+        box.setInformativeText(lines.join("\n"));
+        box.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+        box.button(QMessageBox::Yes)->setText(tr("Export"));
+        box.setDefaultButton(QMessageBox::Yes);
+        return box.exec() == QMessageBox::Yes ? FrameExportApprovalDecision::Export
+                                              : FrameExportApprovalDecision::Cancel;
+    };
+}
+
+FrameExportController::~FrameExportController() {
+    if (auto* compiling = std::get_if<CompileHandle>(&inFlight_)) {
+        compiling->handle.cancel();
+    } else if (auto* runner = std::get_if<host::OutputAnalysisAttemptRunnerV1>(&inFlight_)) {
+        runner->requestCancellation();
+    } else if (auto* job = std::get_if<ExportJobHandle>(&inFlight_)) {
+        job->handle.cancel();
+    }
+}
+
+bool FrameExportController::canExport() const noexcept {
+    return activity_ == FrameExportActivity::Idle && session_.composition() != nullptr;
+}
+
+bool FrameExportController::isBusy() const noexcept {
+    return activity_ != FrameExportActivity::Idle;
+}
+
+FrameExportActivity FrameExportController::activity() const noexcept { return activity_; }
+
+const std::filesystem::path& FrameExportController::scratchDirectory() const noexcept {
+    return scratchDirectory_;
+}
+
+std::uint64_t FrameExportController::chargedResourceBytes() const noexcept {
+    return ledger_.chargedBytes();
+}
+
+void FrameExportController::setDestinationProvider(FrameExportDestinationProvider provider) {
+    destinationProvider_ = std::move(provider);
+}
+
+void FrameExportController::setApprovalDecisionProvider(
+    FrameExportApprovalDecisionProvider provider) {
+    approvalDecisionProvider_ = std::move(provider);
+}
+
+void FrameExportController::requestExport() {
+    if (!canExport()) {
+        emit exportFinished(FrameExportOutcome::Refused,
+                            tr("Another export is already in progress, or there is nothing to "
+                               "export."));
+        return;
+    }
+    if (!destinationProvider_) {
+        emit exportFinished(FrameExportOutcome::Refused,
+                            tr("No export destination dialog is configured."));
+        return;
+    }
+    auto chosen = destinationProvider_();
+    if (!chosen.has_value()) {
+        return; // The artist cancelled the dialog; not an error.
+    }
+    beginExport(std::move(*chosen));
+}
+
+void FrameExportController::beginExport(std::filesystem::path destination) {
+    if (!canExport()) {
+        emit exportFinished(FrameExportOutcome::Refused,
+                            tr("Another export is already in progress, or there is nothing to "
+                               "export."));
+        return;
+    }
+    if (destination.empty()) {
+        emit exportFinished(FrameExportOutcome::Refused, tr("No destination was chosen."));
+        return;
+    }
+
+    // The one-truth "current frame" source (cited in the implementor's report): CompositionSession
+    // owns currentTime()/compositionId()/snapshot(), the SAME accessors
+    // CompositionPreviewController::requestPreview() reads to build every preview request
+    // (composition_preview_controller.cpp).
+    const document::Snapshot snapshot = session_.snapshot();
+    const document::CompositionId compositionId = session_.compositionId();
+    if (snapshot.project().findComposition(compositionId) == nullptr) {
+        emit exportFinished(FrameExportOutcome::Refused,
+                            tr("No composition is available to export."));
+        return;
+    }
+
+    pendingDestination_ = std::move(destination);
+
+    runtime::TaskRequest request(
+        "Compile composition for frame export",
+        {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)},
+        runtime::TaskPriority::Foreground, runtime::TaskExecutor::Cpu);
+
+    // Init-capture `&compiler = compiler_` (never a same-scope local by reference -- this task runs
+    // on a Cpu worker thread strictly after beginExport() has already returned): binds directly to
+    // the long-lived compiler this controller was constructed with.
+    auto submission = scheduler_.submit<std::shared_ptr<const runtime::CompiledCompositionPlan>>(
+        std::move(request),
+        [snapshot, compositionId, &compiler = compiler_](runtime::TaskContext& context) {
+            using TaskResult =
+                runtime::TaskResult<std::shared_ptr<const runtime::CompiledCompositionPlan>>;
+            if (context.isCancellationRequested()) {
+                return TaskResult::cancelled();
+            }
+            context.reportProgress({.phase = "Compiling composition",
+                                    .subphase = "",
+                                    .completed = 0,
+                                    .total = std::nullopt});
+            auto compileResult = compiler.compile(
+                {.snapshot = snapshot, .compositionId = compositionId}, context.cancellation());
+            switch (compileResult.status) {
+            case runtime::SnapshotCompileStatus::Cancelled:
+                return TaskResult::cancelled();
+            case runtime::SnapshotCompileStatus::Unsupported:
+                return TaskResult::failed(
+                    runtime::TaskDiagnostic{.code = "bloom.ui.frame-export.compile-unsupported",
+                                            .severity = runtime::DiagnosticSeverity::Error,
+                                            .summary = "The composition contains operations "
+                                                       "frame export cannot compile",
+                                            .detail = {},
+                                            .suggestedAction = "Review the composition graph."});
+            case runtime::SnapshotCompileStatus::Failed:
+                return TaskResult::failed(
+                    runtime::TaskDiagnostic{.code = "bloom.ui.frame-export.compile-failed",
+                                            .severity = runtime::DiagnosticSeverity::Error,
+                                            .summary = "The composition could not be compiled "
+                                                       "for export",
+                                            .detail = {},
+                                            .suggestedAction = "Review the composition graph."});
+            case runtime::SnapshotCompileStatus::Compiled:
+                break;
+            }
+            if (compileResult.plan == nullptr) {
+                return TaskResult::failed(runtime::TaskDiagnostic{
+                    .code = "bloom.ui.frame-export.compile-no-plan",
+                    .severity = runtime::DiagnosticSeverity::Error,
+                    .summary = "Composition compilation returned no plan",
+                    .detail = {},
+                    .suggestedAction = "Report this internal error and retry."});
+            }
+            return TaskResult::succeeded(compileResult.plan);
+        });
+
+    if (!submission.accepted()) {
+        emit exportFinished(FrameExportOutcome::Failed, tr("The export could not be started."));
+        return;
+    }
+    inFlight_.emplace<CompileHandle>(CompileHandle{std::move(submission.handle)});
+    setActivity(FrameExportActivity::CompilingPlan);
+    taskUiBridge_.wake();
+}
+
+void FrameExportController::pollOnce() {
+    if (auto* compiling = std::get_if<CompileHandle>(&inFlight_)) {
+        handleCompileResult(*compiling);
+        return;
+    }
+    if (auto* runner = std::get_if<host::OutputAnalysisAttemptRunnerV1>(&inFlight_)) {
+        handleAttemptResult(*runner);
+        return;
+    }
+    if (auto* job = std::get_if<ExportJobHandle>(&inFlight_)) {
+        handleExportJobResult(*job);
+        return;
+    }
+}
+
+void FrameExportController::handleCompileResult(CompileHandle& compiling) {
+    auto result = compiling.handle.tryTakeResult();
+    if (!result.has_value()) {
+        return;
+    }
+    if (result->state() != runtime::TaskState::Succeeded || !result->value().has_value() ||
+        *result->value() == nullptr) {
+        const auto outcome = result->state() == runtime::TaskState::Cancelled
+                                 ? FrameExportOutcome::Cancelled
+                                 : FrameExportOutcome::Failed;
+        const QString message =
+            outcome == FrameExportOutcome::Cancelled
+                ? tr("The export was cancelled.")
+                : firstDiagnosticSummary(result->diagnostics(),
+                                         tr("The composition could not be compiled for export."));
+        inFlight_.emplace<std::monostate>();
+        setActivity(FrameExportActivity::Idle);
+        finish(outcome, message);
+        return;
+    }
+
+    const auto plan = *result->value();
+    inFlight_.emplace<std::monostate>();
+
+    // The evaluation memory budget reuses CompositionPreviewController's own default (composition_
+    // preview_controller.hpp's kDefaultPreviewPixelStorageByteLimit): the same working-set bound
+    // the viewer's own full-resolution preview already runs under for this composition, not a new
+    // invented number. This is distinct from (and independent of) the export job's own resource
+    // ledger admission below, which governs retained/staged export bytes, not evaluator scratch.
+    host::OutputAnalysisAttemptRequestV1 request{
+        .plan = plan,
+        .evaluation = {.time = session_.currentTime(),
+                       .output = plan->output(),
+                       .resolution = runtime::CompositionFormatResolution{},
+                       .quality = runtime::EvaluationQuality::Reference,
+                       .colorIntent = runtime::EvaluationColorIntent::LinearRec709Scene,
+                       .pixelStorageByteLimit = kDefaultPreviewPixelStorageByteLimit},
+        .targetPath = pendingDestination_,
+        .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
+        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)}};
+
+    auto begin = host::beginOutputAnalysisAttemptV1(scheduler_, artifactCoordinator_, ledger_,
+                                                    std::move(request));
+    if (!begin) {
+        setActivity(FrameExportActivity::Idle);
+        finish(FrameExportOutcome::Failed, tr("The export analysis could not be started."));
+        return;
+    }
+    inFlight_.emplace<host::OutputAnalysisAttemptRunnerV1>(std::move(begin).takeHandle());
+    setActivity(FrameExportActivity::Analyzing);
+    taskUiBridge_.wake();
+}
+
+void FrameExportController::handleAttemptResult(host::OutputAnalysisAttemptRunnerV1& runner) {
+    auto outcome = runner.tryComplete();
+    if (!outcome.has_value()) {
+        return;
+    }
+    inFlight_.emplace<std::monostate>();
+
+    if (!*outcome) {
+        setActivity(FrameExportActivity::Idle);
+        const auto* failure = outcome->failure();
+        const auto exportOutcome = (failure != nullptr && failure->cancelled())
+                                       ? FrameExportOutcome::Cancelled
+                                       : FrameExportOutcome::Failed;
+        finish(exportOutcome, describeAttemptFailure(failure));
+        return;
+    }
+
+    // OutputAnalysisAttemptOutcomeV1::operator bool() is exactly `attempt_ != nullptr`, so
+    // `*outcome` true above already guarantees this; the null check is defensive only.
+    auto attempt = outcome->attempt();
+    if (attempt == nullptr) {
+        setActivity(FrameExportActivity::Idle);
+        finish(FrameExportOutcome::Failed, tr("The export analysis returned no attempt."));
+        return;
+    }
+    if (!attempt->approvable() || !attempt->digest().has_value()) {
+        setActivity(FrameExportActivity::Idle);
+        const auto& report = attempt->report();
+        finish(FrameExportOutcome::NotApprovable, report != nullptr
+                                                      ? describeNonApprovable(*report)
+                                                      : tr("This frame cannot be exported."));
+        return;
+    }
+
+    presentApproval(attempt);
+}
+
+void FrameExportController::presentApproval(
+    const std::shared_ptr<const output::OutputAnalysisAttemptV1>& attempt) {
+    setActivity(FrameExportActivity::AwaitingApproval);
+
+    // The one place attempt->digest() (a fresh std::optional temporary on every call) is
+    // dereferenced: guarded right here, then reused for both the prompt's short form and the
+    // approveFrameExportV1() call below, rather than repeating an unprovable-at-a-distance check
+    // (handleAttemptResult() already confirmed has_value() before calling this function, but that
+    // was a DIFFERENT temporary).
+    const auto digest = attempt->digest();
+    if (!digest.has_value()) {
+        setActivity(FrameExportActivity::Idle);
+        finish(FrameExportOutcome::Failed, tr("The export analysis lost its approval digest."));
+        return;
+    }
+
+    FrameExportApprovalPrompt prompt;
+    prompt.destination = pendingDestination_;
+    if (attempt->frame() != nullptr) {
+        if (const auto* descriptor = attempt->frame()->processImage().descriptor();
+            descriptor != nullptr) {
+            prompt.width = descriptor->displayWindow().extent().width();
+            prompt.height = descriptor->displayWindow().extent().height();
+        }
+    }
+    const auto presetIdentity =
+        output::outputPresetIdentityV1(output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1);
+    prompt.presetName =
+        presetIdentity.has_value()
+            ? QString::fromUtf8(presetIdentity->serializedId.data(),
+                                static_cast<int>(presetIdentity->serializedId.size()))
+            : QStringLiteral("FlatExrRgba32fLinRec709SceneV1");
+    prompt.facets = summarizeFacets(attempt->report()->view());
+    const auto digestHex = digest->toLowercaseHex();
+    prompt.digestShortForm = QString::fromLatin1(digestHex.data(), 16);
+
+    const auto decision = approvalDecisionProvider_ ? approvalDecisionProvider_(prompt)
+                                                    : FrameExportApprovalDecision::Cancel;
+
+    if (decision == FrameExportApprovalDecision::Cancel) {
+        setActivity(FrameExportActivity::Idle);
+        // Discards cleanly: `attempt` (this function's own const& parameter) never held its own
+        // strong reference; the ONLY strong reference is handleAttemptResult()'s local `attempt`
+        // variable, which unwinds the instant that function returns (right after this call), so its
+        // retained ExportResourceReservationV1 drops to zero references and releases the charged
+        // bytes then -- no explicit release call exists or is needed (docs/architecture/frame-
+        // output.md: "Dismissal ... releases the completed attempt and its reservations"). Verified
+        // by this task's cancel-at-approval test via chargedResourceBytes().
+        finish(FrameExportOutcome::Cancelled, tr("The export was cancelled."));
+        return;
+    }
+
+    // Export calls approveFrameExportV1() with the attempt's OWN digest -- never recomputed or
+    // edited (docs/architecture/frame-output.md, "Non-Blocking Execution": "Approval itself
+    // performs no evaluation, hashing, color work, or filesystem access"; the API's byte-equality
+    // is the guard).
+    auto approval = host::approveFrameExportV1(publicationCoordinator_, attempt, *digest);
+    if (!approval) {
+        setActivity(FrameExportActivity::Idle);
+        finish(FrameExportOutcome::Failed, tr("The export could not be approved."));
+        return;
+    }
+    beginExportJob(std::move(approval).takeRequest());
+}
+
+void FrameExportController::beginExportJob(std::unique_ptr<host::FrameExportRequestV1> request) {
+    if (request == nullptr) {
+        setActivity(FrameExportActivity::Idle);
+        finish(FrameExportOutcome::Failed, tr("The export could not be started."));
+        return;
+    }
+    auto shared = std::make_shared<std::optional<host::FrameExportPublicationResultV1>>();
+    auto sharedRequest = std::shared_ptr<host::FrameExportRequestV1>(std::move(request));
+    const auto scratchDirectory = scratchDirectory_;
+
+    runtime::TaskRequest taskRequest(
+        "Publish exported frame",
+        {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)},
+        runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo);
+
+    // Init-capture `&artifacts = artifactCoordinator_` (matching src/host/tests/
+    // frame_export_publication_tests.cpp's own `beginExportRun()`): binds the closure's own
+    // captured reference directly to the long-lived, application-wide coordinator this controller
+    // was constructed with, never to a same-scope local -- this task runs on a BlockingIo worker
+    // thread strictly after beginExportJob() has already returned, so capturing any local variable
+    // by reference here would dangle.
+    auto submission = scheduler_.submit<void>(
+        std::move(taskRequest), [&artifacts = artifactCoordinator_, sharedRequest, shared,
+                                 scratchDirectory](runtime::TaskContext& context) {
+            output::OutputExportProgressCallbackV1 progress =
+                [&context](const output::OutputExportProgressV1& update) {
+                    context.reportProgress(
+                        {.phase = outputExportStagePhase(update.stage),
+                         .subphase = "",
+                         .completed = update.completed,
+                         .total = update.total == 0 ? std::nullopt
+                                                    : std::optional<std::uint64_t>(update.total)});
+                };
+            auto result = host::executeExportPublication(
+                context, artifacts, std::move(*sharedRequest), scratchDirectory,
+                output::systemOutputExportClockV1(), std::move(progress));
+            shared->emplace(std::move(result));
+            return runtime::TaskResult<void>::succeeded();
+        });
+
+    if (!submission.accepted()) {
+        setActivity(FrameExportActivity::Idle);
+        finish(FrameExportOutcome::Failed, tr("The export job could not be started."));
+        return;
+    }
+    inFlight_.emplace<ExportJobHandle>(ExportJobHandle{std::move(submission.handle), shared});
+    setActivity(FrameExportActivity::Publishing);
+    taskUiBridge_.wake();
+}
+
+void FrameExportController::handleExportJobResult(ExportJobHandle& job) {
+    auto taskResult = job.handle.tryTakeResult();
+    if (!taskResult.has_value()) {
+        return;
+    }
+    auto resultOpt = std::move(*job.result);
+    inFlight_.emplace<std::monostate>();
+    setActivity(FrameExportActivity::Idle);
+
+    if (!resultOpt.has_value()) {
+        finish(FrameExportOutcome::Failed, tr("The export job ended without a result."));
+        return;
+    }
+    const auto& result = *resultOpt;
+    if (!result) {
+        const auto* failure = result.failure();
+        finish(exportFailureOutcome(failure), describeExportFailure(failure));
+        return;
+    }
+
+    const auto* publication = result.publication();
+    const auto publicationOutcome =
+        publication != nullptr
+            ? publication->outcome
+            : platform::StagedArtifactPublicationOutcome::FailedBeforePublication;
+    const auto destinationText = QString::fromStdString(pendingDestination_.string());
+    switch (publicationOutcome) {
+    case platform::StagedArtifactPublicationOutcome::Published:
+        finish(FrameExportOutcome::Published, tr("Frame exported to %1.").arg(destinationText));
+        break;
+    case platform::StagedArtifactPublicationOutcome::PublishedWithDurabilityWarning:
+        finish(FrameExportOutcome::PublishedWithWarning,
+               tr("Frame exported to %1, but a later durability step failed. Consider exporting "
+                  "again.")
+                   .arg(destinationText));
+        break;
+    case platform::StagedArtifactPublicationOutcome::Superseded:
+        finish(FrameExportOutcome::Cancelled,
+               tr("This export was superseded by a newer export or save to the same file."));
+        break;
+    case platform::StagedArtifactPublicationOutcome::CancelledBeforePublication:
+        finish(FrameExportOutcome::Cancelled, tr("The export was cancelled."));
+        break;
+    case platform::StagedArtifactPublicationOutcome::ExternalModificationConflict:
+        finish(FrameExportOutcome::Failed,
+               tr("The destination file changed outside Bloom. Choose a different location or "
+                  "overwrite explicitly."));
+        break;
+    case platform::StagedArtifactPublicationOutcome::FailedBeforePublication:
+        finish(FrameExportOutcome::Failed,
+               tr("The export failed before the file could be replaced; the previous target, if "
+                  "any, is unchanged."));
+        break;
+    }
+}
+
+void FrameExportController::setActivity(const FrameExportActivity activity) {
+    if (activity_ == activity) {
+        return;
+    }
+    activity_ = activity;
+    emit busyChanged();
+}
+
+void FrameExportController::finish(const FrameExportOutcome outcome, QString message) {
+    emit exportFinished(outcome, std::move(message));
+}
+
+QString FrameExportController::describeAttemptFailure(
+    const host::OutputAnalysisAttemptFailureV1* failure) const {
+    if (failure == nullptr) {
+        return tr("The export analysis failed for an unknown reason.");
+    }
+    if (failure->cancelled()) {
+        return tr("The export was cancelled while %1.").arg(stageName(failure->stage()));
+    }
+    if (const auto* resourceError = failure->payloadAs<output::OutputAnalysisAttemptErrorCodeV1>();
+        resourceError != nullptr &&
+        *resourceError == output::OutputAnalysisAttemptErrorCodeV1::ResourceReservationFailed) {
+        return tr("The export could not reserve enough memory while %1.")
+            .arg(stageName(failure->stage()));
+    }
+    return tr("The export analysis failed while %1.").arg(stageName(failure->stage()));
+}
+
+QString
+FrameExportController::describeNonApprovable(const output::OutputAnalysisReportV1& report) const {
+    QStringList reasons;
+    for (const auto& facet : report.view().facets) {
+        if (facet.state == output::OutputPreservationStateV1::Missing ||
+            facet.state == output::OutputPreservationStateV1::Unsupported) {
+            const auto code = output::outputFacetStableCodeTextV1(facet.stableCode);
+            const QString codeText =
+                code.has_value() ? QString::fromUtf8(code->data(), static_cast<int>(code->size()))
+                                 : tr("unspecified");
+            reasons << QStringLiteral("%1: %2").arg(facetDisplayName(facet.facet), codeText);
+        }
+    }
+    if (reasons.isEmpty()) {
+        return tr("This frame cannot be exported (analysis reported a non-approvable preservation "
+                  "result).");
+    }
+    return tr("This frame cannot be exported: %1").arg(reasons.join("; "));
+}
+
+QString FrameExportController::describeExportFailure(
+    const host::FrameExportPublicationFailureV1* failure) const {
+    if (failure == nullptr) {
+        return tr(
+            "The export failed before the file could be written; the previous target, if any, "
+            "is unchanged.");
+    }
+    if (failure->stage() == host::FrameExportPublicationStageV1::Cancelled) {
+        return tr("The export was cancelled; the previous target, if any, is unchanged.");
+    }
+    if (const auto* staged = failure->payloadAs<platform::StagedArtifactError>();
+        staged != nullptr &&
+        *staged == platform::StagedArtifactError::ExternalModificationConflict) {
+        return tr("The destination file changed outside Bloom. Choose a different location or "
+                  "overwrite explicitly.");
+    }
+    if (failure->payloadAs<host::FrameExportDeadlineExceededV1>() != nullptr) {
+        return tr("The export exceeded its total time limit during %1; the previous target, if "
+                  "any, is unchanged.")
+            .arg(jobStageName(failure->stage()));
+    }
+    if (failure->payloadAs<host::FrameExportNoProgressExceededV1>() != nullptr) {
+        return tr("The export made no progress for too long during %1; the previous target, if "
+                  "any, is unchanged.")
+            .arg(jobStageName(failure->stage()));
+    }
+    if (failure->payloadAs<host::FrameExportResourceExhaustedV1>() != nullptr) {
+        return tr("The export ran out of its resource budget during %1; the previous target, if "
+                  "any, is unchanged.")
+            .arg(jobStageName(failure->stage()));
+    }
+    return tr("The export failed during %1; the previous target, if any, is unchanged.")
+        .arg(jobStageName(failure->stage()));
+}
+
+} // namespace bloom::ui

--- a/src/ui/include/bloom/ui/frame_export_controller.hpp
+++ b/src/ui/include/bloom/ui/frame_export_controller.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/host/frame_export_publication.hpp>
+#include <bloom/host/output_analysis_attempt_runner.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/output/output_analysis.hpp>
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/output/output_export_resource_ledger.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <variant>
+
+namespace bloom::ui {
+
+class CompositionSession;
+class TaskUiBridge;
+
+// What the artist is offered to approve before FrameExportController calls
+// bloom::host::approveFrameExportV1() (task F3, issue #103, design decision 3). Every field is read
+// straight off the completed, retained bloom::output::OutputAnalysisAttemptV1 -- never recomputed,
+// never user-editable. digestShortForm is a DISPLAY truncation of attempt->digest(); Export always
+// approves with the attempt's own full digest (see FrameExportController::presentApproval() in
+// frame_export_controller.cpp) -- the UI never invents, edits, or recomputes it.
+struct FrameExportFacetSummary final {
+    int exactFacetCount = 0;
+    int nonExactFacetCount = 0;
+    // Display-ready facet names (e.g. "Pixel Aspect") for every facet whose state is not Exact, in
+    // fixed facet-ID order (docs/architecture/frame-output.md's eleven-facet table).
+    QStringList nonExactFacetNames;
+};
+
+struct FrameExportApprovalPrompt final {
+    std::filesystem::path destination;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    // The exact serialized preset ID (docs/architecture/frame-output.md's typed-preset table) --
+    // "FlatExrRgba32fLinRec709SceneV1" in version 1, never a paraphrase.
+    QString presetName;
+    FrameExportFacetSummary facets;
+    // The first 16 lowercase hex characters of attempt->digest()->toLowercaseHex() -- "the digest's
+    // short form" (design decision 3).
+    QString digestShortForm;
+};
+
+enum class FrameExportApprovalDecision : std::uint8_t {
+    Export,
+    Cancel,
+};
+
+// Terminal, artist-facing outcomes. Mirrors ProjectHostOperationOutcome's honesty contract: never
+// collapse a non-published, non-approvable, or failed outcome into success.
+enum class FrameExportOutcome : std::uint8_t {
+    Published,
+    PublishedWithWarning,
+    Cancelled,
+    NotApprovable,
+    Failed,
+    Refused,
+};
+
+enum class FrameExportActivity : std::uint8_t {
+    Idle,
+    CompilingPlan,
+    Analyzing,
+    AwaitingApproval,
+    Publishing,
+};
+
+using FrameExportDestinationProvider = std::function<std::optional<std::filesystem::path>()>;
+using FrameExportApprovalDecisionProvider =
+    std::function<FrameExportApprovalDecision(const FrameExportApprovalPrompt&)>;
+
+// Composition root for "File -> Export Frame..." (task F3, issue #103). Drives the ACTIVE
+// composition at CompositionSession::currentTime() -- the same one-truth "current frame" source
+// CompositionPreviewController::requestPreview() already reads (composition_preview_controller.cpp)
+// -- through: a plan-compile Cpu task (runtime::SnapshotCompiler, this controller's own thin
+// UI-side task submission -- src/output/src/host add no new ABI for it), then
+// bloom::host::beginOutputAnalysisAttemptV1() (Resolving/Evaluating/Identifying/Analyzing, polled
+// off TaskUiBridge::snapshotsPolled per the qualified-display-processor bootstrap's poll-and-
+// publish-once precedent), an artist approval decision, bloom::host::approveFrameExportV1(), and
+// finally bloom::host::executeExportPublication() on its own BlockingIo task. Every stage is a real
+// bloom::runtime::TaskScheduler task, so attempt/job progress reaches the ordinary
+// Jobs/task-monitor surface automatically -- no separate progress plumbing is added here.
+//
+// One export at a time per window (design decision 5): the action stays disabled for the whole
+// CompilingPlan/Analyzing/AwaitingApproval/Publishing span, exactly like ProjectHost's single
+// in-flight Save/Open/Save-Copy. No queueing UI.
+class FrameExportController final : public QObject {
+    Q_OBJECT
+
+  public:
+    // `session`, `scheduler`, `taskUiBridge`, and `compiler` must outlive this object.
+    // `publicationCoordinator`/`artifactCoordinator` must be the SAME application-wide instances
+    // ProjectHost owns (ProjectHost::publicationCoordinator()/artifactCoordinator()) so save/export
+    // target ordering and supersession share one truth (docs/architecture/frame-output.md,
+    // "Capability Boundary": "Project saves and frame exports reuse one
+    // src/platform::StagedArtifactCoordinator" and "The application-wide PublicationCoordinator
+    // owns ... supersession across saves and exports"). `scratchDirectory`, when non-empty,
+    // overrides the default app-private temp location (tests use this to stay inside their own temp
+    // fixture); either way the resolved directory is created if missing.
+    FrameExportController(CompositionSession& session, runtime::TaskScheduler& scheduler,
+                          TaskUiBridge& taskUiBridge, const runtime::SnapshotCompiler& compiler,
+                          host::PublicationCoordinator& publicationCoordinator,
+                          platform::StagedArtifactCoordinator& artifactCoordinator,
+                          std::filesystem::path scratchDirectory = {}, QObject* parent = nullptr);
+    ~FrameExportController() override;
+
+    // A composition exists and no export is currently in flight (menu-enabled rule; MainWindow
+    // additionally folds in its own read-only-placeholder check -- see main_window.cpp).
+    [[nodiscard]] bool canExport() const noexcept;
+    [[nodiscard]] bool isBusy() const noexcept;
+    [[nodiscard]] FrameExportActivity activity() const noexcept;
+    [[nodiscard]] const std::filesystem::path& scratchDirectory() const noexcept;
+    // Test observability seam: bloom::output::ExportResourceLedgerV1::chargedBytes() for the ledger
+    // this controller privately owns. Used to verify a dismissed/cancelled attempt charges nothing
+    // (docs/architecture/frame-output.md: "Dismissal or supersession cancels unfinished work and
+    // releases the completed attempt and its reservations").
+    [[nodiscard]] std::uint64_t chargedResourceBytes() const noexcept;
+
+    // Seam setters (ProjectHost's decision-4 precedent). Defaults are installed at construction (a
+    // real QFileDialog::getSaveFileName ".exr" filter; a real QMessageBox Export/Cancel prompt), so
+    // offscreen tests can drive the whole flow without a real dialog appearing.
+    void setDestinationProvider(FrameExportDestinationProvider provider);
+    void setApprovalDecisionProvider(FrameExportApprovalDecisionProvider provider);
+
+  public slots:
+    // "File -> Export Frame..." entry point: refuses while busy or without a composition, else
+    // invokes the destination-dialog seam, then beginExport() with the chosen path.
+    void requestExport();
+    // Lower-level primitive (mirrors ProjectHost::beginSaveAs()): begins export against an
+    // already-known destination, bypassing the destination dialog seam. Public so tests can drive
+    // it directly.
+    void beginExport(std::filesystem::path destination);
+
+  signals:
+    void busyChanged();
+    // Typed outcome + a display-ready message, exactly like ProjectHost's saveFinished()/
+    // openFinished() (never collapses a non-published or failed outcome into success).
+    void exportFinished(bloom::ui::FrameExportOutcome outcome, QString message);
+
+  private:
+    struct CompileHandle final {
+        runtime::TaskHandle<std::shared_ptr<const runtime::CompiledCompositionPlan>> handle;
+    };
+    struct ExportJobHandle final {
+        runtime::TaskHandle<void> handle;
+        std::shared_ptr<std::optional<host::FrameExportPublicationResultV1>> result;
+    };
+
+    void pollOnce();
+    void handleCompileResult(CompileHandle& compiling);
+    void handleAttemptResult(host::OutputAnalysisAttemptRunnerV1& runner);
+    void handleExportJobResult(ExportJobHandle& job);
+    void presentApproval(const std::shared_ptr<const output::OutputAnalysisAttemptV1>& attempt);
+    void beginExportJob(std::unique_ptr<host::FrameExportRequestV1> request);
+    void setActivity(FrameExportActivity activity);
+    void finish(FrameExportOutcome outcome, QString message);
+    [[nodiscard]] QString
+    describeAttemptFailure(const host::OutputAnalysisAttemptFailureV1* failure) const;
+    [[nodiscard]] QString describeNonApprovable(const output::OutputAnalysisReportV1& report) const;
+    [[nodiscard]] QString
+    describeExportFailure(const host::FrameExportPublicationFailureV1* failure) const;
+
+    CompositionSession& session_;
+    runtime::TaskScheduler& scheduler_;
+    TaskUiBridge& taskUiBridge_;
+    const runtime::SnapshotCompiler& compiler_;
+    host::PublicationCoordinator& publicationCoordinator_;
+    platform::StagedArtifactCoordinator& artifactCoordinator_;
+    output::ExportResourceLedgerV1 ledger_;
+    std::filesystem::path scratchDirectory_;
+
+    FrameExportDestinationProvider destinationProvider_;
+    FrameExportApprovalDecisionProvider approvalDecisionProvider_;
+
+    FrameExportActivity activity_ = FrameExportActivity::Idle;
+    std::filesystem::path pendingDestination_;
+
+    std::variant<std::monostate, CompileHandle, host::OutputAnalysisAttemptRunnerV1,
+                 ExportJobHandle>
+        inFlight_;
+};
+
+} // namespace bloom::ui

--- a/src/ui/include/bloom/ui/main_window.hpp
+++ b/src/ui/include/bloom/ui/main_window.hpp
@@ -13,6 +13,7 @@ namespace bloom::ui {
 
 class CompositionSession;
 class EditorRegistry;
+class FrameExportController;
 class ProjectHost;
 class WorkspaceHost;
 enum class WorkspaceLayoutRestoreResult;
@@ -22,7 +23,8 @@ class MainWindow final : public QMainWindow {
 
   public:
     MainWindow(const EditorRegistry& editorRegistry, CompositionSession& compositionSession,
-               ProjectHost& projectHost, QWidget* parent = nullptr);
+               ProjectHost& projectHost, FrameExportController& frameExportController,
+               QWidget* parent = nullptr);
 
     [[nodiscard]] WorkspaceHost* workspaceHost() const noexcept;
     [[nodiscard]] WorkspaceLayoutRestoreResult restoreApplicationState(QSettings& settings);
@@ -52,12 +54,14 @@ class MainWindow final : public QMainWindow {
     void updateEditActions();
     void updateWorkspaceActions();
     void updateFileActions();
+    void updateExportAction();
     void updateWindowTitle();
     void updateContentSurface();
     void applyFoundationTheme();
 
     CompositionSession& compositionSession_;
     ProjectHost& projectHost_;
+    FrameExportController& frameExportController_;
     QMenu* windowMenu_ = nullptr;
     QStackedWidget* centralStack_ = nullptr;
     WorkspaceHost* workspaceHost_ = nullptr;
@@ -69,6 +73,7 @@ class MainWindow final : public QMainWindow {
     QAction* saveProjectAction_ = nullptr;
     QAction* saveProjectAsAction_ = nullptr;
     QAction* saveProjectCopyAction_ = nullptr;
+    QAction* exportFrameAction_ = nullptr;
     QAction* undoAction_ = nullptr;
     QAction* redoAction_ = nullptr;
     QAction* splitLeftRightAction_ = nullptr;

--- a/src/ui/include/bloom/ui/project_host.hpp
+++ b/src/ui/include/bloom/ui/project_host.hpp
@@ -118,6 +118,18 @@ class ProjectHost final : public QObject {
     [[nodiscard]] ProjectHostActivity activity() const noexcept;
     [[nodiscard]] std::optional<std::filesystem::path> displayPath() const;
 
+    // Application-wide sharing seam (task F3, issue #103): docs/architecture/frame-output.md,
+    // "Capability Boundary" / "Atomic Publication" -- "Project saves and frame exports reuse one
+    // src/platform::StagedArtifactCoordinator" and "The application-wide PublicationCoordinator
+    // owns monotonic intent IDs, per-target ordering, and supersession across saves and exports."
+    // ProjectHost already owns the application's one instance of each (constructed once, above);
+    // frame export must bind to the SAME live instances rather than constructing its own, or
+    // same-target save/export ordering and supersession would silently split across two unrelated
+    // coordinators. Both are guaranteed populated for the lifetime of this object (the constructor
+    // throws if either fails to construct), so these never return a moved-from/empty optional.
+    [[nodiscard]] host::PublicationCoordinator& publicationCoordinator() noexcept;
+    [[nodiscard]] platform::StagedArtifactCoordinator& artifactCoordinator() noexcept;
+
     // Design decision 2's UI seam, forwarded from the live ProjectSession: raw, non-owning
     // pointers to the currently installed document/command-stack pair (null for non-decoded
     // content). The caller hands these to a projection's own rebind() (e.g.

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -4,6 +4,7 @@
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_area.hpp>
 #include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/frame_export_controller.hpp>
 #include <bloom/ui/project_host.hpp>
 #include <bloom/ui/workspace_host.hpp>
 
@@ -36,8 +37,10 @@ constexpr auto windowGeometryKey = "window/main/geometry";
 namespace bloom::ui {
 
 MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession& compositionSession,
-                       ProjectHost& projectHost, QWidget* parent)
-    : QMainWindow(parent), compositionSession_(compositionSession), projectHost_(projectHost) {
+                       ProjectHost& projectHost, FrameExportController& frameExportController,
+                       QWidget* parent)
+    : QMainWindow(parent), compositionSession_(compositionSession), projectHost_(projectHost),
+      frameExportController_(frameExportController) {
     setObjectName("bloomMainWindow");
     setWindowTitle("Bloom");
     resize(1600, 1000);
@@ -91,9 +94,36 @@ MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession&
                 }
                 QMessageBox::warning(this, tr("Save a Copy"), message);
             });
+
+    // "File -> Export Frame..." gating (task F3, issue #103): a composition exists and no export
+    // is currently in flight (FrameExportController::canExport()), and the read-only placeholder is
+    // not currently authoritative (a preserved-read-only install leaves CompositionSession bound to
+    // its stale prior document -- see updateContentSurface()'s own comment -- so this action must
+    // never be offered while that placeholder is showing). Every signal that can change either
+    // condition is wired here, mirroring updateFileActions()'s own precedent.
+    connect(&frameExportController_, &FrameExportController::busyChanged, this,
+            &MainWindow::updateExportAction);
+    connect(&compositionSession_, &CompositionSession::compositionChanged, this,
+            &MainWindow::updateExportAction);
+    connect(&projectHost_, &ProjectHost::sessionReplaced, this, &MainWindow::updateExportAction);
+    connect(&frameExportController_, &FrameExportController::exportFinished, this,
+            [this](const FrameExportOutcome outcome, const QString& message) {
+                if (outcome == FrameExportOutcome::Published ||
+                    outcome == FrameExportOutcome::PublishedWithWarning) {
+                    statusBar()->showMessage(message, 4000);
+                    return;
+                }
+                if (outcome == FrameExportOutcome::Cancelled) {
+                    statusBar()->clearMessage();
+                    return;
+                }
+                QMessageBox::warning(this, tr("Export Frame"), message);
+            });
+
     updateFileActions();
     updateWindowTitle();
     updateContentSurface();
+    updateExportAction();
 }
 
 WorkspaceHost* MainWindow::workspaceHost() const noexcept { return workspaceHost_; }
@@ -205,6 +235,15 @@ void MainWindow::createFileMenu(QMenu& fileMenu) {
             &ProjectHost::requestSaveCopy);
 
     fileMenu.addSeparator();
+
+    // "Export Frame…" (task F3, issue #103): no default shortcut, its own group below the
+    // project-file actions.
+    exportFrameAction_ = fileMenu.addAction("Export &Frame…");
+    exportFrameAction_->setObjectName("exportFrameAction");
+    connect(exportFrameAction_, &QAction::triggered, &frameExportController_,
+            &FrameExportController::requestExport);
+
+    fileMenu.addSeparator();
 }
 
 void MainWindow::updateFileActions() {
@@ -234,6 +273,11 @@ void MainWindow::updateFileActions() {
         }
         break;
     }
+}
+
+void MainWindow::updateExportAction() {
+    exportFrameAction_->setEnabled(frameExportController_.canExport() &&
+                                   !isShowingReadOnlyPlaceholder());
 }
 
 void MainWindow::updateWindowTitle() {

--- a/src/ui/project_host.cpp
+++ b/src/ui/project_host.cpp
@@ -146,6 +146,16 @@ std::optional<std::filesystem::path> ProjectHost::displayPath() const {
     return snapshot.displayPath->value();
 }
 
+host::PublicationCoordinator& ProjectHost::publicationCoordinator() noexcept {
+    return *publicationCoordinator_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed
+                                     // populated by the constructor (which throws otherwise).
+}
+
+platform::StagedArtifactCoordinator& ProjectHost::artifactCoordinator() noexcept {
+    return *artifactCoordinator_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed
+                                  // populated by the constructor (which throws otherwise).
+}
+
 std::pair<document::Document*, commands::CommandStack*>
 ProjectHost::liveDocumentAndStack() noexcept {
     if (!session_.has_value()) {

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -34,6 +34,9 @@ add_executable(bloom_composition_session_position_interaction_test
 add_executable(bloom_direct_manipulation_test
     direct_manipulation_tests.cpp
 )
+add_executable(bloom_frame_export_controller_test
+    frame_export_controller_tests.cpp
+)
 
 # Links ZLIB::ZLIB directly for its own trimmed hand-rolled ZIP-writer fixture (a preserved-
 # read-only archive builder) -- mirroring src/host/CMakeLists.txt's bloom_host_session_open_test,
@@ -57,6 +60,7 @@ target_link_libraries(bloom_timeline_frame_math_test PRIVATE bloom_ui)
 target_link_libraries(bloom_timeline_ruler_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_session_position_interaction_test PRIVATE bloom_ui)
 target_link_libraries(bloom_direct_manipulation_test PRIVATE bloom_ui)
+target_link_libraries(bloom_frame_export_controller_test PRIVATE bloom_ui)
 target_link_libraries(bloom_main_window_readonly_placeholder_test PRIVATE bloom_ui ZLIB::ZLIB)
 bloom_enable_warnings(bloom_composition_projection_test)
 bloom_enable_warnings(bloom_composition_preview_controller_test)
@@ -70,6 +74,7 @@ bloom_enable_warnings(bloom_timeline_frame_math_test)
 bloom_enable_warnings(bloom_timeline_ruler_test)
 bloom_enable_warnings(bloom_composition_session_position_interaction_test)
 bloom_enable_warnings(bloom_direct_manipulation_test)
+bloom_enable_warnings(bloom_frame_export_controller_test)
 bloom_enable_warnings(bloom_main_window_readonly_placeholder_test)
 
 include(BloomTesting)
@@ -174,6 +179,14 @@ bloom_add_test(
     NAME bloom.ui.main_window_readonly_placeholder
     COMMAND bloom_main_window_readonly_placeholder_test
     LABELS ui integration host
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.frame_export_controller
+    COMMAND bloom_frame_export_controller_test
+    LABELS ui integration host output
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )

--- a/src/ui/tests/application_shutdown_tests.cpp
+++ b/src/ui/tests/application_shutdown_tests.cpp
@@ -2,11 +2,14 @@
 #include <bloom/core/rational_time.hpp>
 #include <bloom/document/document.hpp>
 #include <bloom/document/new_project.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
 #include <bloom/ui/application_shutdown_coordinator.hpp>
 #include <bloom/ui/composition_preview_controller.hpp>
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/frame_export_controller.hpp>
 #include <bloom/ui/main_window.hpp>
 #include <bloom/ui/project_host.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
@@ -127,7 +130,13 @@ void testShutdownAndCloseRouting(Expectations& expectations) {
 
     ui::ProjectHost projectHost(scheduler);
     ui::EditorRegistry registry;
-    ui::MainWindow window(registry, session, projectHost);
+    runtime::NodeDefinitionRegistry nodeDefinitions;
+    nodeDefinitions.freeze();
+    runtime::SnapshotCompiler snapshotCompiler(nodeDefinitions);
+    ui::FrameExportController frameExportController(session, scheduler, bridge, snapshotCompiler,
+                                                    projectHost.publicationCoordinator(),
+                                                    projectHost.artifactCoordinator());
+    ui::MainWindow window(registry, session, projectHost, frameExportController);
     window.resize(913, 577);
     QTemporaryDir settingsDirectory;
     QSettings settings(settingsDirectory.filePath(QStringLiteral("shutdown-state.ini")),

--- a/src/ui/tests/frame_export_controller_tests.cpp
+++ b/src/ui/tests/frame_export_controller_tests.cpp
@@ -1,0 +1,577 @@
+#include <bloom/ui/frame_export_controller.hpp>
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/host/output_analysis_attempt_runner.hpp>
+#include <bloom/host/publication_coordinator.hpp>
+#include <bloom/output/flat_exr_reopen_verifier.hpp>
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/evaluation.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QString>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <utility>
+
+// Task F3 (issue #103): drives bloom::ui::FrameExportController's public surface -- "File -> Export
+// Frame..." -- end to end over a REAL bloom::runtime::TaskScheduler, mirroring
+// src/ui/tests/project_host_tests.cpp's fixture/pumped-event-loop idiom and src/host/tests/
+// frame_export_publication_tests.cpp's fixture-attempt-building AND require()-accessor idioms
+// (which this file cannot directly reuse -- src modules may not reach across a sibling module's
+// tests/ directory, exactly as src/ui/tests/main_window_readonly_placeholder_tests.cpp's own
+// comment documents for its own duplicate of a src/host/tests/ helper).
+
+namespace {
+
+namespace commands = bloom::commands;
+namespace core = bloom::core;
+namespace document = bloom::document;
+namespace host = bloom::host;
+namespace output = bloom::output;
+namespace platform = bloom::platform;
+namespace runtime = bloom::runtime;
+
+using bloom::ui::CompositionSession;
+using bloom::ui::FrameExportApprovalDecision;
+using bloom::ui::FrameExportApprovalPrompt;
+using bloom::ui::FrameExportController;
+using bloom::ui::FrameExportOutcome;
+using bloom::ui::TaskUiBridge;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+// The one place this file dereferences a std::optional (or optional-shaped result type) without a
+// directly-adjacent has_value()/operator bool() check: it performs that check right here and
+// returns a raw pointer, so every call site below works with a plain (possibly-null) pointer
+// instead -- mirrors src/host/tests/frame_export_publication_tests.cpp's own require() exactly
+// (clang-tidy's bugprone-unchecked-optional-access only tracks std::optional itself across
+// statements, so converting to a pointer once, in one place, is the established way to avoid
+// repeating an unprovable-at-a-distance check at dozens of call sites).
+template <typename Optional>
+[[nodiscard]] auto require(Optional& value, Expectations& expectations,
+                           const std::string_view message) -> decltype(&*value) {
+    expectations.expect(static_cast<bool>(value), message);
+    if (!value) {
+        return nullptr;
+    }
+    return &*value; // NOLINT(bugprone-unchecked-optional-access) -- guarded immediately above.
+}
+
+class TempDirectory final {
+  public:
+    TempDirectory() {
+        std::array<char, 64> pattern{};
+        constexpr std::string_view prefix = "/tmp/bloom-frame-export-controller-XXXXXX";
+        std::ranges::copy(prefix, pattern.begin());
+        const auto* result = ::mkdtemp(pattern.data());
+        if (result != nullptr) {
+            path_ = result;
+        }
+    }
+    TempDirectory(const TempDirectory&) = delete;
+    TempDirectory& operator=(const TempDirectory&) = delete;
+    ~TempDirectory() {
+        if (!path_.empty()) {
+            std::error_code error;
+            std::filesystem::remove_all(path_, error);
+        }
+    }
+
+    [[nodiscard]] bool isValid() const noexcept { return !path_.empty(); }
+    [[nodiscard]] const std::filesystem::path& path() const noexcept { return path_; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+template <typename Predicate> [[nodiscard]] bool waitUntil(Predicate predicate) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 8'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (std::invoke(predicate)) {
+            return true;
+        }
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return std::invoke(predicate);
+}
+
+// A small, cheap-to-evaluate composition format (mirrors src/ui/tests/composition_preview_
+// controller_tests.cpp's own smallFormat()).
+[[nodiscard]] document::CompositionFormat smallFormat() {
+    const auto format = document::CompositionFormat::create(4, 4);
+    if (!format.has_value()) {
+        std::abort();
+    }
+    return *format;
+}
+
+// A composition format whose width alone exceeds the version-1 export hard limit (32768 px) while
+// its total pixel count stays tiny (docs/architecture/frame-output.md's "export hard-limit result":
+// "exceeded iff any source or target pixel width or height ... exceeds 32768"). Empirically (see
+// this task's implementor report's "defects found" -- not this test's fault, and nothing here
+// works around it): this trips ProcessFrameSemanticIdentityV1Preparer's OWN identical
+// exceedsOutputLimits() preflight (src/output/process_frame_semantic_identity.cpp,
+// output_limits.hpp's kOutputAnalysisMaximumDimensionV1/kOutputAnalysisMaximumPixelCountV1) at the
+// Identifying stage, BEFORE the analyzer ever runs -- so it fails the whole attempt
+// (OutputAnalysisAttemptFailureV1) rather than reaching a valid-but-non-approvable
+// OutputAnalysisReportV1. The analyzer's own documented resource.limit-exceeded facet path is real
+// (exercised by src/output/tests/output_analysis_analyzer_tests.cpp's hand-constructed inputs) but
+// is unreachable through the real production pipeline for this reason -- see
+// testAttemptFailureViaOverLimitCompositionSurfacesDiagnostics() below, which exercises the outcome
+// this composition ACTUALLY produces (a typed Failed attempt, not NotApprovable).
+[[nodiscard]] document::CompositionFormat overLimitFormat() {
+    const auto format = document::CompositionFormat::create(33000, 2);
+    if (!format.has_value()) {
+        std::abort();
+    }
+    return *format;
+}
+
+// Owns the fixture set every test below needs. platform::StagedArtifactCoordinator/
+// host::PublicationCoordinator are only constructible through their own ::create() factories and
+// bloom::ui::FrameExportController is neither copyable nor movable, so all three are held in-place
+// inside a std::optional and populated by setUp() -- the accessor methods below are the ONE place
+// each member's optional is dereferenced (guarded by setUp()'s own already-checked success),
+// mirroring src/host/tests/frame_export_publication_tests.cpp's ExportFixture exactly.
+struct Fixture final {
+    document::NewProject newProject;
+    document::Document document;
+    commands::CommandStack commandStack;
+    CompositionSession session;
+    runtime::NodeDefinitionRegistry nodeDefinitions;
+    runtime::SnapshotCompiler compiler;
+    runtime::TaskScheduler scheduler;
+    TaskUiBridge bridge;
+    TempDirectory directory;
+
+    explicit Fixture(const document::CompositionFormat format = smallFormat())
+        : newProject(document::makeNewProject("Export Test", "Main",
+                                              core::RationalTime::fromInteger(10), format)),
+          document(std::move(newProject.project)), commandStack(document),
+          session(document, commandStack, newProject.initialCompositionId),
+          // SnapshotCompiler has no default constructor -- only `explicit SnapshotCompiler(const
+          // NodeDefinitionRegistry&)` -- but it only STORES the reference at construction; the
+          // referenced registry does not need to be populated/frozen yet (that happens in the body
+          // below, before any test ever calls compiler.compile()). Declaration order places
+          // `nodeDefinitions` before `compiler`, so the reference is already valid here.
+          compiler(nodeDefinitions), bridge(scheduler, nullptr, std::chrono::milliseconds{1}) {
+        if (!runtime::registerBuiltInNodeDefinitions(nodeDefinitions)) {
+            std::abort();
+        }
+        nodeDefinitions.freeze();
+    }
+
+    // Two-phase construction: the controller needs `directory` (a member, constructed above) and
+    // the coordinators to outlive it, so all three are built here rather than in the initializer
+    // list.
+    [[nodiscard]] bool setUp(Expectations& expectations, const std::string_view context) {
+        if (!directory.isValid()) {
+            expectations.expect(false, context);
+            return false;
+        }
+        auto artifactsResult = platform::StagedArtifactCoordinator::create({});
+        auto coordinatorResult = host::PublicationCoordinator::create();
+        const bool ok = artifactsResult.succeeded() && coordinatorResult.has_value();
+        expectations.expect(ok, context);
+        if (!ok) {
+            return false;
+        }
+        artifacts_.emplace(std::move(artifactsResult).takeCoordinator());
+        coordinator_.emplace(
+            std::move(*coordinatorResult)); // NOLINT(bugprone-unchecked-optional-access)
+        controller_.emplace(session, scheduler, bridge, compiler, *coordinator_, *artifacts_,
+                            directory.path() / "scratch");
+        return true;
+    }
+
+    [[nodiscard]] platform::StagedArtifactCoordinator& artifacts() noexcept {
+        return *artifacts_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed by setUp().
+    }
+    [[nodiscard]] host::PublicationCoordinator& coordinator() noexcept {
+        return *coordinator_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed by
+                              // setUp().
+    }
+    [[nodiscard]] FrameExportController& controller() noexcept {
+        return *controller_; // NOLINT(bugprone-unchecked-optional-access) -- guaranteed by
+                             // setUp().
+    }
+
+  private:
+    std::optional<platform::StagedArtifactCoordinator> artifacts_;
+    std::optional<host::PublicationCoordinator> coordinator_;
+    std::optional<FrameExportController> controller_;
+};
+
+// Compiles and analyzes the SAME snapshot/time an already-published export used, independently of
+// FrameExportController, purely to obtain a processIdentity()/report() pair to feed the F1 reopen
+// verifier ("the published file passes the F1 verifier independently"). Evaluation is deterministic
+// (docs/architecture/frame-output.md: "the digest is stable across two independent runs over the
+// identical fixture"), so this reproduces the same process identity/report the controller's own
+// (by-then-discarded) attempt used.
+[[nodiscard]] std::shared_ptr<const output::OutputAnalysisAttemptV1>
+independentlyReanalyze(Expectations& expectations, Fixture& fixture,
+                       const std::filesystem::path& verifyTarget) {
+    const auto compileResult = fixture.compiler.compile(
+        {.snapshot = fixture.session.snapshot(), .compositionId = fixture.session.compositionId()},
+        {});
+    if (compileResult.status != runtime::SnapshotCompileStatus::Compiled ||
+        compileResult.plan == nullptr) {
+        expectations.expect(false, "independent reanalysis: the composition compiles");
+        return nullptr;
+    }
+
+    // Non-static: ExportResourceLedgerV1::reserve() hands the built reservation a shared_ptr to the
+    // ledger's own internal state, not a raw reference to this wrapper object, so the returned
+    // attempt's reservation stays valid correctly independent of this local going out of scope.
+    output::ExportResourceLedgerV1 verifyLedger;
+    host::OutputAnalysisAttemptRequestV1 request{
+        .plan = compileResult.plan,
+        .evaluation = {.time = fixture.session.currentTime(),
+                       .output = compileResult.plan->output(),
+                       .resolution = runtime::CompositionFormatResolution{},
+                       .quality = runtime::EvaluationQuality::Reference,
+                       .colorIntent = runtime::EvaluationColorIntent::LinearRec709Scene,
+                       .pixelStorageByteLimit = bloom::ui::kDefaultPreviewPixelStorageByteLimit},
+        .targetPath = verifyTarget,
+        .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
+        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(99)}};
+
+    auto begin = host::beginOutputAnalysisAttemptV1(fixture.scheduler, fixture.artifacts(),
+                                                    verifyLedger, std::move(request));
+    if (!begin) {
+        expectations.expect(false, "independent reanalysis: begin submits the Resolving task");
+        return nullptr;
+    }
+    auto runner = std::move(begin).takeHandle();
+    std::optional<host::OutputAnalysisAttemptOutcomeV1> outcome;
+    (void)waitUntil([&] {
+        outcome = runner.tryComplete();
+        return outcome.has_value();
+    });
+    const auto* outcomeValue = require(
+        outcome, expectations, "independent reanalysis: the attempt reaches a terminal outcome");
+    if (outcomeValue == nullptr) {
+        return nullptr;
+    }
+    expectations.expect(static_cast<bool>(*outcomeValue),
+                        "independent reanalysis: the attempt completes successfully");
+    return *outcomeValue ? outcomeValue->attempt() : nullptr;
+}
+
+// -------------------------------------------------------------------------------------------
+// Menu action gating: no composition vs. a real composition (design decision 1).
+// -------------------------------------------------------------------------------------------
+
+void testCanExportGatesOnComposition(Expectations& expectations) {
+    Fixture fixture;
+    if (!fixture.setUp(expectations, "gating: fixture is available")) {
+        return;
+    }
+    expectations.expect(fixture.controller().canExport(),
+                        "gating: a fresh composition with an idle controller can export");
+
+    // Rebind to an invalid composition id, matching what ProjectHost::lowestCompositionId() returns
+    // for content with no live composition (e.g. preserved-read-only) -- session.composition()
+    // becomes null.
+    fixture.session.rebind(fixture.document, fixture.commandStack, document::CompositionId{});
+    expectations.expect(fixture.session.composition() == nullptr,
+                        "gating: rebinding to an invalid id leaves no live composition");
+    expectations.expect(!fixture.controller().canExport(),
+                        "gating: canExport() is false with no composition");
+
+    fixture.session.rebind(fixture.document, fixture.commandStack,
+                           fixture.newProject.initialCompositionId);
+    expectations.expect(fixture.controller().canExport(),
+                        "gating: canExport() is true again once a composition is live");
+}
+
+// -------------------------------------------------------------------------------------------
+// Full successful drive: destination -> attempt -> approval prompt data -> approve -> job ->
+// Published, with the file independently reopen-verified.
+// -------------------------------------------------------------------------------------------
+
+void testFullDriveApprovedAndPublished(Expectations& expectations) {
+    Fixture fixture;
+    if (!fixture.setUp(expectations, "full drive: fixture is available")) {
+        return;
+    }
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.25, 0.5, 0.75, 1.0}),
+        "full drive: the solid layer is added");
+
+    const auto target = fixture.directory.path() / "published.exr";
+    fixture.controller().setDestinationProvider(
+        [&target]() -> std::optional<std::filesystem::path> { return target; });
+
+    std::optional<FrameExportApprovalPrompt> capturedPrompt;
+    fixture.controller().setApprovalDecisionProvider(
+        [&capturedPrompt](const FrameExportApprovalPrompt& prompt) {
+            capturedPrompt = prompt;
+            return FrameExportApprovalDecision::Export;
+        });
+
+    int finishedCount = 0;
+    FrameExportOutcome outcome = FrameExportOutcome::Refused;
+    QString message;
+    QObject::connect(&fixture.controller(), &FrameExportController::exportFinished,
+                     [&](const FrameExportOutcome resultOutcome, const QString& resultMessage) {
+                         ++finishedCount;
+                         outcome = resultOutcome;
+                         message = resultMessage;
+                     });
+
+    fixture.controller().requestExport();
+    expectations.expect(fixture.controller().isBusy(), "full drive: the export starts busy");
+    expectations.expect(waitUntil([&] { return finishedCount == 1; }),
+                        "full drive: the export reaches a terminal outcome");
+    expectations.expect(!fixture.controller().isBusy(),
+                        "full drive: the action re-enables after the terminal outcome");
+    expectations.expect(fixture.controller().canExport(),
+                        "full drive: canExport() is true again after the terminal outcome");
+
+    expectations.expect(outcome == FrameExportOutcome::Published,
+                        "full drive: the export publishes");
+    expectations.expect(!message.isEmpty(), "full drive: a display-ready message is provided");
+    expectations.expect(std::filesystem::exists(target),
+                        "full drive: the target file really exists");
+
+    // Approval dialog data assertions (design decision 3): destination, resolution, preset name,
+    // facet summary, digest short form.
+    const auto* prompt =
+        require(capturedPrompt, expectations, "full drive: the approval prompt was presented");
+    if (prompt != nullptr) {
+        expectations.expect(prompt->destination == target,
+                            "full drive: the prompt names the chosen destination");
+        expectations.expect(prompt->width == 4 && prompt->height == 4,
+                            "full drive: the prompt names the composition's own resolution");
+        expectations.expect(prompt->presetName == QStringLiteral("FlatExrRgba32fLinRec709SceneV1"),
+                            "full drive: the prompt names the exact serialized preset id");
+        expectations.expect(prompt->facets.exactFacetCount == 11 &&
+                                prompt->facets.nonExactFacetCount == 0,
+                            "full drive: a nominal EXR export reports all eleven facets Exact");
+        expectations.expect(prompt->digestShortForm.size() == 16,
+                            "full drive: the digest short form is 16 hex characters");
+    }
+
+    // "the file REALLY existing and passing the F1 verifier independently".
+    auto independentAttempt =
+        independentlyReanalyze(expectations, fixture, fixture.directory.path() / "verify-only.exr");
+    if (independentAttempt != nullptr) {
+        const output::FlatExrRgba32fLinRec709SceneReopenVerifierV1 verifier;
+        const auto verifyResult = verifier.verify(target, independentAttempt->processIdentity(),
+                                                  independentAttempt->report(), {});
+        expectations.expect(verifyResult.status() == output::FlatExrVerifyStatusV1::Verified,
+                            "full drive: the published file independently reopen-verifies");
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// Attempt failure via an impossible limit: an over-limit composition format surfaces typed
+// diagnostics instead of an approval prompt, and never writes a file. See overLimitFormat()'s own
+// comment for why this exercises the attempt-FAILURE path (ResourceLimitExceeded at the Identifying
+// stage) rather than a non-approvable-but-successfully-built report: empirically, the identity
+// preparer's own resource-limit preflight always intercepts an over-limit process frame before the
+// analyzer ever runs, so a genuinely non-approvable OutputAnalysisReportV1 is unreachable through
+// the real production pipeline for EXR v1 (documented as a finding in this task's report, not
+// worked around here per the task's scope guard).
+// -------------------------------------------------------------------------------------------
+
+void testAttemptFailureViaOverLimitCompositionSurfacesDiagnostics(Expectations& expectations) {
+    Fixture fixture(overLimitFormat());
+    if (!fixture.setUp(expectations, "impossible limit: fixture is available")) {
+        return;
+    }
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.1, 0.2, 0.3, 1.0}),
+        "impossible limit: the solid layer is added");
+
+    const auto target = fixture.directory.path() / "impossible-limit.exr";
+    fixture.controller().setDestinationProvider(
+        [&target]() -> std::optional<std::filesystem::path> { return target; });
+    bool approvalPromptShown = false;
+    fixture.controller().setApprovalDecisionProvider(
+        [&approvalPromptShown](const FrameExportApprovalPrompt&) {
+            approvalPromptShown = true;
+            return FrameExportApprovalDecision::Export;
+        });
+
+    int finishedCount = 0;
+    FrameExportOutcome outcome = FrameExportOutcome::Refused;
+    QString message;
+    QObject::connect(&fixture.controller(), &FrameExportController::exportFinished,
+                     [&](const FrameExportOutcome resultOutcome, const QString& resultMessage) {
+                         ++finishedCount;
+                         outcome = resultOutcome;
+                         message = resultMessage;
+                     });
+
+    fixture.controller().requestExport();
+    expectations.expect(waitUntil([&] { return finishedCount == 1; }),
+                        "impossible limit: the export reaches a terminal outcome");
+    expectations.expect(outcome == FrameExportOutcome::Failed,
+                        "impossible limit: the outcome is typed Failed (ResourceLimitExceeded at "
+                        "Identifying), not silently Published or Refused");
+    expectations.expect(!message.isEmpty(),
+                        "impossible limit: a typed diagnostic message is given");
+    expectations.expect(!approvalPromptShown,
+                        "impossible limit: the approval dialog is never presented");
+    expectations.expect(!std::filesystem::exists(target),
+                        "impossible limit: no file is ever written");
+    expectations.expect(!fixture.controller().isBusy(),
+                        "impossible limit: the action re-enables afterward");
+}
+
+// -------------------------------------------------------------------------------------------
+// Cancel at approval discards cleanly: no file, and the ledger charges nothing once the declined
+// attempt's shared_ptr is released.
+// -------------------------------------------------------------------------------------------
+
+void testCancelAtApprovalDiscardsCleanly(Expectations& expectations) {
+    Fixture fixture;
+    if (!fixture.setUp(expectations, "cancel: fixture is available")) {
+        return;
+    }
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.4, 0.4, 0.4, 1.0}),
+        "cancel: the solid layer is added");
+
+    const auto target = fixture.directory.path() / "cancelled.exr";
+    fixture.controller().setDestinationProvider(
+        [&target]() -> std::optional<std::filesystem::path> { return target; });
+    fixture.controller().setApprovalDecisionProvider(
+        [](const FrameExportApprovalPrompt&) { return FrameExportApprovalDecision::Cancel; });
+
+    int finishedCount = 0;
+    FrameExportOutcome outcome = FrameExportOutcome::Refused;
+    QObject::connect(&fixture.controller(), &FrameExportController::exportFinished,
+                     [&](const FrameExportOutcome resultOutcome, const QString&) {
+                         ++finishedCount;
+                         outcome = resultOutcome;
+                     });
+
+    fixture.controller().requestExport();
+    expectations.expect(waitUntil([&] { return finishedCount == 1; }),
+                        "cancel: the export reaches a terminal outcome");
+    expectations.expect(outcome == FrameExportOutcome::Cancelled,
+                        "cancel: the outcome is typed Cancelled");
+    expectations.expect(!std::filesystem::exists(target), "cancel: no file was ever written");
+    // A brief pump lets the last shared_ptr<const OutputAnalysisAttemptV1> reference (dropped when
+    // presentApproval()/handleAttemptResult() return) actually unwind before checking the ledger.
+    expectations.expect(
+        waitUntil([&] { return fixture.controller().chargedResourceBytes() == 0; }),
+        "cancel: the discarded attempt's reservation releases (zero charged bytes)");
+    expectations.expect(!fixture.controller().isBusy(), "cancel: the action re-enables afterward");
+    expectations.expect(fixture.controller().canExport(), "cancel: canExport() is true again");
+}
+
+// -------------------------------------------------------------------------------------------
+// Failure outcome surfaced: an external modification between approval and publish is a typed
+// conflict, not a crash, and leaves the externally-written target untouched.
+// -------------------------------------------------------------------------------------------
+
+void testExternalModificationConflictSurfacedAsFailure(Expectations& expectations) {
+    Fixture fixture;
+    if (!fixture.setUp(expectations, "external conflict: fixture is available")) {
+        return;
+    }
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.6, 0.1, 0.2, 1.0}),
+        "external conflict: the solid layer is added");
+
+    const auto target = fixture.directory.path() / "conflict.exr";
+    fixture.controller().setDestinationProvider(
+        [&target]() -> std::optional<std::filesystem::path> { return target; });
+    // The attempt's own Resolving stage observed an absent target (it ran before this callback);
+    // writing the conflicting file from inside the (synchronous) approval callback -- immediately
+    // before the job is ever submitted -- reproduces "external modification between approval and
+    // publish" deterministically instead of racing a background worker thread.
+    fixture.controller().setApprovalDecisionProvider([&target](const FrameExportApprovalPrompt&) {
+        std::ofstream external(target, std::ios::binary);
+        external << "not a bloom export";
+        return FrameExportApprovalDecision::Export;
+    });
+
+    int finishedCount = 0;
+    FrameExportOutcome outcome = FrameExportOutcome::Refused;
+    QString message;
+    QObject::connect(&fixture.controller(), &FrameExportController::exportFinished,
+                     [&](const FrameExportOutcome resultOutcome, const QString& resultMessage) {
+                         ++finishedCount;
+                         outcome = resultOutcome;
+                         message = resultMessage;
+                     });
+
+    fixture.controller().requestExport();
+    expectations.expect(waitUntil([&] { return finishedCount == 1; }),
+                        "external conflict: the export reaches a terminal outcome");
+    expectations.expect(outcome == FrameExportOutcome::Failed,
+                        "external conflict: the outcome is typed Failed, not silently Published");
+    expectations.expect(!message.isEmpty(), "external conflict: a typed message is given");
+    expectations.expect(!fixture.controller().isBusy(),
+                        "external conflict: the action re-enables afterward");
+
+    std::ifstream reopened(target);
+    std::string contents((std::istreambuf_iterator<char>(reopened)),
+                         std::istreambuf_iterator<char>());
+    expectations.expect(contents == "not a bloom export",
+                        "external conflict: the externally-written target is left exactly as it "
+                        "was");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testCanExportGatesOnComposition(expectations);
+    testFullDriveApprovedAndPublished(expectations);
+    testAttemptFailureViaOverLimitCompositionSurfacesDiagnostics(expectations);
+    testCancelAtApprovalDiscardsCleanly(expectations);
+    testExternalModificationConflictSurfacedAsFailure(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/ui/tests/main_window_readonly_placeholder_tests.cpp
+++ b/src/ui/tests/main_window_readonly_placeholder_tests.cpp
@@ -10,10 +10,14 @@
 #include <bloom/project/canonical_manifest.hpp>
 #include <bloom/project/project_io_memory.hpp>
 #include <bloom/project/save_archive.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/frame_export_controller.hpp>
 #include <bloom/ui/project_host.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
 #include <bloom/ui/workspace_host.hpp>
 
 #include <zlib.h>
@@ -430,7 +434,18 @@ void testPlaceholderSwitchesOnPreservedReadOnlyOpenAndBack(Expectations& expecta
     bloom::ui::CompositionSession compositionSession(*initialDocument, *initialCommandStack,
                                                      projectHost.lowestCompositionId());
 
-    MainWindow window(registry, compositionSession, projectHost);
+    // MainWindow's own "Export Frame..." menu action needs a real FrameExportController (task F3,
+    // issue #103) -- this test drives the read-only-placeholder switch, not export itself, so a
+    // minimal fixture (an empty, frozen NodeDefinitionRegistry) is enough.
+    bloom::runtime::NodeDefinitionRegistry nodeDefinitions;
+    nodeDefinitions.freeze();
+    bloom::runtime::SnapshotCompiler snapshotCompiler(nodeDefinitions);
+    bloom::ui::TaskUiBridge taskUiBridge(scheduler);
+    bloom::ui::FrameExportController frameExportController(
+        compositionSession, scheduler, taskUiBridge, snapshotCompiler,
+        projectHost.publicationCoordinator(), projectHost.artifactCoordinator());
+
+    MainWindow window(registry, compositionSession, projectHost, frameExportController);
     window.show();
     QApplication::processEvents();
 
@@ -546,7 +561,15 @@ void testSaveCopyFromReadOnlyPlaceholder(Expectations& expectations) {
     bloom::ui::CompositionSession compositionSession(*initialDocument, *initialCommandStack,
                                                      projectHost.lowestCompositionId());
 
-    MainWindow window(registry, compositionSession, projectHost);
+    bloom::runtime::NodeDefinitionRegistry nodeDefinitions;
+    nodeDefinitions.freeze();
+    bloom::runtime::SnapshotCompiler snapshotCompiler(nodeDefinitions);
+    bloom::ui::TaskUiBridge taskUiBridge(scheduler);
+    bloom::ui::FrameExportController frameExportController(
+        compositionSession, scheduler, taskUiBridge, snapshotCompiler,
+        projectHost.publicationCoordinator(), projectHost.artifactCoordinator());
+
+    MainWindow window(registry, compositionSession, projectHost, frameExportController);
     window.show();
     QApplication::processEvents();
 

--- a/tests/ui_smoke.cpp
+++ b/tests/ui_smoke.cpp
@@ -2,12 +2,16 @@
 #include <bloom/core/rational_time.hpp>
 #include <bloom/document/document.hpp>
 #include <bloom/document/new_project.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_area.hpp>
 #include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/frame_export_controller.hpp>
 #include <bloom/ui/main_window.hpp>
 #include <bloom/ui/project_host.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
 #include <bloom/ui/workspace_host.hpp>
 
 #include <QAction>
@@ -416,8 +420,9 @@ int testMaximizeAndPersistence(const EditorRegistry& registry) {
 
 int testMainWindow(const EditorRegistry& registry,
                    bloom::ui::CompositionSession& compositionSession,
-                   bloom::ui::ProjectHost& projectHost) {
-    bloom::ui::MainWindow window(registry, compositionSession, projectHost);
+                   bloom::ui::ProjectHost& projectHost,
+                   bloom::ui::FrameExportController& frameExportController) {
+    bloom::ui::MainWindow window(registry, compositionSession, projectHost, frameExportController);
     if (!require(window.workspaceHost() != nullptr, 40)) {
         return 40;
     }
@@ -563,5 +568,12 @@ int main(int argc, char* argv[]) {
 
     bloom::runtime::TaskScheduler taskScheduler;
     bloom::ui::ProjectHost projectHost(taskScheduler);
-    return testMainWindow(registry, compositionSession, projectHost);
+    bloom::runtime::NodeDefinitionRegistry nodeDefinitions;
+    nodeDefinitions.freeze();
+    bloom::runtime::SnapshotCompiler snapshotCompiler(nodeDefinitions);
+    bloom::ui::TaskUiBridge taskUiBridge(taskScheduler);
+    bloom::ui::FrameExportController frameExportController(
+        compositionSession, taskScheduler, taskUiBridge, snapshotCompiler,
+        projectHost.publicationCoordinator(), projectHost.artifactCoordinator());
+    return testMainWindow(registry, compositionSession, projectHost, frameExportController);
 }


### PR DESCRIPTION
Makes the export pipeline artist-touchable — File → Export Frame… drives the full landed machinery with zero new publication ABI:

- **`FrameExportController`** (src/ui): destination pick → composition-plan compile as its own scheduler task → `beginOutputAnalysisAttemptV1` polled off the existing snapshot bridge → an explicit approval prompt built strictly from the attempt's retained state (destination, resolution, preset, exact/non-exact facet summary, digest short form) → `approveFrameExportV1` with the attempt's own digest, never recomputed → `executeExportPublication` with stage progress mapped into the existing task monitor.
- **Honest gating and outcomes**: the action gates on a live composition and refuses the read-only placeholder state (exporting from a stale document would be dishonest); Published/durability-warning/Superseded/ExternalModificationConflict/Failed/Cancelled each surface truthfully; cancel-at-approval releases the attempt's resource reservation by ownership (pinned to zero by test).
- Uses the same application-wide publication and staged-artifact coordinators as saves (contract's supersession-across-kinds rule), the viewer's own one-truth current-time source, and a per-user app-private scratch directory.
- End-to-end test: exported file re-verified independently by the reopen verifier. Findings recorded: the analyzer's non-approvable limit facet is structurally unreachable from the production pipeline (the identity preparer's identical preflight intercepts first — consistent, not a bug); two would-be dangling captures self-caught pre-build and fixed with init-captures.

Desktop 100/100 and native 85/85, quality checks clean.

Closes #103.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.