### PR TITLE
feat: play compositions in real time

### DIFF
--- a/src/core/frame_time_mapping.cpp
+++ b/src/core/frame_time_mapping.cpp
@@ -184,4 +184,18 @@ std::uint64_t FrameTimeMapping::nearestFrameIndex(const RationalTime time) const
     return doubledAtLeast(result.remainder, denominator) ? result.quotient + 1 : result.quotient;
 }
 
+std::optional<std::uint64_t> FrameTimeMapping::frameOffsetForElapsedNanoseconds(
+    const std::uint64_t elapsedNanoseconds) const noexcept {
+    constexpr auto nanosecondsPerSecond = std::uint64_t{1'000'000'000};
+    const auto numerator =
+        multiplyToUInt128(elapsedNanoseconds, static_cast<std::uint64_t>(rateNumerator_));
+    const auto denominator =
+        multiplyToUInt128(nanosecondsPerSecond, static_cast<std::uint64_t>(rateDenominator_));
+    const auto result = divideToUInt64(numerator, denominator);
+    if (result.quotientOverflow) {
+        return std::nullopt;
+    }
+    return result.quotient;
+}
+
 } // namespace bloom::core

--- a/src/core/include/bloom/core/frame_time_mapping.hpp
+++ b/src/core/include/bloom/core/frame_time_mapping.hpp
@@ -48,6 +48,22 @@ class FrameTimeMapping final {
     // greater frame index.
     [[nodiscard]] std::uint64_t nearestFrameIndex(RationalTime time) const noexcept;
 
+    // Playback transport support (issue #105): the exact non-negative frame OFFSET covered by
+    // `elapsedNanoseconds` nanoseconds of continuous playback measured from a fixed start, computed
+    // as floor(elapsedNanoseconds / 1e9 * rateNumerator / rateDenominator) using the same checked
+    // multiword arithmetic as timeForFrame()/nearestFrameIndex() -- never floating point. Unlike
+    // nearestFrameIndex()'s round-to-nearest tie-to-greater SCRUB semantics, this FLOORS: at
+    // elapsed E since a playback start, the frame showing is the one that began at-or-before E,
+    // matching ordinary real-time playback (frame N spans the half-open interval
+    // [N/rate, (N+1)/rate)). The result is a relative offset, not clamped to maximumFrameIndex() --
+    // a playback controller adds it to a start frame index and wraps (modulo the frame count) for
+    // looping; recomputing this from a fixed elapsed-since-start each tick (rather than
+    // accumulating a running time) is what keeps repeated calls exact and drift-free.
+    // std::nullopt only if the checked product cannot be represented in 64 bits -- unreachable for
+    // realistic elapsed durations and frame rates, but kept checked rather than UB.
+    [[nodiscard]] std::optional<std::uint64_t>
+    frameOffsetForElapsedNanoseconds(std::uint64_t elapsedNanoseconds) const noexcept;
+
   private:
     friend class FrameTimeMappingCreateResult;
 

--- a/src/core/tests/frame_time_mapping_tests.cpp
+++ b/src/core/tests/frame_time_mapping_tests.cpp
@@ -182,6 +182,47 @@ void testStructuredFailures() {
             "a valid index reports when its exact time exceeds RationalTime representation");
 }
 
+// issue #105 (playback transport): frameOffsetForElapsedNanoseconds() floors rather than rounds
+// to nearest -- unlike nearestFrameIndex()'s scrub tie-to-greater semantics, ordinary real-time
+// playback at elapsed E shows the frame that began at-or-before E.
+void testFrameOffsetForElapsedNanosecondsFloorsExactly() {
+    // 1000 fps: 1 frame == 1,000,000 ns exactly, so boundaries land on integer nanoseconds and the
+    // floor/no-floor distinction is directly testable without an inexact rate.
+    const auto oneKilohertz = mapping(time(1), 1000, 1);
+    require(oneKilohertz.frameOffsetForElapsedNanoseconds(0) == 0,
+            "zero elapsed time is frame offset zero");
+    require(oneKilohertz.frameOffsetForElapsedNanoseconds(999'999) == 0,
+            "one nanosecond below a frame boundary still floors to the earlier frame");
+    require(oneKilohertz.frameOffsetForElapsedNanoseconds(1'000'000) == 1,
+            "exactly one frame duration floors to the next frame, matching timeForFrame(1)");
+    require(oneKilohertz.frameOffsetForElapsedNanoseconds(1'000'001) == 1,
+            "one nanosecond past a frame boundary stays on that frame");
+    require(oneKilohertz.frameOffsetForElapsedNanoseconds(2'500'000) == 2,
+            "a non-multiple elapsed duration floors, never rounds to nearest");
+
+    // A fractional rate (24000/1001, i.e. ~23.976 fps) exercises the same checked multiword
+    // arithmetic timeForFrame()/nearestFrameIndex() use, not just an integer-friendly rate. Frame
+    // ten's exact time is 10 * 1001 / 24000 seconds == 417,083,333.333... ns (not an integer
+    // nanosecond count), so the whole-nanosecond boundary straddles it: one nanosecond below still
+    // floors to frame nine, one nanosecond above already floors to frame ten.
+    const auto fractional = mapping(time(10), 24000, 1001);
+    const auto frameTenTime = fractional.timeForFrame(10);
+    require(frameTenTime.hasValue(), "frame ten is within the ten-second duration");
+    require(fractional.frameOffsetForElapsedNanoseconds(417'083'333) == 9,
+            "elapsed time strictly before a fractional-rate frame boundary floors to the prior "
+            "frame");
+    require(fractional.frameOffsetForElapsedNanoseconds(417'083'334) == 10,
+            "elapsed time at/past a fractional-rate frame boundary floors to that frame");
+
+    // Overflow is checked, not UB: an elapsed duration paired with the maximal representable rate
+    // numerator overflows the 64-bit quotient and must report std::nullopt rather than wrap.
+    constexpr auto maximumRate = std::numeric_limits<std::uint32_t>::max();
+    const auto huge = mapping(time(1), maximumRate, 1);
+    require(!huge.frameOffsetForElapsedNanoseconds(std::numeric_limits<std::uint64_t>::max())
+                 .has_value(),
+            "an unrepresentable frame offset is refused rather than silently wrapped");
+}
+
 } // namespace
 
 int main() {
@@ -192,5 +233,6 @@ int main() {
     testMaximumIndexDomainBoundary();
     testExactTimeRepresentationBoundary();
     testStructuredFailures();
+    testFrameOffsetForElapsedNanosecondsFloorsExactly();
     return 0;
 }

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
         jobs_editor.cpp
         main_window.cpp
         node_editor.cpp
+        playback_controller.cpp
         project_host.cpp
         qualified_display_processor_bootstrap.cpp
         task_monitor_model.cpp
@@ -37,6 +38,7 @@ target_sources(
             include/bloom/ui/jobs_editor.hpp
             include/bloom/ui/main_window.hpp
             include/bloom/ui/node_editor.hpp
+            include/bloom/ui/playback_controller.hpp
             include/bloom/ui/project_host.hpp
             include/bloom/ui/qualified_display_processor_bootstrap.hpp
             include/bloom/ui/task_monitor_model.hpp

--- a/src/ui/composition_editors.cpp
+++ b/src/ui/composition_editors.cpp
@@ -14,6 +14,7 @@
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QKeySequence>
 #include <QLabel>
 #include <QListWidget>
 #include <QMenu>
@@ -26,6 +27,7 @@
 #include <algorithm>
 #include <array>
 #include <charconv>
+#include <chrono>
 #include <cstdint>
 #include <limits>
 #include <optional>
@@ -217,16 +219,25 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     addTextAction->setObjectName("addTextLayerAction");
     addTextAction->setToolTip(tr("Add a text layer"));
     addButton_->setMenu(addMenu);
+    // Playback transport (issue #105, decision 4): a play/pause toggle beside the ruler, using the
+    // same makeToolButton() idiom as Add/Undo/Redo. Owned per-panel (see the header's comment on
+    // playback_) -- constructed here, directly beside the ruler it drives.
+    playPauseButton_ = makeToolButton(tr("Play"), tr("Toggle playback"), controls);
+    playPauseButton_->setObjectName("playPauseButton");
+    playPauseButton_->setCheckable(true);
     undoButton_ = makeToolButton(tr("Undo"), tr("Undo last edit"), controls);
     redoButton_ = makeToolButton(tr("Redo"), tr("Redo last edit"), controls);
     controlsLayout->addWidget(title);
     controlsLayout->addWidget(addButton_);
+    controlsLayout->addWidget(playPauseButton_);
     controlsLayout->addStretch(1);
     controlsLayout->addWidget(undoButton_);
     controlsLayout->addWidget(redoButton_);
 
     ruler_ = new TimelineRuler(session_, previewController, this);
     keyframes_ = new TimelineKeyframePanel(session_, this);
+    playback_ = new PlaybackController(session_, previewController, &std::chrono::steady_clock::now,
+                                       std::chrono::milliseconds{16}, this);
 
     layers_ = new QTreeWidget(this);
     layers_->setObjectName("layerStackView");
@@ -261,6 +272,26 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     });
     connect(undoButton_, &QToolButton::clicked, &session_, &CompositionSession::undo);
     connect(redoButton_, &QToolButton::clicked, &session_, &CompositionSession::redo);
