### PR TITLE
feat: step frames and read exact time in the timeline

### DIFF
--- a/src/ui/composition_editors.cpp
+++ b/src/ui/composition_editors.cpp
@@ -1,15 +1,19 @@
 #include <bloom/ui/composition_editors.hpp>
 
 #include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/timeline_frame_math.hpp>
 #include <bloom/ui/timeline_ruler.hpp>
 
 #include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/parameter.hpp>
 #include <bloom/document/project.hpp>
 
 #include <QAbstractItemView>
 #include <QAction>
+#include <QApplication>
 #include <QDoubleSpinBox>
 #include <QFormLayout>
 #include <QHBoxLayout>
@@ -184,6 +188,67 @@ QToolButton* makeToolButton(const QString& text, const QString& accessibleName, 
     return button;
 }
 
+// Frame stepping / readout (issue #108): the frame rate, duration, and checked maximum frame index
+// every stepFrame()/stepToStart()/stepToEnd()/updateTimeReadout() call needs, resolved the one
+// place so they cannot silently drift from each other's notion of the composition's valid frame
+// range -- mirroring mappingForComposition() in playback_controller.cpp, which this deliberately
+// does NOT reuse (it is private to that translation unit and this task's fence forbids touching the
+// playback controller beyond the smallest justified accessor -- see stepFrame()'s own comment on
+// why none was needed). std::nullopt covers no live composition or a rate/duration
+// bloom::core::FrameTimeMapping itself refuses, exactly like every other caller of
+// timeline_frame_math.hpp's adapters.
+struct TimelineFrameContext final {
+    document::FrameRate frameRate;
+    core::RationalTime duration;
+    std::uint64_t maxFrameIndexValue;
+};
+
+[[nodiscard]] std::optional<TimelineFrameContext>
+frameContextFor(const CompositionSession& session) {
+    const auto* composition = session.composition();
+    if (composition == nullptr) {
+        return std::nullopt;
+    }
+    const auto frameRate = composition->format().frameRate();
+    const auto duration = composition->duration();
+    const auto maxIndex = maxFrameIndex(frameRate, duration);
+    if (!maxIndex.has_value()) {
+        return std::nullopt;
+    }
+    return TimelineFrameContext{frameRate, duration, *maxIndex};
+}
+
+// Formats an exact RationalTime as seconds with EXACTLY 3 truncated decimal digits (millisecond
+// resolution), computed purely from the integer numerator/denominator -- never through
+// RationalTime::toSeconds()'s binary64 conversion -- so the digits shown are always the value's
+// true leading digits, never a rounded/binary64-approximated one (design decision 3: "no
+// floating-point accumulation... a subframe time must display honestly"). Three places is a
+// deliberately BOUNDED cut of what can be an infinite decimal expansion (e.g. 1 s / 3 has no exact
+// finite decimal form); truncating rather than rounding means the displayed digits never overstate
+// the exact value. The widening multiply uses a 128-bit intermediate purely so an extreme
+// duration's denominator cannot silently overflow a 64-bit product -- unreachable for any realistic
+// composition, kept checked rather than UB regardless; this is ordinary display arithmetic, not
+// part of the sampling contract's own "no compiler-specific extended integers" rule
+// (docs/architecture/animation-and-time.md, "Sampling Semantics Version 1"), which governs curve
+// evaluation only.
+[[nodiscard]] QString formatExactSeconds(const core::RationalTime time) {
+    constexpr int kDecimalPlaces = 3;
+    constexpr unsigned __int128 kScale = 1000;
+    const std::int64_t numerator = time.numerator();
+    const auto denominator = static_cast<unsigned __int128>(time.denominator());
+    const bool negative = numerator < 0;
+    const auto magnitude = negative
+                               ? static_cast<unsigned __int128>(-static_cast<__int128>(numerator))
+                               : static_cast<unsigned __int128>(numerator);
+    const auto wholeSeconds = static_cast<qulonglong>(magnitude / denominator);
+    const auto remainder = magnitude % denominator;
+    const auto scaledFraction = static_cast<qulonglong>((remainder * kScale) / denominator);
+    return QStringLiteral("%1%2.%3s")
+        .arg(negative ? QStringLiteral("-") : QString())
+        .arg(wholeSeconds)
+        .arg(scaledFraction, kDecimalPlaces, 10, QChar('0'));
+}
+
 } // namespace
 
 TimelineEditor::TimelineEditor(CompositionSession& session,
@@ -225,11 +290,19 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     playPauseButton_ = makeToolButton(tr("Play"), tr("Toggle playback"), controls);
     playPauseButton_->setObjectName("playPauseButton");
     playPauseButton_->setCheckable(true);
+    // Current time readout (issue #108, decision 3): a small label beside the transport, matching
+    // PropertiesEditor::selectionLabel_'s plain-QLabel idiom (setObjectName + selectable text, no
+    // bespoke styling). Text is set by updateTimeReadout() below, not here.
+    timeReadout_ = new QLabel(controls);
+    timeReadout_->setObjectName("timelineTimeReadout");
+    timeReadout_->setAccessibleName(tr("Current frame and time"));
+    timeReadout_->setTextInteractionFlags(Qt::TextSelectableByMouse);
     undoButton_ = makeToolButton(tr("Undo"), tr("Undo last edit"), controls);
     redoButton_ = makeToolButton(tr("Redo"), tr("Redo last edit"), controls);
     controlsLayout->addWidget(title);
     controlsLayout->addWidget(addButton_);
     controlsLayout->addWidget(playPauseButton_);
+    controlsLayout->addWidget(timeReadout_);
     controlsLayout->addStretch(1);
     controlsLayout->addWidget(undoButton_);
     controlsLayout->addWidget(redoButton_);
@@ -292,6 +365,63 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     playPauseAction->setShortcutContext(Qt::WindowShortcut);
     addAction(playPauseAction);
     connect(playPauseAction, &QAction::triggered, playback_, &PlaybackController::toggle);
+
+    // Frame-stepping shortcuts (issue #108, decisions 1/2), mirroring playPauseAction's own
+    // WindowShortcut idiom exactly (same setObjectName/setShortcut/setShortcutContext/addAction
+    // shape, same reliance on Qt's ShortcutOverride mechanism to let a focused text-entry widget --
+    // e.g. PropertiesEditor's QDoubleSpinBox editors, verified with a standalone Qt harness to
+    // accept ShortcutOverride for Left/Right/Home/End exactly like QLineEdit does -- win over these
+    // shortcuts without any bespoke check here).
+    stepBackwardAction_ = new QAction(tr("Step Back One Frame"), this);
+    stepBackwardAction_->setObjectName("stepBackwardAction");
+    stepBackwardAction_->setShortcut(QKeySequence(Qt::Key_Left));
+    stepBackwardAction_->setShortcutContext(Qt::WindowShortcut);
+    addAction(stepBackwardAction_);
+    connect(stepBackwardAction_, &QAction::triggered, this, [this] { stepFrame(-1); });
+
+    stepForwardAction_ = new QAction(tr("Step Forward One Frame"), this);
+    stepForwardAction_->setObjectName("stepForwardAction");
+    stepForwardAction_->setShortcut(QKeySequence(Qt::Key_Right));
+    stepForwardAction_->setShortcutContext(Qt::WindowShortcut);
+    addAction(stepForwardAction_);
+    connect(stepForwardAction_, &QAction::triggered, this, [this] { stepFrame(1); });
+
+    stepToStartAction_ = new QAction(tr("Go To Start"), this);
+    stepToStartAction_->setObjectName("stepToStartAction");
+    stepToStartAction_->setShortcut(QKeySequence(Qt::Key_Home));
+    stepToStartAction_->setShortcutContext(Qt::WindowShortcut);
+    addAction(stepToStartAction_);
+    connect(stepToStartAction_, &QAction::triggered, this, &TimelineEditor::stepToStart);
+
+    stepToEndAction_ = new QAction(tr("Go To End"), this);
+    stepToEndAction_->setObjectName("stepToEndAction");
+    stepToEndAction_->setShortcut(QKeySequence(Qt::Key_End));
+    stepToEndAction_->setShortcutContext(Qt::WindowShortcut);
+    addAction(stepToEndAction_);
+    connect(stepToEndAction_, &QAction::triggered, this, &TimelineEditor::stepToEnd);
+
+    // Arrow-key conflict finding (this task's own investigation, verified with a standalone Qt
+    // harness before writing this code): layers_ (QTreeWidget) already consumes Left/Right/Home/End
+    // itself -- Left/Right collapse/expand the current item, Home/End jump to the first/last item
+    // -- but, unlike QLineEdit/QDoubleSpinBox, QAbstractItemView does NOT accept the
+    // ShortcutOverride event for those keys. That means a WindowShortcut action bound to the same
+    // key silently wins over the tree's OWN keyPressEvent()-based navigation the instant it exists:
+    // the harness showed the tree's current item and expand state never change at all once a
+    // same-key action is installed, with no error -- a genuine behavior change this task must not
+    // ship silently. The reconciliation rule (frozen by this task): widget-focus wins; the step
+    // action fires otherwise. Implemented by disabling these four actions outright while layers_
+    // holds keyboard focus -- a disabled QAction never claims ShortcutOverride, so the key event
+    // reaches layers_ and its native navigation runs completely unchanged; every other focus
+    // location (including no focus, the ruler, the keyframe panel, or a QDoubleSpinBox that itself
+    // already wins via ShortcutOverride) leaves the actions enabled and the step fires.
+    connect(qApp, &QApplication::focusChanged, this, [this](QWidget*, QWidget* now) {
+        const bool layersFocused = (now == layers_);
+        stepBackwardAction_->setEnabled(!layersFocused);
+        stepForwardAction_->setEnabled(!layersFocused);
+        stepToStartAction_->setEnabled(!layersFocused);
+        stepToEndAction_->setEnabled(!layersFocused);
+    });
+
     connect(layers_, &QTreeWidget::itemSelectionChanged, this, [this] {
         if (rebuilding_) {
             return;
@@ -310,9 +440,19 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
             &TimelineEditor::updateSelection);
     connect(&session_, &CompositionSession::historyChanged, this,
             &TimelineEditor::updateHistoryActions);
+    // Readout updates on every session-time change and on a composition switch (which resets
+    // session time to exact zero -- docs/architecture/animation-and-time.md, "Session Time And
+    // Scrubbing": "Switching compositions resets the session time to exact zero in version 1"), so
+    // the label always reflects the SAME time compositionChanged's reset already produced rather
+    // than momentarily showing the previous composition's stale frame/time.
+    connect(&session_, &CompositionSession::currentTimeChanged, this,
+            &TimelineEditor::updateTimeReadout);
+    connect(&session_, &CompositionSession::compositionChanged, this,
+            &TimelineEditor::updateTimeReadout);
 
     rebuild();
     updateHistoryActions();
+    updateTimeReadout();
 }
 
 void TimelineEditor::rebuild() {
@@ -390,6 +530,87 @@ void TimelineEditor::updatePlaybackButton(const PlaybackState state) {
     playPauseButton_->setText(playing ? tr("Pause") : tr("Play"));
     playPauseButton_->setToolTip(playing ? tr("Pause playback (Space)")
                                          : tr("Play from the current time (Space)"));
+}
+
+void TimelineEditor::stepFrame(const int delta) {
+    const auto context = frameContextFor(session_);
+    if (!context.has_value()) {
+        return;
+    }
+    const auto nearest =
+        nearestFrameIndexForTime(context->frameRate, context->duration, session_.currentTime());
+    if (!nearest.has_value()) {
+        return;
+    }
+    // Stepping while playing pauses playback FIRST through PlaybackController's own public
+    // transport API (design decision 1) -- composing with pause() explicitly here rather than
+    // relying on handleCurrentTimeChanged()'s existing "any external setCurrentTime() while playing
+    // pauses" side effect (playback_controller.cpp), so this call site is honest about what it does
+    // and the transport state change is never a coincidental side effect of the time write below.
+    // Called unconditionally (idempotent no-op if already Stopped -- PlaybackController::pause()'s
+    // own documented guard), not only when the step actually moves the playhead, matching the
+    // decision's "stepping... pauses playback FIRST" without making pausing conditional on the
+    // clamp outcome.
+    playback_->pause();
+
+    // Left/Right move exactly one frame index from the nearest index to the CURRENT (possibly
+    // subframe) time, clamped to [0, maxFrameIndex] (design decision 1). nearestFrameIndex()'s own
+    // tie rule (bloom::core::FrameTimeMapping::nearestFrameIndex(), and docs/architecture/
+    // animation-and-time.md's "Session Time And Scrubbing": "selects the nearest index with an
+    // exact halfway tie going to the greater index") decides which frame a subframe time steps
+    // from, not this call site.
+    std::uint64_t target = *nearest;
+    if (delta < 0) {
+        target = target > 0 ? target - 1 : 0;
+    } else {
+        target = target < context->maxFrameIndexValue ? target + 1 : context->maxFrameIndexValue;
+    }
+    const auto targetTime = frameTimeForIndex(context->frameRate, context->duration, target);
+    if (targetTime.has_value()) {
+        // A clamped step that lands back on the CURRENT exact time (e.g. Left at frame 0) is a
+        // true no-op through CompositionSession::setCurrentTime()'s own early-return-on-equal-time
+        // guard (composition_session.cpp) -- no currentTimeChanged signal churn, verified by that
+        // mutator's own implementation rather than re-checked here.
+        (void)session_.setCurrentTime(*targetTime);
+    }
+}
+
+void TimelineEditor::stepToStart() {
+    const auto context = frameContextFor(session_);
+    if (!context.has_value()) {
+        return;
+    }
+    playback_->pause();
+    const auto targetTime = frameTimeForIndex(context->frameRate, context->duration, 0);
+    if (targetTime.has_value()) {
+        (void)session_.setCurrentTime(*targetTime);
+    }
+}
+
+void TimelineEditor::stepToEnd() {
+    const auto context = frameContextFor(session_);
+    if (!context.has_value()) {
+        return;
+    }
+    playback_->pause();
+    const auto targetTime =
+        frameTimeForIndex(context->frameRate, context->duration, context->maxFrameIndexValue);
+    if (targetTime.has_value()) {
+        (void)session_.setCurrentTime(*targetTime);
+    }
+}
+
+void TimelineEditor::updateTimeReadout() {
+    const auto time = session_.currentTime();
+    const auto context = frameContextFor(session_);
+    QString frameText = QStringLiteral("—");
+    if (context.has_value()) {
+        const auto nearest = nearestFrameIndexForTime(context->frameRate, context->duration, time);
+        if (nearest.has_value()) {
+            frameText = QString::number(*nearest);
+        }
+    }
+    timeReadout_->setText(tr("Frame %1 · %2").arg(frameText, formatExactSeconds(time)));
 }
 
 PropertiesEditor::PropertiesEditor(CompositionSession& session, QWidget* parent)

--- a/src/ui/include/bloom/ui/composition_editors.hpp
+++ b/src/ui/include/bloom/ui/composition_editors.hpp
@@ -4,6 +4,7 @@
 
 #include <QWidget>
 
+class QAction;
 class QDoubleSpinBox;
 class QLabel;
 class QListWidget;
@@ -31,6 +32,17 @@ class TimelineEditor final : public QWidget {
     // Reflects PlaybackController::stateChanged() onto the toggle button's text/tooltip/checked
     // state (design decision 4: "button/icon state reflects transport state via a signal").
     void updatePlaybackButton(PlaybackState state);
+    // Frame stepping (issue #108, decisions 1/2): Left/Right step one frame back/forward from
+    // nearestFrameIndex(currentTime()), clamped to [0, maxFrameIndex]; delta is -1 or +1. Home/End
+    // (stepToStart()/stepToEnd()) jump to frame 0 / the last frame. Every landing goes through the
+    // exact mapped frame time via CompositionSession::setCurrentTime(), and pauses playback FIRST
+    // through PlaybackController's own public pause() -- never by racing its tick().
+    void stepFrame(int delta);
+    void stepToStart();
+    void stepToEnd();
+    // Updates timeReadout_'s text to the current frame index / exact time (design decision 3),
+    // wired to currentTimeChanged() and compositionChanged().
+    void updateTimeReadout();
 
     CompositionSession& session_;
     TimelineRuler* ruler_ = nullptr;
@@ -46,6 +58,15 @@ class TimelineEditor final : public QWidget {
     // CompositionPreviewController rather than a single cross-panel singleton.
     PlaybackController* playback_ = nullptr;
     QToolButton* playPauseButton_ = nullptr;
+    // Current frame index / exact time readout (design decision 3), living beside playPauseButton_
+    // in the same controls row.
+    QLabel* timeReadout_ = nullptr;
+    // Frame-stepping QActions (design decision 2), disabled while layers_ holds keyboard focus --
+    // see their construction site in the .cpp for the arrow-key conflict this reconciles.
+    QAction* stepBackwardAction_ = nullptr;
+    QAction* stepForwardAction_ = nullptr;
+    QAction* stepToStartAction_ = nullptr;
+    QAction* stepToEndAction_ = nullptr;
     bool rebuilding_ = false;
 };
 

--- a/src/ui/tests/playback_controller_tests.cpp
+++ b/src/ui/tests/playback_controller_tests.cpp
@@ -1,4 +1,5 @@
 #include <bloom/commands/command_stack.hpp>
+#include <bloom/core/color.hpp>
 #include <bloom/core/frame_time_mapping.hpp>
 #include <bloom/core/rational_time.hpp>
 #include <bloom/document/document.hpp>
@@ -18,13 +19,17 @@
 #include <bloom/ui/playback_controller.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 
+#include <QAction>
 #include <QApplication>
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QEventLoop>
+#include <QLabel>
 #include <QLineEdit>
 #include <QTest>
 #include <QToolButton>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -612,6 +617,361 @@ void testPlaybackToggleButtonAndSpaceShortcut(Expectations& expectations) {
     finishFixture(fixture, expectations);
 }
 
+// Frame stepping (issue #108, decision 1): Right from t=0 lands exactly on frame one's exact
+// mapped time (1/25 s at this fixture's 25 fps rate), through the SAME CompositionSession::
+// setCurrentTime() mutator the ruler/keyframe gestures already use. Exercised through the real
+// stepForwardAction QAction (TimelineEditor::stepFrame()'s public seam), not a reimplementation of
+// the frame math.
+void testStepForwardFromZeroLandsOnFrameOne(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step Forward", time(4)));
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* stepForward = editor->findChild<QAction*>("stepForwardAction");
+    expectations.expect(stepForward != nullptr, "the step-forward action is reachable by name");
+    if (stepForward == nullptr) {
+        delete editor;
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    expectations.expect(fixture.session.currentTime() == time(0), "session starts at exact zero");
+    stepForward->trigger();
+    expectations.expect(fixture.session.currentTime() == time(1, 25),
+                        "stepping forward from t=0 lands exactly on frame one's mapped time");
+
+    delete editor;
+    finishFixture(fixture, expectations);
+}
+
+// Left at frame 0 clamps to frame 0 -- landing on the SAME exact time CompositionSession::
+// setCurrentTime() already refuses to re-emit for (composition_session.cpp's early-return-on-
+// equal-time guard), so no signal churn reaches observers.
+void testStepBackwardAtZeroClampsWithNoSignalChurn(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step Clamp", time(4)));
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* stepBackward = editor->findChild<QAction*>("stepBackwardAction");
+    expectations.expect(stepBackward != nullptr, "the step-backward action is reachable by name");
+    if (stepBackward == nullptr) {
+        delete editor;
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    int changeCount = 0;
+    QObject::connect(&fixture.session, &ui::CompositionSession::currentTimeChanged,
+                     [&changeCount] { ++changeCount; });
+    stepBackward->trigger();
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "stepping backward at frame 0 clamps to frame 0");
+    expectations.expect(changeCount == 0,
+                        "clamping to the SAME exact time emits no currentTimeChanged -- no signal "
+                        "churn");
+
+    delete editor;
+    finishFixture(fixture, expectations);
+}
+
+// End jumps to the exact maximum frame time (4 s at 25 fps == 100 frames, indices 0..99).
+void testStepToEndLandsAtExactMaxFrame(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step End", time(4)));
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* stepToEnd = editor->findChild<QAction*>("stepToEndAction");
+    expectations.expect(stepToEnd != nullptr, "the go-to-end action is reachable by name");
+    if (stepToEnd == nullptr) {
+        delete editor;
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    stepToEnd->trigger();
+    expectations.expect(
+        fixture.session.currentTime() == time(99, 25),
+        "End lands exactly on the last frame's mapped time (index 99 at 25 fps over "
+        "a 4 s duration)");
+
+    delete editor;
+    finishFixture(fixture, expectations);
+}
+
+// Home jumps to exact zero from anywhere.
+void testStepToStartLandsAtExactZero(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step Home", time(4)));
+    expectations.expect(fixture.session.setCurrentTime(time(50, 25)),
+                        "session time moves away from zero first");
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* stepToStart = editor->findChild<QAction*>("stepToStartAction");
+    expectations.expect(stepToStart != nullptr, "the go-to-start action is reachable by name");
+    if (stepToStart == nullptr) {
+        delete editor;
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    stepToStart->trigger();
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "Home lands exactly on frame zero");
+
+    delete editor;
+    finishFixture(fixture, expectations);
+}
+
+// A step from a SUBFRAME time lands per FrameTimeMapping::nearestFrameIndex()'s own documented tie
+// rule (frame_time_mapping.hpp: "Clamps to the valid frame range and rounds to nearest; an exact
+// halfway result selects the greater frame index" -- restated by docs/architecture/
+// animation-and-time.md, "Session Time And Scrubbing": "selects the nearest index with an exact
+// halfway tie going to the greater index"). 1/50 s is EXACTLY halfway between frame 0 (0 s) and
+// frame 1 (1/25 s == 2/50 s) at this fixture's 25 fps rate, so nearestFrameIndex(1/50 s) == 1 (the
+// GREATER of the tied indices) -- both step directions below are computed from that index 1 base.
+void testStepFromSubframeTimeUsesNearestIndexTieRule(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step Subframe Tie", time(4)));
+    expectations.expect(fixture.session.setCurrentTime(time(1, 50)),
+                        "session time moves to the exact halfway-tie subframe time");
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* stepBackward = editor->findChild<QAction*>("stepBackwardAction");
+    auto* stepForward = editor->findChild<QAction*>("stepForwardAction");
+    expectations.expect(stepBackward != nullptr && stepForward != nullptr,
+                        "both step actions are reachable by name");
+    if (stepBackward == nullptr || stepForward == nullptr) {
+        delete editor;
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    stepForward->trigger();
+    expectations.expect(
+        fixture.session.currentTime() == time(2, 25),
+        "stepping forward from the tied subframe time steps from index 1 (the tie's "
+        "greater index), landing on frame 2's exact time -- not frame 1");
+
+    expectations.expect(fixture.session.setCurrentTime(time(1, 50)),
+                        "session time returns to the same tied subframe time");
+    stepBackward->trigger();
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "stepping backward from the SAME tied subframe time steps from the SAME "
+                        "index 1 base, landing on frame 0 -- confirming both directions read the "
+                        "tie identically rather than each independently floor/ceiling-ing the "
+                        "subframe time");
+
+    delete editor;
+    finishFixture(fixture, expectations);
+}
+
+// Stepping while playing pauses playback FIRST through PlaybackController's own public pause()
+// (design decision 1), asserted via the SAME play/pause button state the Space test above already
+// uses as its transport-state proxy (TimelineEditor owns playback_ privately -- this button is the
+// one observable seam).
+void testStepDuringPlaybackPausesThenSteps(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step Playback Pause", time(4)));
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* button = editor->findChild<QToolButton*>("playPauseButton");
+    auto* stepForward = editor->findChild<QAction*>("stepForwardAction");
+    expectations.expect(button != nullptr && stepForward != nullptr,
+                        "the play/pause button and step-forward action are reachable by name");
+    if (button == nullptr || stepForward == nullptr) {
+        delete editor;
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    button->click();
+    expectations.expect(button->isChecked(), "playback starts Playing");
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "play() itself has not moved session time (no tick has fired)");
+
+    stepForward->trigger();
+    expectations.expect(!button->isChecked(), "stepping while playing pauses the transport FIRST");
+    expectations.expect(fixture.session.currentTime() == time(1, 25),
+                        "the step itself still lands exactly on frame one's mapped time");
+
+    delete editor;
+    finishFixture(fixture, expectations);
+}
+
+// Shortcuts (design decision 2): QActions mirroring the Space idiom exactly -- Left/Right/Home/End
+// move session time when no text-entry widget has focus; a focused QLineEdit keeps the keys for
+// its own cursor movement via the SAME Qt ShortcutOverride mechanism the Space test above already
+// exercises for real.
+void testFrameStepShortcutsMoveTimeAndTextEntryFocusWins(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step Shortcuts", time(4)));
+
+    QWidget host;
+    auto* layout = new QVBoxLayout(&host);
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller, &host);
+    auto* probeLineEdit = new QLineEdit(&host);
+    probeLineEdit->setObjectName("frameStepTestProbeLineEdit");
+    layout->addWidget(editor);
+    layout->addWidget(probeLineEdit);
+    host.show();
+    host.activateWindow();
+    QCoreApplication::processEvents();
+
+    editor->setFocus();
+    QCoreApplication::processEvents();
+    QTest::keyClick(editor, Qt::Key_Right);
+    QCoreApplication::processEvents();
+    expectations.expect(fixture.session.currentTime() == time(1, 25),
+                        "the Right application shortcut steps forward one frame when no text-entry "
+                        "widget has focus");
+
+    QTest::keyClick(editor, Qt::Key_Home);
+    QCoreApplication::processEvents();
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "the Home application shortcut jumps to frame zero");
+
+    QTest::keyClick(editor, Qt::Key_End);
+    QCoreApplication::processEvents();
+    expectations.expect(fixture.session.currentTime() == time(99, 25),
+                        "the End application shortcut jumps to the last frame");
+
+    probeLineEdit->setFocus(Qt::OtherFocusReason);
+    QCoreApplication::processEvents();
+    expectations.expect(QApplication::focusWidget() == probeLineEdit,
+                        "the probe line edit genuinely holds keyboard focus");
+    probeLineEdit->setText(QStringLiteral("ab"));
+    probeLineEdit->setCursorPosition(2);
+    QTest::keyClick(probeLineEdit, Qt::Key_Left);
+    QCoreApplication::processEvents();
+    expectations.expect(fixture.session.currentTime() == time(99, 25),
+                        "Left is NOT stolen from a focused text-entry widget: session time is "
+                        "unchanged by this keystroke");
+    expectations.expect(probeLineEdit->cursorPosition() == 1,
+                        "the focused line edit consumed Left as ordinary cursor movement, "
+                        "confirming it -- not a dropped/ignored event -- is what won the key");
+
+    finishFixture(fixture, expectations);
+}
+
+// Arrow-key conflict finding (this task's own investigation, verified with a standalone Qt harness
+// before writing composition_editors.cpp): layers_ (the QTreeWidget layer stack) already consumes
+// Left/Right/Home/End for its OWN keyboard navigation (Home/End jump to the first/last row), but --
+// unlike a text-entry widget -- does not claim the ShortcutOverride event for those keys, so a
+// same-key WindowShortcut action would otherwise silently swallow the tree's navigation the instant
+// it existed. The reconciliation rule implemented in composition_editors.cpp: widget-focus wins --
+// stepping is suppressed while the tree has focus, and the tree's native navigation runs completely
+// unchanged; step fires again once focus leaves the tree.
+void testArrowKeysOnLayerTreeStillNavigateAndStepIsSuppressed(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Frame Step Tree Conflict", time(4)));
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("A"), core::Color4d{0.0, 0.0, 0.0, 1.0}),
+        "first layer added");
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("B"), core::Color4d{0.0, 0.0, 0.0, 1.0}),
+        "second layer added");
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("C"), core::Color4d{0.0, 0.0, 0.0, 1.0}),
+        "third layer added");
+
+    QWidget host;
+    auto* layout = new QVBoxLayout(&host);
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller, &host);
+    layout->addWidget(editor);
+    host.show();
+    host.activateWindow();
+    QCoreApplication::processEvents();
+
+    auto* tree = editor->findChild<QTreeWidget*>("layerStackView");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 3,
+                        "the layer stack tree has all three rows");
+    if (tree == nullptr || tree->topLevelItemCount() != 3) {
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    editor->setFocus();
+    QCoreApplication::processEvents();
+    QTest::keyClick(editor, Qt::Key_Right);
+    QCoreApplication::processEvents();
+    expectations.expect(fixture.session.currentTime() == time(1, 25),
+                        "stepping works normally before the tree has focus");
+
+    tree->setFocus(Qt::OtherFocusReason);
+    tree->setCurrentItem(tree->topLevelItem(1));
+    QCoreApplication::processEvents();
+    expectations.expect(QApplication::focusWidget() == tree, "the tree genuinely holds focus");
+
+    QTest::keyClick(tree, Qt::Key_Home);
+    QCoreApplication::processEvents();
+    expectations.expect(tree->currentItem() == tree->topLevelItem(0),
+                        "the tree's OWN Home navigation (jump to the first row) still runs "
+                        "unchanged while it has focus");
+    expectations.expect(
+        fixture.session.currentTime() == time(1, 25),
+        "the step-to-start action is suppressed while the tree has focus -- session "
+        "time is untouched");
+
+    QTest::keyClick(tree, Qt::Key_End);
+    QCoreApplication::processEvents();
+    expectations.expect(tree->currentItem() == tree->topLevelItem(2),
+                        "the tree's OWN End navigation (jump to the last row) still runs unchanged "
+                        "while it has focus");
+    expectations.expect(fixture.session.currentTime() == time(1, 25),
+                        "the step-to-end action is suppressed while the tree has focus -- session "
+                        "time is still untouched");
+
+    editor->setFocus(Qt::OtherFocusReason);
+    QCoreApplication::processEvents();
+    QTest::keyClick(editor, Qt::Key_Home);
+    QCoreApplication::processEvents();
+    expectations.expect(fixture.session.currentTime() == time(0),
+                        "stepping resumes once focus leaves the tree");
+
+    finishFixture(fixture, expectations);
+}
+
+// Readout (design decision 3): the label tracks frame index / exact time across an exact frame
+// time, a genuinely subframe exact time (honest, not hidden/rounded away), and a composition switch
+// (which resets session time to exact zero -- docs/architecture/animation-and-time.md, "Session
+// Time And Scrubbing": "Switching compositions resets the session time to exact zero in version
+// 1").
+void testTimeReadoutFormatsFrameExactTimeAndResetsOnCompositionSwitch(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Readout Format", time(4));
+    expectations.expect(newProject.project.addComposition(secondComposition(time(4), testFormat())),
+                        "a second composition is added to the project");
+    SessionFixture fixture(std::move(newProject));
+
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* readout = editor->findChild<QLabel*>("timelineTimeReadout");
+    expectations.expect(readout != nullptr, "the time readout label is reachable by name");
+    if (readout == nullptr) {
+        delete editor;
+        finishFixture(fixture, expectations);
+        return;
+    }
+
+    expectations.expect(readout->text() == QStringLiteral("Frame 0 · 0.000s"),
+                        "the readout starts at exact frame 0 / 0.000s");
+
+    expectations.expect(fixture.session.setCurrentTime(time(1, 25)),
+                        "session time advances to exactly frame one's time");
+    expectations.expect(readout->text() == QStringLiteral("Frame 1 · 0.040s"),
+                        "the readout tracks currentTimeChanged() at an exact frame time");
+
+    expectations.expect(fixture.session.setCurrentTime(time(1, 3)),
+                        "session time moves to a genuinely subframe exact time (1/3 s)");
+    expectations.expect(readout->text() == QStringLiteral("Frame 8 · 0.333s"),
+                        "a subframe time displays its true nearest-index / truncated-exact-seconds "
+                        "reading rather than hiding that it is not frame-aligned (1/3 s truncates "
+                        "to 0.333s, never rounding up to overstate it, and 1/3 s is nearest to "
+                        "frame index 8 at this fixture's 25 fps rate)");
+
+    expectations.expect(fixture.session.setComposition(document::CompositionId::fromRaw(2)),
+                        "switching composition succeeds");
+    expectations.expect(readout->text() == QStringLiteral("Frame 0 · 0.000s"),
+                        "the readout resets to frame 0 / 0.000s across a composition switch, "
+                        "matching CompositionSession's own session-time reset");
+
+    delete editor;
+    finishFixture(fixture, expectations);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -626,5 +986,14 @@ int main(int argc, char** argv) {
     testOverflowingDurationCompositionPlaybackIsNoOp(expectations);
     testIntegrationPlaybackDrivesInteractivePriorityUnderGate(expectations);
     testPlaybackToggleButtonAndSpaceShortcut(expectations);
+    testStepForwardFromZeroLandsOnFrameOne(expectations);
+    testStepBackwardAtZeroClampsWithNoSignalChurn(expectations);
+    testStepToEndLandsAtExactMaxFrame(expectations);
+    testStepToStartLandsAtExactZero(expectations);
+    testStepFromSubframeTimeUsesNearestIndexTieRule(expectations);
+    testStepDuringPlaybackPausesThenSteps(expectations);
+    testFrameStepShortcutsMoveTimeAndTextEntryFocusWins(expectations);
+    testArrowKeysOnLayerTreeStillNavigateAndStepIsSuppressed(expectations);
+    testTimeReadoutFormatsFrameExactTimeAndResetsOnCompositionSwitch(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Completes the transport basics over the playback controller:

- **Frame stepping**: Left/Right step one exact frame (clamped), Home/End jump to first/last frame — all through the session's one-truth mutator at Visible priority per the contract's discrete-entry rule (cited in-code; the Interactive trio is scrub/playback/direct-manipulation, and a key-step is discrete). Stepping during playback pauses first, unconditionally.
- **Shortcut correctness proven empirically**: a standalone harness established that the layer tree does not claim ShortcutOverride for arrows — so the actions disable while the tree holds focus (its native navigation is byte-for-byte untouched, pinned by test) and re-enable on focus change; text-entry widgets win the standard way.
- **Exact time readout**: frame index plus seconds formatted entirely from the rational's integers (128-bit widening, truncation never rounding — a subframe display never overstates), resetting across composition switches.

No changes to the playback controller, session, or preview controller. Desktop 101/101 and native 85/85, format check clean.

Closes #108.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.