### PR TITLE
feat: encode and verify constrained PNG frames

### DIFF
--- a/docs/architecture/frame-output.md
+++ b/docs/architecture/frame-output.md
@@ -9,20 +9,26 @@ digest, preset-specific bound-analysis products, the module-private Output Seman
 1 streaming serializer/preparer, portable golden vectors, the flat OpenEXR adapter with its
 semantic reopen verifier and verifier-product issuance, and headless end-to-end EXR export
 publication (analysis attempt graph, immutable export request, and the shared-coordinator
-publication job), and the interactive frame-export command with explicit digest approval are
-implemented. The PNG adapter remains pending.
+publication job), the interactive frame-export command with explicit digest approval, and the
+constrained PNG codec with strict chunk-profile verification and kind-1 identity issuance are
+implemented. The export job's PNG color-preparation wiring and export-command preset choice
+remain pending.
 
 Updated: 2026-08-31
 
 ## Purpose
 
 Bloom's first delivery surface renders one immutable composition frame to a deterministic PNG or a
-flat OpenEXR. OpenImageIO (OIIO) and OpenEXR are private implementation libraries; Bloom owns the
+flat OpenEXR. The version 1 format adapters are Bloom-owned over qualified private implementation
+libraries: the flat OpenEXR preset writes through the qualified OpenEXR components, and the
+constrained PNG profile writes through a Bloom-owned codec over the qualified zlib — its closed
+chunk profile requires contract-level verification no library surface provides. OpenImageIO
+remains a future candidate for broad media ingest (media-io.md), not these presets. Bloom owns the
 request, preservation analysis, cancellation, diagnostics, verification, and filesystem
 publication contracts.
 
-Writing bytes is not proof that an export preserved its requested meaning. OIIO documents that an
-output plugin may coerce unsupported data types, channel names, or metadata, and some formats cannot
+Writing bytes is not proof that an export preserved its requested meaning. General-purpose image
+libraries may coerce unsupported data types, channel names, or metadata, and some formats cannot
 represent Bloom's process image. Every staged output is therefore reopened and verified before it
 can replace the destination.
 

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -19,6 +19,9 @@ target_sources(
         output_semantic_identity.cpp
         output_semantic_identity_numeric.cpp
         output_semantic_identity_ownership.cpp
+        png_output_adapter.cpp
+        png_preset_contract.hpp
+        png_reopen_verifier.cpp
         process_frame_semantic_identity.cpp
     PUBLIC
         FILE_SET HEADERS
@@ -35,6 +38,8 @@ target_sources(
             include/bloom/output/output_export_stage.hpp
             include/bloom/output/output_facet_descriptor.hpp
             include/bloom/output/output_limits.hpp
+            include/bloom/output/png_output_adapter.hpp
+            include/bloom/output/png_reopen_verifier.hpp
             include/bloom/output/process_frame_semantic_identity.hpp
 )
 
@@ -62,6 +67,20 @@ bloom_enable_warnings(bloom_output)
 # chain with no changes needed here.
 bloom_find_dependency(OpenEXR)
 target_link_libraries(bloom_output PRIVATE OpenEXR::OpenEXR)
+
+# issue #107 (PNG codec + strict chunk-profile verification): the PNG format layer is Bloom-owned
+# over the qualified zlib (design decision 1) -- no OIIO, no libpng anywhere. bloom_find_dependency
+# now resolves ZLIB in Config mode directly (issue #93 fixed the static-only prefix's
+# ZLIBConfig.cmake so an unqualified find_package(ZLIB CONFIG) no longer hard-fails). That direct
+# Config-mode resolution's own native CMake export names its imported target `ZLIB::ZLIBSTATIC`,
+# not the conventional `ZLIB::ZLIB` src/project's tests link -- those get `ZLIB::ZLIB` only
+# because it is transitively created by libzip's own nested Module-mode find_dependency(ZLIB)
+# call (forced by this same function's ZLIB_ROOT/CMAKE_FIND_PACKAGE_PREFER_CONFIG handling while
+# resolving libzip itself), never by a direct bloom_find_dependency(ZLIB) call like this one. Only
+# png_output_adapter.cpp/png_reopen_verifier.cpp see the real zlib.h API, and never in a public
+# bloom/output header.
+bloom_find_dependency(ZLIB)
+target_link_libraries(bloom_output PRIVATE ZLIB::ZLIBSTATIC)
 
 if(BUILD_TESTING)
     include(BloomTesting)
@@ -253,6 +272,45 @@ if(BUILD_TESTING)
     bloom_add_test(
         NAME bloom.output.flat_exr_export_write
         COMMAND bloom_output_flat_exr_export_write_test
+        LABELS unit output identity render
+    )
+
+    # issue #107 (PNG codec + strict chunk-profile verification).
+    add_executable(
+        bloom_output_png_output_adapter_test
+        tests/png_output_adapter_tests.cpp
+    )
+    target_include_directories(
+        bloom_output_png_output_adapter_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_output_png_output_adapter_test
+        PRIVATE bloom_output ZLIB::ZLIBSTATIC
+    )
+    bloom_enable_warnings(bloom_output_png_output_adapter_test)
+    bloom_add_test(
+        NAME bloom.output.png_output_adapter
+        COMMAND bloom_output_png_output_adapter_test
+        LABELS unit output render
+    )
+
+    add_executable(
+        bloom_output_png_reopen_verifier_test
+        tests/png_reopen_verifier_tests.cpp
+    )
+    target_include_directories(
+        bloom_output_png_reopen_verifier_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_output_png_reopen_verifier_test
+        PRIVATE bloom_output ZLIB::ZLIBSTATIC
+    )
+    bloom_enable_warnings(bloom_output_png_reopen_verifier_test)
+    bloom_add_test(
+        NAME bloom.output.png_reopen_verifier
+        COMMAND bloom_output_png_reopen_verifier_test
         LABELS unit output identity render
     )
 endif()

--- a/src/output/include/bloom/output/png_output_adapter.hpp
+++ b/src/output/include/bloom/output/png_output_adapter.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <bloom/render/image_types.hpp>
+#include <bloom/runtime/cancellation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <span>
+
+namespace bloom::output {
+
+// The encoder's (and verifier's) input surface: packed straight RGBA8 sRGB rows plus dimensions,
+// row-major and tightly packed (row stride == width * 4 bytes, no padding -- exactly
+// render::checkedRgba8Layout's own packed-layout rule). This is deliberately narrower than a full
+// bloom::color::PreparedDisplayFrame: only the two fields this preset's writer/verifier actually
+// need, chosen so wiring PreparedDisplayFrame's real product into this encoder (the next slice's
+// ColorPreparing stage) is a trivial two-field aggregate construction --
+// `PngRgba8SrgbPreparedStreamV1{preparedFrame.displayWindow().extent(), preparedFrame.pixels()}` --
+// with no reshaping, copy, or stride translation. `pixels` is non-owning; the caller keeps it
+// alive for the duration of the call.
+struct PngRgba8SrgbPreparedStreamV1 final {
+    render::ImageExtent dimensions;
+    std::span<const render::Rgba8> pixels;
+};
+
+// Reported between bounded row chunks (never more finely) so a caller can observe monotonic write
+// progress and, in tests, deterministically synchronize a mid-write cancellation instead of racing
+// a background thread against an unobserved internal loop.
+struct PngWriteProgressV1 final {
+    std::uint64_t completedRows = 0;
+    std::uint64_t totalRows = 0;
+
+    friend bool operator==(const PngWriteProgressV1&, const PngWriteProgressV1&) noexcept = default;
+};
+
+using PngWriteProgressCallbackV1 = std::function<void(const PngWriteProgressV1&)>;
+
+enum class PngWriteStatusV1 : std::uint8_t {
+    Written,
+    Cancelled,
+    Failed,
+};
+
+// Version 1 has no partial-success outcome: a Failed or Cancelled result never leaves a usable
+// artifact at `destination` (see `PngWriteResultV1::destinationRemoved()`). This adapter does not
+// implement the exclusive staging, atomic replace, or durability contract owned by the future
+// `StagedArtifactCoordinator` (docs/architecture/frame-output.md, "Atomic Publication") -- it only
+// writes to the caller-supplied destination path, which that future coordinator-owned staging file
+// is expected to be (mirrors flat_exr_output_adapter.hpp's identical note).
+enum class PngWriteErrorCodeV1 : std::uint8_t {
+    None,
+    // dimensions.width()/height() is zero, or pixels.size() does not equal
+    // dimensions.width() * dimensions.height().
+    InvalidPreparedStream,
+    // Dimensions or pixel/byte counts exceed output_limits.hpp's closed version 1 ceilings.
+    ResourceLimitExceeded,
+    // The destination file could not be created/opened for writing.
+    DestinationUnavailable,
+    // A filesystem error occurred while streaming chunk bytes.
+    IoFailure,
+    // zlib's deflateInit2/deflate returned an unexpected status.
+    CompressorFailure,
+    AllocationFailure,
+    InternalInvariant,
+};
+
+class [[nodiscard]] PngWriteResultV1 final {
+  public:
+    [[nodiscard]] static PngWriteResultV1 written() noexcept;
+    [[nodiscard]] static PngWriteResultV1 cancelled(bool destinationRemoved) noexcept;
+    [[nodiscard]] static PngWriteResultV1 failed(PngWriteErrorCodeV1 error,
+                                                 bool destinationRemoved) noexcept;
+
+    [[nodiscard]] PngWriteStatusV1 status() const noexcept { return status_; }
+    [[nodiscard]] PngWriteErrorCodeV1 error() const noexcept { return error_; }
+    // True when, after a non-Written outcome, the writer's own best-effort cleanup confirmed the
+    // destination path holds no partial artifact (either it removed one or none was ever
+    // created). False means a partial file may remain and the caller must not treat the path as
+    // clean. Always true when status() is Written (there is nothing to remove).
+    [[nodiscard]] bool destinationRemoved() const noexcept { return destinationRemoved_; }
+
+  private:
+    PngWriteResultV1(PngWriteStatusV1 status, PngWriteErrorCodeV1 error,
+                     bool destinationRemoved) noexcept;
+
+    PngWriteStatusV1 status_ = PngWriteStatusV1::Failed;
+    PngWriteErrorCodeV1 error_ = PngWriteErrorCodeV1::InternalInvariant;
+    bool destinationRemoved_ = true;
+};
+
+// Writes `prepared` as the version 1 `png.ihdr-srgb-idat-iend.v1` profile
+// (`PngRgba8SrgbV1`, docs/architecture/frame-output.md "PNG Preset Version 1") to `destination`:
+// 8-byte signature; one IHDR (bit depth 8, color type 6, compression/filter/interlace method 0);
+// one sRGB (rendering intent 0); one or more contiguous IDAT holding a single zlib (deflate)
+// stream of every row's filtered bytes -- filter type 0 (None) fixed on every row, DEFLATE level
+// 6/default strategy/32 KiB window (see png_preset_contract.hpp for the exact fixed parameter
+// set), split into fixed `kOutputAdapterMaximumStreamingChunkBytesV1`-sized IDAT chunks only when
+// the compressed stream exceeds that ceiling; one IEND. CRC-32 per chunk via zlib's `crc32_z`;
+// nothing else -- no other chunk. Bloom-owned encoder over the qualified ZLIB only; no OIIO/libpng
+// anywhere. Streaming, bounded-chunk, cancellation-checked between row chunks; typed failures; no
+// partial success. No zlib type appears in this public header; the real writer lives in a private
+// translation unit (same boundary discipline as flat_exr_output_adapter.hpp/bloom_color_ocio).
+class PngRgba8SrgbWriterV1 final {
+  public:
+    [[nodiscard]] PngWriteResultV1
+    write(const PngRgba8SrgbPreparedStreamV1& prepared, const std::filesystem::path& destination,
+          const runtime::CancellationToken& cancellation,
+          const PngWriteProgressCallbackV1& progress = {}) const noexcept;
+};
+
+} // namespace bloom::output

--- a/src/output/include/bloom/output/png_reopen_verifier.hpp
+++ b/src/output/include/bloom/output/png_reopen_verifier.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <bloom/color/display_processor_identity.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/output/output_analysis.hpp>
+#include <bloom/output/png_output_adapter.hpp>
+#include <bloom/output/process_frame_semantic_identity.hpp>
+#include <bloom/runtime/cancellation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace bloom::output {
+
+// Reported between bounded row-chunks during IDAT decode/comparison. Lets a caller observe
+// monotonic verify progress and, in tests, deterministically synchronize a mid-verify cancellation
+// instead of racing a background thread against an unobserved internal loop.
+struct PngVerifyProgressV1 final {
+    std::uint64_t completedRows = 0;
+    std::uint64_t totalRows = 0;
+
+    friend bool operator==(const PngVerifyProgressV1&,
+                           const PngVerifyProgressV1&) noexcept = default;
+};
+
+using PngVerifyProgressCallbackV1 = std::function<void(const PngVerifyProgressV1&)>;
+
+enum class PngVerifyStatusV1 : std::uint8_t {
+    Verified,
+    Cancelled,
+    Failed,
+};
+
+// Every code below is a typed diagnosis of a specific reopen-verification step, in the order
+// docs/architecture/frame-output.md's "PNG Preset Version 1" and "Determinism And Portable Output
+// Identity" sections require and design decision 3 restates: signature, then the exact chunk
+// sequence with every CRC valid, then IHDR/sRGB field values, then the IDAT zlib stream decoded
+// within checked ceilings with every row filter byte 0, then (only once every prior check passes)
+// bit-exact sample comparison against the caller-supplied prepared stream, then kind-1 semantic
+// identity issuance.
+enum class PngVerifyErrorCodeV1 : std::uint8_t {
+    None,
+    // The staged path could not be opened/read at all before signature parsing began.
+    SourceUnavailable,
+    // Fewer than 8 bytes, or a chunk header/data/CRC was cut off mid-chunk.
+    TruncatedFile,
+    // The first 8 bytes are not the exact PNG signature.
+    InvalidSignature,
+    // A declared chunk length exceeds the checked per-chunk ceiling before its data is read.
+    ChunkLengthExceedsLimit,
+    // A chunk's type is not the one required at this point in the closed sequence
+    // IHDR -> sRGB -> IDAT+ -> IEND -- names the unexpected type (an inserted foreign ancillary or
+    // critical chunk, a chunk out of order, or IDAT/IEND appearing before any IDAT was seen).
+    UnexpectedChunkType,
+    // IHDR/sRGB/IEND's declared length is not its exact required fixed size (13/1/0 bytes).
+    FixedChunkLengthMismatch,
+    // End of file reached before at least one IDAT, or before IEND.
+    MissingChunk,
+    // A chunk's stored CRC-32 does not match the CRC-32 computed over its type and data.
+    ChunkCrcMismatch,
+    // A decoded IHDR field (width, height, bit depth, color type, compression method, filter
+    // method, or interlace method) does not equal the required/expected value.
+    IhdrFieldMismatch,
+    // The decoded sRGB rendering-intent byte is not exactly 0.
+    SrgbIntentMismatch,
+    // The concatenated IDAT payload is not a well-formed zlib (deflate) stream (bad header,
+    // corrupt compressed data, or an incomplete stream).
+    IdatZlibStreamInvalid,
+    // The IDAT stream would inflate to more bytes than the checked expected ceiling
+    // (width*height*4 + height filter bytes) -- a zlib-bomb shape, rejected as a resource failure
+    // before decoding past that bound.
+    IdatExpandedSizeExceeded,
+    // A decoded scanline's leading filter byte is not exactly 0 (None).
+    RowFilterByteNonzero,
+    // A decoded RGBA8 sample differs from the caller-supplied prepared stream.
+    SampleMismatch,
+    // Bytes remain in the file after the IEND chunk.
+    TrailingBytesAfterIend,
+    // Dimensions/pixel/byte counts exceed output_limits.hpp's closed version 1 ceilings.
+    ResourceLimitExceeded,
+    // Every structural and sample check passed, but binding or issuing the kind-1
+    // `OutputSemanticIdentity` from the decoded values failed -- an input-construction problem
+    // (e.g. a null/mismatched processIdentity/report/displayProcessorIdentity) rather than a file-
+    // content defect.
+    IdentityIssuanceFailed,
+    AllocationFailure,
+    InternalInvariant,
+};
+
+// Names the exact location of a Failed diagnosis. Fields are populated only for the codes that
+// name a location; an unused field stays at its default.
+struct PngVerifyDiagnosticV1 final {
+    PngVerifyErrorCodeV1 code = PngVerifyErrorCodeV1::None;
+    std::string chunkType;                   // the 4-byte ASCII chunk type, when applicable
+    std::optional<std::uint64_t> chunkIndex; // zero-based chunk occurrence, when applicable
+    std::optional<std::uint64_t> byteOffset; // file offset the defective chunk started at
+    std::optional<std::uint64_t> row;        // zero-based scanline, when applicable
+
+    friend bool operator==(const PngVerifyDiagnosticV1&, const PngVerifyDiagnosticV1&) = default;
+};
+
+// `OutputSemanticIdentityV1` itself is module-private (docs/architecture/frame-output.md: "the
+// module-private Output Semantic Identity version 1 streaming serializer/preparer"), so this
+// public result surfaces only the one thing design decision 4 asks for: the resulting digest.
+class [[nodiscard]] PngVerifyResultV1 final {
+  public:
+    [[nodiscard]] static PngVerifyResultV1 verified(core::Sha256Digest digest) noexcept;
+    [[nodiscard]] static PngVerifyResultV1 cancelled() noexcept;
+    [[nodiscard]] static PngVerifyResultV1 failed(PngVerifyDiagnosticV1 diagnostic) noexcept;
+
+    [[nodiscard]] PngVerifyStatusV1 status() const noexcept { return status_; }
+    // Valid only when status() is Verified.
+    [[nodiscard]] const core::Sha256Digest& digest() const& noexcept { return digest_; }
+    [[nodiscard]] const core::Sha256Digest& digest() const&& = delete;
+    [[nodiscard]] const PngVerifyDiagnosticV1& diagnostic() const& noexcept { return diagnostic_; }
+    [[nodiscard]] const PngVerifyDiagnosticV1& diagnostic() const&& = delete;
+
+  private:
+    PngVerifyResultV1(PngVerifyStatusV1 status, core::Sha256Digest digest,
+                      PngVerifyDiagnosticV1 diagnostic) noexcept;
+
+    PngVerifyStatusV1 status_ = PngVerifyStatusV1::Failed;
+    core::Sha256Digest digest_{};
+    PngVerifyDiagnosticV1 diagnostic_{};
+};
+
+// Reopens `stagedPath` (a path/handle a future publication slice will own), proves the closed
+// version 1 chunk/IHDR/sRGB/IDAT contract independently of any writer state, then compares the
+// decoded RGBA8 samples bit-exact against `prepared` (this preset's own encoder input surface --
+// design decision 3). Only once every check passes does it feed the DECODED reopened values (not
+// `prepared`) into the existing kind-1 output-semantic-identity serializer, binding them through
+// the same module-private seam the pre-approval analysis pipeline already produces
+// processIdentity/report/displayProcessorIdentity for
+// (`bloom::output::analyzePngRgba8SrgbV1`/`bloom::color::DisplayProcessorIdentityV1`), and
+// surfacing the resulting digest as this result's `digest()`. A Failed or Cancelled result never
+// surfaces a digest. `expectedOcioRevision` and `displayProcessorIdentity` are the caller-supplied
+// products the PNG kind-1 payload's identity-issuance seam requires (design decision 4) -- the
+// same two inputs `bindPngRgba8SrgbOutputAnalysisV1` itself takes, alongside `processIdentity` and
+// `report`. Bounded memory (row-chunked reads/inflate), cancellation-checked between chunks. No
+// zlib type appears in this public header.
+class PngRgba8SrgbReopenVerifierV1 final {
+  public:
+    [[nodiscard]] PngVerifyResultV1
+    verify(const std::filesystem::path& stagedPath, const PngRgba8SrgbPreparedStreamV1& prepared,
+           const std::shared_ptr<const ProcessFrameSemanticIdentityV1>& processIdentity,
+           const std::shared_ptr<const OutputAnalysisReportV1>& report,
+           const core::Sha256Digest& expectedOcioRevision,
+           const std::shared_ptr<const color::DisplayProcessorIdentityV1>& displayProcessorIdentity,
+           const runtime::CancellationToken& cancellation,
+           const PngVerifyProgressCallbackV1& progress = {}) const noexcept;
+};
+
+} // namespace bloom::output