+    connect(playPauseButton_, &QToolButton::clicked, playback_, &PlaybackController::toggle);
+    connect(playback_, &PlaybackController::stateChanged, this,
+            &TimelineEditor::updatePlaybackButton);
+    updatePlaybackButton(playback_->state());
+
+    // Spacebar application shortcut (decision 4), gated against stealing Space from text-entry
+    // focus using the SAME idiom main_window.cpp's own window-level shortcuts use (QAction +
+    // setShortcutContext(Qt::WindowShortcut), e.g. undoAction_/redoAction_ in createMenus()):
+    // Qt::WindowShortcut fires whenever this widget's top-level window is active, independent of
+    // which descendant currently holds focus, EXCEPT that a focused text-entry widget (QLineEdit/
+    // QTextEdit and friends) accepts the ShortcutOverride event for an ordinary printable key like
+    // Space itself first, so the widget's own text-input handling wins over this action's shortcut
+    // whenever a text field has focus -- the standard Qt mechanism for exactly this gating, not a
+    // bespoke focus check.
+    auto* playPauseAction = new QAction(tr("Play/Pause"), this);
+    playPauseAction->setObjectName("playPauseAction");
+    playPauseAction->setShortcut(QKeySequence(Qt::Key_Space));
+    playPauseAction->setShortcutContext(Qt::WindowShortcut);
+    addAction(playPauseAction);
+    connect(playPauseAction, &QAction::triggered, playback_, &PlaybackController::toggle);
     connect(layers_, &QTreeWidget::itemSelectionChanged, this, [this] {
         if (rebuilding_) {
             return;
@@ -351,6 +382,14 @@ void TimelineEditor::updateHistoryActions() {
                                                 : tr("Undo %1").arg(undoLabel));
     redoButton_->setToolTip(redoLabel.isEmpty() ? tr("Nothing to redo")
                                                 : tr("Redo %1").arg(redoLabel));
+}
+
+void TimelineEditor::updatePlaybackButton(const PlaybackState state) {
+    const bool playing = state == PlaybackState::Playing;
+    playPauseButton_->setChecked(playing);
+    playPauseButton_->setText(playing ? tr("Pause") : tr("Play"));
+    playPauseButton_->setToolTip(playing ? tr("Pause playback (Space)")
+                                         : tr("Play from the current time (Space)"));
 }
 
 PropertiesEditor::PropertiesEditor(CompositionSession& session, QWidget* parent)

--- a/src/ui/include/bloom/ui/composition_editors.hpp
+++ b/src/ui/include/bloom/ui/composition_editors.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bloom/ui/playback_controller.hpp>
+
 #include <QWidget>
 
 class QDoubleSpinBox;
@@ -26,6 +28,9 @@ class TimelineEditor final : public QWidget {
     void rebuild();
     void updateSelection();
     void updateHistoryActions();
+    // Reflects PlaybackController::stateChanged() onto the toggle button's text/tooltip/checked
+    // state (design decision 4: "button/icon state reflects transport state via a signal").
+    void updatePlaybackButton(PlaybackState state);
 
     CompositionSession& session_;
     TimelineRuler* ruler_ = nullptr;
@@ -34,6 +39,13 @@ class TimelineEditor final : public QWidget {
     QToolButton* addButton_ = nullptr;
     QToolButton* undoButton_ = nullptr;
     QToolButton* redoButton_ = nullptr;
+    // Owned here rather than shared with any sibling TimelineEditor a workspace split could open
+    // (issue #105): each TimelineEditor instance gets its own transport, matching how every other
+    // per-panel affordance in this class (the layer tree selection sync, the undo/redo buttons'
+    // enabled state) is already independently driven off the shared CompositionSession/
+    // CompositionPreviewController rather than a single cross-panel singleton.
+    PlaybackController* playback_ = nullptr;
+    QToolButton* playPauseButton_ = nullptr;
     bool rebuilding_ = false;
 };
 

--- a/src/ui/include/bloom/ui/playback_controller.hpp
+++ b/src/ui/include/bloom/ui/playback_controller.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <QObject>
+#include <QTimer>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+namespace bloom::ui {
+
+class CompositionSession;
+class CompositionPreviewController;
+
+// Transport state for composition preview playback (issue #105). Only two states exist: a paused
+// transport and a playing one both freeze/advance the SAME CompositionSession::currentTime(), so
+// there is no separate "paused at a different time" state to model.
+enum class PlaybackState : std::uint8_t {
+    Stopped,
+    Playing,
+};
+
+// Composes with CompositionSession and CompositionPreviewController without modifying either
+// (docs/architecture/animation-and-time.md, "Session Time And Scrubbing"; this task's frozen
+// design). Advances session time through the SAME CompositionSession::setCurrentTime() mutator a
+// scrub gesture uses, and arms/disarms the preview controller's existing Interactive-cadence gate
+// through its existing beginInteractiveScrub()/notifyScrubEnded() seam
+// (CompositionPreviewController:: handleCurrentTimeChanged() already grants Interactive priority to
+// any current-time change made while that arming flag is set -- verified by reading
+// composition_preview_controller.cpp; no new request kind was added). The
+// one-active/one-newest-pending gate, cadence, and stale-result rejection inside
+// CompositionPreviewController are never touched.
+//
+// Real-time, drop-frames-never-slow policy: every tick recomputes the target frame from the TOTAL
+// elapsed time since play() captured its start clock/frame (never `lastFrame + 1` and never an
+// accumulated running clock), so a slow evaluation causes the next tick to skip straight to
+// whatever frame elapsed time now demands rather than slowing played-back motion down. Frame
+// arithmetic is exact and checked throughout: index -> time uses
+// bloom::core::FrameTimeMapping::timeForFrame() (exact rational multiplication, no rounding), and
+// elapsed-time -> frame-offset uses the new FrameTimeMapping::frameOffsetForElapsedNanoseconds()
+// (issue #105; checked multiword arithmetic, floors rather than rounds -- see its own
+// documentation for why playback needs floor semantics where scrub's nearestFrameIndex() rounds to
+// nearest). No floating-point time accumulates across ticks.
+class PlaybackController final : public QObject {
+    Q_OBJECT
+
+  public:
+    // Injectable monotonic clock (design decision 1): production reads
+    // std::chrono::steady_clock::now(); tests substitute a manually-advanced fake with no
+    // dependency on real elapsed wall time.
+    using ClockFunction = std::function<std::chrono::steady_clock::time_point()>;
+
+    explicit PlaybackController(
+        CompositionSession& session, CompositionPreviewController& previewController,
+        ClockFunction clock = &std::chrono::steady_clock::now,
+        std::chrono::milliseconds tickInterval = std::chrono::milliseconds{16},
+        QObject* parent = nullptr);
+
+    [[nodiscard]] PlaybackState state() const noexcept;
+
+  public slots:
+    // No-op (guarded) if already playing, if no composition is available, or if the composition's
+    // duration/frame rate cannot form a valid bloom::core::FrameTimeMapping (covers the
+    // zero-duration case). Captures the CURRENT session time as the new start time -- a later
+    // play() after a pause resumes from wherever the session is now, never from the original start
+    // (design decision 2).
+    void play();
+    // No-op if already stopped. Freezes session time exactly where the last applied tick (or
+    // play() itself, if no tick has landed yet) left it -- no snap-back.
+    void pause();
+    void toggle();
+
+    // Advances playback by one tick using the injected clock's current reading. Production wires
+    // the internal ~16 ms QTimer's timeout() here (mirroring CompositionPreviewController's
+    // injectable-cadence constructor seam); tests call this directly after advancing the injected
+    // clock, with no dependency on a real event loop or real elapsed wall time -- the timer is
+    // still constructed and started in production but a test that never pumps Qt's event loop
+    // never observes it fire, so manual tick() calls stay fully deterministic.
+    void tick();
+
+  signals:
+    void stateChanged(PlaybackState state);
+
+  private:
+    void handleCompositionChanged();
+    void handleCurrentTimeChanged();
+
+    CompositionSession& session_;
+    CompositionPreviewController& previewController_;
+    ClockFunction clock_;
+    QTimer timer_;
+    PlaybackState state_ = PlaybackState::Stopped;
+    std::chrono::steady_clock::time_point startClock_{};
+    std::uint64_t startFrameIndex_ = 0;
+    std::optional<std::uint64_t> lastAppliedFrameIndex_;
+    // Guards handleCurrentTimeChanged()'s scrub-during-playback detection: set around
+    // PlaybackController's own session_.setCurrentTime() call so that signal is not mistaken for
+    // an external scrub/direct-manipulation change while playing (see tick()'s only caller of
+    // setCurrentTime() and handleCurrentTimeChanged()'s own comment).
+    bool applyingOwnTimeChange_ = false;
+};
+
+} // namespace bloom::ui

--- a/src/ui/playback_controller.cpp
+++ b/src/ui/playback_controller.cpp
@@ -1,0 +1,195 @@
+#include <bloom/ui/playback_controller.hpp>
+
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_session.hpp>
+
+#include <bloom/core/frame_time_mapping.hpp>
+#include <bloom/document/project.hpp>
+
+#include <QThread>
+
+#include <limits>
+#include <utility>
+
+namespace bloom::ui {
+namespace {
+
+// The one place that turns the current composition's duration/frame rate into a checked
+// bloom::core::FrameTimeMapping, refusing (std::nullopt) exactly the cases design decision 5's
+// "playback of an empty/zero-duration composition is a no-op" covers, plus any other invalid
+// rate/duration FrameTimeMapping::create() itself refuses. play() and tick() both call this rather
+// than re-deriving it, so they cannot silently drift from each other's notion of valid.
+[[nodiscard]] std::optional<core::FrameTimeMapping>
+mappingForComposition(const document::Composition& composition) noexcept {
+    const auto rate = composition.format().frameRate();
+    const auto result = core::FrameTimeMapping::create(composition.duration(), rate.numerator(),
+                                                       rate.denominator());
+    if (!result.hasValue()) {
+        return std::nullopt;
+    }
+    return *result.value();
+}
+
+} // namespace
+
+PlaybackController::PlaybackController(CompositionSession& session,
+                                       CompositionPreviewController& previewController,
+                                       ClockFunction clock,
+                                       const std::chrono::milliseconds tickInterval,
+                                       QObject* parent)
+    : QObject(parent), session_(session), previewController_(previewController),
+      clock_(std::move(clock)) {
+    timer_.setTimerType(Qt::PreciseTimer);
+    timer_.setInterval(static_cast<int>(tickInterval.count()));
+    connect(&timer_, &QTimer::timeout, this, &PlaybackController::tick);
+
+    // Design decision 2: a composition switch or document rebind stops playback rather than
+    // leaving it running against whatever composition happens to be live next.
+    // CompositionSession::setComposition()/rebind() both emit compositionChanged() (verified by
+    // reading composition_session.cpp), so this one connection covers both triggers.
+    connect(&session_, &CompositionSession::compositionChanged, this,
+            &PlaybackController::handleCompositionChanged);
+    // Scrub-during-playback rule (design decision 3, reported per this task's "when done" list):
+    // a scrub gesture PAUSES playback -- the simplest honest rule, chosen because playback and
+    // scrub both drive CompositionSession::setCurrentTime() and TimelineRuler's own scrub gesture
+    // has no way to know playback is running and coordinate with it; letting both write
+    // concurrently would make the playhead fight the artist's drag every tick. currentTimeChanged()
+    // fires for every setCurrentTime() call regardless of caller, so applyingOwnTimeChange_
+    // distinguishes tick()'s own writes (ignored here) from every other source (scrub, direct
+    // time entry, undo/redo) reaching the session while playing.
+    connect(&session_, &CompositionSession::currentTimeChanged, this,
+            &PlaybackController::handleCurrentTimeChanged);
+}
+
+PlaybackState PlaybackController::state() const noexcept { return state_; }
+
+void PlaybackController::play() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (state_ == PlaybackState::Playing) {
+        return;
+    }
+    const auto* composition = session_.composition();
+    if (composition == nullptr) {
+        return;
+    }
+    const auto mapping = mappingForComposition(*composition);
+    if (!mapping.has_value()) {
+        // Covers the zero/invalid-duration no-op (design decision 5) and any other rate/duration
+        // FrameTimeMapping itself refuses.
+        return;
+    }
+
+    // A later play() after a pause resumes from the CURRENT session time, never the original
+    // start (design decision 2) -- read fresh here every time, not cached from a prior play().
+    startClock_ = clock_();
+    startFrameIndex_ = mapping->nearestFrameIndex(session_.currentTime());
+    lastAppliedFrameIndex_ = startFrameIndex_;
+
+    state_ = PlaybackState::Playing;
+    // Same arming CompositionPreviewController::beginInteractiveScrub()/notifyScrubEnded()
+    // TimelineRuler's own scrub gesture and the Viewer's position-drag gesture already use (see
+    // timeline_ruler.cpp's mousePressEvent/mouseReleaseEvent and viewer_editor.cpp's endDrag()):
+    // read directly in composition_preview_controller.cpp, handleCurrentTimeChanged() submits at
+    // Interactive priority precisely while this flag is armed, and this is the one place that
+    // grants that priority to session-time changes -- no new request kind needed.
+    previewController_.beginInteractiveScrub();
+    timer_.start();
+    emit stateChanged(state_);
+}
+
+void PlaybackController::pause() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (state_ != PlaybackState::Playing) {
+        return;
+    }
+    state_ = PlaybackState::Stopped;
+    timer_.stop();
+    // Bypasses any remaining trailing-cadence delay for the last applied time, mirroring
+    // TimelineRuler::mouseReleaseEvent()/ViewerEditor::endDrag()'s own notifyScrubEnded() call on
+    // gesture end.
+    previewController_.notifyScrubEnded();
+    emit stateChanged(state_);
+}
+
+void PlaybackController::toggle() {
+    if (state_ == PlaybackState::Playing) {
+        pause();
+    } else {
+        play();
+    }
+}
+
+void PlaybackController::tick() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (state_ != PlaybackState::Playing) {
+        return;
+    }
+    const auto* composition = session_.composition();
+    if (composition == nullptr) {
+        pause();
+        return;
+    }
+    const auto mapping = mappingForComposition(*composition);
+    if (!mapping.has_value()) {
+        pause();
+        return;
+    }
+
+    const auto now = clock_();
+    if (now < startClock_) {
+        // A non-monotonic injected clock (only reachable from a test double) -- no-op rather than
+        // treat a negative duration as unsigned wraparound.
+        return;
+    }
+    const auto elapsed = now - startClock_;
+    const auto elapsedNanoseconds = static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count());
+
+    // Real-time, drop-frames-never-slow policy: the target frame is derived from TOTAL elapsed
+    // time since play()'s fixed start every tick (never `lastFrame + 1`, never an accumulated
+    // running clock), so a slow tick jumps straight to the frame elapsed time now demands instead
+    // of catching up frame-by-frame.
+    const auto frameOffset = mapping->frameOffsetForElapsedNanoseconds(elapsedNanoseconds);
+    if (!frameOffset.has_value()) {
+        // Checked-arithmetic overflow guard (unreachable for any realistic elapsed duration and
+        // frame rate) -- no-op rather than wrap.
+        return;
+    }
+
+    const auto frameCount = mapping->maximumFrameIndex() + 1;
+    if (*frameOffset > std::numeric_limits<std::uint64_t>::max() - startFrameIndex_) {
+        // Same checked-overflow discipline applied to the addition below.
+        return;
+    }
+    // Looping (design decision 2): wraps within [0, duration) via exact modulo of the frame count.
+    // Recomputed fresh from the fixed start/elapsed every tick -- never an accumulated running
+    // index -- so repeated wraps never drift.
+    const auto targetFrameIndex = (startFrameIndex_ + *frameOffset) % frameCount;
+
+    if (lastAppliedFrameIndex_.has_value() && *lastAppliedFrameIndex_ == targetFrameIndex) {
+        return;
+    }
+    const auto targetTime = mapping->timeForFrame(targetFrameIndex);
+    if (!targetTime.hasValue()) {
+        return;
+    }
+
+    lastAppliedFrameIndex_ = targetFrameIndex;
+    applyingOwnTimeChange_ = true;
+    (void)session_.setCurrentTime(*targetTime.value());
+    applyingOwnTimeChange_ = false;
+}
+
+void PlaybackController::handleCompositionChanged() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    pause();
+}
+
+void PlaybackController::handleCurrentTimeChanged() {
+    Q_ASSERT(QThread::currentThread() == thread());
+    if (state_ == PlaybackState::Playing && !applyingOwnTimeChange_) {
+        pause();
+    }
+}
+
+} // namespace bloom::ui

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -38,6 +38,16 @@ add_executable(bloom_frame_export_controller_test
     frame_export_controller_tests.cpp
 )
 