--- a/src/output/png_output_adapter.cpp
+++ b/src/output/png_output_adapter.cpp
@@ -1,0 +1,346 @@
+#include "png_preset_contract.hpp"
+
+#include <bloom/output/output_limits.hpp>
+#include <bloom/output/png_output_adapter.hpp>
+
+// zlib is Bloom's Bloom-owned codec's only dependency (design decision 1): deflate for IDAT,
+// crc32_z for every chunk's CRC-32. No OIIO/libpng anywhere. src/project/zip_container_writer.cpp
+// already establishes this exact deflateInit2/deflate/crc32_z consumption idiom for the qualified
+// prefix's ZLIB target; this writer reuses it with PNG's own (positive, zlib-wrapped) windowBits.
+#include <zlib.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <optional>
+#include <span>
+#include <system_error>
+#include <vector>
+
+namespace {
+
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+
+static_assert(output::detail::kPngDeflateStrategyV1 == Z_DEFAULT_STRATEGY,
+              "png_preset_contract.hpp's spelled-out strategy constant must track zlib.h");
+
+[[nodiscard]] bool removeDestinationBestEffort(const std::filesystem::path& destination) noexcept {
+    std::error_code removeError;
+    std::filesystem::remove(destination, removeError);
+    std::error_code existsError;
+    const bool stillExists = std::filesystem::exists(destination, existsError);
+    return !existsError && !stillExists;
+}
+
+[[nodiscard]] output::PngWriteResultV1 fail(const output::PngWriteErrorCodeV1 error,
+                                            const std::filesystem::path& destination,
+                                            const bool destinationWasCreated) noexcept {
+    const bool removed = !destinationWasCreated || removeDestinationBestEffort(destination);
+    return output::PngWriteResultV1::failed(error, removed);
+}
+
+[[nodiscard]] constexpr std::optional<std::uint64_t>
+multiplyChecked(const std::uint64_t left, const std::uint64_t right) noexcept {
+    if (right != 0 && left > std::numeric_limits<std::uint64_t>::max() / right) {
+        return std::nullopt;
+    }
+    return left * right;
+}
+
+[[nodiscard]] constexpr std::optional<std::uint64_t>
+addChecked(const std::uint64_t left, const std::uint64_t right) noexcept {
+    if (right > std::numeric_limits<std::uint64_t>::max() - left) {
+        return std::nullopt;
+    }
+    return left + right;
+}
+
+struct ValidatedGeometry final {
+    std::uint32_t width;
+    std::uint32_t height;
+    std::uint64_t rowRgbaBytes;     // width * 4
+    std::uint64_t rowOutputBytes;   // 1 (filter byte) + rowRgbaBytes
+    std::uint64_t totalOutputBytes; // height * rowOutputBytes -- the deflate source length
+};
+
+// Checked preflight, before any allocation or file I/O: `output_limits.hpp`'s closed version 1
+// dimension/pixel-count ceilings, `prepared`'s own internal consistency (pixels.size() must equal
+// width * height), and the arithmetic this writer needs to size its deflate source length.
+[[nodiscard]] std::optional<ValidatedGeometry>
+validateGeometry(const output::PngRgba8SrgbPreparedStreamV1& prepared) noexcept {
+    const auto width = prepared.dimensions.width();
+    const auto height = prepared.dimensions.height();
+    if (width == 0 || height == 0) {
+        return std::nullopt;
+    }
+    if (width > output::kOutputAnalysisMaximumDimensionV1 ||
+        height > output::kOutputAnalysisMaximumDimensionV1) {
+        return std::nullopt;
+    }
+    const auto pixelCount = multiplyChecked(width, height);
+    if (!pixelCount || *pixelCount > output::kOutputAnalysisMaximumPixelCountV1) {
+        return std::nullopt;
+    }
+    if (prepared.pixels.size() != *pixelCount) {
+        return std::nullopt;
+    }
+    const auto rowRgbaBytes = multiplyChecked(width, 4U);
+    const auto rowOutputBytes = rowRgbaBytes ? addChecked(*rowRgbaBytes, 1U) : std::nullopt;
+    const auto totalOutputBytes =
+        rowOutputBytes ? multiplyChecked(*rowOutputBytes, height) : std::nullopt;
+    if (!rowRgbaBytes || !rowOutputBytes || !totalOutputBytes ||
+        *totalOutputBytes > output::kOutputAnalysisMaximumProcessPixelBytesV1) {
+        return std::nullopt;
+    }
+    return ValidatedGeometry{width, height, *rowRgbaBytes, *rowOutputBytes, *totalOutputBytes};
+}
+
+void reportProgress(const output::PngWriteProgressCallbackV1& callback,
+                    const output::PngWriteProgressV1& progress) noexcept {
+    if (!callback) {
+        return;
+    }
+    try {
+        callback(progress);
+    } catch (...) {
+        // Monitoring cannot change a portable write outcome.
+        return;
+    }
+}
+
+void putBigEndianU32(std::vector<std::byte>& out, const std::uint32_t value) {
+    out.push_back(static_cast<std::byte>((value >> 24U) & 0xFFU));
+    out.push_back(static_cast<std::byte>((value >> 16U) & 0xFFU));
+    out.push_back(static_cast<std::byte>((value >> 8U) & 0xFFU));
+    out.push_back(static_cast<std::byte>(value & 0xFFU));
+}
+
+// Writes one complete chunk (length + type + data + CRC-32) to `file`. The CRC covers the type and
+// data bytes only (never the length field), via zlib's crc32_z -- the same incremental-CRC idiom
+// src/project/zip_container_writer.cpp already uses for its own entries.
+[[nodiscard]] bool writeChunk(std::ofstream& file, const std::array<char, 4>& type,
+                              const std::span<const std::byte> data) {
+    std::vector<std::byte> header;
+    header.reserve(8);
+    if (data.size() > std::numeric_limits<std::uint32_t>::max()) {
+        return false;
+    }
+    putBigEndianU32(header, static_cast<std::uint32_t>(data.size()));
+    file.write(reinterpret_cast<const char*>(header.data()),
+               static_cast<std::streamsize>(header.size()));
+    file.write(type.data(), static_cast<std::streamsize>(type.size()));
+    if (!data.empty()) {
+        file.write(reinterpret_cast<const char*>(data.data()),
+                   static_cast<std::streamsize>(data.size()));
+    }
+    auto crc = crc32_z(0L, reinterpret_cast<const Bytef*>(type.data()), type.size());
+    if (!data.empty()) {
+        crc = crc32_z(crc, reinterpret_cast<const Bytef*>(data.data()), data.size());
+    }
+    std::vector<std::byte> crcBytes;
+    crcBytes.reserve(4);
+    putBigEndianU32(crcBytes, static_cast<std::uint32_t>(crc));
+    file.write(reinterpret_cast<const char*>(crcBytes.data()),
+               static_cast<std::streamsize>(crcBytes.size()));
+    return static_cast<bool>(file);
+}
+
+struct DeflateStreamGuard final {
+    z_stream* handle;
+    ~DeflateStreamGuard() { deflateEnd(handle); }
+};
+
+} // namespace
+
+namespace bloom::output {
+
+PngWriteResultV1::PngWriteResultV1(const PngWriteStatusV1 status, const PngWriteErrorCodeV1 error,
+                                   const bool destinationRemoved) noexcept
+    : status_(status), error_(error), destinationRemoved_(destinationRemoved) {}
+
+PngWriteResultV1 PngWriteResultV1::written() noexcept {
+    return {PngWriteStatusV1::Written, PngWriteErrorCodeV1::None, true};
+}
+
+PngWriteResultV1 PngWriteResultV1::cancelled(const bool destinationRemoved) noexcept {
+    return {PngWriteStatusV1::Cancelled, PngWriteErrorCodeV1::None, destinationRemoved};
+}
+
+PngWriteResultV1 PngWriteResultV1::failed(const PngWriteErrorCodeV1 error,
+                                          const bool destinationRemoved) noexcept {
+    return {PngWriteStatusV1::Failed,
+            error == PngWriteErrorCodeV1::None ? PngWriteErrorCodeV1::InternalInvariant : error,
+            destinationRemoved};
+}
+
+PngWriteResultV1
+PngRgba8SrgbWriterV1::write(const PngRgba8SrgbPreparedStreamV1& prepared,
+                            const std::filesystem::path& destination,
+                            const runtime::CancellationToken& cancellation,
+                            const PngWriteProgressCallbackV1& progress) const noexcept {
+    const auto geometry = ::validateGeometry(prepared);
+    if (!geometry) {
+        const auto width = prepared.dimensions.width();
+        const auto height = prepared.dimensions.height();
+        const auto error = (width == 0 || height == 0 ||
+                            prepared.pixels.size() != static_cast<std::uint64_t>(width) * height)
+                               ? PngWriteErrorCodeV1::InvalidPreparedStream
+                               : PngWriteErrorCodeV1::ResourceLimitExceeded;
+        return ::fail(error, destination, false);
+    }
+    if (cancellation.isCancellationRequested()) {
+        return PngWriteResultV1::cancelled(true);
+    }
+
+    bool destinationCreated = false;
+    try {
+        std::ofstream file(destination, std::ios::binary | std::ios::trunc);
+        if (!file) {
+            return ::fail(PngWriteErrorCodeV1::DestinationUnavailable, destination, false);
+        }
+        destinationCreated = true;
+
+        file.write(reinterpret_cast<const char*>(detail::kPngSignatureV1.data()),
+                   static_cast<std::streamsize>(detail::kPngSignatureV1.size()));
+
+        std::vector<std::byte> ihdrData;
+        ihdrData.reserve(detail::kPngIhdrDataBytesV1);
+        ::putBigEndianU32(ihdrData, geometry->width);
+        ::putBigEndianU32(ihdrData, geometry->height);
+        ihdrData.push_back(static_cast<std::byte>(detail::kPngBitDepthV1));
+        ihdrData.push_back(static_cast<std::byte>(detail::kPngColorTypeRgbaV1));
+        ihdrData.push_back(static_cast<std::byte>(detail::kPngCompressionMethodV1));
+        ihdrData.push_back(static_cast<std::byte>(detail::kPngFilterMethodV1));
+        ihdrData.push_back(static_cast<std::byte>(detail::kPngInterlaceMethodV1));
+        if (!::writeChunk(file, detail::kPngChunkTypeIhdrV1, ihdrData)) {
+            return ::fail(PngWriteErrorCodeV1::IoFailure, destination, destinationCreated);
+        }
+
+        const std::array<std::byte, 1> srgbData{
+            static_cast<std::byte>(detail::kPngSrgbRenderingIntentV1)};
+        if (!::writeChunk(file, detail::kPngChunkTypeSrgbV1, srgbData)) {
+            return ::fail(PngWriteErrorCodeV1::IoFailure, destination, destinationCreated);
+        }
+
+        if (cancellation.isCancellationRequested()) {
+            return PngWriteResultV1::cancelled(::removeDestinationBestEffort(destination));
+        }
+
+        z_stream stream{};
+        if (deflateInit2(&stream, detail::kPngDeflateLevelV1, Z_DEFLATED,
+                         detail::kPngDeflateWindowBitsV1, detail::kPngDeflateMemLevelV1,
+                         detail::kPngDeflateStrategyV1) != Z_OK) {
+            return ::fail(PngWriteErrorCodeV1::CompressorFailure, destination, destinationCreated);
+        }
+        ::DeflateStreamGuard guard{&stream};
+
+        std::vector<std::byte> compressed;
+        compressed.reserve(deflateBound(&stream, static_cast<uLong>(geometry->totalOutputBytes)));
+
+        const auto rowsPerChunk =
+            std::max<std::uint64_t>(1, kOutputAdapterMaximumStreamingChunkBytesV1 /
+                                           std::max<std::uint64_t>(geometry->rowOutputBytes, 1));
+        std::vector<std::byte> rowChunkBuffer;
+        constexpr std::size_t kDrainBufferBytes = 1U << 16U;
+        std::array<std::byte, kDrainBufferBytes> drainBuffer{};
+
+        std::uint64_t rowsRemaining = geometry->height;
+        std::uint64_t completedRows = 0;
+        ::reportProgress(progress, {0, geometry->height});
+        bool compressorFailed = false;
+        while (rowsRemaining > 0) {
+            if (cancellation.isCancellationRequested()) {
+                return PngWriteResultV1::cancelled(::removeDestinationBestEffort(destination));
+            }
+            const auto chunkRows = std::min(rowsPerChunk, rowsRemaining);
+            const bool isLastChunk = chunkRows == rowsRemaining;
+            rowChunkBuffer.resize(chunkRows * geometry->rowOutputBytes);
+            for (std::uint64_t row = 0; row < chunkRows; ++row) {
+                const auto rowIndex = completedRows + row;
+                auto* const rowOut = rowChunkBuffer.data() +
+                                     static_cast<std::ptrdiff_t>(row * geometry->rowOutputBytes);
+                rowOut[0] = static_cast<std::byte>(detail::kPngFilterTypeNoneV1);
+                const auto* const sourceRow =
+                    prepared.pixels.data() +
+                    static_cast<std::ptrdiff_t>(rowIndex * geometry->width);
+                std::memcpy(rowOut + 1, sourceRow,
+                            static_cast<std::size_t>(geometry->rowRgbaBytes));
+            }
+
+            stream.next_in = reinterpret_cast<Bytef*>(rowChunkBuffer.data());
+            stream.avail_in = static_cast<uInt>(rowChunkBuffer.size());
+            const int flush = isLastChunk ? Z_FINISH : Z_NO_FLUSH;
+            int deflateStatus = Z_OK;
+            do {
+                stream.next_out = reinterpret_cast<Bytef*>(drainBuffer.data());
+                stream.avail_out = static_cast<uInt>(drainBuffer.size());
+                deflateStatus = deflate(&stream, flush);
+                if (deflateStatus == Z_STREAM_ERROR) {
+                    compressorFailed = true;
+                    break;
+                }
+                const auto produced = drainBuffer.size() - stream.avail_out;
+                compressed.insert(compressed.end(), drainBuffer.begin(),
+                                  drainBuffer.begin() + static_cast<std::ptrdiff_t>(produced));
+            } while (!compressorFailed &&
+                     (stream.avail_out == 0 || (isLastChunk && deflateStatus != Z_STREAM_END)));
+            if (compressorFailed) {
+                break;
+            }
+
+            rowsRemaining -= chunkRows;
+            completedRows += chunkRows;
+            ::reportProgress(progress, {completedRows, geometry->height});
+        }
+        if (compressorFailed) {
+            return ::fail(PngWriteErrorCodeV1::CompressorFailure, destination, destinationCreated);
+        }
+
+        // Deterministic fixed-size IDAT splits (png_preset_contract.hpp): one chunk unless the
+        // compressed stream exceeds kOutputAdapterMaximumStreamingChunkBytesV1, in which case
+        // every chunk but the last is exactly that size.
+        std::size_t offset = 0;
+        do {
+            if (cancellation.isCancellationRequested()) {
+                return PngWriteResultV1::cancelled(::removeDestinationBestEffort(destination));
+            }
+            const auto remaining = compressed.size() - offset;
+            const auto thisChunkBytes =
+                std::min<std::size_t>(remaining, kOutputAdapterMaximumStreamingChunkBytesV1);
+            const std::span<const std::byte> chunkData(compressed.data() + offset, thisChunkBytes);
+            if (!::writeChunk(file, detail::kPngChunkTypeIdatV1, chunkData)) {
+                return ::fail(PngWriteErrorCodeV1::IoFailure, destination, destinationCreated);
+            }
+            offset += thisChunkBytes;
+        } while (offset < compressed.size());
+
+        if (!::writeChunk(file, detail::kPngChunkTypeIendV1, {})) {
+            return ::fail(PngWriteErrorCodeV1::IoFailure, destination, destinationCreated);
+        }
+
+        file.flush();
+        if (!file) {
+            return ::fail(PngWriteErrorCodeV1::IoFailure, destination, destinationCreated);
+        }
+    } catch (const std::bad_alloc&) {
+        return ::fail(PngWriteErrorCodeV1::AllocationFailure, destination, destinationCreated);
+    } catch (const std::exception&) {
+        return ::fail(destinationCreated ? PngWriteErrorCodeV1::IoFailure
+                                         : PngWriteErrorCodeV1::DestinationUnavailable,
+                      destination, destinationCreated);
+    } catch (...) {
+        return ::fail(PngWriteErrorCodeV1::InternalInvariant, destination, destinationCreated);
+    }
+
+    return PngWriteResultV1::written();
+}
+
+} // namespace bloom::output

--- a/src/output/png_preset_contract.hpp
+++ b/src/output/png_preset_contract.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+// Private (non-FILE_SET, non-installed) header shared by the PNG writer and reopen verifier,
+// mirroring flat_exr_preset_contract.hpp's role for the flat OpenEXR pair: one literal table
+// copied from docs/architecture/frame-output.md ("PNG Preset Version 1" and "Determinism And
+// Portable Output Identity"), so the writer and verifier stay driven by the same constants instead
+// of by each other. Nothing here names a zlib type; both translation units include <zlib.h>
+// themselves for the calls they actually make (deflate*/inflate*/crc32_z), keeping this header a
+// plain literal table like its EXR counterpart.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace bloom::output::detail {
+
+// The eight-byte PNG signature (ISO/IEC 15948, PNG Preset Version 1).
+inline constexpr std::array<std::uint8_t, 8> kPngSignatureV1{137, 80, 78, 71, 13, 10, 26, 10};
+
+// IHDR fixed field values -- design decision 2 / "PNG Preset Version 1": bit depth 8, color type 6
+// (truecolor+alpha), compression method 0, filter method 0 (per-scanline filtering, distinct from
+// the per-row filter TYPE byte below), interlace method 0 (non-interlaced).
+inline constexpr std::uint8_t kPngBitDepthV1 = 8;
+inline constexpr std::uint8_t kPngColorTypeRgbaV1 = 6;
+inline constexpr std::uint8_t kPngCompressionMethodV1 = 0;
+inline constexpr std::uint8_t kPngFilterMethodV1 = 0;
+inline constexpr std::uint8_t kPngInterlaceMethodV1 = 0;
+
+// The fixed per-scanline filter TYPE byte every row's filtered data begins with -- design decision
+// 2: "fixed filter type 0 (None) on every row". None means the row's filtered bytes are its
+// literal sample bytes; no arithmetic reconstruction is needed on read-back.
+inline constexpr std::uint8_t kPngFilterTypeNoneV1 = 0;
+
+// sRGB rendering intent 0 (perceptual) -- the kind-1 payload's "PNG sRGB rendering-intent byte".
+inline constexpr std::uint8_t kPngSrgbRenderingIntentV1 = 0;
+
+inline constexpr std::array<char, 4> kPngChunkTypeIhdrV1{'I', 'H', 'D', 'R'};
+inline constexpr std::array<char, 4> kPngChunkTypeSrgbV1{'s', 'R', 'G', 'B'};
+inline constexpr std::array<char, 4> kPngChunkTypeIdatV1{'I', 'D', 'A', 'T'};
+inline constexpr std::array<char, 4> kPngChunkTypeIendV1{'I', 'E', 'N', 'D'};
+
+inline constexpr std::size_t kPngIhdrDataBytesV1 = 13;
+inline constexpr std::size_t kPngSrgbDataBytesV1 = 1;
+inline constexpr std::size_t kPngIendDataBytesV1 = 0;
+
+// Fixed, explicitly-set deflate parameters -- design decision 2: "deflate with FIXED,
+// explicitly-set parameters (level, strategy, window) so bytes are deterministic under the
+// qualified zlib". Level 6 and PNG row-filter type 0 are the doc's own "PNG Preset Version 1"
+// wording ("DEFLATE level 6, default zlib strategy, and PNG row-filter type 0"). windowBits is
+// positive 15: a zlib-wrapped stream (2-byte header + 4-byte Adler-32 trailer, not raw deflate) at
+// the doc's own "32 KiB window" ("Flat OpenEXR"/"PNG Preset Version 1" sections both name this
+// exact IDAT shape). memLevel 8 is zlib's documented default, matching
+// src/project/zip_container_writer.cpp's own deflateInit2 call (used here for parity, not because
+// the doc names it -- the doc is silent on memLevel, and 8 is the value deflateInit()'s convenience
+// wrapper always uses). kPngDeflateStrategyV1's value (0) is Z_DEFAULT_STRATEGY from zlib.h; it is
+// spelled out numerically (with the writer/verifier .cpp files' own static_assert against the real
+// macro) so this literal-table header never needs a zlib.h include for a single named constant.
+inline constexpr int kPngDeflateLevelV1 = 6;
+inline constexpr int kPngDeflateWindowBitsV1 = 15;
+inline constexpr int kPngDeflateMemLevelV1 = 8;
+inline constexpr int kPngDeflateStrategyV1 = 0; // Z_DEFAULT_STRATEGY
+
+// IDAT split rule -- design decision 2: "single IDAT chunk unless the checked chunk-size ceiling
+// forces splitting (then deterministic fixed-size splits)". The checked chunk-size ceiling reused
+// here is output_limits.hpp's existing kOutputAdapterMaximumStreamingChunkBytesV1 (16 MiB): the
+// same "one encoder or verifier streaming chunk" ceiling the flat OpenEXR writer/verifier already
+// apply to their own scanline chunking, so the compressed IDAT payload is split into fixed
+// 16 MiB chunks (the final chunk shorter) whenever it exceeds that bound, and left as one chunk
+// otherwise. No PNG-specific ceiling is added: the doc's PNG section names no chunk-size number of
+// its own, only the general "Version 1 export limits" table's per-chunk figure that
+// kOutputAdapterMaximumStreamingChunkBytesV1 already materializes (frame-output.md, "Version 1
+// export limits", "one encoder or verifier streaming chunk").
+
+} // namespace bloom::output::detail