+# QTest::keyClick (issue #105's widget test: a real key-event dispatch through Qt's own shortcut
+# machinery, not a synthesized focus check) needs Qt6::Test, which no other bloom_ui test target
+# links -- scoped to this one executable rather than bloom_ui itself.
+if(NOT TARGET Qt6::Test)
+    find_package(Qt6 6.8 REQUIRED COMPONENTS Test)
+endif()
+add_executable(bloom_playback_controller_test
+    playback_controller_tests.cpp
+)
+
 # Links ZLIB::ZLIB directly for its own trimmed hand-rolled ZIP-writer fixture (a preserved-
 # read-only archive builder) -- mirroring src/host/CMakeLists.txt's bloom_host_session_open_test,
 # which documents the same src-module tests/-directory boundary this duplicate exists to respect.
@@ -62,6 +72,7 @@ target_link_libraries(bloom_composition_session_position_interaction_test PRIVAT
 target_link_libraries(bloom_direct_manipulation_test PRIVATE bloom_ui)
 target_link_libraries(bloom_frame_export_controller_test PRIVATE bloom_ui)
 target_link_libraries(bloom_main_window_readonly_placeholder_test PRIVATE bloom_ui ZLIB::ZLIB)
+target_link_libraries(bloom_playback_controller_test PRIVATE bloom_ui Qt6::Test)
 bloom_enable_warnings(bloom_composition_projection_test)
 bloom_enable_warnings(bloom_composition_preview_controller_test)
 bloom_enable_warnings(bloom_composition_session_animation_test)
@@ -76,6 +87,7 @@ bloom_enable_warnings(bloom_composition_session_position_interaction_test)
 bloom_enable_warnings(bloom_direct_manipulation_test)
 bloom_enable_warnings(bloom_frame_export_controller_test)
 bloom_enable_warnings(bloom_main_window_readonly_placeholder_test)
+bloom_enable_warnings(bloom_playback_controller_test)
 
 include(BloomTesting)
 
@@ -187,6 +199,14 @@ bloom_add_test(
     NAME bloom.ui.frame_export_controller
     COMMAND bloom_frame_export_controller_test
     LABELS ui integration host output
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.playback_controller
+    COMMAND bloom_playback_controller_test
+    LABELS ui integration animation
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )

--- a/src/ui/tests/playback_controller_tests.cpp
+++ b/src/ui/tests/playback_controller_tests.cpp
@@ -1,0 +1,630 @@
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/core/frame_time_mapping.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
+#include <bloom/runtime/reference_display_preparation.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_editors.hpp>
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_preview_pipeline.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/playback_controller.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QLineEdit>
+#include <QTest>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <mutex>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+template <typename Predicate> bool waitUntil(Predicate predicate) {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 4'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        if (std::invoke(predicate)) {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    return std::invoke(predicate);
+}
+
+bloom::runtime::TaskSchedulerConfig testSchedulerConfig() {
+    return {.cpuWorkerCount = 1,
+            .blockingIoWorkerCount = 1,
+            .cpuQueueCapacity = 16,
+            .blockingIoQueueCapacity = 4,
+            .terminalHistoryCapacity = 32,
+            .diagnosticsPerTask = 8,
+            .groupRegistryCapacity = 8};
+}
+
+[[nodiscard]] bloom::core::RationalTime time(const std::int64_t numerator,
+                                             const std::int64_t denominator = 1) {
+    const auto value = bloom::core::RationalTime::create(numerator, denominator);
+    if (!value.has_value()) {
+        std::abort();
+    }
+    return *value;
+}
+
+// 25 fps rather than the default 24 fps (docs/architecture/animation-and-time.md's default via
+// bloom::document::FrameRate::framesPerSecond24()): 25 divides 1e9 nanoseconds evenly (one frame
+// == exactly 40,000,000 ns), so every elapsed value below lands exactly on or off a frame boundary
+// with no fractional-nanosecond ambiguity -- the frame-math tests below need that exactness, not
+// an inexact rate like frame_time_mapping_tests.cpp's own fractional-rate coverage already handles
+// at the bloom::core level.
+bloom::document::CompositionFormat testFormat() {
+    const auto rate = bloom::document::FrameRate::create(25, 1);
+    if (!rate.has_value()) {
+        std::abort();
+    }
+    const auto format = bloom::document::CompositionFormat::create(
+        4, 3, bloom::core::PixelAspectRatio::square(), *rate);
+    if (!format.has_value()) {
+        std::abort();
+    }
+    return *format;
+}
+
+bloom::document::NewProject makeTestProject(std::string projectName,
+                                            const bloom::core::RationalTime duration) {
+    return bloom::document::makeNewProject(std::move(projectName), "Main", duration, testFormat());
+}
+
+// Mirrors composition_preview_controller_tests.cpp's makeSecondComposition(): a second, minimal,
+// layer-less composition added directly to the project (bypassing makeNewProject, which only
+// builds one) so testStopsOnCompositionSwitch()/testOverflowingDurationCompositionPlaybackIsNoOp()
+// have somewhere else to switch to.
+bloom::document::Composition secondComposition(const bloom::core::RationalTime duration,
+                                               const bloom::document::CompositionFormat format) {
+    using namespace bloom::document;
+    const auto compositionId = CompositionId::fromRaw(2);
+    const auto stackId = NodeId::fromRaw(100);
+    const auto outputId = NodeId::fromRaw(101);
+    const auto edgeId = EdgeId::fromRaw(100);
+    CanonicalGraph graph(stackId);
+    const bool built =
+        graph.addNode(
+            {stackId, std::string(kLayerStackNodeType), {}, kLayerStackNodeSchemaVersion}) &&
+        graph.addNode({outputId,
+                       std::string(kCompositionOutputNodeType),
+                       {},
+                       kCompositionOutputNodeSchemaVersion}) &&
+        graph.addEdge({edgeId,
+                       {stackId, std::string(kLayerStackOutputPort)},
+                       NodeInputRef{outputId, std::string(kCompositionOutputInputPort)}});
+    graph.setCompositionOutput({outputId, std::string(kCompositionOutputOutputPort)});
+    if (!built) {
+        std::abort();
+    }
+    return Composition(compositionId, "Second", duration, std::move(graph), format);
+}
+
+// A manually-advanced fake for PlaybackController::ClockFunction (design decision 1's "tests:
+// manual" injectable clock) -- no dependency on real elapsed wall time. Every controller unit test
+// below drives playback purely by calling advance() then tick(), never by waiting on a real timer.
+struct ManualClock final {
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+
+    void advance(const std::chrono::nanoseconds delta) { now += delta; }
+};
+
+struct PipelineFixture final {
+    bloom::runtime::NodeDefinitionRegistry definitions;
+    bloom::runtime::SnapshotCompiler compiler;
+    bloom::runtime::CpuCompositionEvaluator evaluator;
+    bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    bloom::runtime::QualifiedDisplayProcessorProvider qualifiedProcessorProvider;
+    bloom::ui::PreviewPreparationFunction pipeline;
+
+    PipelineFixture() : compiler(definitions) {
+        if (!bloom::runtime::registerBuiltInNodeDefinitions(definitions)) {
+            std::abort();
+        }
+        definitions.freeze();
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                             qualifiedProcessorProvider);
+    }
+};
+
+// Same bundling idiom as timeline_ruler_tests.cpp's own SessionFixture: a real document, command
+// stack, session, scheduler, bridge, and preview controller (offscreen). PlaybackController is
+// composed with CompositionSession/CompositionPreviewController, never a mock of either (this
+// task's frozen design), so every controller-unit test below still needs this full real stack.
+struct SessionFixture final {
+    bloom::document::Document document;
+    bloom::commands::CommandStack commands;
+    bloom::ui::CompositionSession session;
+    bloom::runtime::TaskScheduler scheduler;
+    bloom::ui::TaskUiBridge bridge;
+    PipelineFixture pipeline;
+    bloom::ui::CompositionPreviewController controller;
+
+    explicit SessionFixture(bloom::document::NewProject newProject)
+        : document(std::move(newProject.project)), commands(document),
+          session(document, commands, newProject.initialCompositionId),
+          scheduler(testSchedulerConfig()), bridge(scheduler, nullptr, 1ms),
+          controller(session, scheduler, bridge, pipeline.pipeline) {}
+};
+
+// Drains the fixture's scheduler the same way every SessionFixture-based test in
+// timeline_ruler_tests.cpp/composition_preview_controller_tests.cpp does, so no background worker
+// thread outlives the test process.
+void finishFixture(SessionFixture& fixture, Expectations& expectations) {
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the playback fixture reaches asynchronous scheduler quiescence");
+}
+
+// Controller test 1: play from t=0 advances session time through the exact expected frame times
+// for a synthetic elapsed sequence, including a multi-frame jump that produces exactly ONE session
+// advance (drop-not-slow, never catch-up-frame-by-frame).
+void testPlayAdvancesExactFrameTimesAndDropsFrames(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Playback Frame Math", time(4)));
+    ManualClock clock;
+    ui::PlaybackController playback(
+        fixture.session, fixture.controller, [&clock] { return clock.now; }, 16ms);
+
+    expectations.expect(playback.state() == ui::PlaybackState::Stopped, "playback starts Stopped");
+
+    playback.play();
+    expectations.expect(playback.state() == ui::PlaybackState::Playing,
+                        "play() enters the Playing state");
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "play() itself does not move session time before any tick");
+
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "a tick at zero elapsed makes no session-time change");
+
+    clock.advance(40'000'000ns); // exactly one 25 fps frame
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(1, 25),
+                        "one frame duration elapsed advances session time to exactly frame one's "
+                        "exact time");
+
+    int currentTimeChangedCount = 0;
+    QObject::connect(&fixture.session, &ui::CompositionSession::currentTimeChanged,
+                     [&currentTimeChangedCount] { ++currentTimeChangedCount; });
+    clock.advance(200'000'000ns); // five more frames: total elapsed == six frame durations
+    playback.tick();
+    expectations.expect(currentTimeChangedCount == 1,
+                        "a tick spanning several frame durations advances session time exactly "
+                        "ONCE, to the latest frame");
+    expectations.expect(fixture.session.currentTime() == time(6, 25),
+                        "the single advance lands on the frame TOTAL elapsed time now demands, "
+                        "not lastFrame + 1");
+
+    playback.pause();
+    finishFixture(fixture, expectations);
+}
+
+// Controller test 2: loop wrap at duration is exact -- no drift after several wraps, verified by
+// exact RationalTime equality (never an approximate/epsilon comparison).
+void testLoopWrapExactAfterManyWraps(Expectations& expectations) {
+    using namespace bloom;
+    // 4 seconds @ 25 fps == 100 frames per loop (frame indices 0..99).
+    SessionFixture fixture(makeTestProject("Playback Loop Wrap", time(4)));
+    ManualClock clock;
+    ui::PlaybackController playback(
+        fixture.session, fixture.controller, [&clock] { return clock.now; }, 16ms);
+
+    playback.play();
+
+    clock.advance(250 * 40'000'000ns); // 2.5 loops: 250 frames elapsed
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(50, 25),
+                        "elapsed time past two full loops wraps to the exact mid-loop frame time");
+
+    clock.advance(49 * 40'000'000ns); // total elapsed now 299 frames (one before the third wrap)
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(99, 25),
+                        "the frame immediately before a wrap is exact");
+
+    clock.advance(1 * 40'000'000ns); // total elapsed now exactly 300 frames: three full loops
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "landing on an exact loop boundary after three full wraps returns to "
+                        "exact zero with no accumulated drift");
+
+    playback.pause();
+    finishFixture(fixture, expectations);
+}
+
+// Controller test 3: pause freezes time (a later stopped tick is a no-op), and a later play()
+// resumes from the CURRENT session time -- including a time set by something other than playback
+// itself while stopped -- never the original start.
+void testPauseFreezesAndResumeUsesCurrentSessionTime(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Playback Pause Resume", time(4)));
+    ManualClock clock;
+    ui::PlaybackController playback(
+        fixture.session, fixture.controller, [&clock] { return clock.now; }, 16ms);
+
+    playback.play();
+    clock.advance(3 * 40'000'000ns);
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(3, 25), "advances to frame three");
+
+    playback.pause();
+    expectations.expect(playback.state() == ui::PlaybackState::Stopped, "pause() stops playback");
+    expectations.expect(fixture.session.currentTime() == time(3, 25),
+                        "pause freezes session time at the last applied exact time -- no "
+                        "snap-back");
+
+    clock.advance(10s);
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(3, 25),
+                        "a tick while stopped is a no-op regardless of elapsed clock time");
+
+    // Something other than playback moves the session time while stopped (the honest stand-in for
+    // a scrub gesture or direct time entry landing here).
+    expectations.expect(fixture.session.setCurrentTime(time(50, 25)),
+                        "the session time can change while playback is stopped");
+
+    playback.play();
+    clock.advance(1 * 40'000'000ns);
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(51, 25),
+                        "resuming after a pause plays forward from the CURRENT session time "
+                        "(frame fifty), never the original start (frame zero) or the old pause "
+                        "time (frame three)");
+
+    playback.pause();
+    finishFixture(fixture, expectations);
+}
+
+// Design decision 3's reported rule: a scrub gesture PAUSES playback. Simulated here the honest
+// way -- calling the exact CompositionSession::setCurrentTime() mutator TimelineRuler's own scrub
+// gesture calls -- rather than constructing a full TimelineRuler widget and synthesizing pointer
+// events, since only the session-time-mutator boundary matters to this rule.
+void testScrubDuringPlaybackPauses(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Playback Scrub Pause", time(4)));
+    ManualClock clock;
+    ui::PlaybackController playback(
+        fixture.session, fixture.controller, [&clock] { return clock.now; }, 16ms);
+
+    playback.play();
+    clock.advance(2 * 40'000'000ns);
+    playback.tick();
+    expectations.expect(fixture.session.currentTime() == time(2, 25), "advances to frame two");
+    expectations.expect(playback.state() == ui::PlaybackState::Playing, "still playing");
+
+    expectations.expect(fixture.session.setCurrentTime(time(10, 25)),
+                        "a scrub-shaped setCurrentTime() call succeeds mid-playback");
+    expectations.expect(playback.state() == ui::PlaybackState::Stopped,
+                        "a session-time change PlaybackController did not itself make pauses "
+                        "playback");
+    expectations.expect(fixture.session.currentTime() == time(10, 25),
+                        "the scrub's own target time is left exactly as the scrub set it -- "
+                        "playback does not fight or revert it");
+
+    finishFixture(fixture, expectations);
+}
+
+// If the composition/session changes (composition switch here; CompositionSession::rebind() --
+// the document-close/open path -- emits the SAME compositionChanged() signal, verified by reading
+// composition_session.cpp, so one connection covers both), playback stops.
+void testStopsOnCompositionSwitch(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Playback Composition Switch", time(4));
+    const auto firstCompositionId = newProject.initialCompositionId;
+    expectations.expect(newProject.project.addComposition(secondComposition(time(4), testFormat())),
+                        "a second composition is added to the project");
+    SessionFixture fixture(std::move(newProject));
+
+    ManualClock clock;
+    ui::PlaybackController playback(
+        fixture.session, fixture.controller, [&clock] { return clock.now; }, 16ms);
+
+    playback.play();
+    clock.advance(40'000'000ns);
+    playback.tick();
+    expectations.expect(playback.state() == ui::PlaybackState::Playing, "playing normally");
+
+    expectations.expect(fixture.session.setComposition(document::CompositionId::fromRaw(2)),
+                        "switching composition succeeds");
+    expectations.expect(playback.state() == ui::PlaybackState::Stopped,
+                        "a composition switch stops playback");
+
+    // Switching back does not resurrect the old Playing state on its own.
+    expectations.expect(fixture.session.setComposition(firstCompositionId),
+                        "switching back succeeds");
+    expectations.expect(playback.state() == ui::PlaybackState::Stopped,
+                        "playback stays stopped after switching composition again");
+
+    finishFixture(fixture, expectations);
+}
+
+// Design decision 5: playback of an empty/zero-duration composition is a no-op (typed/guarded).
+// Deviation worth reporting: a genuinely zero-duration composition cannot be reached through any
+// real bloom::document::Document -- document::Project::validate() rejects duration <= 0
+// (project.cpp), and Document's constructor throws on an invalid project (document.cpp), so the
+// zero-duration branch is unreachable via live session state today (defensive-only, matching
+// FrameTimeMapping's own "checked, not merely assumed" philosophy). This instead exercises the
+// SAME guard -- PlaybackController::play() refusing when bloom::core::FrameTimeMapping::create()
+// itself refuses -- through a duration/frame-rate pair that DOES pass document validation
+// (duration is a large but positive RationalTime) yet still overflows FrameTimeMapping's checked
+// frame-index range, the identical extreme pairing frame_time_mapping_tests.cpp's own
+// testRateNormalizationAndExtremeArithmetic() already proves FrameTimeMapping::create() refuses.
+void testOverflowingDurationCompositionPlaybackIsNoOp(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Playback Overflow Guard", time(4));
+    const auto overflowRateOptional =
+        document::FrameRate::create(std::numeric_limits<std::uint32_t>::max(), 1);
+    if (!overflowRateOptional.has_value()) {
+        std::abort();
+    }
+    const auto overflowRate = *overflowRateOptional;
+    const auto overflowFormatOptional =
+        document::CompositionFormat::create(4, 3, core::PixelAspectRatio::square(), overflowRate);
+    if (!overflowFormatOptional.has_value()) {
+        std::abort();
+    }
+    const auto overflowFormat = *overflowFormatOptional;
+    const auto overflowDuration = time(std::numeric_limits<std::int64_t>::max());
+    const auto overflowCompositionId = document::CompositionId::fromRaw(2);
+    expectations.expect(
+        newProject.project.addComposition(secondComposition(overflowDuration, overflowFormat)),
+        "a large-but-positive-duration, extreme-rate composition is added to the project -- "
+        "document validation only requires duration > 0, so this passes it");
+
+    SessionFixture fixture(std::move(newProject));
+    expectations.expect(fixture.session.setComposition(overflowCompositionId),
+                        "switching to the overflow-guard composition succeeds");
+    expectations.expect(
+        core::FrameTimeMapping::create(overflowDuration, overflowRate.numerator(),
+                                       overflowRate.denominator())
+                .hasValue() == false,
+        "this duration/rate pair really does overflow FrameTimeMapping's checked frame-index "
+        "range");
+
+    ManualClock clock;
+    ui::PlaybackController playback(
+        fixture.session, fixture.controller, [&clock] { return clock.now; }, 16ms);
+    playback.play();
+    expectations.expect(playback.state() == ui::PlaybackState::Stopped,
+                        "play() guards against an unrepresentable FrameTimeMapping instead of "
+                        "constructing one anyway (design decision 5's guarded no-op, exercised "
+                        "at its checked-arithmetic boundary rather than via an unreachable "
+                        "zero-duration document state)");
+
+    finishFixture(fixture, expectations);
+}
+
+// Integration test: with the real CompositionPreviewController, playing produces Interactive-kind
+// requests honoring the one-active/newest-pending gate -- asserted via the controller's existing
+// observable seams (runtime::TaskScheduler::snapshots(), each TaskSnapshot's sourceVersion/
+// priority), with NO gate modification, mirroring composition_preview_controller_tests.cpp's own
+// testNewestPendingRequestGate()/testInteractiveCadenceCoalescesBurstAndVisibleBypasses() idiom.
+struct WorkerGate final {
+    void enterAndWait() {
+        std::unique_lock lock(mutex_);
+        entered_ = true;
+        condition_.notify_all();
+        condition_.wait(lock, [this] { return released_; });
+    }
+
+    [[nodiscard]] bool entered() const {
+        std::lock_guard lock(mutex_);
+        return entered_;
+    }
+
+    void release() {
+        std::lock_guard lock(mutex_);
+        released_ = true;
+        condition_.notify_all();
+    }
+
+  private:
+    mutable std::mutex mutex_;
+    std::condition_variable condition_;
+    bool entered_ = false;
+    bool released_ = false;
+};
+
+std::optional<bloom::runtime::TaskSnapshot>
+snapshotForGeneration(const bloom::runtime::TaskScheduler& scheduler,
+                      const std::uint64_t generation) {
+    for (const auto& snapshot : scheduler.snapshots()) {
+        if (snapshot.sourceVersion.requestGeneration == generation) {
+            return snapshot;
+        }
+    }
+    return std::nullopt;
+}
+
+void testIntegrationPlaybackDrivesInteractivePriorityUnderGate(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Playback Interactive Gate", time(4));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, compositionId);
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+    PipelineFixture fixture;
+    WorkerGate firstRequest;
+    std::atomic<int> invocationCount = 0;
+    ui::CompositionPreviewController controller(
+        session, scheduler, bridge,
+        [&firstRequest, &invocationCount, pipeline = fixture.pipeline](
+            const document::Snapshot& snapshot,
+            const runtime::PreviewRequestIdentity& desiredIdentity,
+            const std::size_t pixelStorageByteLimit,
+            const std::optional<runtime::SnapshotParameterOverride>& interactionOverride,
+            runtime::TaskContext& context) mutable {
+            if (invocationCount.fetch_add(1) == 0) {
+                firstRequest.enterAndWait();
+            }
+            return pipeline(snapshot, desiredIdentity, pixelStorageByteLimit, interactionOverride,
+                            context);
+        });
+
+    expectations.expect(waitUntil([&] { return firstRequest.entered(); }),
+                        "the controller's own initial preview request enters preparation and "
+                        "gates as the active request");
+    expectations.expect(scheduler.snapshots().size() == 1,
+                        "exactly the initial (Visible) request has been submitted so far");
+
+    ManualClock clock;
+    ui::PlaybackController playback(session, controller, [&clock] { return clock.now; }, 16ms);
+    playback.play();
+    clock.advance(40'000'000ns); // one 25 fps frame
+    playback.tick();
+    const auto tickGeneration = controller.state().desiredIdentity.has_value()
+                                    ? controller.state().desiredIdentity->requestGeneration
+                                    : 0;
+    expectations.expect(tickGeneration != 0, "the tick's own request identity is observable");
+    expectations.expect(scheduler.snapshots().size() == 1,
+                        "the tick's request is held as the newest pending request behind the "
+                        "still-active initial request -- the gate is not bypassed");
+
+    firstRequest.release();
+    expectations.expect(
+        waitUntil([&] { return scheduler.snapshots().size() == 2; }),
+        "the pending request submits once the active initial request reaches terminal");
+    const auto tickSnapshot = snapshotForGeneration(scheduler, tickGeneration);
+    expectations.expect(tickSnapshot.has_value() &&
+                            tickSnapshot->priority == runtime::TaskPriority::Interactive,
+                        "playback's own session-time change submits at Interactive priority, "
+                        "through the SAME arming CompositionPreviewController::"
+                        "beginInteractiveScrub() already grants scrub -- no new request kind");
+
+    playback.pause();
+    controller.beginShutdown();
+    bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return scheduler.isQuiescent(); }),
+                        "the interactive-gate fixture reaches asynchronous scheduler quiescence");
+}
+
+// Widget test: the play/pause toggle button and Space application shortcut flip transport state
+// offscreen; Space while a QLineEdit has focus does NOT toggle. TimelineEditor itself owns no
+// QLineEdit (verified by reading composition_editors.cpp), so this builds the closest honest
+// fixture: a plain QLineEdit as a sibling of the real TimelineEditor inside one shown top-level
+// window, so Qt::WindowShortcut's real per-window dispatch (not a synthetic focus check) decides
+// whether Space reaches the action.
+void testPlaybackToggleButtonAndSpaceShortcut(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Playback Widget", time(4)));
+
+    QWidget host;
+    auto* layout = new QVBoxLayout(&host);
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller, &host);
+    auto* probeLineEdit = new QLineEdit(&host);
+    probeLineEdit->setObjectName("playbackTestProbeLineEdit");
+    layout->addWidget(editor);
+    layout->addWidget(probeLineEdit);
+    host.show();
+    host.activateWindow();
+    QCoreApplication::processEvents();
+
+    auto* button = editor->findChild<QToolButton*>("playPauseButton");
+    expectations.expect(button != nullptr, "the play/pause toggle button is reachable by name");
+    if (button == nullptr) {
+        finishFixture(fixture, expectations);
+        return;
+    }
+    expectations.expect(!button->isChecked() && button->text() == QStringLiteral("Play"),
+                        "the button starts in the Stopped/Play visual state");
+
+    button->click();
+    expectations.expect(button->isChecked() && button->text() == QStringLiteral("Pause"),
+                        "clicking the button toggles to the Playing/Pause visual state");
+    button->click();
+    expectations.expect(!button->isChecked() && button->text() == QStringLiteral("Play"),
+                        "clicking it again toggles back to Stopped/Play");
+
+    editor->setFocus();
+    QCoreApplication::processEvents();
+    QTest::keyClick(editor, Qt::Key_Space);
+    QCoreApplication::processEvents();
+    expectations.expect(button->isChecked() && button->text() == QStringLiteral("Pause"),
+                        "the Space application shortcut toggles playback when no text-entry "
+                        "widget has focus");
+
+    probeLineEdit->setFocus(Qt::OtherFocusReason);
+    QCoreApplication::processEvents();
+    expectations.expect(QApplication::focusWidget() == probeLineEdit,
+                        "the probe line edit genuinely holds keyboard focus");
+    QTest::keyClick(probeLineEdit, Qt::Key_Space);
+    QCoreApplication::processEvents();
+    expectations.expect(button->isChecked() && button->text() == QStringLiteral("Pause"),
+                        "Space is NOT stolen from a focused text-entry widget: playback state is "
+                        "unchanged by this keystroke");
+    expectations.expect(probeLineEdit->text() == QStringLiteral(" "),
+                        "the focused line edit consumed Space as ordinary text input, confirming "
+                        "it -- not a dropped/ignored event -- is what won the key");
+
+    finishFixture(fixture, expectations);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testPlayAdvancesExactFrameTimesAndDropsFrames(expectations);
+    testLoopWrapExactAfterManyWraps(expectations);
+    testPauseFreezesAndResumeUsesCurrentSessionTime(expectations);
+    testScrubDuringPlaybackPauses(expectations);
+    testStopsOnCompositionSwitch(expectations);
+    testOverflowingDurationCompositionPlaybackIsNoOp(expectations);
+    testIntegrationPlaybackDrivesInteractivePriorityUnderGate(expectations);
+    testPlaybackToggleButtonAndSpaceShortcut(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Adds the playback transport over the existing preview machinery — the last interaction primitive of the core loop:

- **`PlaybackController`**: play/pause advancing the session's one-truth current time along exact rational frame times. Every tick recomputes the target frame from total wall-clock elapsed via a new checked `FrameTimeMapping::frameOffsetForElapsedNanoseconds` (floor semantics — scrub's round-to-nearest is the wrong rule for playback), so slow evaluation drops frames and never slows playback, and loop wrap stays exactly drift-free after any number of cycles (pinned by test).
- **Composes the scrub seam verbatim**: the same `setCurrentTime` mutator and the same `beginInteractiveScrub()`/`notifyScrubEnded()` arming, so playback frames flow as Interactive requests through the untouched one-active-plus-newest-pending gate. Scrubbing (or any other time write) during playback pauses it — the two writers never fight over the mutator.
- **Transport UI**: play/pause toggle in the timeline plus a window-level Space shortcut that defers to text-entry focus via Qt's standard shortcut-override path, verified with real key dispatch offscreen.
- Playback stops on composition switch; overflow-range compositions are a guarded no-op.

Desktop 101/101 and native 85/85, format check clean.

Closes #105.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.