--- a/src/output/png_reopen_verifier.cpp
+++ b/src/output/png_reopen_verifier.cpp
@@ -1,0 +1,571 @@
+// output_semantic_identity.hpp is module-private (no public bloom/output/ path exists for it --
+// docs/architecture/frame-output.md calls it "the module-private Output Semantic Identity version
+// 1 streaming serializer/preparer"); this translation unit lives inside src/output/ itself, so the
+// quoted include resolves relative to this file, matching every other src/output/*.cpp that
+// touches it. This is also where the friend seam class below (forward-declared in that header as
+// `detail::PngRgba8SrgbSemanticPayloadVerifierV1`) is defined -- the PNG counterpart of
+// flat_exr_reopen_verifier.cpp's identically-shaped `FlatExrRgba32fLinRec709SceneSemanticPayload
+// VerifierV1`.
+#include "output_semantic_identity.hpp"
+
+#include "png_preset_contract.hpp"
+
+#include <bloom/output/output_limits.hpp>
+#include <bloom/output/png_reopen_verifier.hpp>
+
+// zlib is this Bloom-owned codec's only dependency (design decision 1): inflate for the IDAT
+// stream, crc32_z for every chunk's CRC-32 -- the read-back counterpart of
+// png_output_adapter.cpp's deflate/crc32_z usage. No OIIO/libpng anywhere.
+#include <zlib.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <fstream>
+#include <limits>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+namespace color = bloom::color;
+namespace core = bloom::core;
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+
+// Positional aggregate construction (never designated) so every PngVerifyDiagnosticV1 site stays a
+// one-line call regardless of how many trailing fields default -- mirrors
+// flat_exr_reopen_verifier.cpp's `diag()` helper.
+[[nodiscard]] output::PngVerifyDiagnosticV1
+diag(const output::PngVerifyErrorCodeV1 code, std::string chunkType = {},
+     const std::optional<std::uint64_t> chunkIndex = std::nullopt,
+     const std::optional<std::uint64_t> byteOffset = std::nullopt,
+     const std::optional<std::uint64_t> row = std::nullopt) noexcept {
+    return output::PngVerifyDiagnosticV1{code, std::move(chunkType), chunkIndex, byteOffset, row};
+}
+
+void reportProgress(const output::PngVerifyProgressCallbackV1& callback,
+                    const output::PngVerifyProgressV1& progress) noexcept {
+    if (!callback) {
+        return;
+    }
+    try {
+        callback(progress);
+    } catch (...) {
+        // Monitoring cannot change a portable verification outcome.
+        return;
+    }
+}
+
+[[nodiscard]] constexpr std::optional<std::uint64_t>
+multiplyChecked(const std::uint64_t left, const std::uint64_t right) noexcept {
+    if (right != 0 && left > std::numeric_limits<std::uint64_t>::max() / right) {
+        return std::nullopt;
+    }
+    return left * right;
+}
+
+[[nodiscard]] constexpr std::optional<std::uint64_t>
+addChecked(const std::uint64_t left, const std::uint64_t right) noexcept {
+    if (right > std::numeric_limits<std::uint64_t>::max() - left) {
+        return std::nullopt;
+    }
+    return left + right;
+}
+
+struct GeometryExpectation final {
+    std::uint32_t width;
+    std::uint32_t height;
+    std::uint64_t rowRgbaBytes;     // width * 4
+    std::uint64_t rowOutputBytes;   // 1 (filter byte) + rowRgbaBytes
+    std::uint64_t totalOutputBytes; // height * rowOutputBytes -- the checked inflate ceiling
+};
+
+// Same checked-arithmetic preflight as png_output_adapter.cpp's validateGeometry(): the caller-
+// supplied `prepared` stream's own internal consistency plus output_limits.hpp's closed version 1
+// dimension/pixel-count/byte ceilings (reused, not duplicated with new PNG-specific numbers --
+// design decision 5).
+[[nodiscard]] std::optional<GeometryExpectation>
+validateGeometry(const output::PngRgba8SrgbPreparedStreamV1& prepared) noexcept {
+    const auto width = prepared.dimensions.width();
+    const auto height = prepared.dimensions.height();
+    if (width == 0 || height == 0) {
+        return std::nullopt;
+    }
+    if (width > output::kOutputAnalysisMaximumDimensionV1 ||
+        height > output::kOutputAnalysisMaximumDimensionV1) {
+        return std::nullopt;
+    }
+    const auto pixelCount = multiplyChecked(width, height);
+    if (!pixelCount || *pixelCount > output::kOutputAnalysisMaximumPixelCountV1 ||
+        prepared.pixels.size() != *pixelCount) {
+        return std::nullopt;
+    }
+    const auto rowRgbaBytes = multiplyChecked(width, 4U);
+    const auto rowOutputBytes = rowRgbaBytes ? addChecked(*rowRgbaBytes, 1U) : std::nullopt;
+    const auto totalOutputBytes =
+        rowOutputBytes ? multiplyChecked(*rowOutputBytes, height) : std::nullopt;
+    if (!rowRgbaBytes || !rowOutputBytes || !totalOutputBytes ||
+        *totalOutputBytes > output::kOutputAnalysisMaximumProcessPixelBytesV1) {
+        return std::nullopt;
+    }
+    return GeometryExpectation{width, height, *rowRgbaBytes, *rowOutputBytes, *totalOutputBytes};
+}
+
+[[nodiscard]] std::uint32_t readBigEndianU32(const std::span<const std::byte> bytes) noexcept {
+    return (static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[0])) << 24U) |
+           (static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[1])) << 16U) |
+           (static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[2])) << 8U) |
+           static_cast<std::uint32_t>(std::to_integer<std::uint8_t>(bytes[3]));
+}
+
+[[nodiscard]] std::uint32_t crc32Of(const std::array<char, 4>& type,
+                                    const std::span<const std::byte> data) noexcept {
+    auto crc = crc32_z(0L, reinterpret_cast<const Bytef*>(type.data()), type.size());
+    if (!data.empty()) {
+        crc = crc32_z(crc, reinterpret_cast<const Bytef*>(data.data()), data.size());
+    }
+    return static_cast<std::uint32_t>(crc);
+}
+
+// A minimal buffered raw-file reader that tracks its own cursor for diagnostics. `Eof` means zero
+// bytes were available (a clean end of file exactly at a chunk boundary); `Short` means some but
+// not all of the requested bytes were available (a cut-off mid-chunk).
+enum class ReadStatus : std::uint8_t { Complete, Eof, Short };
+
+class RawFileReader final {
+  public:
+    explicit RawFileReader(const std::filesystem::path& path) : stream_(path, std::ios::binary) {}
+
+    [[nodiscard]] bool isOpen() const noexcept { return static_cast<bool>(stream_); }
+    [[nodiscard]] std::uint64_t position() const noexcept { return position_; }
+
+    [[nodiscard]] ReadStatus readExact(const std::span<std::byte> destination) noexcept {
+        stream_.read(reinterpret_cast<char*>(destination.data()),
+                     static_cast<std::streamsize>(destination.size()));
+        const auto got = stream_.gcount();
+        stream_.clear(stream_.rdstate() & ~std::ios::failbit);
+        position_ += static_cast<std::uint64_t>(got);
+        if (got == static_cast<std::streamsize>(destination.size())) {
+            return ReadStatus::Complete;
+        }
+        return got == 0 ? ReadStatus::Eof : ReadStatus::Short;
+    }
+
+    // True when no byte remains (used only after the closed sequence's IEND is consumed).
+    [[nodiscard]] bool atEof() noexcept { return stream_.peek() == std::char_traits<char>::eof(); }
+
+  private:
+    std::ifstream stream_;
+    std::uint64_t position_ = 0;
+};
+
+struct InflateStreamGuard final {
+    z_stream* handle;
+    bool initialized;
+    ~InflateStreamGuard() {
+        if (initialized) {
+            inflateEnd(handle);
+        }
+    }
+};
+
+} // namespace
+
+namespace bloom::output::detail {
+
+// The friend seam `output_semantic_identity.hpp` forward-declares
+// (`friend class detail::PngRgba8SrgbSemanticPayloadVerifierV1;`) for exactly one purpose: only
+// this reopen verifier -- never the writer, never a test -- may construct a
+// `PngRgba8SrgbVerifiedSemanticProductV1` from decoded reopened values.
+class PngRgba8SrgbSemanticPayloadVerifierV1 final {
+  public:
+    [[nodiscard]] static PngRgba8SrgbVerifiedSemanticProductV1 buildVerifiedProduct(
+        const std::shared_ptr<const PngRgba8SrgbBoundOutputAnalysisV1>& boundAnalysis,
+        const render::ImageExtent dimensions, std::vector<std::uint8_t>&& rgbaBytes) {
+        return PngRgba8SrgbVerifiedSemanticProductV1(boundAnalysis, dimensions,
+                                                     std::move(rgbaBytes));
+    }
+};
+
+} // namespace bloom::output::detail
+
+namespace bloom::output {
+
+PngVerifyResultV1::PngVerifyResultV1(const PngVerifyStatusV1 status,
+                                     const core::Sha256Digest digest,
+                                     PngVerifyDiagnosticV1 diagnostic) noexcept
+    : status_(status), digest_(digest), diagnostic_(std::move(diagnostic)) {}
+
+PngVerifyResultV1 PngVerifyResultV1::verified(const core::Sha256Digest digest) noexcept {
+    return {PngVerifyStatusV1::Verified, digest, {}};
+}
+
+PngVerifyResultV1 PngVerifyResultV1::cancelled() noexcept {
+    return {PngVerifyStatusV1::Cancelled, {}, {}};
+}
+
+PngVerifyResultV1 PngVerifyResultV1::failed(PngVerifyDiagnosticV1 diagnostic) noexcept {
+    if (diagnostic.code == PngVerifyErrorCodeV1::None) {
+        diagnostic.code = PngVerifyErrorCodeV1::InternalInvariant;
+    }
+    return {PngVerifyStatusV1::Failed, {}, std::move(diagnostic)};
+}
+
+PngVerifyResultV1 PngRgba8SrgbReopenVerifierV1::verify(
+    const std::filesystem::path& stagedPath, const PngRgba8SrgbPreparedStreamV1& prepared,
+    const std::shared_ptr<const ProcessFrameSemanticIdentityV1>& processIdentity,
+    const std::shared_ptr<const OutputAnalysisReportV1>& report,
+    const core::Sha256Digest& expectedOcioRevision,
+    const std::shared_ptr<const color::DisplayProcessorIdentityV1>& displayProcessorIdentity,
+    const runtime::CancellationToken& cancellation,
+    const PngVerifyProgressCallbackV1& progress) const noexcept {
+    if (processIdentity == nullptr || report == nullptr || displayProcessorIdentity == nullptr) {
+        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::IdentityIssuanceFailed));
+    }
+    const auto geometry = ::validateGeometry(prepared);
+    if (!geometry) {
+        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::InternalInvariant));
+    }
+    if (cancellation.isCancellationRequested()) {
+        return PngVerifyResultV1::cancelled();
+    }
+
+    try {
+        ::RawFileReader reader(stagedPath);
+        if (!reader.isOpen()) {
+            return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::SourceUnavailable));
+        }
+
+        std::array<std::byte, 8> signature{};
+        if (reader.readExact(signature) != ::ReadStatus::Complete) {
+            return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile));
+        }
+        for (std::size_t index = 0; index < signature.size(); ++index) {
+            if (signature[index] != static_cast<std::byte>(detail::kPngSignatureV1[index])) {
+                return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::InvalidSignature));
+            }
+        }
+
+        enum class State : std::uint8_t { NeedIhdr, NeedSrgb, NeedIdat, Done };
+        auto state = State::NeedIhdr;
+        bool sawIdat = false;
+        std::uint64_t chunkIndex = 0;
+
+        z_stream inflateStream{};
+        bool inflateInitialized = false;
+        ::InflateStreamGuard inflateGuard{&inflateStream, false};
+
+        std::vector<std::byte> decoded(static_cast<std::size_t>(geometry->totalOutputBytes));
+        std::size_t decodedFilled = 0;
+        bool sawStreamEnd = false;
+
+        while (state != State::Done) {
+            if (cancellation.isCancellationRequested()) {
+                return PngVerifyResultV1::cancelled();
+            }
+            const auto chunkOffset = reader.position();
+            std::array<std::byte, 8> chunkHeader{};
+            const auto headerStatus = reader.readExact(chunkHeader);
+            if (headerStatus == ::ReadStatus::Eof) {
+                return PngVerifyResultV1::failed(
+                    ::diag(PngVerifyErrorCodeV1::MissingChunk, {}, chunkIndex, chunkOffset));
+            }
+            if (headerStatus == ::ReadStatus::Short) {
+                return PngVerifyResultV1::failed(
+                    ::diag(PngVerifyErrorCodeV1::TruncatedFile, {}, chunkIndex, chunkOffset));
+            }
+            const auto length =
+                ::readBigEndianU32(std::span<const std::byte>(chunkHeader).first(4));
+            const std::array<char, 4> type{
+                static_cast<char>(std::to_integer<unsigned char>(chunkHeader[4])),
+                static_cast<char>(std::to_integer<unsigned char>(chunkHeader[5])),
+                static_cast<char>(std::to_integer<unsigned char>(chunkHeader[6])),
+                static_cast<char>(std::to_integer<unsigned char>(chunkHeader[7]))};
+            const std::string typeName(type.begin(), type.end());
+
+            if (state == State::NeedIhdr) {
+                if (type != detail::kPngChunkTypeIhdrV1) {
+                    return PngVerifyResultV1::failed(
+                        ::diag(PngVerifyErrorCodeV1::UnexpectedChunkType, typeName, chunkIndex,
+                               chunkOffset));
+                }
+                if (length != detail::kPngIhdrDataBytesV1) {
+                    return PngVerifyResultV1::failed(
+                        ::diag(PngVerifyErrorCodeV1::FixedChunkLengthMismatch, typeName, chunkIndex,
+                               chunkOffset));
+                }
+                std::array<std::byte, 13> data{};
+                if (reader.readExact(data) != ::ReadStatus::Complete) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile,
+                                                            typeName, chunkIndex, chunkOffset));
+                }
+                std::array<std::byte, 4> crcBytes{};
+                if (reader.readExact(crcBytes) != ::ReadStatus::Complete) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile,
+                                                            typeName, chunkIndex, chunkOffset));
+                }
+                if (::crc32Of(type, data) != ::readBigEndianU32(crcBytes)) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::ChunkCrcMismatch,
+                                                            typeName, chunkIndex, chunkOffset));
+                }
+                const auto width = ::readBigEndianU32(std::span<const std::byte>(data).first(4));
+                const auto height =
+                    ::readBigEndianU32(std::span<const std::byte>(data).subspan(4, 4));
+                const auto bitDepth = std::to_integer<std::uint8_t>(data[8]);
+                const auto colorType = std::to_integer<std::uint8_t>(data[9]);
+                const auto compressionMethod = std::to_integer<std::uint8_t>(data[10]);
+                const auto filterMethod = std::to_integer<std::uint8_t>(data[11]);
+                const auto interlaceMethod = std::to_integer<std::uint8_t>(data[12]);
+                if (width != geometry->width || height != geometry->height ||
+                    bitDepth != detail::kPngBitDepthV1 ||
+                    colorType != detail::kPngColorTypeRgbaV1 ||
+                    compressionMethod != detail::kPngCompressionMethodV1 ||
+                    filterMethod != detail::kPngFilterMethodV1 ||
+                    interlaceMethod != detail::kPngInterlaceMethodV1) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::IhdrFieldMismatch,
+                                                            typeName, chunkIndex, chunkOffset));
+                }
+                state = State::NeedSrgb;
+            } else if (state == State::NeedSrgb) {
+                if (type != detail::kPngChunkTypeSrgbV1) {
+                    return PngVerifyResultV1::failed(
+                        ::diag(PngVerifyErrorCodeV1::UnexpectedChunkType, typeName, chunkIndex,
+                               chunkOffset));
+                }
+                if (length != detail::kPngSrgbDataBytesV1) {
+                    return PngVerifyResultV1::failed(
+                        ::diag(PngVerifyErrorCodeV1::FixedChunkLengthMismatch, typeName, chunkIndex,
+                               chunkOffset));
+                }
+                std::array<std::byte, 1> data{};
+                if (reader.readExact(data) != ::ReadStatus::Complete) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile,
+                                                            typeName, chunkIndex, chunkOffset));
+                }
+                std::array<std::byte, 4> crcBytes{};
+                if (reader.readExact(crcBytes) != ::ReadStatus::Complete) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile,
+                                                            typeName, chunkIndex, chunkOffset));
+                }
+                if (::crc32Of(type, data) != ::readBigEndianU32(crcBytes)) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::ChunkCrcMismatch,
+                                                            typeName, chunkIndex, chunkOffset));
+                }
+                if (std::to_integer<std::uint8_t>(data[0]) != detail::kPngSrgbRenderingIntentV1) {
+                    return PngVerifyResultV1::failed(
+                        ::diag(PngVerifyErrorCodeV1::SrgbIntentMismatch, typeName, chunkIndex,
+                               chunkOffset));
+                }
+                state = State::NeedIdat;
+            } else { // State::NeedIdat
+                if (type == detail::kPngChunkTypeIdatV1) {
+                    if (length > kOutputAdapterMaximumStreamingChunkBytesV1) {
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::ChunkLengthExceedsLimit, typeName,
+                                   chunkIndex, chunkOffset));
+                    }
+                    std::vector<std::byte> data(length);
+                    if (reader.readExact(data) != ::ReadStatus::Complete) {
+                        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile,
+                                                                typeName, chunkIndex, chunkOffset));
+                    }
+                    std::array<std::byte, 4> crcBytes{};
+                    if (reader.readExact(crcBytes) != ::ReadStatus::Complete) {
+                        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile,
+                                                                typeName, chunkIndex, chunkOffset));
+                    }
+                    if (::crc32Of(type, data) != ::readBigEndianU32(crcBytes)) {
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::ChunkCrcMismatch, typeName, chunkIndex,
+                                   chunkOffset));
+                    }
+                    sawIdat = true;
+
+                    if (!inflateInitialized) {
+                        if (inflateInit(&inflateStream) != Z_OK) {
+                            return PngVerifyResultV1::failed(
+                                ::diag(PngVerifyErrorCodeV1::AllocationFailure, typeName,
+                                       chunkIndex, chunkOffset));
+                        }
+                        inflateInitialized = true;
+                        inflateGuard.initialized = true;
+                    }
+                    if (sawStreamEnd && !data.empty()) {
+                        // Trailing IDAT bytes after the zlib stream already finished.
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::IdatZlibStreamInvalid, typeName,
+                                   chunkIndex, chunkOffset));
+                    }
+                    inflateStream.next_in = reinterpret_cast<Bytef*>(data.data());
+                    inflateStream.avail_in = static_cast<uInt>(data.size());
+                    bool exceeded = false;
+                    bool zlibError = false;
+                    while (inflateStream.avail_in > 0 && !sawStreamEnd) {
+                        const auto capacity = decoded.size() - decodedFilled;
+                        if (capacity == 0) {
+                            exceeded = true;
+                            break;
+                        }
+                        inflateStream.next_out =
+                            reinterpret_cast<Bytef*>(decoded.data() + decodedFilled);
+                        inflateStream.avail_out = static_cast<uInt>(
+                            std::min<std::size_t>(capacity, std::numeric_limits<uInt>::max()));
+                        const auto beforeOut = inflateStream.avail_out;
+                        const auto ret = inflate(&inflateStream, Z_NO_FLUSH);
+                        const auto produced = beforeOut - inflateStream.avail_out;
+                        decodedFilled += produced;
+                        if (ret == Z_STREAM_END) {
+                            sawStreamEnd = true;
+                            break;
+                        }
+                        if (ret == Z_OK) {
+                            continue;
+                        }
+                        if (ret == Z_BUF_ERROR && inflateStream.avail_out == 0) {
+                            exceeded = true;
+                            break;
+                        }
+                        zlibError = true;
+                        break;
+                    }
+                    if (exceeded) {
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::IdatExpandedSizeExceeded, typeName,
+                                   chunkIndex, chunkOffset));
+                    }
+                    if (zlibError) {
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::IdatZlibStreamInvalid, typeName,
+                                   chunkIndex, chunkOffset));
+                    }
+                } else if (type == detail::kPngChunkTypeIendV1 && sawIdat) {
+                    if (length != detail::kPngIendDataBytesV1) {
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::FixedChunkLengthMismatch, typeName,
+                                   chunkIndex, chunkOffset));
+                    }
+                    std::array<std::byte, 4> crcBytes{};
+                    if (reader.readExact(crcBytes) != ::ReadStatus::Complete) {
+                        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TruncatedFile,
+                                                                typeName, chunkIndex, chunkOffset));
+                    }
+                    if (::crc32Of(type, std::span<const std::byte>{}) !=
+                        ::readBigEndianU32(crcBytes)) {
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::ChunkCrcMismatch, typeName, chunkIndex,
+                                   chunkOffset));
+                    }
+                    if (!sawStreamEnd || decodedFilled != decoded.size()) {
+                        return PngVerifyResultV1::failed(
+                            ::diag(PngVerifyErrorCodeV1::IdatZlibStreamInvalid, typeName,
+                                   chunkIndex, chunkOffset));
+                    }
+                    state = State::Done;
+                } else {
+                    return PngVerifyResultV1::failed(
+                        ::diag(PngVerifyErrorCodeV1::UnexpectedChunkType, typeName, chunkIndex,
+                               chunkOffset));
+                }
+            }
+            ++chunkIndex;
+        }
+
+        if (!reader.atEof()) {
+            return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::TrailingBytesAfterIend));
+        }
+
+        // Every scanline's leading filter byte must be exactly 0 (None); the remaining
+        // width * 4 bytes must bit-exact match `prepared`'s own row. Processed in bounded row
+        // chunks -- the same kOutputAdapterMaximumStreamingChunkBytesV1 cadence the writer uses --
+        // with cancellation checked and progress reported between chunks.
+        const auto rowsPerChunk =
+            std::max<std::uint64_t>(1, kOutputAdapterMaximumStreamingChunkBytesV1 /
+                                           std::max<std::uint64_t>(geometry->rowOutputBytes, 1));
+        std::uint64_t completedRows = 0;
+        ::reportProgress(progress, {0, geometry->height});
+        while (completedRows < geometry->height) {
+            if (cancellation.isCancellationRequested()) {
+                return PngVerifyResultV1::cancelled();
+            }
+            const auto chunkRows =
+                std::min<std::uint64_t>(rowsPerChunk, geometry->height - completedRows);
+            for (std::uint64_t row = 0; row < chunkRows; ++row) {
+                const auto rowIndex = completedRows + row;
+                const auto rowOffset =
+                    static_cast<std::size_t>(rowIndex * geometry->rowOutputBytes);
+                if (decoded[rowOffset] != static_cast<std::byte>(detail::kPngFilterTypeNoneV1)) {
+                    return PngVerifyResultV1::failed(
+                        ::diag(PngVerifyErrorCodeV1::RowFilterByteNonzero, {}, std::nullopt,
+                               rowOffset, rowIndex));
+                }
+                const auto* const decodedRow =
+                    decoded.data() + static_cast<std::ptrdiff_t>(rowOffset) + 1;
+                const auto* const expectedRow = reinterpret_cast<const std::byte*>(
+                    prepared.pixels.data() +
+                    static_cast<std::ptrdiff_t>(rowIndex * geometry->width));
+                if (std::memcmp(decodedRow, expectedRow,
+                                static_cast<std::size_t>(geometry->rowRgbaBytes)) != 0) {
+                    return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::SampleMismatch,
+                                                            {}, std::nullopt, std::nullopt,
+                                                            rowIndex));
+                }
+            }
+            completedRows += chunkRows;
+            ::reportProgress(progress, {completedRows, geometry->height});
+        }
+
+        // Feed the DECODED reopened values (design decision 4), not `prepared`, into the kind-1
+        // identity seam.
+        std::vector<std::uint8_t> rgbaBytes(static_cast<std::size_t>(geometry->rowRgbaBytes) *
+                                            geometry->height);
+        for (std::uint64_t row = 0; row < geometry->height; ++row) {
+            const auto sourceOffset = static_cast<std::size_t>(row * geometry->rowOutputBytes) + 1;
+            const auto destOffset = static_cast<std::size_t>(row * geometry->rowRgbaBytes);
+            std::memcpy(rgbaBytes.data() + destOffset, decoded.data() + sourceOffset,
+                        static_cast<std::size_t>(geometry->rowRgbaBytes));
+        }
+
+        auto bound = bindPngRgba8SrgbOutputAnalysisV1(processIdentity, report, expectedOcioRevision,
+                                                      displayProcessorIdentity);
+        if (bound.analysis() == nullptr) {
+            return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::IdentityIssuanceFailed));
+        }
+
+        auto verifiedProduct = detail::PngRgba8SrgbSemanticPayloadVerifierV1::buildVerifiedProduct(
+            bound.analysis(), prepared.dimensions, std::move(rgbaBytes));
+
+        const OutputSemanticIdentityV1Preparer identityPreparer;
+        const auto issuance = identityPreparer.preparePngRgba8SrgbV1(
+            PngRgba8SrgbOutputSemanticIdentityInputV1{std::move(verifiedProduct)}, cancellation);
+
+        switch (issuance.status()) {
+        case OutputSemanticIdentityPreparationStatusV1::Prepared:
+            if (issuance.identity() == nullptr) {
+                return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::InternalInvariant));
+            }
+            return PngVerifyResultV1::verified(issuance.identity()->digest());
+        case OutputSemanticIdentityPreparationStatusV1::Cancelled:
+            return PngVerifyResultV1::cancelled();
+        case OutputSemanticIdentityPreparationStatusV1::Failed:
+        default:
+            return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::IdentityIssuanceFailed));
+        }
+    } catch (const std::bad_alloc&) {
+        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::AllocationFailure));
+    } catch (const std::length_error&) {
+        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::AllocationFailure));
+    } catch (const std::exception&) {
+        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::InternalInvariant));
+    } catch (...) {
+        return PngVerifyResultV1::failed(::diag(PngVerifyErrorCodeV1::InternalInvariant));
+    }
+}
+
+} // namespace bloom::output

--- a/src/output/tests/png_output_adapter_tests.cpp
+++ b/src/output/tests/png_output_adapter_tests.cpp
@@ -1,0 +1,227 @@
+// Tests for PngRgba8SrgbWriterV1 (issue #107): chunk conformance via an independent (zlib-direct)
+// decode, invalid-input/resource-limit rejection, and cancellation mid-write. Round trip,
+// determinism, and adversarial reopen-verification tests live in png_reopen_verifier_tests.cpp --
+// they need both the writer and the verifier together (mirrors flat_exr_output_adapter_tests.cpp's
+// own split rationale).
+
+#include "png_test_support.hpp"
+
+#include <bloom/output/png_output_adapter.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+namespace support = bloom_output_png_test_support;
+
+// Opaque, translucent, zero-alpha, and byte-endpoint (0/255) extremes -- design decision 6's
+// fixture list -- at a small 3x2 image.
+[[nodiscard]] std::vector<render::Rgba8> fixturePixels() {
+    return {
+        render::Rgba8{255, 0, 0, 255}, render::Rgba8{0, 255, 0, 128},
+        render::Rgba8{0, 0, 255, 0},   render::Rgba8{255, 255, 255, 255},
+        render::Rgba8{0, 0, 0, 0},     render::Rgba8{17, 34, 51, 200},
+    };
+}
+
+[[nodiscard]] output::PngRgba8SrgbPreparedStreamV1
+preparedStream(const std::vector<render::Rgba8>& pixels, const std::uint32_t width,
+               const std::uint32_t height) {
+    const auto extent = render::ImageExtent::create(width, height);
+    if (!extent) {
+        std::abort();
+    }
+    return {*extent.value(), std::span<const render::Rgba8>(pixels)};
+}
+
+void testChunkConformanceAndIndependentDecode(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("chunk-conformance");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, 3, 2);
+    const auto destination = scratch.file("conformance.png");
+
+    const output::PngRgba8SrgbWriterV1 writer;
+    const auto written = writer.write(prepared, destination, {});
+    expectations.expect(written.status() == output::PngWriteStatusV1::Written,
+                        "a valid fixture writes successfully");
+
+    const auto decoded = support::independentlyDecodePng(destination);
+    expectations.expect(decoded.ok, "an independent (zlib-direct) reader parses the written file");
+    expectations.expect(
+        decoded.chunkTypesInOrder.size() >= 4 && decoded.chunkTypesInOrder.front() == "IHDR" &&
+            decoded.chunkTypesInOrder[1] == "sRGB" && decoded.chunkTypesInOrder.back() == "IEND",
+        "chunks appear in exactly IHDR, sRGB, IDAT(s), IEND order");
+    for (std::size_t index = 2; index + 1 < decoded.chunkTypesInOrder.size(); ++index) {
+        expectations.expect(decoded.chunkTypesInOrder[index] == "IDAT",
+                            "every chunk between sRGB and IEND is IDAT");
+    }
+    expectations.expect(decoded.everyCrcValid, "every chunk's CRC-32 is valid");
+    expectations.expect(decoded.width == 3 && decoded.height == 2 && decoded.bitDepth == 8 &&
+                            decoded.colorType == 6 && decoded.compressionMethod == 0 &&
+                            decoded.filterMethod == 0 && decoded.interlaceMethod == 0,
+                        "IHDR carries exactly the required version 1 field values");
+    expectations.expect(decoded.srgbIntent == 0, "sRGB rendering intent is exactly 0 (perceptual)");
+    expectations.expect(decoded.everyRowFilterZero, "every row's filter byte is exactly 0 (None)");
+
+    expectations.expect(decoded.rgba.size() == pixels.size() * 4, "decoded byte count matches");
+    bool sampleMatch = decoded.rgba.size() == pixels.size() * 4;
+    if (sampleMatch) {
+        for (std::size_t index = 0; index < pixels.size(); ++index) {
+            const auto& pixel = pixels[index];
+            sampleMatch = sampleMatch && decoded.rgba[index * 4 + 0] == pixel.red &&
+                          decoded.rgba[index * 4 + 1] == pixel.green &&
+                          decoded.rgba[index * 4 + 2] == pixel.blue &&
+                          decoded.rgba[index * 4 + 3] == pixel.alpha;
+        }
+    }
+    expectations.expect(sampleMatch,
+                        "independently decoded RGBA8 samples exactly match the prepared stream "
+                        "(opaque/translucent/zero-alpha/extreme fixture)");
+}
+
+void testInvalidPreparedStreamRejected(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("invalid-prepared-stream");
+    const auto pixels = fixturePixels(); // 6 pixels, but claim 3x3 (9) below.
+    const auto extent = render::ImageExtent::create(3, 3);
+    if (!extent) {
+        std::abort();
+    }
+    const output::PngRgba8SrgbPreparedStreamV1 prepared{*extent.value(),
+                                                        std::span<const render::Rgba8>(pixels)};
+    const auto destination = scratch.file("mismatch.png");
+
+    const output::PngRgba8SrgbWriterV1 writer;
+    const auto result = writer.write(prepared, destination, {});
+    expectations.expect(result.status() == output::PngWriteStatusV1::Failed &&
+                            result.error() == output::PngWriteErrorCodeV1::InvalidPreparedStream &&
+                            result.destinationRemoved(),
+                        "a pixel-count/dimension mismatch is a typed InvalidPreparedStream "
+                        "failure, no partial file");
+    expectations.expect(!std::filesystem::exists(destination), "no file was created");
+}
+
+void testResourceLimitExceededRejected(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("resource-limit");
+    // Individually within the per-dimension ceiling (32768) but their product exceeds the pixel-
+    // count ceiling (67108864). The claimed pixel span is never dereferenced -- write() rejects
+    // before any pixel access once geometry validation fails -- so a null-backed span of the
+    // right claimed size is safe and avoids allocating an impractically large real buffer.
+    const auto extent = render::ImageExtent::create(32'768, 2'049);
+    if (!extent) {
+        std::abort();
+    }
+    const output::PngRgba8SrgbPreparedStreamV1 prepared{
+        *extent.value(), std::span<const render::Rgba8>(static_cast<const render::Rgba8*>(nullptr),
+                                                        std::size_t{32'768} * 2'049)};
+    const auto destination = scratch.file("oversized.png");
+
+    const output::PngRgba8SrgbWriterV1 writer;
+    const auto result = writer.write(prepared, destination, {});
+    expectations.expect(result.status() == output::PngWriteStatusV1::Failed &&
+                            result.error() == output::PngWriteErrorCodeV1::ResourceLimitExceeded &&
+                            result.destinationRemoved(),
+                        "a pixel count over the closed version 1 ceiling is a typed "
+                        "ResourceLimitExceeded failure, no partial file");
+}
+
+void testCancellationMidWrite(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("cancel-mid-write");
+    const auto destination = scratch.file("cancelled.png");
+
+    // A wide image so each row-chunk's byte cost is a meaningful fraction of the writer's 16 MiB
+    // streaming-chunk cap (kOutputAdapterMaximumStreamingChunkBytesV1); at the maximum permitted
+    // width (32768) a chunk is roughly 128 rows, so kHeight below spans several chunks, giving a
+    // deterministic chunk boundary to block on (mirrors flat_exr_output_adapter_tests.cpp's
+    // testCancellationMidWrite exactly).
+    constexpr std::uint32_t kWidth = 32'768;
+    constexpr std::uint32_t kHeight = 600;
+    std::vector<render::Rgba8> pixels(std::size_t{kWidth} * kHeight, render::Rgba8{1, 2, 3, 255});
+    const auto prepared = preparedStream(pixels, kWidth, kHeight);
+
+    runtime::TaskSchedulerConfig config = runtime::TaskSchedulerConfig::defaults();
+    config.cpuWorkerCount = 1;
+    config.blockingIoWorkerCount = 1;
+    runtime::TaskScheduler scheduler(config);
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool reachedRow = false;
+    bool released = false;
+    std::atomic_bool cancelled = false;
+    std::atomic_bool written = false;
+    const output::PngRgba8SrgbWriterV1 writer;
+
+    auto submission = scheduler.submit<void>(
+        runtime::TaskRequest("PNG write cancellation", {.kind = runtime::TaskOwnerKind::Composition,
+                                                        .id = runtime::TaskOwnerId::fromRaw(1)}),
+        [&](runtime::TaskContext& context) {
+            const auto result =
+                writer.write(prepared, destination, context.cancellation(),
+                             [&](const output::PngWriteProgressV1& progress) {
+                                 if (progress.completedRows == 0) {
+                                     return;
+                                 }
+                                 std::unique_lock lock(mutex);
+                                 reachedRow = true;
+                                 condition.notify_all();
+                                 condition.wait(lock, [&released] { return released; });
+                             });
+            cancelled.store(result.status() == output::PngWriteStatusV1::Cancelled,
+                            std::memory_order_release);
+            written.store(result.status() == output::PngWriteStatusV1::Written,
+                          std::memory_order_release);
+            return result.status() == output::PngWriteStatusV1::Cancelled
+                       ? runtime::TaskResult<void>::cancelled()
+                       : runtime::TaskResult<void>::succeeded();
+        });
+    {
+        std::unique_lock lock(mutex);
+        expectations.expect(submission.accepted() &&
+                                condition.wait_for(lock, 5s, [&reachedRow] { return reachedRow; }),
+                            "cancellation fixture reaches a deterministic chunk boundary");
+    }
+    submission.handle.cancel();
+    {
+        std::lock_guard lock(mutex);
+        released = true;
+        condition.notify_all();
+    }
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    std::optional<runtime::TaskResult<void>> taskResult;
+    while (!taskResult && std::chrono::steady_clock::now() < deadline) {
+        taskResult = submission.handle.tryTakeResult();
+        std::this_thread::yield();
+    }
+    expectations.expect(taskResult && taskResult->state() == runtime::TaskState::Cancelled &&
+                            cancelled.load(std::memory_order_acquire) &&
+                            !written.load(std::memory_order_acquire),
+                        "cancellation mid-write yields a typed Cancelled result, never Written");
+    expectations.expect(!std::filesystem::exists(destination),
+                        "cancellation mid-write leaves no partial staged file behind");
+    scheduler.beginShutdown();
+    while (!scheduler.isQuiescent() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    expectations.expect(scheduler.isQuiescent(), "cancellation fixture shuts down cleanly");
+}
+
+} // namespace
+
+int main() {
+    support::Expectations expectations;
+    testChunkConformanceAndIndependentDecode(expectations);
+    testInvalidPreparedStreamRejected(expectations);
+    testResourceLimitExceededRejected(expectations);
+    testCancellationMidWrite(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/output/tests/png_reopen_verifier_tests.cpp
+++ b/src/output/tests/png_reopen_verifier_tests.cpp
@@ -1,0 +1,552 @@
+// Tests for PngRgba8SrgbReopenVerifierV1 (issue #107): round trip (write, verify, issue identity;
+// semantic determinism AND byte-identical artifacts across two independent runs -- design decision
+// 6, claimable for this Bloom-owned encoder over pinned zlib, unlike the EXR case), an independent
+// (zlib-direct) decode cross-check, adversarial byte-surgery fixtures (each a typed failure naming
+// the defect, no identity issued), and cancellation mid-verify.
+
+#include "png_test_support.hpp"
+
+#include <bloom/output/png_output_adapter.hpp>
+#include <bloom/output/png_reopen_verifier.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+// zlib is used directly here twice, both deliberately independent of src/output's own writer/
+// verifier: (1) the round trip's "independent decode cross-check" (via
+// support::independentlyDecodePng) and (2) the "re-encode route" a few adversarial fixtures below
+// use (per F1's precedent: raw byte surgery on compressed IDAT bytes is unreliable -- a single
+// flipped compressed byte corrupts the whole deflate stream rather than proving one clean defect --
+// so those fixtures build a byte-valid replacement file with zlib directly instead).
+#include <zlib.h>
+
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <fstream>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+namespace core = bloom::core;
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+namespace support = bloom_output_png_test_support;
+
+// Opaque, translucent, zero-alpha, and byte-endpoint (0/255) extremes -- design decision 6's
+// fixture list -- at a small 3x2 image (matches png_output_adapter_tests.cpp's own copy; kept
+// local rather than shared since each test binary owns its own anonymous-namespace helpers, the
+// same idiom flat_exr_output_adapter_tests.cpp/flat_exr_reopen_verifier_tests.cpp already follow).
+[[nodiscard]] std::vector<render::Rgba8> fixturePixels() {
+    return {
+        render::Rgba8{255, 0, 0, 255}, render::Rgba8{0, 255, 0, 128},
+        render::Rgba8{0, 0, 255, 0},   render::Rgba8{255, 255, 255, 255},
+        render::Rgba8{0, 0, 0, 0},     render::Rgba8{17, 34, 51, 200},
+    };
+}
+
+constexpr std::uint32_t kFixtureWidth = 3;
+constexpr std::uint32_t kFixtureHeight = 2;
+
+[[nodiscard]] output::PngRgba8SrgbPreparedStreamV1
+preparedStream(const std::vector<render::Rgba8>& pixels, const std::uint32_t width,
+               const std::uint32_t height) {
+    const auto extent = render::ImageExtent::create(width, height);
+    if (!extent) {
+        std::abort();
+    }
+    return {*extent.value(), std::span<const render::Rgba8>(pixels)};
+}
+
+struct WrittenFixture final {
+    support::PreparedSource source;
+    std::filesystem::path path;
+};
+
+[[nodiscard]] WrittenFixture writeValidFixture(const support::ScratchDirectory& scratch,
+                                               const std::string& fileName,
+                                               const output::PngRgba8SrgbPreparedStreamV1& prepared,
+                                               const std::uint32_t width,
+                                               const std::uint32_t height) {
+    auto source = support::prepareSource(support::pngShapedFixture(width, height));
+    const auto path = scratch.file(fileName);
+    const output::PngRgba8SrgbWriterV1 writer;
+    const auto written = writer.write(prepared, path, {});
+    if (written.status() != output::PngWriteStatusV1::Written) {
+        std::abort();
+    }
+    return {std::move(source), path};
+}
+
+[[nodiscard]] output::PngVerifyResultV1
+verifyFixture(const WrittenFixture& fixture, const output::PngRgba8SrgbPreparedStreamV1& prepared) {
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    return verifier.verify(fixture.path, prepared, fixture.source.processIdentity,
+                           fixture.source.report, fixture.source.expectedOcioRevision,
+                           fixture.source.displayProcessorIdentity, {});
+}
+
+void testRoundTrip(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("round-trip");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto runA = writeValidFixture(scratch, "run-a.png", prepared, kFixtureWidth, kFixtureHeight);
+    auto runB = writeValidFixture(scratch, "run-b.png", prepared, kFixtureWidth, kFixtureHeight);
+
+    const auto resultA = verifyFixture(runA, prepared);
+    const auto resultB = verifyFixture(runB, prepared);
+    expectations.expect(resultA.status() == output::PngVerifyStatusV1::Verified,
+                        "an independent write+verify of a valid fixture is Verified");
+    expectations.expect(resultB.status() == output::PngVerifyStatusV1::Verified,
+                        "a second independent write+verify of the same fixture is Verified");
+    expectations.expect(resultA.status() == output::PngVerifyStatusV1::Verified &&
+                            resultB.status() == output::PngVerifyStatusV1::Verified &&
+                            resultA.digest() == resultB.digest(),
+                        "the kind-1 semantic identity digest is stable across two independent "
+                        "write+verify runs (semantic determinism)");
+
+    // Design decision 6: for this Bloom-owned encoder over the pinned qualified zlib, byte-
+    // identical artifacts across two independent encode runs over the same prepared stream is
+    // claimable and asserted, unlike the EXR case.
+    std::ifstream streamA(runA.path, std::ios::binary);
+    std::ifstream streamB(runB.path, std::ios::binary);
+    const std::vector<char> contentA((std::istreambuf_iterator<char>(streamA)),
+                                     std::istreambuf_iterator<char>());
+    const std::vector<char> contentB((std::istreambuf_iterator<char>(streamB)),
+                                     std::istreambuf_iterator<char>());
+    expectations.expect(contentA == contentB,
+                        "two independent encode runs over the same prepared stream are "
+                        "byte-identical");
+
+    // Independent decode cross-check: a from-scratch zlib-direct reader (never calling this
+    // verifier's own internals) proves the encoder's artifact a second way.
+    const auto independent = support::independentlyDecodePng(runA.path);
+    expectations.expect(independent.ok && independent.everyCrcValid &&
+                            independent.everyRowFilterZero,
+                        "an independent zlib-direct decode also proves valid CRCs and filter-0 "
+                        "rows");
+    bool sampleMatch = independent.ok && independent.rgba.size() == pixels.size() * 4;
+    if (sampleMatch) {
+        for (std::size_t index = 0; index < pixels.size(); ++index) {
+            const auto& pixel = pixels[index];
+            sampleMatch = sampleMatch && independent.rgba[index * 4 + 0] == pixel.red &&
+                          independent.rgba[index * 4 + 1] == pixel.green &&
+                          independent.rgba[index * 4 + 2] == pixel.blue &&
+                          independent.rgba[index * 4 + 3] == pixel.alpha;
+        }
+    }
+    expectations.expect(sampleMatch,
+                        "the independent decode's samples exactly match the prepared stream");
+}
+
+void testForeignAncillaryChunk(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-foreign-ancillary");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto fixture = writeValidFixture(scratch, "base.png", prepared, kFixtureWidth, kFixtureHeight);
+    const auto corruptPath = scratch.file("foreign-ancillary.png");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::PngChunkBytes bytes(corruptPath);
+    const auto [idatDataOffset, idatLength] = bytes.dataRange("IDAT", 0);
+    (void)idatLength;
+    bytes.insertChunk(idatDataOffset - 8, "tEXt", {'C', 'o', 'm', 'm', 'e', 'n', 't', 0, 'h', 'i'});
+    bytes.save();
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result = verifier.verify(corruptPath, prepared, fixture.source.processIdentity,
+                                        fixture.source.report, fixture.source.expectedOcioRevision,
+                                        fixture.source.displayProcessorIdentity, {});
+    expectations.expect(result.status() == output::PngVerifyStatusV1::Failed &&
+                            result.diagnostic().code ==
+                                output::PngVerifyErrorCodeV1::UnexpectedChunkType &&
+                            result.diagnostic().chunkType == "tEXt",
+                        "a spliced foreign ancillary chunk (tEXt) is a typed failure naming it, no "
+                        "identity issued");
+}
+
+void testForeignCriticalChunk(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-foreign-critical");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto fixture = writeValidFixture(scratch, "base.png", prepared, kFixtureWidth, kFixtureHeight);
+    const auto corruptPath = scratch.file("foreign-critical.png");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::PngChunkBytes bytes(corruptPath);
+    const auto [idatDataOffset, idatLength] = bytes.dataRange("IDAT", 0);
+    (void)idatLength;
+    // PLTE is a real critical PNG chunk this v1 profile forbids -- inserted before the first IDAT.
+    bytes.insertChunk(idatDataOffset - 8, "PLTE", {0, 0, 0});
+    bytes.save();
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result = verifier.verify(corruptPath, prepared, fixture.source.processIdentity,
+                                        fixture.source.report, fixture.source.expectedOcioRevision,
+                                        fixture.source.displayProcessorIdentity, {});
+    expectations.expect(
+        result.status() == output::PngVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::PngVerifyErrorCodeV1::UnexpectedChunkType &&
+            result.diagnostic().chunkType == "PLTE",
+        "a spliced foreign critical chunk (PLTE) is a typed failure naming it, no identity issued");
+}
+
+void testCorruptedCrc(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-crc");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto fixture = writeValidFixture(scratch, "base.png", prepared, kFixtureWidth, kFixtureHeight);
+    const auto corruptPath = scratch.file("bad-crc.png");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::PngChunkBytes bytes(corruptPath);
+    const auto [dataOffset, length] = bytes.dataRange("IHDR", 0);
+    (void)length;
+    // Flip a byte inside IHDR's data without fixing up the CRC.
+    bytes.patchByteBreakingCrc(dataOffset,
+                               static_cast<unsigned char>(bytes.byteAt(dataOffset) ^ 1U));
+    bytes.save();
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result = verifier.verify(corruptPath, prepared, fixture.source.processIdentity,
+                                        fixture.source.report, fixture.source.expectedOcioRevision,
+                                        fixture.source.displayProcessorIdentity, {});
+    expectations.expect(result.status() == output::PngVerifyStatusV1::Failed &&
+                            result.diagnostic().code ==
+                                output::PngVerifyErrorCodeV1::ChunkCrcMismatch &&
+                            result.diagnostic().chunkType == "IHDR",
+                        "a corrupted CRC is a typed ChunkCrcMismatch failure naming the chunk, no "
+                        "identity issued");
+}
+
+void testIhdrFieldPerturbation(support::Expectations& expectations) {
+    const struct {
+        const char* label;
+        std::size_t offset;
+        unsigned char value;
+    } cases[] = {
+        {"bit depth", 8, 16},
+        {"color type", 9, 2},
+        {"interlace method", 12, 1},
+    };
+    for (const auto& testCase : cases) {
+        const support::ScratchDirectory scratch(std::string("adversarial-ihdr-") + testCase.label);
+        const auto pixels = fixturePixels();
+        const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+        auto fixture =
+            writeValidFixture(scratch, "base.png", prepared, kFixtureWidth, kFixtureHeight);
+        const auto corruptPath = scratch.file("perturbed.png");
+        std::filesystem::copy_file(fixture.path, corruptPath);
+
+        support::PngChunkBytes bytes(corruptPath);
+        bytes.patchDataByteWithValidCrc("IHDR", 0, testCase.offset, testCase.value);
+        bytes.save();
+
+        const output::PngRgba8SrgbReopenVerifierV1 verifier;
+        const auto result = verifier.verify(
+            corruptPath, prepared, fixture.source.processIdentity, fixture.source.report,
+            fixture.source.expectedOcioRevision, fixture.source.displayProcessorIdentity, {});
+        expectations.expect(result.status() == output::PngVerifyStatusV1::Failed &&
+                                result.diagnostic().code ==
+                                    output::PngVerifyErrorCodeV1::IhdrFieldMismatch,
+                            std::string("an IHDR ") + testCase.label +
+                                " perturbation (CRC kept valid) is a typed "
+                                "IhdrFieldMismatch failure");
+    }
+}
+
+void testSrgbIntentNonZero(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-srgb-intent");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto fixture = writeValidFixture(scratch, "base.png", prepared, kFixtureWidth, kFixtureHeight);
+    const auto corruptPath = scratch.file("bad-intent.png");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::PngChunkBytes bytes(corruptPath);
+    bytes.patchDataByteWithValidCrc("sRGB", 0, 0, 1);
+    bytes.save();
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result = verifier.verify(corruptPath, prepared, fixture.source.processIdentity,
+                                        fixture.source.report, fixture.source.expectedOcioRevision,
+                                        fixture.source.displayProcessorIdentity, {});
+    expectations.expect(
+        result.status() == output::PngVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::PngVerifyErrorCodeV1::SrgbIntentMismatch,
+        "an sRGB rendering intent other than 0 (CRC kept valid) is a typed SrgbIntentMismatch "
+        "failure");
+}
+
+void testTruncationMidChunk(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-truncated");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto fixture = writeValidFixture(scratch, "base.png", prepared, kFixtureWidth, kFixtureHeight);
+    const auto corruptPath = scratch.file("truncated.png");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::PngChunkBytes bytes(corruptPath);
+    const auto [idatDataOffset, idatLength] = bytes.dataRange("IDAT", 0);
+    bytes.truncateTo(idatDataOffset + idatLength / 2); // well inside the IDAT data, before its CRC
+    bytes.save();
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result = verifier.verify(corruptPath, prepared, fixture.source.processIdentity,
+                                        fixture.source.report, fixture.source.expectedOcioRevision,
+                                        fixture.source.displayProcessorIdentity, {});
+    expectations.expect(result.status() == output::PngVerifyStatusV1::Failed &&
+                            result.diagnostic().code == output::PngVerifyErrorCodeV1::TruncatedFile,
+                        "a file truncated mid-chunk is a typed TruncatedFile failure, no identity "
+                        "issued");
+}
+
+void testTrailingBytesAfterIend(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-trailing");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto fixture = writeValidFixture(scratch, "base.png", prepared, kFixtureWidth, kFixtureHeight);
+    const auto corruptPath = scratch.file("trailing.png");
+    std::filesystem::copy_file(fixture.path, corruptPath);
+
+    support::PngChunkBytes bytes(corruptPath);
+    bytes.appendBytes(std::array<unsigned char, 4>{0xDE, 0xAD, 0xBE, 0xEF});
+    bytes.save();
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result = verifier.verify(corruptPath, prepared, fixture.source.processIdentity,
+                                        fixture.source.report, fixture.source.expectedOcioRevision,
+                                        fixture.source.displayProcessorIdentity, {});
+    expectations.expect(
+        result.status() == output::PngVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::PngVerifyErrorCodeV1::TrailingBytesAfterIend,
+        "trailing bytes after IEND are a typed TrailingBytesAfterIend failure, no identity issued");
+}
+
+void appendU32(std::vector<unsigned char>& out, const std::uint32_t value) {
+    out.push_back(static_cast<unsigned char>((value >> 24U) & 0xFFU));
+    out.push_back(static_cast<unsigned char>((value >> 16U) & 0xFFU));
+    out.push_back(static_cast<unsigned char>((value >> 8U) & 0xFFU));
+    out.push_back(static_cast<unsigned char>(value & 0xFFU));
+}
+
+void appendChunk(std::vector<unsigned char>& out, const std::array<char, 4>& type,
+                 const std::vector<unsigned char>& data) {
+    appendU32(out, static_cast<std::uint32_t>(data.size()));
+    for (const char character : type) {
+        out.push_back(static_cast<unsigned char>(character));
+    }
+    out.insert(out.end(), data.begin(), data.end());
+    auto crc = crc32_z(0L, reinterpret_cast<const Bytef*>(type.data()), type.size());
+    if (!data.empty()) {
+        crc = crc32_z(crc, data.data(), data.size());
+    }
+    appendU32(out, static_cast<std::uint32_t>(crc));
+}
+
+// Builds a byte-valid PNG (correct signature/IHDR/sRGB/IEND, one IDAT holding
+// deflate(uncompressedPayload) under this preset's exact fixed parameters) with zlib directly --
+// the "re-encode route" for adversarial cases pure byte surgery on compressed bytes cannot reach
+// cleanly (per F1's ExrHeaderBytes precedent comment).
+void writeCustomPng(const std::filesystem::path& path, const std::uint32_t width,
+                    const std::uint32_t height,
+                    const std::vector<unsigned char>& uncompressedPayload) {
+    std::vector<unsigned char> bytes;
+    static constexpr std::array<unsigned char, 8> kSignature{137, 80, 78, 71, 13, 10, 26, 10};
+    bytes.insert(bytes.end(), kSignature.begin(), kSignature.end());
+
+    std::vector<unsigned char> ihdr;
+    appendU32(ihdr, width);
+    appendU32(ihdr, height);
+    ihdr.push_back(8);
+    ihdr.push_back(6);
+    ihdr.push_back(0);
+    ihdr.push_back(0);
+    ihdr.push_back(0);
+    appendChunk(bytes, {'I', 'H', 'D', 'R'}, ihdr);
+    appendChunk(bytes, {'s', 'R', 'G', 'B'}, {0});
+
+    z_stream stream{};
+    if (deflateInit2(&stream, 6, Z_DEFLATED, 15, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
+        std::abort();
+    }
+    std::vector<unsigned char> compressed(
+        deflateBound(&stream, static_cast<uLong>(uncompressedPayload.size())));
+    stream.next_in = const_cast<Bytef*>(uncompressedPayload.data());
+    stream.avail_in = static_cast<uInt>(uncompressedPayload.size());
+    stream.next_out = compressed.data();
+    stream.avail_out = static_cast<uInt>(compressed.size());
+    if (deflate(&stream, Z_FINISH) != Z_STREAM_END) {
+        std::abort();
+    }
+    compressed.resize(compressed.size() - stream.avail_out);
+    deflateEnd(&stream);
+    appendChunk(bytes, {'I', 'D', 'A', 'T'}, compressed);
+    appendChunk(bytes, {'I', 'E', 'N', 'D'}, {});
+
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        std::abort();
+    }
+    out.write(reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+}
+
+void testNonzeroRowFilterByte(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-row-filter");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto source = support::prepareSource(support::pngShapedFixture(kFixtureWidth, kFixtureHeight));
+    const auto path = scratch.file("nonzero-filter.png");
+
+    std::vector<unsigned char> payload;
+    for (std::uint32_t row = 0; row < kFixtureHeight; ++row) {
+        // Row 1 declares filter type 1 (Sub) instead of the required 0 (None); the raw sample
+        // bytes are left unchanged, which is exactly the defect under test -- the verifier only
+        // requires the filter byte itself to be 0, independent of whether the row would decode
+        // correctly under a different declared filter.
+        payload.push_back(row == 1 ? 1 : 0);
+        for (std::uint32_t x = 0; x < kFixtureWidth; ++x) {
+            const auto& pixel = pixels[(row * kFixtureWidth) + x];
+            payload.push_back(pixel.red);
+            payload.push_back(pixel.green);
+            payload.push_back(pixel.blue);
+            payload.push_back(pixel.alpha);
+        }
+    }
+    writeCustomPng(path, kFixtureWidth, kFixtureHeight, payload);
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(path, prepared, source.processIdentity, source.report,
+                        source.expectedOcioRevision, source.displayProcessorIdentity, {});
+    expectations.expect(result.status() == output::PngVerifyStatusV1::Failed &&
+                            result.diagnostic().code ==
+                                output::PngVerifyErrorCodeV1::RowFilterByteNonzero &&
+                            result.diagnostic().row.has_value() && *result.diagnostic().row == 1,
+                        "a nonzero row filter byte is caught and the failing row is named exactly");
+}
+
+void testOversizedIdatExpansion(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("adversarial-zlib-bomb");
+    const auto pixels = fixturePixels();
+    const auto prepared = preparedStream(pixels, kFixtureWidth, kFixtureHeight);
+    auto source = support::prepareSource(support::pngShapedFixture(kFixtureWidth, kFixtureHeight));
+    const auto path = scratch.file("oversized.png");
+
+    // Expected inflate size is height*(1+width*4) = 2*(1+12) = 26 bytes. This payload's true
+    // (highly compressible, so still a small IDAT chunk) uncompressed size is far larger --
+    // exactly the zlib-bomb shape the checked expanded-size ceiling exists to catch.
+    const std::vector<unsigned char> oversizedPayload(1U << 16U, 0);
+    writeCustomPng(path, kFixtureWidth, kFixtureHeight, oversizedPayload);
+
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto result =
+        verifier.verify(path, prepared, source.processIdentity, source.report,
+                        source.expectedOcioRevision, source.displayProcessorIdentity, {});
+    expectations.expect(
+        result.status() == output::PngVerifyStatusV1::Failed &&
+            result.diagnostic().code == output::PngVerifyErrorCodeV1::IdatExpandedSizeExceeded,
+        "an IDAT stream declaring far more decompressed bytes than the checked expected ceiling "
+        "(a zlib-bomb shape) is a typed resource failure, no identity issued");
+}
+
+void testCancellationMidVerify(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("cancel-mid-verify");
+    // A wide image so each row-chunk is a meaningful fraction of the verifier's 16 MiB streaming
+    // chunk cap, giving a deterministic chunk boundary to block on during the sample-comparison
+    // phase (mirrors flat_exr_reopen_verifier_tests.cpp's testCancellationMidVerify exactly).
+    constexpr std::uint32_t kWidth = 32'768;
+    constexpr std::uint32_t kHeight = 600;
+    std::vector<render::Rgba8> pixels(std::size_t{kWidth} * kHeight, render::Rgba8{9, 8, 7, 255});
+    const auto prepared = preparedStream(pixels, kWidth, kHeight);
+    auto fixture = writeValidFixture(scratch, "large.png", prepared, kWidth, kHeight);
+
+    runtime::TaskSchedulerConfig config = runtime::TaskSchedulerConfig::defaults();
+    config.cpuWorkerCount = 1;
+    config.blockingIoWorkerCount = 1;
+    runtime::TaskScheduler scheduler(config);
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool reachedRow = false;
+    bool released = false;
+    std::atomic_bool cancelled = false;
+    std::atomic_bool verified = false;
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+
+    auto submission = scheduler.submit<void>(
+        runtime::TaskRequest(
+            "PNG verify cancellation",
+            {.kind = runtime::TaskOwnerKind::Composition, .id = runtime::TaskOwnerId::fromRaw(1)}),
+        [&](runtime::TaskContext& context) {
+            const auto result = verifier.verify(
+                fixture.path, prepared, fixture.source.processIdentity, fixture.source.report,
+                fixture.source.expectedOcioRevision, fixture.source.displayProcessorIdentity,
+                context.cancellation(), [&](const output::PngVerifyProgressV1& progress) {
+                    if (progress.completedRows == 0) {
+                        return;
+                    }
+                    std::unique_lock lock(mutex);
+                    reachedRow = true;
+                    condition.notify_all();
+                    condition.wait(lock, [&released] { return released; });
+                });
+            cancelled.store(result.status() == output::PngVerifyStatusV1::Cancelled,
+                            std::memory_order_release);
+            verified.store(result.status() == output::PngVerifyStatusV1::Verified,
+                           std::memory_order_release);
+            return result.status() == output::PngVerifyStatusV1::Cancelled
+                       ? runtime::TaskResult<void>::cancelled()
+                       : runtime::TaskResult<void>::succeeded();
+        });
+    {
+        std::unique_lock lock(mutex);
+        expectations.expect(submission.accepted() &&
+                                condition.wait_for(lock, 5s, [&reachedRow] { return reachedRow; }),
+                            "cancellation fixture reaches a deterministic row-chunk boundary");
+    }
+    submission.handle.cancel();
+    {
+        std::lock_guard lock(mutex);
+        released = true;
+        condition.notify_all();
+    }
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    std::optional<runtime::TaskResult<void>> taskResult;
+    while (!taskResult && std::chrono::steady_clock::now() < deadline) {
+        taskResult = submission.handle.tryTakeResult();
+        std::this_thread::yield();
+    }
+    expectations.expect(taskResult && taskResult->state() == runtime::TaskState::Cancelled &&
+                            cancelled.load(std::memory_order_acquire) &&
+                            !verified.load(std::memory_order_acquire),
+                        "cancellation mid-verify yields a typed Cancelled result, never Verified "
+                        "(no identity issued)");
+    scheduler.beginShutdown();
+    while (!scheduler.isQuiescent() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    expectations.expect(scheduler.isQuiescent(), "cancellation fixture shuts down cleanly");
+}
+
+} // namespace
+
+int main() {
+    support::Expectations expectations;
+    testRoundTrip(expectations);
+    testForeignAncillaryChunk(expectations);
+    testForeignCriticalChunk(expectations);
+    testCorruptedCrc(expectations);
+    testIhdrFieldPerturbation(expectations);
+    testSrgbIntentNonZero(expectations);
+    testTruncationMidChunk(expectations);
+    testTrailingBytesAfterIend(expectations);
+    testNonzeroRowFilterByte(expectations);
+    testOversizedIdatExpansion(expectations);
+    testCancellationMidVerify(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/output/tests/png_test_support.hpp
+++ b/src/output/tests/png_test_support.hpp
@@ -1,0 +1,678 @@
+#pragma once
+
+// Shared fixture/harness support for the PNG writer and reopen-verifier test binaries (issue
+// #107). Mirrors flat_exr_test_support.hpp's golden idiom for obtaining a real
+// `ProcessFrameSemanticIdentityV1` (evaluate a trivial one-pixel plan through the actual
+// `CpuCompositionEvaluator`, then move-assign an arbitrary fixture identity/image into the
+// published frame) and adds the two PNG-only fixtures flat OpenEXR never needed: a real
+// `DisplayProcessorIdentityV1` (built through the color module's own public
+// validate/write/adopt sequence -- the same one display_processor_identity_tests.cpp's
+// `goldenInput()` idiom exercises) and the caller-supplied `PngRgba8SrgbPreparedStreamV1` RGBA8
+// byte fixture itself (this preset's encoder input surface, independent of the process frame's
+// own RGBA32F content -- see png_output_adapter.hpp's own design-decision-3 rationale).
+
+#include <bloom/color/display_processor_identity.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/core/sha256.hpp>
+#include <bloom/output/output_analysis.hpp>
+#include <bloom/output/output_analysis_analyzer.hpp>
+#include <bloom/output/process_frame_semantic_identity.hpp>
+#include <bloom/render/image.hpp>
+#include <bloom/runtime/compiled_plan.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/evaluation.hpp>
+
+// Used only by independentlyDecodePng() below -- a from-scratch reader (raw chunk parse + zlib
+// inflate) that never calls into src/output's own png_output_adapter.cpp/png_reopen_verifier.cpp,
+// so a round-trip test can "prove the encoder against a second reading" (design decision's own
+// wording) rather than exercising the verifier's internals a second time.
+#include <zlib.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <source_location>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace bloom_output_png_test_support {
+
+namespace color = bloom::color;
+namespace core = bloom::core;
+namespace document = bloom::document;
+namespace output = bloom::output;
+namespace render = bloom::render;
+namespace runtime = bloom::runtime;
+
+constexpr auto kProjectId = document::ProjectId::fromRaw(0x11121314151617ULL);
+constexpr auto kCompositionId = document::CompositionId::fromRaw(0x21222324252627ULL);
+constexpr auto kOutputNodeId = document::NodeId::fromRaw(0x31323334353637ULL);
+constexpr auto kInputNodeId = document::NodeId::fromRaw(0x41424344454647ULL);
+constexpr auto kColorParameterId = document::ParameterId::fromRaw(0x51525354555657ULL);
+constexpr auto kSourceRevision = document::Revision::fromRaw(0x61626364656667ULL);
+constexpr auto kShellLayerNodeId = document::NodeId::fromRaw(0x71);
+constexpr auto kShellLayerId = document::LayerId::fromRaw(0x72);
+constexpr auto kShellStackNodeId = document::NodeId::fromRaw(0x73);
+constexpr auto kShellSlotId = document::LayerSlotId::fromRaw(0x74);
+constexpr auto kShellPositionParameterId = document::ParameterId::fromRaw(0x75);
+constexpr auto kShellOpacityParameterId = document::ParameterId::fromRaw(0x76);
+
+// The revision fixture bytes both `expectedOcioRevision` and the built `DisplayProcessorIdentityV1`
+// embed -- the doc's own cross-check ("the separate expected OCIO revision must equal ... the
+// revision embedded in the canonical DisplayProcessorIdentity").
+constexpr core::Sha256Digest::Bytes kRevisionBytes{
+    0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
+    0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF,
+};
+
+[[nodiscard]] inline render::ImageWindow window(const std::int64_t originX,
+                                                const std::int64_t originY,
+                                                const std::uint32_t width,
+                                                const std::uint32_t height) {
+    const auto value = render::ImageWindow::create(originX, originY, width, height);
+    if (!value) {
+        std::abort();
+    }
+    return *value.value();
+}
+
+[[nodiscard]] inline render::Rgba32f pixel(const float red, const float green, const float blue,
+                                           const float alpha) {
+    const auto value = render::Rgba32f::fromPremultiplied(red, green, blue, alpha);
+    if (!value) {
+        std::abort();
+    }
+    return *value.value();
+}
+
+// The process frame's own pixel content is never observed by the PNG verifier (design decision 3:
+// the prepared RGBA8 stream, not the process frame, is what gets compared bit-exact) -- it only
+// needs a valid image whose data/display windows equal (0,0,width,height) and whose pixel aspect
+// is square, matching PNG's own required source-descriptor shape
+// (docs/architecture/frame-output.md, "PNG Preset Version 1": "origin (0, 0), identical data and
+// display windows, and square pixel aspect").
+[[nodiscard]] inline render::Rgba32fImage pngShapedImage(const std::uint32_t width,
+                                                         const std::uint32_t height) {
+    const auto dataWindow = window(0, 0, width, height);
+    const auto descriptor = render::Rgba32fImageDescriptor::create(
+        dataWindow, dataWindow, core::PixelAspectRatio::square());
+    if (!descriptor) {
+        std::abort();
+    }
+    auto builder = render::Rgba32fImageBuilder::create(
+        *descriptor.value(), descriptor.value()->layout().pixelStorageBytes);
+    if (!builder) {
+        std::abort();
+    }
+    const auto fill = pixel(0.25F, 0.5F, 0.75F, 1.0F);
+    for (std::uint32_t rowIndex = 0; rowIndex < height; ++rowIndex) {
+        auto row = builder.value()->row(static_cast<std::int64_t>(rowIndex));
+        if (!row) {
+            std::abort();
+        }
+        std::ranges::fill(*row.value(), fill);
+    }
+    auto frozen = std::move(*builder.value()).freeze();
+    if (!frozen) {
+        std::abort();
+    }
+    return std::move(*frozen.value());
+}
+
+// Composition Output requires a layer-stack input, not a bare solid (mirrors
+// flat_exr_test_support.hpp's shellPlan()). This plan's own pixels are never observed: publish()
+// immediately overwrites the evaluated frame's image/identity with a fixture.
+[[nodiscard]] inline std::shared_ptr<const runtime::CompiledCompositionPlan> shellPlan() {
+    const auto format = document::CompositionFormat::create(1, 1);
+    if (!format) {
+        std::abort();
+    }
+    std::vector<runtime::CompiledOperation> operations;
+    operations.emplace_back(
+        runtime::CompiledSolid{kInputNodeId, kColorParameterId, {0.0, 0.0, 0.0, 0.0}});
+    operations.emplace_back(runtime::CompiledLayerOutput{
+        kShellLayerNodeId, kShellLayerId, runtime::OperationIndex::fromRaw(0),
+        runtime::CompiledVec2Parameter{kShellPositionParameterId, document::Vec2d{0.5, 0.5}},
+        runtime::CompiledScalarParameter{kShellOpacityParameterId, 1.0}});
+    operations.emplace_back(runtime::CompiledLayerStack{
+        kShellStackNodeId, {{kShellSlotId, kShellLayerId, runtime::OperationIndex::fromRaw(1)}}});
+    operations.emplace_back(
+        runtime::CompiledCompositionOutput{kOutputNodeId, runtime::OperationIndex::fromRaw(2)});
+    return std::make_shared<const runtime::CompiledCompositionPlan>(
+        runtime::CompiledCompositionPlanDefinition{.sourceRevision = kSourceRevision,
+                                                   .projectId = kProjectId,
+                                                   .compositionId = kCompositionId,
+                                                   .format = *format,
+                                                   .operations = std::move(operations),
+                                                   .output = runtime::OperationIndex::fromRaw(3)});
+}
+
+// A minimal plan used only to give ProcessFrameIdentity an opaque `.plan` handle whose
+// CompositionFormat declares the exact width/height a fixture's display window claims (mirrors
+// flat_exr_test_support.hpp's identityPlan()). This plan is never evaluated.
+[[nodiscard]] inline std::shared_ptr<const runtime::CompiledCompositionPlan>
+identityPlan(const std::uint32_t width, const std::uint32_t height) {
+    const auto format = document::CompositionFormat::create(width, height);
+    if (!format) {
+        std::abort();
+    }
+    std::vector<runtime::CompiledOperation> operations;
+    operations.emplace_back(runtime::CompiledSolid{kInputNodeId, kColorParameterId, {}});
+    operations.emplace_back(
+        runtime::CompiledCompositionOutput{kOutputNodeId, runtime::OperationIndex::fromRaw(0)});
+    return std::make_shared<const runtime::CompiledCompositionPlan>(
+        runtime::CompiledCompositionPlanDefinition{.sourceRevision = kSourceRevision,
+                                                   .projectId = kProjectId,
+                                                   .compositionId = kCompositionId,
+                                                   .format = *format,
+                                                   .operations = std::move(operations),
+                                                   .output = runtime::OperationIndex::fromRaw(1)});
+}
+
+[[nodiscard]] inline std::shared_ptr<const runtime::ProcessFrame> evaluateShell() {
+    const auto compiledPlan = shellPlan();
+    const runtime::EvaluationRequest request{.time = core::RationalTime::fromInteger(0),
+                                             .output = compiledPlan->output(),
+                                             .resolution = runtime::CompositionFormatResolution{},
+                                             .quality = runtime::EvaluationQuality::Reference,
+                                             .colorIntent =
+                                                 runtime::EvaluationColorIntent::LinearRec709Scene,
+                                             .pixelStorageByteLimit = 4096};
+    const runtime::CpuCompositionEvaluator evaluator;
+    const auto result = evaluator.evaluate(compiledPlan, request, {});
+    if (result.status() != runtime::EvaluationStatus::Evaluated || result.frame() == nullptr) {
+        for (const auto& diagnostic : result.diagnostics()) {
+            std::cerr << "evaluateShell diagnostic: "
+                      << runtime::evaluationDiagnosticCodeId(diagnostic.code)
+                      << " summary=" << diagnostic.summary << " detail=" << diagnostic.detail
+                      << '\n';
+        }
+        std::abort();
+    }
+    return result.frame();
+}
+
+struct Fixture final {
+    runtime::ProcessFrameIdentity identity;
+    render::Rgba32fImage processImage;
+};
+
+// Publishes `fixture` as the retained image/identity of a real (privately-constructed)
+// `ProcessFrame` (mirrors flat_exr_test_support.hpp's publish()).
+[[nodiscard]] inline std::shared_ptr<const runtime::ProcessFrame> publish(Fixture fixture) {
+    auto published = std::const_pointer_cast<runtime::ProcessFrame>(evaluateShell());
+    auto& identity = const_cast<runtime::ProcessFrameIdentity&>(published->identity());
+    auto& processImage = const_cast<render::Rgba32fImage&>(published->processImage());
+    identity = std::move(fixture.identity);
+    processImage = std::move(fixture.processImage);
+    return published;
+}
+
+[[nodiscard]] inline runtime::ProcessFrameIdentity
+frameIdentity(const std::shared_ptr<const runtime::CompiledCompositionPlan>& compiledPlan) {
+    const auto time = core::RationalTime::create(1, 2);
+    if (!time) {
+        std::abort();
+    }
+    return {.plan = compiledPlan,
+            .time = *time,
+            .output = compiledPlan->output(),
+            .resolution = runtime::CompositionFormatResolution{},
+            .quality = runtime::EvaluationQuality::Reference,
+            .colorIntent = runtime::EvaluationColorIntent::LinearRec709Scene,
+            .provider = runtime::EvaluationProvider::CpuReference,
+            .evaluatorSemanticsVersion = 1,
+            .animationSamplingSemanticsVersion = 1,
+            .imagePrimitiveSemanticsVersion = 1};
+}
+
+[[nodiscard]] inline Fixture pngShapedFixture(const std::uint32_t width,
+                                              const std::uint32_t height) {
+    return {frameIdentity(identityPlan(width, height)), pngShapedImage(width, height)};
+}
+
+// A real, validated `DisplayProcessorIdentityV1`, built through the color module's own public
+// validate/write/adopt sequence (the same one display_processor_identity_tests.cpp's
+// `goldenInput()`/`writeDisplayProcessorIdentityV1()`/`adoptDisplayProcessorIdentityV1()` idiom
+// exercises). Its embedded revision is exactly kRevisionBytes.
+[[nodiscard]] inline color::DisplayProcessorIdentityV1 fixtureDisplayIdentity() {
+    static constexpr std::array<std::string_view, 0> kNoLooks{};
+    const color::DisplayProcessorIdentityV1InputView input{
+        .expectedOcioRevision = core::Sha256Digest::fromBytes(kRevisionBytes),
+        .contextVariables = {},
+        .sourceColorSpaceId = color::kDisplayProcessorIdentitySourceColorSpaceId,
+        .displayName = "sRGB",
+        .viewName = "Standard",
+        .lookMode = color::DisplayProcessorLookModeV1::Bypass,
+        .lookNames = kNoLooks,
+        .outputColorSpaceId = color::kDisplayProcessorIdentityOutputColorSpaceId,
+        .qualityId = color::kDisplayProcessorIdentityQualityId,
+        .semanticsProfileId = color::kDisplayProcessorIdentitySemanticsProfileId,
+        .packingId = color::kDisplayProcessorIdentityPackingId,
+    };
+    const auto validation = color::validateDisplayProcessorIdentityV1(input);
+    if (!validation) {
+        std::abort();
+    }
+    std::vector<std::byte> storage(validation.requiredByteCount());
+    const auto written = color::writeDisplayProcessorIdentityV1(input, storage);
+    if (!written) {
+        std::abort();
+    }
+    auto adopted = color::adoptDisplayProcessorIdentityV1(std::move(storage));
+    auto identity = std::move(adopted).takeIdentity();
+    if (!identity) {
+        std::abort();
+    }
+    return std::move(*identity);
+}
+
+// Both the process-identity/report pair (the exact public inputs the reopen verifier's
+// processIdentity/report parameters require) and the PNG-only expectedOcioRevision/
+// displayProcessorIdentity pair the kind-1 identity seam additionally requires (design decision
+// 4). Mirrors flat_exr_test_support.hpp's PreparedSource, extended with the two PNG-only fields.
+struct PreparedSource final {
+    std::shared_ptr<const runtime::ProcessFrame> frame;
+    std::shared_ptr<const output::ProcessFrameSemanticIdentityV1> processIdentity;
+    std::shared_ptr<const output::OutputAnalysisReportV1> report;
+    core::Sha256Digest expectedOcioRevision;
+    std::shared_ptr<const color::DisplayProcessorIdentityV1> displayProcessorIdentity;
+};
+
+// Runs the already-implemented pre-approval pipeline this slice consumes but does not
+// reimplement: prepare the frame-bound `ProcessFrameSemanticIdentityV1` and analyze it with the
+// existing PNG analyzer -- the exact public input shape the reopen verifier requires.
+[[nodiscard]] inline PreparedSource prepareSource(Fixture fixture) {
+    auto frame = publish(std::move(fixture));
+
+    const output::ProcessFrameSemanticIdentityV1Preparer identityPreparer;
+    const auto identityResult = identityPreparer.prepare(frame, {});
+    if (identityResult.status() !=
+            output::ProcessFrameSemanticIdentityPreparationStatus::Prepared ||
+        identityResult.identity() == nullptr) {
+        std::abort();
+    }
+
+    const auto expectedRevision = core::Sha256Digest::fromBytes(kRevisionBytes);
+    const auto analyzed = output::analyzePngRgba8SrgbV1(
+        {.process = {.state = output::OutputAnalysisProcessSourceStateV1::Ready,
+                     .readyIdentity = identityResult.identity(),
+                     .missingDescriptor = std::nullopt},
+         .expectedOcioRevision = expectedRevision,
+         .colorResolution = output::PngRgba8SrgbColorResolutionStateV1::Ready});
+    if (!analyzed.hasReport()) {
+        std::abort();
+    }
+
+    auto displayIdentity =
+        std::make_shared<const color::DisplayProcessorIdentityV1>(fixtureDisplayIdentity());
+
+    return {frame, identityResult.identity(), analyzed.report(), expectedRevision,
+            std::move(displayIdentity)};
+}
+
+// RAII per-process scratch directory under the platform temp root, isolating this test binary's
+// staged artifacts from other parallel ctest processes. Best-effort cleanup on destruction.
+class ScratchDirectory final {
+  public:
+    explicit ScratchDirectory(const std::string& label) {
+        static std::atomic<std::uint64_t> counter{0};
+        const auto suffix =
+            std::to_string(static_cast<unsigned long long>(std::hash<std::string>{}(label))) + "-" +
+            std::to_string(counter.fetch_add(1));
+        std::error_code errorCode;
+        path_ =
+            std::filesystem::temp_directory_path(errorCode) / ("bloom-output-png-test-" + suffix);
+        if (errorCode) {
+            std::abort();
+        }
+        std::filesystem::create_directories(path_, errorCode);
+        if (errorCode) {
+            std::abort();
+        }
+    }
+    ScratchDirectory(const ScratchDirectory&) = delete;
+    ScratchDirectory& operator=(const ScratchDirectory&) = delete;
+    ScratchDirectory(ScratchDirectory&&) = delete;
+    ScratchDirectory& operator=(ScratchDirectory&&) = delete;
+    ~ScratchDirectory() {
+        std::error_code errorCode;
+        std::filesystem::remove_all(path_, errorCode);
+    }
+
+    [[nodiscard]] std::filesystem::path file(const std::string& name) const { return path_ / name; }
+
+  private:
+    std::filesystem::path path_;
+};
+
+// The small "Expectations" idiom every src/output test file already uses, duplicated here so both
+// PNG test binaries share one copy instead of two more (same rationale as
+// flat_exr_test_support.hpp's own copy).
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string_view message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+// Minimal raw byte-level access to a valid staged PNG's chunk stream, used by the adversarial
+// fixtures to craft corrupted variants of a real staged file. Mirrors flat_exr_test_support.hpp's
+// ExrHeaderBytes idiom (per F1's precedent, cited by design decision "Adversarial byte surgery").
+// A chunk record is length(4 BE) + type(4 ASCII) + data(length bytes) + crc(4 BE), starting right
+// after the 8-byte signature.
+class PngChunkBytes final {
+  public:
+    explicit PngChunkBytes(const std::filesystem::path& path) : path_(path) {
+        std::ifstream stream(path, std::ios::binary);
+        if (!stream) {
+            std::abort();
+        }
+        bytes_.assign(std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>());
+        if (bytes_.size() < 8) {
+            std::abort();
+        }
+    }
+
+    // Byte offset of one chunk occurrence's data (after its length/type fields) and that chunk's
+    // declared data length. `occurrence` selects among repeated types (e.g. the second IDAT).
+    // Aborts if not present.
+    [[nodiscard]] std::pair<std::size_t, std::size_t>
+    dataRange(const std::string& type, const std::size_t occurrence = 0) const {
+        std::size_t offset = 8;
+        std::size_t seen = 0;
+        while (offset + 8 <= bytes_.size()) {
+            const auto length = readU32(offset);
+            const std::string chunkType(bytes_.begin() + static_cast<std::ptrdiff_t>(offset) + 4,
+                                        bytes_.begin() + static_cast<std::ptrdiff_t>(offset) + 8);
+            const auto dataOffset = offset + 8;
+            if (chunkType == type) {
+                if (seen == occurrence) {
+                    return {dataOffset, length};
+                }
+                ++seen;
+            }
+            offset = dataOffset + length + 4; // data + CRC
+            if (offset > bytes_.size()) {
+                break;
+            }
+        }
+        std::abort();
+    }
+
+    // Patches a single byte with NO CRC fix-up -- deliberately breaks that chunk's CRC, for the
+    // "corrupted CRC" adversarial fixture itself.
+    void patchByteBreakingCrc(const std::size_t offset, const unsigned char value) {
+        bytes_.at(offset) = static_cast<char>(value);
+    }
+
+    // Patches one byte inside a chunk's data and recomputes/rewrites that exact chunk's trailing
+    // CRC-32, so the surrounding chunk stays CRC-valid and the verifier reaches the field-value
+    // check the caller actually wants to exercise (IHDR field perturbation, sRGB intent, a
+    // non-zero row filter byte) rather than tripping over ChunkCrcMismatch first.
+    void patchDataByteWithValidCrc(const std::string& type, const std::size_t occurrence,
+                                   const std::size_t offsetWithinData, const unsigned char value) {
+        const auto [dataOffset, length] = dataRange(type, occurrence);
+        bytes_.at(dataOffset + offsetWithinData) = static_cast<char>(value);
+        const auto typeOffset = dataOffset - 4;
+        auto crc = crc32Seed();
+        for (std::size_t index = 0; index < 4; ++index) {
+            crc = crc32Step(crc, static_cast<unsigned char>(bytes_.at(typeOffset + index)));
+        }
+        for (std::size_t index = 0; index < length; ++index) {
+            crc = crc32Step(crc, static_cast<unsigned char>(bytes_.at(dataOffset + index)));
+        }
+        crc ^= 0xFFFFFFFFU;
+        std::vector<unsigned char> crcBytes;
+        appendU32(crcBytes, crc);
+        for (std::size_t index = 0; index < 4; ++index) {
+            bytes_.at(dataOffset + length + index) = static_cast<char>(crcBytes[index]);
+        }
+    }
+
+    [[nodiscard]] unsigned char byteAt(const std::size_t offset) const {
+        return static_cast<unsigned char>(bytes_.at(offset));
+    }
+
+    [[nodiscard]] std::size_t size() const noexcept { return bytes_.size(); }
+
+    void truncateTo(const std::size_t length) { bytes_.resize(std::min(length, bytes_.size())); }
+
+    void appendBytes(const std::span<const unsigned char> extra) {
+        bytes_.insert(bytes_.end(), extra.begin(), extra.end());
+    }
+
+    // Inserts a complete, well-formed chunk record (length + type + data, CRC recomputed here so
+    // callers never have to hand-compute it) immediately before the given byte offset.
+    void insertChunk(const std::size_t beforeOffset, const std::string& type,
+                     const std::vector<unsigned char>& data) {
+        std::vector<unsigned char> record;
+        record.reserve(12 + data.size());
+        appendU32(record, static_cast<std::uint32_t>(data.size()));
+        for (const char character : type) {
+            record.push_back(static_cast<unsigned char>(character));
+        }
+        record.insert(record.end(), data.begin(), data.end());
+        auto crc = crc32Seed();
+        for (const char character : type) {
+            crc = crc32Step(crc, static_cast<unsigned char>(character));
+        }
+        for (const auto byteValue : data) {
+            crc = crc32Step(crc, byteValue);
+        }
+        crc ^= 0xFFFFFFFFU;
+        appendU32(record, crc);
+        bytes_.insert(bytes_.begin() + static_cast<std::ptrdiff_t>(beforeOffset), record.begin(),
+                      record.end());
+    }
+
+    // Offset immediately after the IEND chunk's CRC (i.e. the true end of a well-formed file);
+    // used both to append trailing bytes and as the natural "insert before this" point for a new
+    // chunk placed right after the last existing one.
+    [[nodiscard]] std::size_t endOffset() const noexcept { return bytes_.size(); }
+
+    void save() const {
+        std::ofstream stream(path_, std::ios::binary | std::ios::trunc);
+        if (!stream) {
+            std::abort();
+        }
+        stream.write(bytes_.data(), static_cast<std::streamsize>(bytes_.size()));
+    }
+
+  private:
+    [[nodiscard]] std::uint32_t readU32(const std::size_t offset) const {
+        return (static_cast<std::uint32_t>(static_cast<unsigned char>(bytes_.at(offset))) << 24U) |
+               (static_cast<std::uint32_t>(static_cast<unsigned char>(bytes_.at(offset + 1)))
+                << 16U) |
+               (static_cast<std::uint32_t>(static_cast<unsigned char>(bytes_.at(offset + 2)))
+                << 8U) |
+               static_cast<std::uint32_t>(static_cast<unsigned char>(bytes_.at(offset + 3)));
+    }
+
+    static void appendU32(std::vector<unsigned char>& out, const std::uint32_t value) {
+        out.push_back(static_cast<unsigned char>((value >> 24U) & 0xFFU));
+        out.push_back(static_cast<unsigned char>((value >> 16U) & 0xFFU));
+        out.push_back(static_cast<unsigned char>((value >> 8U) & 0xFFU));
+        out.push_back(static_cast<unsigned char>(value & 0xFFU));
+    }
+
+    // A tiny standalone CRC-32 (ISO 3309 / ITU-T V.42, the exact PNG/zlib polynomial, pre-inverted
+    // seed with a final XOR the two callers above apply) so this test support header can compute a
+    // valid CRC for a patched/inserted adversarial chunk without depending on zlib itself.
+    [[nodiscard]] static std::uint32_t crc32Seed() noexcept { return 0xFFFFFFFFU; }
+    [[nodiscard]] static std::uint32_t crc32Step(std::uint32_t crc,
+                                                 const unsigned char byteValue) noexcept {
+        crc ^= byteValue;
+        for (int bit = 0; bit < 8; ++bit) {
+            const auto mask = static_cast<std::uint32_t>(-(static_cast<std::int32_t>(crc & 1U)));
+            crc = (crc >> 1U) ^ (0xEDB88320U & mask);
+        }
+        return crc;
+    }
+
+    std::filesystem::path path_;
+    std::vector<char> bytes_;
+};
+
+// The result of a from-scratch, independent read of a staged PNG: chunk order, IHDR/sRGB field
+// values, whether every CRC-32 matched, whether every scanline's filter byte was 0, and the
+// decoded RGBA8 sample bytes -- filter bytes stripped, in increasing row Y then X order. `ok` is
+// false for any structural defect (bad signature/CRC/zlib stream/size mismatch); check it before
+// trusting any other field.
+struct IndependentPngDecode final {
+    bool ok = false;
+    std::vector<std::string> chunkTypesInOrder;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::uint8_t bitDepth = 0;
+    std::uint8_t colorType = 0;
+    std::uint8_t compressionMethod = 0;
+    std::uint8_t filterMethod = 0;
+    std::uint8_t interlaceMethod = 0;
+    std::uint8_t srgbIntent = 0;
+    bool everyCrcValid = false;
+    bool everyRowFilterZero = false;
+    std::vector<std::uint8_t> rgba;
+};
+
+// Reads `path` as a plain PNG byte stream and inflates its concatenated IDAT payload via zlib
+// directly -- no dependency on bloom::output::PngRgba8SrgbWriterV1 or
+// bloom::output::PngRgba8SrgbReopenVerifierV1. Used by the round-trip test's "independent decode
+// cross-check" (proving the encoder against a second reading) and by the chunk-conformance test.
+[[nodiscard]] inline IndependentPngDecode
+independentlyDecodePng(const std::filesystem::path& path) {
+    IndependentPngDecode result;
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream) {
+        return result;
+    }
+    std::vector<unsigned char> bytes((std::istreambuf_iterator<char>(stream)),
+                                     std::istreambuf_iterator<char>());
+    static constexpr std::array<unsigned char, 8> kSignature{137, 80, 78, 71, 13, 10, 26, 10};
+    if (bytes.size() < 8 || !std::equal(kSignature.begin(), kSignature.end(), bytes.begin())) {
+        return result;
+    }
+
+    result.everyCrcValid = true;
+    std::vector<unsigned char> idatConcat;
+    std::size_t offset = 8;
+    bool sawIend = false;
+    while (offset + 8 <= bytes.size()) {
+        const std::uint32_t length = (static_cast<std::uint32_t>(bytes[offset]) << 24U) |
+                                     (static_cast<std::uint32_t>(bytes[offset + 1]) << 16U) |
+                                     (static_cast<std::uint32_t>(bytes[offset + 2]) << 8U) |
+                                     static_cast<std::uint32_t>(bytes[offset + 3]);
+        const std::string type(bytes.begin() + static_cast<std::ptrdiff_t>(offset) + 4,
+                               bytes.begin() + static_cast<std::ptrdiff_t>(offset) + 8);
+        const auto dataOffset = offset + 8;
+        if (dataOffset + length + 4 > bytes.size()) {
+            return result;
+        }
+        const std::span<const unsigned char> data(bytes.data() + dataOffset, length);
+        auto crc = crc32_z(0L, reinterpret_cast<const Bytef*>(type.data()), 4);
+        if (!data.empty()) {
+            crc = crc32_z(crc, reinterpret_cast<const Bytef*>(data.data()), data.size());
+        }
+        const auto crcOffset = dataOffset + length;
+        const std::uint32_t storedCrc = (static_cast<std::uint32_t>(bytes[crcOffset]) << 24U) |
+                                        (static_cast<std::uint32_t>(bytes[crcOffset + 1]) << 16U) |
+                                        (static_cast<std::uint32_t>(bytes[crcOffset + 2]) << 8U) |
+                                        static_cast<std::uint32_t>(bytes[crcOffset + 3]);
+        if (static_cast<std::uint32_t>(crc) != storedCrc) {
+            result.everyCrcValid = false;
+        }
+        result.chunkTypesInOrder.push_back(type);
+        if (type == "IHDR") {
+            if (length != 13) {
+                return result;
+            }
+            result.width = (static_cast<std::uint32_t>(data[0]) << 24U) |
+                           (static_cast<std::uint32_t>(data[1]) << 16U) |
+                           (static_cast<std::uint32_t>(data[2]) << 8U) |
+                           static_cast<std::uint32_t>(data[3]);
+            result.height = (static_cast<std::uint32_t>(data[4]) << 24U) |
+                            (static_cast<std::uint32_t>(data[5]) << 16U) |
+                            (static_cast<std::uint32_t>(data[6]) << 8U) |
+                            static_cast<std::uint32_t>(data[7]);
+            result.bitDepth = data[8];
+            result.colorType = data[9];
+            result.compressionMethod = data[10];
+            result.filterMethod = data[11];
+            result.interlaceMethod = data[12];
+        } else if (type == "sRGB") {
+            if (length != 1) {
+                return result;
+            }
+            result.srgbIntent = data[0];
+        } else if (type == "IDAT") {
+            idatConcat.insert(idatConcat.end(), data.begin(), data.end());
+        } else if (type == "IEND") {
+            sawIend = true;
+        }
+        offset = crcOffset + 4;
+        if (sawIend) {
+            break;
+        }
+    }
+    if (!sawIend || offset != bytes.size()) {
+        return result;
+    }
+
+    const auto expectedTotal =
+        static_cast<std::size_t>(result.width) * result.height * 4 + result.height;
+    std::vector<unsigned char> inflated(expectedTotal);
+    z_stream stream2{};
+    if (inflateInit(&stream2) != Z_OK) {
+        return result;
+    }
+    stream2.next_in = idatConcat.data();
+    stream2.avail_in = static_cast<uInt>(idatConcat.size());
+    stream2.next_out = inflated.data();
+    stream2.avail_out = static_cast<uInt>(inflated.size());
+    const auto ret = inflate(&stream2, Z_FINISH);
+    inflateEnd(&stream2);
+    if (ret != Z_STREAM_END || stream2.avail_out != 0) {
+        return result;
+    }
+
+    result.everyRowFilterZero = true;
+    result.rgba.resize(static_cast<std::size_t>(result.width) * result.height * 4);
+    const auto rowRgbaBytes = static_cast<std::size_t>(result.width) * 4;
+    for (std::uint32_t row = 0; row < result.height; ++row) {
+        const auto rowOffset = static_cast<std::size_t>(row) * (rowRgbaBytes + 1);
+        if (inflated[rowOffset] != 0) {
+            result.everyRowFilterZero = false;
+        }
+        std::memcpy(result.rgba.data() + static_cast<std::size_t>(row) * rowRgbaBytes,
+                    inflated.data() + rowOffset + 1, rowRgbaBytes);
+    }
+    result.ok = true;
+    return result;
+}
+
+} // namespace bloom_output_png_test_support


### PR DESCRIPTION
Implements the `PngRgba8SrgbV1` preset's format layer as a Bloom-owned constrained codec over the qualified zlib — the last format piece of the delivery surface:

- **Encoder**: exactly the `png.ihdr-srgb-idat-iend.v1` profile — signature, IHDR (8-bit RGBA, no interlace), sRGB intent 0, IDAT with fixed recorded deflate parameters (level 6, zlib-wrapped, 32 KiB window, default strategy) and filter-0 rows, IEND — nothing else. Byte-determinism across independent runs is asserted, not just noted (claimable for a Bloom-owned encoder over pinned zlib, unlike the EXR ZIP-block case).
- **Verifier written from the contract first**: exact chunk sequence with any foreign chunk failing typed and named, IHDR field checks, CRC validation, bounded inflate under checked expansion ceilings (zlib-bomb shape rejected typed), row-filter enforcement, then bit-exact sample comparison — and kind-1 `OutputSemanticIdentity` issuance through the identity module's pre-anticipated friend seam, zero merged-file edits.
- **Adversarial fixtures** by real chunk-stream surgery: foreign ancillary/critical chunks, stale CRCs, IHDR perturbations with recomputed CRCs, wrong sRGB intent, truncation, trailing bytes, nonzero filter (re-encode route, documented), oversized expansion.
- Independent from-scratch decoder in the tests (raw chunk parse + direct inflate) cross-checks the encoder without touching production code.
- Records the codec ruling in the contract: OpenImageIO stays a future media-ingest candidate, not these presets.

Desktop 102/102 and native 87/87, format check clean.

Closes #107.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.