### PR TITLE
feat: export PNG frames from the File menu

### DIFF
--- a/apps/bloom/main.cpp
+++ b/apps/bloom/main.cpp
@@ -97,7 +97,8 @@ int main(int argc, char* argv[]) {
     // TaskUiBridge the preview pipeline above already uses.
     bloom::ui::FrameExportController frameExportController(
         compositionSession, taskScheduler, taskUiBridge, snapshotCompiler,
-        projectHost.publicationCoordinator(), projectHost.artifactCoordinator());
+        projectHost.publicationCoordinator(), projectHost.artifactCoordinator(), {},
+        &qualifiedDisplayProcessorProvider);
 
     bloom::ui::EditorRegistry editorRegistry;
     const bool editorsRegistered = bloom::ui::registerFoundationEditors(

--- a/docs/architecture/frame-output.md
+++ b/docs/architecture/frame-output.md
@@ -9,10 +9,11 @@ digest, preset-specific bound-analysis products, the module-private Output Seman
 1 streaming serializer/preparer, portable golden vectors, the flat OpenEXR adapter with its
 semantic reopen verifier and verifier-product issuance, and headless end-to-end EXR export
 publication (analysis attempt graph, immutable export request, and the shared-coordinator
-publication job), the interactive frame-export command with explicit digest approval, and the
-constrained PNG codec with strict chunk-profile verification and kind-1 identity issuance are
-implemented. The export job's PNG color-preparation wiring and export-command preset choice
-remain pending.
+publication job), the interactive frame-export command with explicit digest approval, the
+constrained PNG codec with strict chunk-profile verification and kind-1 identity issuance, and
+the PNG export path end to end (attempt color preparation, prepared-stream production, and the
+export command's preset choice) are implemented. The supervised external-config helper and the
+non-built-in locator kinds remain the pending color-side work.
 
 Updated: 2026-08-31
 

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -62,8 +62,19 @@ target_compile_features(bloom_host PUBLIC cxx_std_20)
 # bloom_runtime dependencies above. {"host", "output"} was already present in
 # tools/quality/repository_checks/repository_checks.cpp's kAllowedModuleDependencies allowlist
 # before this task (no allowlist edit was needed).
-target_link_libraries(bloom_host PUBLIC bloom_color bloom_commands bloom_core bloom_document
-                                        bloom_output bloom_project bloom_platform bloom_runtime)
+# bloom_color_ocio is PUBLIC (issue #111): output_analysis_attempt_runner.cpp performs the PNG
+# attempt graph's step-4 color work directly against the C2 in-process registry
+# (bloom/color/ocio_builtin_registry.hpp) and processor builder
+# (bloom/color/ocio_cpu_display_processor.hpp) so it can map every closed registry outcome onto the
+# analyzer's own closed PNG color-resolution input states one to one -- something
+# bloom::runtime::buildBloomNeutralQualifiedDisplayProcessor()'s free-text TaskDiagnostic result
+# cannot express. PUBLIC because bloom/host/output_analysis_attempt_runner.hpp's request already
+# exposes bloom::runtime::QualifiedDisplayProcessorProvider, whose own public surface carries
+# bloom::color::PreparedCpuDisplayProcessorHandle. {"host", "color"} was already present in
+# tools/quality/repository_checks/repository_checks.cpp's kAllowedModuleDependencies allowlist.
+target_link_libraries(bloom_host PUBLIC bloom_color bloom_color_ocio bloom_commands bloom_core
+                                        bloom_document bloom_output bloom_project bloom_platform
+                                        bloom_runtime)
 bloom_enable_warnings(bloom_host)
 
 if(BUILD_TESTING)
@@ -200,9 +211,16 @@ if(BUILD_TESTING)
         # Task F2 (issue #101): drives approveFrameExportV1()/executeExportPublication() against
         # the same real platform::StagedArtifactCoordinator + PublicationCoordinator save/copy
         # already prove.
+        #
+        # Links ZLIB::ZLIB directly (issue #111) for its own from-scratch PNG reader -- a raw chunk
+        # parse plus a zlib inflate that never calls into bloom::output's PNG writer/verifier, so
+        # the PNG round-trip test proves the published artifact against a second, independent
+        # reading. Same rationale and same target as bloom_host_session_open_test's own direct
+        # ZLIB::ZLIB link above.
         add_executable(bloom_host_frame_export_publication_test
                        tests/frame_export_publication_tests.cpp)
-        target_link_libraries(bloom_host_frame_export_publication_test PRIVATE bloom_host)
+        target_link_libraries(bloom_host_frame_export_publication_test PRIVATE bloom_host
+                                                                               ZLIB::ZLIB)
         bloom_enable_warnings(bloom_host_frame_export_publication_test)
         bloom_add_test(
             NAME bloom.host.frame-export-publication

--- a/src/host/frame_export_publication.cpp
+++ b/src/host/frame_export_publication.cpp
@@ -3,11 +3,14 @@
 #include <bloom/core/sha256.hpp>
 #include <bloom/output/output_limits.hpp>
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <fstream>
 #include <limits>
 #include <new>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -104,12 +107,74 @@ FrameExportPublicationResultV1 FrameExportPublicationResultV1::failure(
 namespace {
 
 [[nodiscard]] std::filesystem::path
-uniqueScratchFilePath(const std::filesystem::path& directory) noexcept {
+uniqueScratchFilePath(const std::filesystem::path& directory,
+                      const std::string_view extension) noexcept {
     static std::atomic<std::uint64_t> counter{0};
     const auto suffix = counter.fetch_add(1, std::memory_order_relaxed);
     const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
-    return directory /
-           (".bloom-export-scratch-" + std::to_string(now) + "-" + std::to_string(suffix) + ".exr");
+    return directory / (".bloom-export-scratch-" + std::to_string(now) + "-" +
+                        std::to_string(suffix) + std::string(extension));
+}
+
+// The doc's ordered stage vocabulary, mapped onto the existing TaskContext::reportProgress()
+// phase strings (frame-output.md, "Non-Blocking Execution"). EXR only ever produces Writing,
+// Verifying, and Publishing here -- exactly the three the previous inline ternary produced.
+[[nodiscard]] std::string exportStagePhase(const output::OutputExportStageV1 stage) {
+    switch (stage) {
+    case output::OutputExportStageV1::Resolving:
+        return "Resolving";
+    case output::OutputExportStageV1::Evaluating:
+        return "Evaluating";
+    case output::OutputExportStageV1::Identifying:
+        return "Identifying";
+    case output::OutputExportStageV1::ColorPreparing:
+        return "ColorPreparing";
+    case output::OutputExportStageV1::Analyzing:
+        return "Analyzing";
+    case output::OutputExportStageV1::PreparingOutput:
+        return "PreparingOutput";
+    case output::OutputExportStageV1::Writing:
+        return "Writing";
+    case output::OutputExportStageV1::Verifying:
+        return "Verifying";
+    case output::OutputExportStageV1::Publishing:
+        break;
+    }
+    return "Publishing";
+}
+
+// The preset-independent shape of "the staged bytes exist at the scratch path and carry these two
+// digests", so the publication half below stays one code path for both presets.
+struct WriteVerifyOutcomeV1 final {
+    bool written = false;
+    bool cancelled = false;
+    FrameExportPublicationStageV1 stage = FrameExportPublicationStageV1::Writing;
+    FrameExportPublicationFailurePayloadV1 payload{};
+    core::Sha256Digest semanticDigest;
+    core::Sha256Digest artifactDigest;
+    std::uint64_t artifactByteCount = 0;
+};
+
+// Maps the PNG bridge's typed error onto the publication stage it happened at. ColorPreparing and
+// PreparingOutput both belong to the doc's node 2 ("dependent output preparation"); the remaining
+// codes belong to node 3's writer/verifier halves.
+[[nodiscard]] FrameExportPublicationStageV1
+pngFailureStage(const output::PngExportWriteErrorCodeV1 error) noexcept {
+    switch (error) {
+    case output::PngExportWriteErrorCodeV1::MissingDisplayProducts:
+    case output::PngExportWriteErrorCodeV1::PreparedBytesLimitExceeded:
+    case output::PngExportWriteErrorCodeV1::ColorPrepareFailed:
+        return FrameExportPublicationStageV1::ColorPreparing;
+    case output::PngExportWriteErrorCodeV1::VerifyFailed:
+        return FrameExportPublicationStageV1::Verifying;
+    case output::PngExportWriteErrorCodeV1::None:
+    case output::PngExportWriteErrorCodeV1::InvalidAttempt:
+    case output::PngExportWriteErrorCodeV1::WriteFailed:
+    case output::PngExportWriteErrorCodeV1::ArtifactHashFailed:
+    case output::PngExportWriteErrorCodeV1::InternalInvariant:
+        break;
+    }
+    return FrameExportPublicationStageV1::Writing;
 }
 
 class ScratchFileGuard final {
@@ -183,18 +248,43 @@ FrameExportPublicationResultV1 executeExportPublication(
             FrameExportPublicationStageV1::Preflight, FrameExportUnexpectedFailureV1{}));
     }
 
+    // PNG's prepared straight-RGBA8 stream is the one buffer the approved job adds on top of the
+    // attempt's already-charged retained products, so it is both checked against its own closed
+    // limit and folded into the expanded reservation below -- BEFORE anything is allocated or any
+    // file is created (frame-output.md: "An insufficient or overflowing reservation rejects the
+    // stage before allocation or file creation"). EXR exposes the retained rows directly and adds
+    // nothing here, which is why its peak arithmetic below is unchanged.
+    const bool isPng = attempt.preset() == output::OutputPresetV1::PngRgba8SrgbV1;
+    std::uint64_t preparedBytes = 0;
+    if (isPng) {
+        const auto counted = output::checkedPngPreparedByteCountV1(attempt);
+        if (!counted.has_value()) {
+            return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
+                FrameExportPublicationStageV1::Preflight, FrameExportUnexpectedFailureV1{}));
+        }
+        const auto preparedLimit =
+            std::min(limits.preparedPngByteLimit, output::kOutputExportPreparedPngBytesMaximumV1);
+        if (preparedLimit == 0 || *counted > preparedLimit) {
+            return FrameExportPublicationResultV1::failure(
+                FrameExportPublicationFailureV1(FrameExportPublicationStageV1::ColorPreparing,
+                                                FrameExportPreparedBytesExceededV1{}));
+        }
+        preparedBytes = *counted;
+    }
+
     // Approved-job admission transactionally expands the SAME reservation the attempt already
     // holds (design decision 5: "Approved-job admission transactionally expands that reservation
     // to the checked peak ... it neither double-charges shared retained storage") -- the checked
-    // peak here is the retained bytes already charged plus one streaming chunk of encoder/
-    // verifier/copy scratch (EXR exposes retained rows directly; there is no separate prepared
-    // display/output buffer to add).
+    // peak here is the retained bytes already charged, plus PNG's prepared display/output pixels
+    // (zero for EXR), plus one streaming chunk of encoder/verifier/copy scratch. The attempt's own
+    // retained storage is never re-added, so nothing is double-charged.
     const auto currentCharge = attempt.resources()->chargedBytes();
     constexpr auto chunkBound =
         static_cast<std::uint64_t>(output::kOutputAdapterMaximumStreamingChunkBytesV1);
-    const auto peak = currentCharge > std::numeric_limits<std::uint64_t>::max() - chunkBound
-                          ? std::numeric_limits<std::uint64_t>::max()
-                          : currentCharge + chunkBound;
+    constexpr auto maximumBytes = std::numeric_limits<std::uint64_t>::max();
+    auto peak =
+        currentCharge > maximumBytes - preparedBytes ? maximumBytes : currentCharge + preparedBytes;
+    peak = peak > maximumBytes - chunkBound ? maximumBytes : peak + chunkBound;
     if (attempt.resources()->expand(peak) != output::ExportResourceAdmissionStatusV1::Reserved) {
         return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
             FrameExportPublicationStageV1::Preflight, FrameExportResourceExhaustedV1{}));
@@ -224,25 +314,52 @@ FrameExportPublicationResultV1 executeExportPublication(
     // uninterruptible from here) call returns -- runtime::CancellationToken exposes no
     // caller-side "request my own cancellation" seam, and changing task_scheduler.hpp is out of
     // this task's scope. See the implementor's report for the full limitation.
-    const ScratchFileGuard scratch(uniqueScratchFilePath(scratchDirectory));
-    const output::FlatExrExportWriterV1 writer;
-    const auto writeVerifyResult = writer.run(
-        attempt, scratch.path(), context.cancellation(),
-        [&](const output::OutputExportProgressV1& stageProgress) {
-            lastProgress = clock();
-            context.reportProgress(
-                {.phase = stageProgress.stage == output::OutputExportStageV1::Writing
-                              ? "Writing"
-                              : (stageProgress.stage == output::OutputExportStageV1::Verifying
-                                     ? "Verifying"
-                                     : "Publishing"),
-                 .subphase = "",
-                 .completed = stageProgress.completed,
-                 .total = stageProgress.total});
-            if (progress) {
-                progress(stageProgress);
-            }
-        });
+    const ScratchFileGuard scratch(
+        uniqueScratchFilePath(scratchDirectory, isPng ? ".png" : ".exr"));
+    const auto stageProgressSink = [&](const output::OutputExportProgressV1& stageProgress) {
+        lastProgress = clock();
+        context.reportProgress({.phase = exportStagePhase(stageProgress.stage),
+                                .subphase = "",
+                                .completed = stageProgress.completed,
+                                .total = stageProgress.total});
+        if (progress) {
+            progress(stageProgress);
+        }
+    };
+
+    WriteVerifyOutcomeV1 writeVerify;
+    if (isPng) {
+        const output::PngExportWriterV1 pngWriter;
+        const auto pngResult = pngWriter.run(attempt, scratch.path(), context.cancellation(),
+                                             stageProgressSink, limits.preparedPngByteLimit);
+        writeVerify.cancelled = pngResult.status() == output::PngExportWriteStatusV1::Cancelled;
+        writeVerify.written = pngResult.status() == output::PngExportWriteStatusV1::Written;
+        if (writeVerify.written) {
+            writeVerify.semanticDigest = pngResult.semanticDigest();
+            writeVerify.artifactDigest = pngResult.artifactDigest();
+            writeVerify.artifactByteCount = pngResult.artifactByteCount();
+        } else if (!writeVerify.cancelled) {
+            writeVerify.stage = pngFailureStage(pngResult.error());
+            writeVerify.payload = pngResult.error();
+        }
+    } else {
+        const output::FlatExrExportWriterV1 writer;
+        const auto exrResult =
+            writer.run(attempt, scratch.path(), context.cancellation(), stageProgressSink);
+        writeVerify.cancelled = exrResult.status() == output::FlatExrExportWriteStatusV1::Cancelled;
+        writeVerify.written = exrResult.status() == output::FlatExrExportWriteStatusV1::Written;
+        if (writeVerify.written) {
+            writeVerify.semanticDigest = exrResult.semanticDigest();
+            writeVerify.artifactDigest = exrResult.artifactDigest();
+            writeVerify.artifactByteCount = exrResult.artifactByteCount();
+        } else if (!writeVerify.cancelled) {
+            writeVerify.stage =
+                exrResult.error() == output::FlatExrExportWriteErrorCodeV1::WriteFailed
+                    ? FrameExportPublicationStageV1::Writing
+                    : FrameExportPublicationStageV1::Verifying;
+            writeVerify.payload = exrResult.error();
+        }
+    }
 
     const auto afterWriteVerify = clock();
     if (deadlineExceeded(afterWriteVerify)) {
@@ -253,16 +370,12 @@ FrameExportPublicationResultV1 executeExportPublication(
         return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
             FrameExportPublicationStageV1::Writing, FrameExportNoProgressExceededV1{}));
     }
-    if (writeVerifyResult.status() == output::FlatExrExportWriteStatusV1::Cancelled) {
+    if (writeVerify.cancelled) {
         return cancelledResult(FrameExportPublicationStageV1::Writing);
     }
-    if (writeVerifyResult.status() != output::FlatExrExportWriteStatusV1::Written) {
-        const auto stage =
-            writeVerifyResult.error() == output::FlatExrExportWriteErrorCodeV1::WriteFailed
-                ? FrameExportPublicationStageV1::Writing
-                : FrameExportPublicationStageV1::Verifying;
+    if (!writeVerify.written) {
         return FrameExportPublicationResultV1::failure(
-            FrameExportPublicationFailureV1(stage, writeVerifyResult.error()));
+            FrameExportPublicationFailureV1(writeVerify.stage, writeVerify.payload));
     }
 
     // --- Artifact copy (design decision 4 node 3's "artifact SHA-256 + flush"): stream the
@@ -356,7 +469,7 @@ FrameExportPublicationResultV1 executeExportPublication(
                 break;
             }
         }
-        if (rehasher.finalize() != writeVerifyResult.artifactDigest()) {
+        if (rehasher.finalize() != writeVerify.artifactDigest) {
             static_cast<void>(lease.rejectVerification());
             return FrameExportPublicationResultV1::failure(FrameExportPublicationFailureV1(
                 FrameExportPublicationStageV1::ArtifactCopy, FrameExportUnexpectedFailureV1{}));
@@ -384,8 +497,8 @@ FrameExportPublicationResultV1 executeExportPublication(
         auto guard = std::move(guardResult).takeGuard();
         auto publication = lease.publish(platform::PublicationDisposition::Proceed);
         return FrameExportPublicationResultV1::published(
-            publication, intentId, writeVerifyResult.semanticDigest(),
-            writeVerifyResult.artifactDigest(), writeVerifyResult.artifactByteCount());
+            publication, intentId, writeVerify.semanticDigest, writeVerify.artifactDigest,
+            writeVerify.artifactByteCount);
     }
     case PublicationGuardStatus::Superseded:
         return FrameExportPublicationResultV1::published(

--- a/src/host/frame_export_publication.cpp
+++ b/src/host/frame_export_publication.cpp
@@ -306,13 +306,17 @@ FrameExportPublicationResultV1 executeExportPublication(
         return cancelledResult(FrameExportPublicationStageV1::Staging);
     }
 
-    // --- Writing + Verifying (design decision 4 node 3's first half): F1's writer/verifier
-    // against a caller-owned scratch path bridging their path-based OpenEXR API to the lease's
-    // byte-oriented staging (see bloom/output/flat_exr_export_write.hpp's own namespace comment
-    // for the full rationale). The bridging progress callback also resets the no-progress clock;
-    // a mid-call deadline/no-progress violation can only be detected once F1's own (synchronous,
-    // uninterruptible from here) call returns -- runtime::CancellationToken exposes no
-    // caller-side "request my own cancellation" seam, and changing task_scheduler.hpp is out of
+    // --- (PNG only: ColorPreparing + PreparingOutput, node 2) then Writing + Verifying (design
+    // decision 4 node 3's first half), through the preset's own bridge: F1's flat OpenEXR
+    // writer/verifier, or G1's PNG writer/verifier behind the retained qualified display
+    // processor. Both target a caller-owned scratch path bridging their path-based APIs to the
+    // lease's byte-oriented staging (see bloom/output/flat_exr_export_write.hpp and
+    // bloom/output/png_export_write.hpp's own namespace comments for the full rationale); the
+    // publication half below is one shared code path for both. The bridging progress callback --
+    // the same sink for both presets -- also resets the no-progress clock;
+    // a mid-call deadline/no-progress violation can only be detected once the bridge's own
+    // (synchronous, uninterruptible from here) call returns -- runtime::CancellationToken exposes
+    // no caller-side "request my own cancellation" seam, and changing task_scheduler.hpp is out of
     // this task's scope. See the implementor's report for the full limitation.
     const ScratchFileGuard scratch(
         uniqueScratchFilePath(scratchDirectory, isPng ? ".png" : ".exr"));

--- a/src/host/include/bloom/host/frame_export_publication.hpp
+++ b/src/host/include/bloom/host/frame_export_publication.hpp
@@ -6,6 +6,8 @@
 #include <bloom/output/output_analysis_attempt.hpp>
 #include <bloom/output/output_export_resource_ledger.hpp>
 #include <bloom/output/output_export_stage.hpp>
+#include <bloom/output/output_limits.hpp>
+#include <bloom/output/png_export_write.hpp>
 #include <bloom/platform/staged_artifact.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
 
@@ -52,6 +54,11 @@ namespace bloom::host {
 struct FrameExportLimitsV1 final {
     std::chrono::steady_clock::duration totalDeadline = std::chrono::hours(24);
     std::chrono::steady_clock::duration noProgressInterval = std::chrono::seconds(120);
+    // The PNG preset's retained-prepared-bytes ceiling (frame-output.md's "Version 1 export
+    // limits": "retained prepared PNG bytes | 256 MiB"). Ignored by the EXR preset, which retains
+    // no prepared display/output buffer at all. A request may LOWER this ("a request may lower but
+    // not raise them"); a higher value is clamped back down to the closed limit.
+    std::uint64_t preparedPngByteLimit = output::kOutputExportPreparedPngBytesMaximumV1;
 };
 
 enum class FrameExportApprovalStatusV1 : std::uint8_t {
@@ -164,6 +171,9 @@ class FrameExportRequestAccessV1 final {
 enum class FrameExportPublicationStageV1 : std::uint8_t {
     Preflight,
     Staging,
+    // PNG only: the retained qualified processor applied to the retained process frame in bounded
+    // chunks. EXR skips it entirely (frame-output.md: "EXR skips ColorPreparing").
+    ColorPreparing,
     Writing,
     Verifying,
     ArtifactCopy,
@@ -174,13 +184,18 @@ enum class FrameExportPublicationStageV1 : std::uint8_t {
 struct FrameExportDeadlineExceededV1 final {};
 struct FrameExportNoProgressExceededV1 final {};
 struct FrameExportResourceExhaustedV1 final {};
+// The PNG prepared straight-RGBA8 stream this export would retain exceeds the effective
+// retained-prepared-PNG-bytes limit. Distinct from FrameExportResourceExhaustedV1 (which reports a
+// refused ledger reservation) because this one names a specific closed per-preset limit.
+struct FrameExportPreparedBytesExceededV1 final {};
 struct FrameExportUnexpectedFailureV1 final {};
 
 using FrameExportPublicationFailurePayloadV1 =
     std::variant<std::monostate, platform::StagedArtifactError,
-                 output::FlatExrExportWriteErrorCodeV1, PublicationGuardStatus,
-                 FrameExportDeadlineExceededV1, FrameExportNoProgressExceededV1,
-                 FrameExportResourceExhaustedV1, FrameExportUnexpectedFailureV1>;
+                 output::FlatExrExportWriteErrorCodeV1, output::PngExportWriteErrorCodeV1,
+                 PublicationGuardStatus, FrameExportDeadlineExceededV1,
+                 FrameExportNoProgressExceededV1, FrameExportResourceExhaustedV1,
+                 FrameExportPreparedBytesExceededV1, FrameExportUnexpectedFailureV1>;
 
 class FrameExportPublicationFailureV1 final {
   public:

--- a/src/host/include/bloom/host/output_analysis_attempt_runner.hpp
+++ b/src/host/include/bloom/host/output_analysis_attempt_runner.hpp
@@ -6,6 +6,7 @@
 #include <bloom/output/process_frame_semantic_identity.hpp>
 #include <bloom/platform/staged_artifact.hpp>
 #include <bloom/runtime/evaluation.hpp>
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
 
 #include <cstdint>
@@ -32,7 +33,13 @@
 //     rather than held open for the lifetime of a pending artist decision -- the job graph
 //     revalidates via a second, real StagedArtifactCoordinator::preflight() call at publish time
 //     (bloom/host/frame_export_publication.hpp), reusing the identical platform call rather than
-//     inventing a way to keep the first live handle alive indefinitely.
+//     inventing a way to keep the first live handle alive indefinitely. For the PNG preset this
+//     same BlockingIo task additionally performs the attempt graph's step-4 color work
+//     (ColorPreparing): resolving Bloom Neutral through the C2 in-process registry and reusing (or,
+//     when the application published none, building) the qualified CPU display processor. It runs
+//     here, not on the Cpu task, because processor preparation is the established one-time BLOCKING
+//     stage (issue #97's decision 3, bloom/runtime/qualified_display_processor_provider.hpp), and
+//     because it is a pure input to the analyzer, which is the very next stage.
 //   - Evaluating, Identifying, and Analyzing are pure CPU work sharing one TaskExecutor::Cpu task
 //     (runtime::CpuCompositionEvaluator, output::ProcessFrameSemanticIdentityV1Preparer,
 //     output::analyzeFlatExrRgba32fLinRec709SceneV1, output::buildOutputAnalysisAttemptV1 in
@@ -58,10 +65,30 @@ struct OutputAnalysisAttemptRequestV1 final {
     platform::ArtifactOverwritePolicy overwritePolicy =
         platform::ArtifactOverwritePolicy::CreateOrReplace;
     runtime::TaskOwner owner{.kind = runtime::TaskOwnerKind::Export, .id = {}};
+    // Which closed preset contract this attempt analyzes for (issue #111). The typed preset selects
+    // the analyzer entry point -- analyzePngRgba8SrgbV1 vs analyzeFlatExrRgba32fLinRec709SceneV1 --
+    // and therefore whether the blocking stage additionally resolves Bloom Neutral and prepares the
+    // qualified display processor at all ("EXR has no display product"). The default keeps every
+    // pre-existing caller on the exact flat OpenEXR path it had before.
+    output::OutputPresetV1 preset = output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1;
+    // Optional, non-owning: the application's already-published qualified display processor
+    // (bloom/runtime/qualified_display_processor_provider.hpp -- the same one-shot startup handoff
+    // the viewer's preview pipeline reads). When it is non-null AND Ready, the PNG blocking stage
+    // REUSES that exact handle instead of resolving and building a second one -- the doc's
+    // "preparation or EXACT REUSE of the qualified display processor". When it is null, Pending, or
+    // Failed, the blocking stage resolves and builds its own; that is a real cost, never a silent
+    // fallback to an unqualified transform. Must outlive the whole asynchronous operation.
+    runtime::QualifiedDisplayProcessorProvider* displayProcessorProvider = nullptr;
 };
 
 enum class OutputAnalysisAttemptStageV1 : std::uint8_t {
     Resolving,
+    // PNG only: bounded Bloom Neutral resolution plus preparation or exact reuse of the qualified
+    // display processor (frame-output.md's attempt-graph step 4 and its ordered stage vocabulary).
+    // A non-Ready color resolution or an unusable adapter is NOT reported here -- it is a truthful
+    // analyzer input state that still produces a completed, non-approvable attempt. Only an
+    // allocation or internal-invariant failure of this stage itself fails the attempt at it.
+    ColorPreparing,
     Evaluating,
     Identifying,
     Analyzing,

--- a/src/host/output_analysis_attempt_runner.cpp
+++ b/src/host/output_analysis_attempt_runner.cpp
@@ -1,7 +1,11 @@
 #include <bloom/host/output_analysis_attempt_runner.hpp>
 
+#include <bloom/color/bloom_neutral_builtin.hpp>
+#include <bloom/color/ocio_builtin_registry.hpp>
+#include <bloom/color/ocio_cpu_display_processor.hpp>
 #include <bloom/runtime/cpu_composition_evaluator.hpp>
 
+#include <new>
 #include <type_traits>
 #include <utility>
 
@@ -9,12 +13,146 @@ namespace bloom::host {
 
 namespace {
 
+// The PNG-only color half of the blocking stage, in the exact closed input vocabulary
+// analyzePngRgba8SrgbV1 accepts. `display` is populated only when both fields below are the
+// nominal Ready/Qualified pair.
+struct ColorResolutionOutcomeV1 final {
+    output::PngRgba8SrgbColorResolutionStateV1 colorResolution =
+        output::PngRgba8SrgbColorResolutionStateV1::Ready;
+    output::OutputAnalysisAdapterStateV1 adapter = output::OutputAnalysisAdapterStateV1::Qualified;
+    output::OutputAnalysisAttemptDisplayProductsV1 display;
+};
+
+// Everything the blocking stage hands the Cpu stage, behind ONE shared_ptr: runtime::
+// TaskResultValue caps a task result at four pointers (task_scheduler.hpp), and the retained
+// target plus the PNG display products exceed that on their own. Bundling them keeps the task
+// result a single small handle while still transferring both products by value semantics.
+struct ResolvedAttemptInputsV1 final {
+    output::OutputAnalysisAttemptTargetV1 target;
+    ColorResolutionOutcomeV1 color;
+};
+
 struct ResolvingOutcomeV1 final {
     bool succeeded = false;
+    // Distinguishes an allocation/internal failure of the PNG color stage (which fails the attempt
+    // AT ColorPreparing) from a target-preflight failure (which fails it at Resolving). A merely
+    // non-Ready color resolution is neither: it travels in `resolved->color` to the analyzer.
+    bool colorStageFailed = false;
     platform::StagedArtifactError error = platform::StagedArtifactError::None;
-    std::shared_ptr<const output::OutputAnalysisAttemptTargetV1> target = nullptr;
+    std::shared_ptr<const ResolvedAttemptInputsV1> resolved = nullptr;
 };
 static_assert(runtime::TaskResultValue<ResolvingOutcomeV1>);
+
+// Maps the C2 in-process registry's own closed outcome set onto the analyzer's closed PNG
+// color-resolution input states, one to one, per frame-output.md's "The five ocio.* codes map
+// one-to-one from the corresponding typed color-resolution failures". `Ready` is handled by the
+// caller (it is the only outcome that carries a resolved product to build a processor from).
+//
+// `LocatorKindRequiresHelper` names a real, planned locator kind that this in-process registry
+// never resolves; it is unreachable for the built-in URI this code always passes, and it maps to
+// `MissingResource` (`ocio.resource-missing`) -- the honest "the configuration resource this build
+// can reach does not cover that locator" state -- rather than being collapsed into `Missing`.
+// `UnsupportedVersion` (`ocio.version-unsupported`) has no producer at all in version 1: the
+// built-in payload's version is frozen with the binary, so nothing can present a newer one.
+[[nodiscard]] output::PngRgba8SrgbColorResolutionStateV1
+mapRegistryOutcome(const color::OcioBuiltInRegistryOutcome outcome) noexcept {
+    switch (outcome) {
+    case color::OcioBuiltInRegistryOutcome::Ready:
+        break; // unreachable here; the caller only maps a non-Ready outcome.
+    case color::OcioBuiltInRegistryOutcome::Missing:
+        return output::PngRgba8SrgbColorResolutionStateV1::Missing;
+    case color::OcioBuiltInRegistryOutcome::Changed:
+        return output::PngRgba8SrgbColorResolutionStateV1::Changed;
+    case color::OcioBuiltInRegistryOutcome::Invalid:
+        return output::PngRgba8SrgbColorResolutionStateV1::Invalid;
+    case color::OcioBuiltInRegistryOutcome::LocatorKindRequiresHelper:
+        return output::PngRgba8SrgbColorResolutionStateV1::MissingResource;
+    }
+    return output::PngRgba8SrgbColorResolutionStateV1::Missing;
+}
+
+// Binds a built or reused processor handle to the retained display-product triple. The identity is
+// an ALIASING shared_ptr into the handle's own DisplayProcessorIdentityV1 member -- never an
+// independently adopted copy -- so the exported identity can never be paired with a different
+// processor (frame-output.md: "Recomputing pixel hashes or substituting an equivalent-looking
+// frame or processor at approval or export is forbidden").
+[[nodiscard]] std::optional<output::OutputAnalysisAttemptDisplayProductsV1>
+retainDisplayProducts(std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle) {
+    core::Sha256Digest expectedRevision;
+    if (const auto view = handle->identity().borrowedView(); view.has_value()) {
+        expectedRevision = view->expectedOcioRevision();
+    } else {
+        return std::nullopt;
+    }
+    std::shared_ptr<const color::DisplayProcessorIdentityV1> identity(handle, &handle->identity());
+    return output::OutputAnalysisAttemptDisplayProductsV1{.processor = std::move(handle),
+                                                          .identity = std::move(identity),
+                                                          .expectedOcioRevision = expectedRevision};
+}
+
+// The attempt graph's step 4. Never throws; a genuine allocation/internal failure is signalled by
+// returning nullopt so the caller can fail the attempt AT the ColorPreparing stage, while every
+// modelled configuration/adapter state returns a populated outcome that the analyzer turns into a
+// truthful, non-approvable report.
+[[nodiscard]] std::optional<ColorResolutionOutcomeV1>
+resolvePngDisplayProducts(runtime::QualifiedDisplayProcessorProvider* const provider) noexcept {
+    try {
+        if (provider != nullptr) {
+            const auto snapshot = provider->snapshot();
+            if (snapshot.readiness == runtime::QualifiedDisplayProcessorReadiness::Ready &&
+                snapshot.handle != nullptr) {
+                auto products = retainDisplayProducts(snapshot.handle);
+                if (!products.has_value()) {
+                    return std::nullopt;
+                }
+                return ColorResolutionOutcomeV1{
+                    .colorResolution = output::PngRgba8SrgbColorResolutionStateV1::Ready,
+                    .adapter = output::OutputAnalysisAdapterStateV1::Qualified,
+                    .display = std::move(*products)};
+            }
+        }
+
+        auto resolution = color::resolveBloomNeutralV1BuiltIn(
+            color::OcioConfigLocatorKind::BloomBuiltIn, color::kBloomNeutralV1ConfigUri,
+            color::kBloomNeutralV1ConfigDigest);
+        if (!resolution.ready()) {
+            return ColorResolutionOutcomeV1{
+                .colorResolution = mapRegistryOutcome(resolution.outcome()),
+                .adapter = output::OutputAnalysisAdapterStateV1::Qualified,
+                .display = {}};
+        }
+        auto resolved = std::move(resolution).takeResolved();
+        if (!resolved.has_value()) {
+            return std::nullopt;
+        }
+
+        // frame-output.md: "A resolved PNG configuration whose helper, processor, or execution
+        // provider cannot run is an adapter-execution failure: Color keeps its Ready nominal tuple
+        // while External Dependencies uses adapter.unavailable."
+        auto built = color::buildBloomNeutralCpuDisplayProcessor(*resolved);
+        auto handleValue = std::move(built).takeHandle();
+        if (!handleValue.has_value()) {
+            return ColorResolutionOutcomeV1{
+                .colorResolution = output::PngRgba8SrgbColorResolutionStateV1::Ready,
+                .adapter = output::OutputAnalysisAdapterStateV1::Unavailable,
+                .display = {}};
+        }
+        auto handle = std::make_shared<const color::PreparedCpuDisplayProcessorHandle>(
+            std::move(*handleValue));
+        auto products = retainDisplayProducts(std::move(handle));
+        if (!products.has_value()) {
+            return std::nullopt;
+        }
+        return ColorResolutionOutcomeV1{.colorResolution =
+                                            output::PngRgba8SrgbColorResolutionStateV1::Ready,
+                                        .adapter = output::OutputAnalysisAdapterStateV1::Qualified,
+                                        .display = std::move(*products)};
+    } catch (const std::bad_alloc&) {
+        return std::nullopt;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
 
 enum class BuildFailureKindV1 : std::uint8_t {
     None,
@@ -145,6 +283,10 @@ std::optional<OutputAnalysisAttemptOutcomeV1> OutputAnalysisAttemptRunnerV1::try
         if (taken->state() != runtime::TaskState::Succeeded || !taken->value().has_value() ||
             !taken->value()->succeeded) {
             state_->completed = true;
+            if (taken->value().has_value() && taken->value()->colorStageFailed) {
+                return OutputAnalysisAttemptOutcomeV1::failure(
+                    {OutputAnalysisAttemptStageV1::ColorPreparing, false, std::monostate{}});
+            }
             const auto error = taken->value().has_value() ? taken->value()->error
                                                           : platform::StagedArtifactError::None;
             return OutputAnalysisAttemptOutcomeV1::failure(
@@ -152,8 +294,15 @@ std::optional<OutputAnalysisAttemptOutcomeV1> OutputAnalysisAttemptRunnerV1::try
         }
 
         // Resolving succeeded: submit the Cpu stage, consuming its typed result (the retained
-        // target) directly into the next task's closure -- never a wait/get/join.
-        auto resolvedTarget = taken->value()->target;
+        // target, and for PNG the retained display products) directly into the next task's closure
+        // -- never a wait/get/join.
+        auto resolved = taken->value()->resolved;
+        if (resolved == nullptr) {
+            state_->completed = true;
+            return OutputAnalysisAttemptOutcomeV1::failure(
+                {OutputAnalysisAttemptStageV1::Resolving, false, std::monostate{}});
+        }
+        const auto preset = state_->request.preset;
         auto* ledger = state_->ledger;
         auto plan = state_->request.plan;
         auto evaluation = state_->request.evaluation;
@@ -163,7 +312,7 @@ std::optional<OutputAnalysisAttemptOutcomeV1> OutputAnalysisAttemptRunnerV1::try
             runtime::TaskPriority::Foreground, runtime::TaskExecutor::Cpu);
         auto submission = state_->scheduler->submit<BuildOutcomeV1>(
             std::move(cpuRequest),
-            [plan = std::move(plan), evaluation, resolvedTarget,
+            [plan = std::move(plan), evaluation, resolved, preset,
              ledger](runtime::TaskContext& context) -> runtime::TaskResult<BuildOutcomeV1> {
                 if (context.isCancellationRequested()) {
                     return runtime::TaskResult<BuildOutcomeV1>::cancelled();
@@ -215,10 +364,25 @@ std::optional<OutputAnalysisAttemptOutcomeV1> OutputAnalysisAttemptRunnerV1::try
 
                 context.reportProgress(
                     {.phase = "Analyzing", .subphase = "", .completed = 0, .total = std::nullopt});
-                auto analyzed = output::analyzeFlatExrRgba32fLinRec709SceneV1(
-                    {.process = {.state = output::OutputAnalysisProcessSourceStateV1::Ready,
-                                 .readyIdentity = identityResult.identity(),
-                                 .missingDescriptor = std::nullopt}});
+                const output::OutputAnalysisProcessSourceV1 processSource{
+                    .state = output::OutputAnalysisProcessSourceStateV1::Ready,
+                    .readyIdentity = identityResult.identity(),
+                    .missingDescriptor = std::nullopt};
+                // The preset-specific analyzer entry points -- never a preset enum plus a union of
+                // optional fields (frame-output.md: "There is no public entry point that accepts a
+                // preset enum plus a union of optional fields"). The PNG input's expected OCIO
+                // revision is the persisted Bloom Neutral v1 expectedRevision, required whether or
+                // not resolution succeeded; when resolution DID succeed it byte-equals the revision
+                // embedded in the retained canonical DisplayProcessorIdentity, which the digest
+                // stage independently re-checks.
+                auto analyzed =
+                    preset == output::OutputPresetV1::PngRgba8SrgbV1
+                        ? output::analyzePngRgba8SrgbV1(
+                              {.process = processSource,
+                               .expectedOcioRevision = color::kBloomNeutralV1ConfigDigest,
+                               .colorResolution = resolved->color.colorResolution,
+                               .adapter = resolved->color.adapter})
+                        : output::analyzeFlatExrRgba32fLinRec709SceneV1({.process = processSource});
                 if (!analyzed.hasReport()) {
                     return runtime::TaskResult<BuildOutcomeV1>::succeeded(
                         {.succeeded = false,
@@ -233,7 +397,8 @@ std::optional<OutputAnalysisAttemptOutcomeV1> OutputAnalysisAttemptRunnerV1::try
                     {.frame = evalResult.frame(),
                      .processIdentity = identityResult.identity(),
                      .report = analyzed.report(),
-                     .target = *resolvedTarget},
+                     .target = resolved->target,
+                     .display = resolved->color.display},
                     *ledger);
                 if (!buildResult) {
                     return runtime::TaskResult<BuildOutcomeV1>::succeeded(
@@ -311,16 +476,21 @@ OutputAnalysisAttemptRunnerResultV1 beginOutputAnalysisAttemptV1(
             .completed = false,
         });
 
+    const auto preset = state->request.preset;
+    auto* const displayProvider = state->request.displayProcessorProvider;
+
     runtime::TaskRequest resolvingRequest(
         "Resolve an export target", attemptOwner(state->request.owner),
         runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo);
     auto submission = scheduler.submit<ResolvingOutcomeV1>(
         std::move(resolvingRequest),
-        [&artifacts, targetPath, overwritePolicy](
+        [&artifacts, targetPath, overwritePolicy, preset, displayProvider](
             runtime::TaskContext& context) -> runtime::TaskResult<ResolvingOutcomeV1> {
             if (context.isCancellationRequested()) {
                 return runtime::TaskResult<ResolvingOutcomeV1>::cancelled();
             }
+            context.reportProgress(
+                {.phase = "Resolving", .subphase = "", .completed = 0, .total = std::nullopt});
             auto preflightResult = artifacts.preflight({.targetPath = targetPath,
                                                         .overwritePolicy = overwritePolicy,
                                                         .expectedTarget = std::nullopt});
@@ -334,20 +504,39 @@ OutputAnalysisAttemptRunnerResultV1 beginOutputAnalysisAttemptV1(
             // `target` goes out of scope here: the live platform active-target admission it holds
             // is released immediately rather than kept open for the duration of a pending artist
             // decision (see this file's own header-level rationale comment).
-            std::shared_ptr<const output::OutputAnalysisAttemptTargetV1> retained;
+            ResolvedAttemptInputsV1 inputs{.target = {.targetKey = targetKey,
+                                                      .observation = observation,
+                                                      .targetPath = targetPath,
+                                                      .overwritePolicy = overwritePolicy},
+                                           .color = {}};
+
+            // EXR has no display product and therefore never enters ColorPreparing at all.
+            if (preset == output::OutputPresetV1::PngRgba8SrgbV1) {
+                if (context.isCancellationRequested()) {
+                    return runtime::TaskResult<ResolvingOutcomeV1>::cancelled();
+                }
+                context.reportProgress({.phase = "ColorPreparing",
+                                        .subphase = "",
+                                        .completed = 0,
+                                        .total = std::nullopt});
+                auto color = resolvePngDisplayProducts(displayProvider);
+                if (!color.has_value()) {
+                    return runtime::TaskResult<ResolvingOutcomeV1>::succeeded(
+                        {.succeeded = false, .colorStageFailed = true});
+                }
+                inputs.color = std::move(*color);
+            }
+
+            std::shared_ptr<const ResolvedAttemptInputsV1> retained;
             try {
-                retained = std::make_shared<const output::OutputAnalysisAttemptTargetV1>(
-                    output::OutputAnalysisAttemptTargetV1{.targetKey = targetKey,
-                                                          .observation = observation,
-                                                          .targetPath = targetPath,
-                                                          .overwritePolicy = overwritePolicy});
+                retained = std::make_shared<const ResolvedAttemptInputsV1>(std::move(inputs));
             } catch (const std::bad_alloc&) {
                 return runtime::TaskResult<ResolvingOutcomeV1>::succeeded(
                     {.succeeded = false,
                      .error = platform::StagedArtifactError::ResourceUnavailable});
             }
             return runtime::TaskResult<ResolvingOutcomeV1>::succeeded(
-                {.succeeded = true, .target = std::move(retained)});
+                {.succeeded = true, .resolved = std::move(retained)});
         });
 
     if (!submission.accepted()) {

--- a/src/host/tests/frame_export_publication_tests.cpp
+++ b/src/host/tests/frame_export_publication_tests.cpp
@@ -3,6 +3,17 @@
 #include <bloom/host/output_analysis_attempt_runner.hpp>
 #include <bloom/host/publication_coordinator.hpp>
 #include <bloom/output/flat_exr_reopen_verifier.hpp>
+#include <bloom/output/png_reopen_verifier.hpp>
+#include <bloom/runtime/qualified_display_preparation.hpp>
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
+
+// Used only by independentlyDecodePng() below -- a from-scratch reader (raw chunk parse + zlib
+// inflate) that never calls into bloom::output's own PNG writer/verifier, so the PNG round-trip
+// test proves the published artifact against a second, independent reading. Mirrors
+// src/output/tests/png_test_support.hpp's own helper, duplicated here because a src module's tests
+// may not reach across a sibling module's tests/ directory (the same boundary
+// src/ui/tests/main_window_readonly_placeholder_tests.cpp documents for its own duplicate).
+#include <zlib.h>
 
 #include <bloom/core/color.hpp>
 #include <bloom/core/rational_time.hpp>
@@ -141,8 +152,9 @@ constexpr auto kOpacityParameterId = document::ParameterId::fromRaw(0x200c);
                                                    .output = runtime::OperationIndex::fromRaw(3)});
 }
 
-[[nodiscard]] host::OutputAnalysisAttemptRequestV1
-attemptRequestFor(const std::filesystem::path& target) {
+[[nodiscard]] host::OutputAnalysisAttemptRequestV1 attemptRequestFor(
+    const std::filesystem::path& target,
+    const output::OutputPresetV1 preset = output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1) {
     const auto plan = smallSolidPlan();
     return {
         .plan = plan,
@@ -154,7 +166,8 @@ attemptRequestFor(const std::filesystem::path& target) {
                        .pixelStorageByteLimit = 4096},
         .targetPath = target,
         .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
-        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)}};
+        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)},
+        .preset = preset};
 }
 
 // Owns a real TaskScheduler/StagedArtifactCoordinator/PublicationCoordinator/ExportResourceLedgerV1
@@ -209,13 +222,13 @@ class ExportFixture final {
 // Runs beginOutputAnalysisAttemptV1() to a completed, approvable attempt over `target`. Every test
 // fixture below needs a real attempt (frame + identity + report + digest), not a hand-built one --
 // approveFrameExportV1() cannot be exercised meaningfully without one.
-[[nodiscard]] std::shared_ptr<const output::OutputAnalysisAttemptV1>
-buildApprovableAttempt(Expectations& expectations, runtime::TaskScheduler& scheduler,
-                       platform::StagedArtifactCoordinator& artifacts,
-                       output::ExportResourceLedgerV1& ledger,
-                       const std::filesystem::path& target) {
-    auto begin =
-        host::beginOutputAnalysisAttemptV1(scheduler, artifacts, ledger, attemptRequestFor(target));
+[[nodiscard]] std::shared_ptr<const output::OutputAnalysisAttemptV1> buildApprovableAttempt(
+    Expectations& expectations, runtime::TaskScheduler& scheduler,
+    platform::StagedArtifactCoordinator& artifacts, output::ExportResourceLedgerV1& ledger,
+    const std::filesystem::path& target,
+    const output::OutputPresetV1 preset = output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1) {
+    auto begin = host::beginOutputAnalysisAttemptV1(scheduler, artifacts, ledger,
+                                                    attemptRequestFor(target, preset));
     expectations.expect(static_cast<bool>(begin),
                         "attempt fixture: begin submits the Resolving task");
     if (!begin) {
@@ -851,6 +864,494 @@ void testNoProgressExpiryViaInjectedClock(Expectations& expectations) {
     expectations.expect(!std::filesystem::exists(target), "no-progress expiry publishes nothing");
 }
 
+// -------------------------------------------------------------------------------------------
+// PNG preset (issue #111)
+// -------------------------------------------------------------------------------------------
+
+struct IndependentPngDecode final {
+    bool ok = false;
+    std::vector<std::string> chunkTypesInOrder;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::uint8_t bitDepth = 0;
+    std::uint8_t colorType = 0;
+    std::uint8_t interlaceMethod = 0;
+    std::uint8_t srgbIntent = 0;
+    bool everyCrcValid = false;
+    bool everyRowFilterZero = false;
+    std::vector<std::uint8_t> rgba;
+};
+
+[[nodiscard]] std::uint32_t readBigEndianU32(const std::vector<unsigned char>& bytes,
+                                             const std::size_t offset) {
+    return (static_cast<std::uint32_t>(bytes[offset]) << 24U) |
+           (static_cast<std::uint32_t>(bytes[offset + 1]) << 16U) |
+           (static_cast<std::uint32_t>(bytes[offset + 2]) << 8U) |
+           static_cast<std::uint32_t>(bytes[offset + 3]);
+}
+
+[[nodiscard]] IndependentPngDecode independentlyDecodePng(const std::filesystem::path& path) {
+    IndependentPngDecode result;
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream) {
+        return result;
+    }
+    std::vector<unsigned char> bytes((std::istreambuf_iterator<char>(stream)),
+                                     std::istreambuf_iterator<char>());
+    static constexpr std::array<unsigned char, 8> kSignature{137, 80, 78, 71, 13, 10, 26, 10};
+    if (bytes.size() < 8 || !std::equal(kSignature.begin(), kSignature.end(), bytes.begin())) {
+        return result;
+    }
+
+    result.everyCrcValid = true;
+    std::vector<unsigned char> idatConcat;
+    std::size_t offset = 8;
+    bool sawIend = false;
+    while (offset + 8 <= bytes.size()) {
+        const auto length = readBigEndianU32(bytes, offset);
+        const std::string type(bytes.begin() + static_cast<std::ptrdiff_t>(offset) + 4,
+                               bytes.begin() + static_cast<std::ptrdiff_t>(offset) + 8);
+        const auto dataOffset = offset + 8;
+        if (dataOffset + length + 4 > bytes.size()) {
+            return result;
+        }
+        const std::span<const unsigned char> data(bytes.data() + dataOffset, length);
+        auto crc = crc32_z(0L, reinterpret_cast<const Bytef*>(type.data()), 4);
+        if (!data.empty()) {
+            crc = crc32_z(crc, reinterpret_cast<const Bytef*>(data.data()), data.size());
+        }
+        const auto crcOffset = dataOffset + length;
+        if (static_cast<std::uint32_t>(crc) != readBigEndianU32(bytes, crcOffset)) {
+            result.everyCrcValid = false;
+        }
+        result.chunkTypesInOrder.push_back(type);
+        if (type == "IHDR") {
+            if (length != 13) {
+                return result;
+            }
+            result.width = readBigEndianU32(bytes, dataOffset);
+            result.height = readBigEndianU32(bytes, dataOffset + 4);
+            result.bitDepth = data[8];
+            result.colorType = data[9];
+            result.interlaceMethod = data[12];
+        } else if (type == "sRGB") {
+            if (length != 1) {
+                return result;
+            }
+            result.srgbIntent = data[0];
+        } else if (type == "IDAT") {
+            idatConcat.insert(idatConcat.end(), data.begin(), data.end());
+        } else if (type == "IEND") {
+            sawIend = true;
+        }
+        offset = crcOffset + 4;
+        if (sawIend) {
+            break;
+        }
+    }
+    if (!sawIend || offset != bytes.size()) {
+        return result;
+    }
+
+    const auto expectedTotal =
+        static_cast<std::size_t>(result.width) * result.height * 4 + result.height;
+    std::vector<unsigned char> inflated(expectedTotal);
+    z_stream inflateStream{};
+    if (inflateInit(&inflateStream) != Z_OK) {
+        return result;
+    }
+    inflateStream.next_in = idatConcat.data();
+    inflateStream.avail_in = static_cast<uInt>(idatConcat.size());
+    inflateStream.next_out = inflated.data();
+    inflateStream.avail_out = static_cast<uInt>(inflated.size());
+    const auto status = inflate(&inflateStream, Z_FINISH);
+    inflateEnd(&inflateStream);
+    if (status != Z_STREAM_END || inflateStream.avail_out != 0) {
+        return result;
+    }
+
+    result.everyRowFilterZero = true;
+    result.rgba.resize(static_cast<std::size_t>(result.width) * result.height * 4);
+    const auto rowRgbaBytes = static_cast<std::size_t>(result.width) * 4;
+    for (std::uint32_t row = 0; row < result.height; ++row) {
+        const auto rowOffset = static_cast<std::size_t>(row) * (rowRgbaBytes + 1);
+        if (inflated[rowOffset] != 0) {
+            result.everyRowFilterZero = false;
+        }
+        const auto destinationOffset = static_cast<std::size_t>(row) * rowRgbaBytes;
+        std::copy_n(inflated.begin() + static_cast<std::ptrdiff_t>(rowOffset) + 1, rowRgbaBytes,
+                    result.rgba.begin() + static_cast<std::ptrdiff_t>(destinationOffset));
+    }
+    result.ok = true;
+    return result;
+}
+
+// Independently re-derives the prepared straight-RGBA8 stream from the attempt's retained process
+// frame, through a FRESHLY built qualified display processor (never the one the export retained),
+// so G1's reopen verifier can be run against the published file with inputs the export path did
+// not hand it.
+[[nodiscard]] bool
+independentlyVerifyPng(Expectations& expectations,
+                       const std::shared_ptr<const output::OutputAnalysisAttemptV1>& attempt,
+                       const std::filesystem::path& target,
+                       const bloom::core::Sha256Digest& expectedSemanticDigest) {
+    const auto built = runtime::buildBloomNeutralQualifiedDisplayProcessor();
+    expectations.expect(built.succeeded(),
+                        "independent PNG verify: a fresh qualified processor builds");
+    if (!built.succeeded()) {
+        return false;
+    }
+    const runtime::CpuQualifiedDisplayPreparer preparer(*built.handle());
+    const auto prepared = preparer.prepare(
+        attempt->frame(),
+        {.aggregatePixelStorageByteLimit = output::kOutputExportPreparedPngBytesMaximumV1,
+         .chunkPixelCount = runtime::kDefaultQualifiedDisplayChunkPixelCount},
+        {});
+    expectations.expect(prepared.status() == runtime::QualifiedDisplayPreparationStatus::Prepared &&
+                            prepared.frame() != nullptr,
+                        "independent PNG verify: the display frame re-derives");
+    if (prepared.status() != runtime::QualifiedDisplayPreparationStatus::Prepared ||
+        prepared.frame() == nullptr) {
+        return false;
+    }
+    const auto& buffer = prepared.frame()->buffer();
+    const output::PngRgba8SrgbPreparedStreamV1 stream{.dimensions = buffer.displayWindow().extent(),
+                                                      .pixels = buffer.pixels()};
+    const auto& display = attempt->display();
+    expectations.expect(display.isPresent(),
+                        "independent PNG verify: the attempt retains its display products");
+    bloom::core::Sha256Digest revision;
+    if (display.expectedOcioRevision.has_value()) {
+        revision = *display.expectedOcioRevision;
+    } else {
+        return false;
+    }
+    const output::PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto verifyResult = verifier.verify(target, stream, attempt->processIdentity(),
+                                              attempt->report(), revision, display.identity, {});
+    expectations.expect(verifyResult.status() == output::PngVerifyStatusV1::Verified,
+                        "independent PNG verify: the published file reopen-verifies");
+    if (verifyResult.status() != output::PngVerifyStatusV1::Verified) {
+        return false;
+    }
+    expectations.expect(verifyResult.digest() == expectedSemanticDigest,
+                        "independent PNG verify: the independently issued kind-1 digest equals the "
+                        "digest the export surfaced");
+    return true;
+}
+
+void testEndToEndPngExportPublished(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "png end to end: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "published.png";
+    auto attempt =
+        buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                               fixture.ledger(), target, output::OutputPresetV1::PngRgba8SrgbV1);
+    if (attempt == nullptr) {
+        return;
+    }
+    expectations.expect(attempt->preset() == output::OutputPresetV1::PngRgba8SrgbV1 &&
+                            attempt->display().isPresent(),
+                        "png end to end: the attempt is a PNG attempt retaining its qualified "
+                        "display-processor handle, identity, and expected OCIO revision");
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval), "png end to end: approval succeeds");
+    if (!approval) {
+        return;
+    }
+    auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                              std::move(approval).takeRequest(), fixture.path());
+    auto* runValue = require(run, expectations, "png end to end: the export job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result =
+        require(resultOpt, expectations, "png end to end: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    expectations.expect(static_cast<bool>(*result) && result->publication() != nullptr &&
+                            result->publication()->outcome ==
+                                platform::StagedArtifactPublicationOutcome::Published,
+                        "png end to end: the export publishes");
+    expectations.expect(std::filesystem::exists(target),
+                        "png end to end: the target file now exists");
+    const auto semanticDigest = result->semanticDigest();
+    expectations.expect(semanticDigest.has_value() && result->artifactDigest().has_value(),
+                        "png end to end: both the semantic and artifact digests are surfaced");
+    if (!semanticDigest.has_value()) {
+        return;
+    }
+
+    const auto decoded = independentlyDecodePng(target);
+    expectations.expect(decoded.ok && decoded.everyCrcValid && decoded.everyRowFilterZero,
+                        "png end to end: the published file independently decodes with valid CRCs "
+                        "and zero row filters");
+    expectations.expect(decoded.chunkTypesInOrder ==
+                            std::vector<std::string>{"IHDR", "sRGB", "IDAT", "IEND"},
+                        "png end to end: the published file carries exactly the closed chunk "
+                        "profile");
+    expectations.expect(decoded.width == 2 && decoded.height == 2 && decoded.bitDepth == 8 &&
+                            decoded.colorType == 6 && decoded.interlaceMethod == 0 &&
+                            decoded.srgbIntent == 0,
+                        "png end to end: the independent decode sees the required IHDR/sRGB "
+                        "fields");
+
+    static_cast<void>(independentlyVerifyPng(
+        expectations, attempt, target,
+        *semanticDigest)); // NOLINT(bugprone-unchecked-optional-access) -- guarded above.
+}
+
+void testPngSemanticDigestStableAcrossTwoRuns(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "png digest stability: fixture is available")) {
+        return;
+    }
+    std::array<std::optional<bloom::core::Sha256Digest>, 2> digests;
+    for (int index = 0; index < 2; ++index) {
+        const auto target = fixture.path() / ("stable-" + std::to_string(index) + ".png");
+        auto attempt = buildApprovableAttempt(expectations, fixture.scheduler(),
+                                              fixture.artifacts(), fixture.ledger(), target,
+                                              output::OutputPresetV1::PngRgba8SrgbV1);
+        if (attempt == nullptr) {
+            return;
+        }
+        auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                                   requireDigest(attempt, expectations));
+        if (!approval) {
+            expectations.expect(false, "png digest stability: approval succeeds");
+            return;
+        }
+        auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                                  std::move(approval).takeRequest(), fixture.path());
+        auto* runValue = require(run, expectations, "png digest stability: the job is submitted");
+        if (runValue == nullptr) {
+            return;
+        }
+        auto resultOpt = awaitExportRun(*runValue);
+        const auto* result = require(resultOpt, expectations,
+                                     "png digest stability: the job reaches a terminal state");
+        if (result == nullptr) {
+            return;
+        }
+        digests.at(static_cast<std::size_t>(index)) = result->semanticDigest();
+    }
+    expectations.expect(digests[0].has_value() && digests[1].has_value() &&
+                            digests[0] == digests[1],
+                        "png digest stability: the kind-1 semantic identity digest is identical "
+                        "across two full publications of the identical fixture");
+}
+
+void testBothPresetsExportFromTheSameFixture(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "both presets: fixture is available")) {
+        return;
+    }
+    const auto exrTarget = fixture.path() / "both.exr";
+    const auto pngTarget = fixture.path() / "both.png";
+
+    auto exrAttempt = buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                                             fixture.ledger(), exrTarget);
+    auto pngAttempt =
+        buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                               fixture.ledger(), pngTarget, output::OutputPresetV1::PngRgba8SrgbV1);
+    if (exrAttempt == nullptr || pngAttempt == nullptr) {
+        return;
+    }
+    expectations.expect(exrAttempt->preset() ==
+                                output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1 &&
+                            exrAttempt->display().isAbsent(),
+                        "both presets: the EXR attempt retains no display product at all");
+    expectations.expect(pngAttempt->preset() == output::OutputPresetV1::PngRgba8SrgbV1 &&
+                            pngAttempt->display().isPresent(),
+                        "both presets: the PNG attempt retains its display products");
+    expectations.expect(*exrAttempt->digest() != *pngAttempt->digest(), // NOLINT
+                        "both presets: the two presets' approval digests differ over the same "
+                        "frame");
+
+    std::array<std::optional<bloom::core::Sha256Digest>, 2> semantic;
+    const std::array<std::shared_ptr<const output::OutputAnalysisAttemptV1>, 2> attempts{
+        exrAttempt, pngAttempt};
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        auto approval = host::approveFrameExportV1(fixture.coordinator(), attempts.at(index),
+                                                   requireDigest(attempts.at(index), expectations));
+        if (!approval) {
+            expectations.expect(false, "both presets: approval succeeds");
+            return;
+        }
+        auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                                  std::move(approval).takeRequest(), fixture.path());
+        auto* runValue = require(run, expectations, "both presets: the job is submitted");
+        if (runValue == nullptr) {
+            return;
+        }
+        auto resultOpt = awaitExportRun(*runValue);
+        const auto* result =
+            require(resultOpt, expectations, "both presets: the job reaches a terminal state");
+        if (result == nullptr) {
+            return;
+        }
+        expectations.expect(static_cast<bool>(*result) && result->publication() != nullptr &&
+                                result->publication()->outcome ==
+                                    platform::StagedArtifactPublicationOutcome::Published,
+                            "both presets: the export publishes");
+        semantic.at(index) = result->semanticDigest();
+    }
+    expectations.expect(std::filesystem::exists(exrTarget) && std::filesystem::exists(pngTarget),
+                        "both presets: both target files exist");
+    expectations.expect(semantic[0].has_value() && semantic[1].has_value() &&
+                            semantic[0] != semantic[1],
+                        "both presets: the two presets' output semantic identities differ");
+
+    // EXR magic (0x76 0x2f 0x31 0x01) vs the PNG signature -- proof each preset actually wrote its
+    // own container, not the other one under a different extension.
+    const auto readMagic = [](const std::filesystem::path& path) {
+        std::ifstream stream(path, std::ios::binary);
+        std::array<char, 4> magic{};
+        stream.read(magic.data(), 4);
+        return magic;
+    };
+    const auto exrMagic = readMagic(exrTarget);
+    const auto pngMagic = readMagic(pngTarget);
+    expectations.expect(static_cast<unsigned char>(exrMagic[0]) == 0x76U &&
+                            static_cast<unsigned char>(exrMagic[1]) == 0x2FU,
+                        "both presets: the .exr target really is an OpenEXR file");
+    expectations.expect(static_cast<unsigned char>(pngMagic[0]) == 137U && pngMagic[1] == 'P' &&
+                            pngMagic[2] == 'N' && pngMagic[3] == 'G',
+                        "both presets: the .png target really is a PNG file");
+}
+
+void testPngPreparedBytesLimitExceededIsTyped(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "png prepared limit: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "prepared-limit.png";
+    auto attempt =
+        buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                               fixture.ledger(), target, output::OutputPresetV1::PngRgba8SrgbV1);
+    if (attempt == nullptr) {
+        return;
+    }
+    // A LOWERED prepared-bytes ceiling ("a request may lower but not raise them"): the 2x2 fixture
+    // needs 16 prepared bytes, so 8 is over-limit. The closed 256 MiB ceiling itself can never be
+    // exceeded through the production pipeline (the closed 2^26 pixel-count limit caps prepared
+    // bytes at exactly 256 MiB), so this seam is the only way to reach the rejection -- see
+    // output_limits.hpp's own reachability note.
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations),
+                                               {.totalDeadline = std::chrono::hours(24),
+                                                .noProgressInterval = std::chrono::seconds(120),
+                                                .preparedPngByteLimit = 8});
+    expectations.expect(static_cast<bool>(approval), "png prepared limit: approval succeeds");
+    if (!approval) {
+        return;
+    }
+    auto run = beginExportRun(fixture.scheduler(), fixture.artifacts(),
+                              std::move(approval).takeRequest(), fixture.path());
+    auto* runValue = require(run, expectations, "png prepared limit: the job is submitted");
+    if (runValue == nullptr) {
+        return;
+    }
+    auto resultOpt = awaitExportRun(*runValue);
+    const auto* result =
+        require(resultOpt, expectations, "png prepared limit: the job reaches a terminal state");
+    if (result == nullptr) {
+        return;
+    }
+    const auto* failure = result->failure();
+    expectations.expect(failure != nullptr &&
+                            failure->payloadAs<host::FrameExportPreparedBytesExceededV1>() !=
+                                nullptr &&
+                            failure->stage() == host::FrameExportPublicationStageV1::ColorPreparing,
+                        "png prepared limit: an over-limit prepared stream is a typed "
+                        "FrameExportPreparedBytesExceededV1 failure at ColorPreparing");
+    expectations.expect(!std::filesystem::exists(target),
+                        "png prepared limit: nothing is published");
+}
+
+void testPngColorPreparingCancellationPublishesNothing(Expectations& expectations) {
+    ExportFixture fixture;
+    if (!fixture.setUp(expectations, "png color cancellation: fixture is available")) {
+        return;
+    }
+    const auto target = fixture.path() / "colour-cancelled.png";
+    auto attempt =
+        buildApprovableAttempt(expectations, fixture.scheduler(), fixture.artifacts(),
+                               fixture.ledger(), target, output::OutputPresetV1::PngRgba8SrgbV1);
+    if (attempt == nullptr) {
+        return;
+    }
+    auto approval = host::approveFrameExportV1(fixture.coordinator(), attempt,
+                                               requireDigest(attempt, expectations));
+    expectations.expect(static_cast<bool>(approval), "png color cancellation: approval succeeds");
+    if (!approval) {
+        return;
+    }
+
+    auto shared = std::make_shared<std::optional<host::FrameExportPublicationResultV1>>();
+    auto sharedRequest =
+        std::shared_ptr<host::FrameExportRequestV1>(std::move(approval).takeRequest());
+    auto scratchDir = fixture.path();
+    auto reachedColorPreparing = std::make_shared<std::atomic_bool>(false);
+    auto released = std::make_shared<std::atomic_bool>(false);
+    auto submission = fixture.scheduler().submit<void>(
+        runtime::TaskRequest("export-publication-color-cancel-test",
+                             runtime::TaskOwner{.kind = runtime::TaskOwnerKind::Export,
+                                                .id = runtime::TaskOwnerId::fromRaw(4)},
+                             runtime::TaskPriority::Foreground, runtime::TaskExecutor::BlockingIo),
+        [&artifacts = fixture.artifacts(), sharedRequest, shared, scratchDir, reachedColorPreparing,
+         released](runtime::TaskContext& context) {
+            // Blocks at the one ColorPreparing report emitted immediately before C2's chunked
+            // apply loop, giving the outer thread a deterministic point to request cancellation --
+            // no sleep, no race against a background worker.
+            output::OutputExportProgressCallbackV1 progress =
+                [reachedColorPreparing, released](const output::OutputExportProgressV1& update) {
+                    if (update.stage != output::OutputExportStageV1::ColorPreparing ||
+                        update.completed != 0 || update.total != 0) {
+                        return;
+                    }
+                    reachedColorPreparing->store(true, std::memory_order_release);
+                    while (!released->load(std::memory_order_acquire)) {
+                        std::this_thread::yield();
+                    }
+                };
+            auto result = host::executeExportPublication(
+                context, artifacts, std::move(*sharedRequest), scratchDir, {}, std::move(progress));
+            shared->emplace(std::move(result));
+            return runtime::TaskResult<void>::succeeded();
+        });
+    expectations.expect(submission.accepted(), "png color cancellation: the job is submitted");
+    if (!submission.accepted()) {
+        return;
+    }
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    while (!reachedColorPreparing->load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    expectations.expect(reachedColorPreparing->load(std::memory_order_acquire),
+                        "png color cancellation: the job reaches the ColorPreparing rendezvous");
+    submission.handle.cancel();
+    released->store(true, std::memory_order_release);
+
+    ExportRun run{std::move(submission.handle), shared};
+    auto resultOpt = awaitExportRun(run);
+    const auto* result = require(resultOpt, expectations,
+                                 "png color cancellation: the job reaches a terminal state");
+    if (result != nullptr) {
+        expectations.expect(!*result && result->publication() == nullptr,
+                            "png color cancellation: a cancelled job never reaches publish()");
+    }
+    expectations.expect(!std::filesystem::exists(target),
+                        "png color cancellation: cancellation during ColorPreparing publishes "
+                        "nothing");
+}
+
 } // namespace
 
 int main() {
@@ -867,6 +1368,11 @@ int main() {
         testCancellationBeforeStagingLeavesTargetIntact(expectations);
         testDeadlineExpiryViaInjectedClock(expectations);
         testNoProgressExpiryViaInjectedClock(expectations);
+        testEndToEndPngExportPublished(expectations);
+        testPngSemanticDigestStableAcrossTwoRuns(expectations);
+        testBothPresetsExportFromTheSameFixture(expectations);
+        testPngPreparedBytesLimitExceededIsTyped(expectations);
+        testPngColorPreparingCancellationPublishesNothing(expectations);
     } catch (const std::exception& error) {
         std::cerr << "unexpected exception: " << error.what() << '\n';
         return EXIT_FAILURE;

--- a/src/output/CMakeLists.txt
+++ b/src/output/CMakeLists.txt
@@ -16,9 +16,11 @@ target_sources(
         output_export_resource_ledger.cpp
         output_facet_descriptor.cpp
         output_analysis_numeric.cpp
+        output_export_artifact_hash.hpp
         output_semantic_identity.cpp
         output_semantic_identity_numeric.cpp
         output_semantic_identity_ownership.cpp
+        png_export_write.cpp
         png_output_adapter.cpp
         png_preset_contract.hpp
         png_reopen_verifier.cpp
@@ -38,6 +40,7 @@ target_sources(
             include/bloom/output/output_export_stage.hpp
             include/bloom/output/output_facet_descriptor.hpp
             include/bloom/output/output_limits.hpp
+            include/bloom/output/png_export_write.hpp
             include/bloom/output/png_output_adapter.hpp
             include/bloom/output/png_reopen_verifier.hpp
             include/bloom/output/process_frame_semantic_identity.hpp
@@ -53,7 +56,18 @@ target_link_libraries(
     # output_analysis_attempt.hpp's own namespace comment). {"output", "platform"} was already
     # present in tools/quality/repository_checks/repository_checks.cpp's kAllowedModuleDependencies
     # allowlist before this task (no allowlist edit was needed).
-    PUBLIC bloom_color bloom_core bloom_platform bloom_render bloom_runtime_evaluator
+    # bloom_color_ocio is PUBLIC (issue #111): bloom/output/output_analysis_attempt.hpp's
+    # OutputAnalysisAttemptDisplayProductsV1 retains a
+    # bloom::color::PreparedCpuDisplayProcessorHandle in its own public surface (the doc's
+    # "Immutable Export Request" bullet: "the qualified PNG display-processor handle and identity
+    # when applicable"), and png_export_write.cpp applies that handle through
+    # bloom::runtime::CpuQualifiedDisplayPreparer. It was already reachable transitively through
+    # bloom_runtime_evaluator's own PUBLIC bloom_color_ocio link; naming it here makes the direct
+    # use explicit. No OpenColorIO type crosses either boundary (bloom_color_ocio links
+    # OpenColorIO::OpenColorIO PRIVATE), and {"output", "color"} was already present in
+    # tools/quality/repository_checks/repository_checks.cpp's kAllowedModuleDependencies allowlist.
+    PUBLIC bloom_color bloom_color_ocio bloom_core bloom_platform bloom_render
+           bloom_runtime_evaluator
 )
 bloom_enable_warnings(bloom_output)
 
@@ -312,5 +326,27 @@ if(BUILD_TESTING)
         NAME bloom.output.png_reopen_verifier
         COMMAND bloom_output_png_reopen_verifier_test
         LABELS unit output identity render
+    )
+
+    # issue #111 (PNG export through color preparation): the approved job's PNG
+    # ColorPreparing/PreparingOutput/Writing/Verifying bridge over a real qualified Bloom Neutral
+    # CPU display processor.
+    add_executable(
+        bloom_output_png_export_write_test
+        tests/png_export_write_tests.cpp
+    )
+    target_include_directories(
+        bloom_output_png_export_write_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    target_link_libraries(
+        bloom_output_png_export_write_test
+        PRIVATE bloom_output ZLIB::ZLIBSTATIC
+    )
+    bloom_enable_warnings(bloom_output_png_export_write_test)
+    bloom_add_test(
+        NAME bloom.output.png_export_write
+        COMMAND bloom_output_png_export_write_test
+        LABELS unit output color identity render
     )
 endif()

--- a/src/output/flat_exr_export_write.cpp
+++ b/src/output/flat_exr_export_write.cpp
@@ -1,10 +1,8 @@
 #include <bloom/output/flat_exr_export_write.hpp>
 
-#include <bloom/output/output_limits.hpp>
+#include "output_export_artifact_hash.hpp"
 
-#include <array>
-#include <fstream>
-#include <vector>
+#include <cstdint>
 
 namespace bloom::output {
 
@@ -42,66 +40,6 @@ FlatExrExportWriteResultV1::failed(const FlatExrExportWriteErrorCodeV1 error,
     return result;
 }
 
-namespace {
-
-void reportProgress(const OutputExportProgressCallbackV1& callback,
-                    const OutputExportProgressV1& progress) noexcept {
-    if (!callback) {
-        return;
-    }
-    try {
-        callback(progress);
-    } catch (...) {
-        return;
-    }
-}
-
-// Streams `path`'s complete raw bytes in bounded chunks, computing their SHA-256. Returns
-// nullopt on I/O failure, allocation failure, or cancellation.
-[[nodiscard]] std::optional<core::Sha256Digest>
-hashArtifactFile(const std::filesystem::path& path, const runtime::CancellationToken& cancellation,
-                 const OutputExportProgressCallbackV1& progress,
-                 std::uint64_t& byteCountOut) noexcept {
-    try {
-        std::ifstream stream(path, std::ios::binary);
-        if (!stream) {
-            return std::nullopt;
-        }
-        std::vector<std::byte> buffer(kOutputAdapterMaximumStreamingChunkBytesV1);
-        core::Sha256Hasher hasher;
-        std::uint64_t total = 0;
-        reportProgress(progress,
-                       {.stage = OutputExportStageV1::Publishing, .completed = 0, .total = 0});
-        while (stream) {
-            if (cancellation.isCancellationRequested()) {
-                return std::nullopt;
-            }
-            stream.read(reinterpret_cast<char*>(buffer.data()),
-                        static_cast<std::streamsize>(buffer.size()));
-            const auto readCount = static_cast<std::size_t>(stream.gcount());
-            if (readCount == 0) {
-                break;
-            }
-            if (!hasher.update(std::span(buffer).first(readCount))) {
-                return std::nullopt;
-            }
-            total += readCount;
-            reportProgress(
-                progress,
-                {.stage = OutputExportStageV1::Publishing, .completed = total, .total = total});
-        }
-        if (stream.bad()) {
-            return std::nullopt;
-        }
-        byteCountOut = total;
-        return hasher.finalize();
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-} // namespace
-
 FlatExrExportWriteResultV1
 FlatExrExportWriterV1::run(const OutputAnalysisAttemptV1& attempt,
                            const std::filesystem::path& scratchPath,
@@ -113,13 +51,13 @@ FlatExrExportWriterV1::run(const OutputAnalysisAttemptV1& attempt,
     }
 
     const FlatExrRgba32fLinRec709SceneWriterV1 writer;
-    const auto writeResult =
-        writer.write(*attempt.frame(), scratchPath, cancellation,
-                     [&progress](const FlatExrWriteProgressV1& writeProgress) {
-                         reportProgress(progress, {.stage = OutputExportStageV1::Writing,
-                                                   .completed = writeProgress.completedScanlines,
-                                                   .total = writeProgress.totalScanlines});
-                     });
+    const auto writeResult = writer.write(
+        *attempt.frame(), scratchPath, cancellation,
+        [&progress](const FlatExrWriteProgressV1& writeProgress) {
+            detail::reportExportProgress(progress, {.stage = OutputExportStageV1::Writing,
+                                                    .completed = writeProgress.completedScanlines,
+                                                    .total = writeProgress.totalScanlines});
+        });
     if (writeResult.status() == FlatExrWriteStatusV1::Cancelled) {
         return FlatExrExportWriteResultV1::cancelled();
     }
@@ -132,9 +70,9 @@ FlatExrExportWriterV1::run(const OutputAnalysisAttemptV1& attempt,
     const auto verifyResult = verifier.verify(
         scratchPath, attempt.processIdentity(), attempt.report(), cancellation,
         [&progress](const FlatExrVerifyScanProgressV1& verifyProgress) {
-            reportProgress(progress, {.stage = OutputExportStageV1::Verifying,
-                                      .completed = verifyProgress.completedScanlines,
-                                      .total = verifyProgress.totalScanlines});
+            detail::reportExportProgress(progress, {.stage = OutputExportStageV1::Verifying,
+                                                    .completed = verifyProgress.completedScanlines,
+                                                    .total = verifyProgress.totalScanlines});
         });
     if (verifyResult.status() == FlatExrVerifyStatusV1::Cancelled) {
         return FlatExrExportWriteResultV1::cancelled();
@@ -146,7 +84,7 @@ FlatExrExportWriterV1::run(const OutputAnalysisAttemptV1& attempt,
 
     std::uint64_t artifactByteCount = 0;
     const auto artifactDigest =
-        hashArtifactFile(scratchPath, cancellation, progress, artifactByteCount);
+        detail::hashExportArtifactFile(scratchPath, cancellation, progress, artifactByteCount);
     if (!artifactDigest.has_value()) {
         if (cancellation.isCancellationRequested()) {
             return FlatExrExportWriteResultV1::cancelled();

--- a/src/output/include/bloom/output/output_analysis_attempt.hpp
+++ b/src/output/include/bloom/output/output_analysis_attempt.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bloom/color/display_processor_identity.hpp>
+#include <bloom/color/ocio_cpu_display_processor.hpp>
 #include <bloom/core/artifact_target_key.hpp>
 #include <bloom/core/sha256.hpp>
 #include <bloom/output/output_analysis_analyzer.hpp>
@@ -32,8 +34,6 @@
 // StagedArtifactCoordinator").
 namespace bloom::output {
 
-// Version 1 ships EXR only (design decision 3's task package scope); PNG's additional retained
-// display-processor identity is future preset breadth, not represented here.
 struct OutputAnalysisAttemptTargetV1 final {
     core::ArtifactTargetKey targetKey;
     platform::ArtifactTargetObservation observation = platform::ArtifactTargetObservation::absent();
@@ -44,12 +44,44 @@ struct OutputAnalysisAttemptTargetV1 final {
     [[nodiscard]] bool isValid() const noexcept { return targetKey.isValid(); }
 };
 
+// The PNG-only products the attempt graph's step 4 produces ("for PNG, bounded color/config
+// resolution plus preparation or exact reuse of the qualified display processor and its canonical
+// DisplayProcessorIdentity; EXR has no display product") and that the "Immutable Export Request"
+// bullet list requires a completed attempt to retain ("the qualified PNG display-processor handle
+// and identity when applicable"). Every field is empty for EXR, and for a PNG attempt whose color
+// resolution or adapter was not Ready -- such an attempt still completes with a truthful
+// non-approvable report (frame-output.md: "A failed or unavailable stage may still produce the
+// truthful nonapprovable report ... but it never produces a placeholder identity or approval
+// digest").
+//
+// `identity` is expected to alias `processor`'s own DisplayProcessorIdentityV1 (the aliasing
+// std::shared_ptr constructor), never an independently-adopted copy: the doc forbids pairing a
+// frame or processor with a substitute identity at approval or export, and aliasing makes that
+// pairing structural rather than checked.
+struct OutputAnalysisAttemptDisplayProductsV1 final {
+    std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> processor;
+    std::shared_ptr<const color::DisplayProcessorIdentityV1> identity;
+    std::optional<core::Sha256Digest> expectedOcioRevision;
+
+    [[nodiscard]] bool isPresent() const noexcept {
+        return processor != nullptr && identity != nullptr && expectedOcioRevision.has_value();
+    }
+    [[nodiscard]] bool isAbsent() const noexcept {
+        return processor == nullptr && identity == nullptr && !expectedOcioRevision.has_value();
+    }
+};
+
 enum class OutputAnalysisAttemptErrorCodeV1 : std::uint8_t {
     None,
     InvalidTarget,
     InvalidFrame,
     InvalidIdentity,
     InvalidReport,
+    // The retained display products do not match the report's own preset: EXR carries any of them
+    // at all, a PNG report carries a partially-populated set, or an APPROVABLE PNG report carries
+    // none (an approvable PNG report exists only when color resolution and the adapter were both
+    // Ready, which is exactly when the processor/identity/revision triple exists).
+    InvalidDisplayProducts,
     DigestFailed,
     ResourceReservationFailed,
     InternalInvariant,
@@ -62,6 +94,7 @@ struct OutputAnalysisAttemptBuildInputsV1 final {
     std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity;
     std::shared_ptr<const OutputAnalysisReportV1> report;
     OutputAnalysisAttemptTargetV1 target;
+    OutputAnalysisAttemptDisplayProductsV1 display;
 };
 
 class [[nodiscard]] OutputAnalysisAttemptBuildResultV1 final {
@@ -90,7 +123,9 @@ class [[nodiscard]] OutputAnalysisAttemptBuildResultV1 final {
 // OutputAnalysisReportV1, the approval OutputAnalysisDigest (present only when the report is
 // approvable -- frame-output.md: "OutputAnalysisDigest becomes available only when a validated
 // frame-bound process identity exists ... Approval requires both that digest and all eleven
-// derived permission bits"), the canonical target preflight, and its own resource reservation
+// derived permission bits"), the typed preset, the qualified PNG display-processor handle and its
+// canonical identity when applicable, the canonical target preflight, and its own resource
+// reservation
 // (released when the last shared_ptr to this attempt, or to a FrameExportRequestV1 that still
 // retains it, is dropped -- "Dismissal or supersession cancels unfinished work and releases the
 // completed attempt and its reservations when no admitted export retains them").
@@ -118,6 +153,13 @@ class OutputAnalysisAttemptV1 final {
     [[nodiscard]] const std::shared_ptr<const OutputAnalysisReportV1>& report() const&& = delete;
     [[nodiscard]] bool approvable() const noexcept { return digest_.has_value(); }
     [[nodiscard]] std::optional<core::Sha256Digest> digest() const noexcept { return digest_; }
+    // The typed preset this attempt was analyzed for -- read straight off the retained report, so
+    // it can never disagree with the report's own facet vocabulary or descriptor schema.
+    [[nodiscard]] OutputPresetV1 preset() const noexcept { return preset_; }
+    [[nodiscard]] const OutputAnalysisAttemptDisplayProductsV1& display() const& noexcept {
+        return display_;
+    }
+    [[nodiscard]] const OutputAnalysisAttemptDisplayProductsV1& display() const&& = delete;
     [[nodiscard]] const OutputAnalysisAttemptTargetV1& target() const noexcept { return target_; }
     [[nodiscard]] const std::shared_ptr<ExportResourceReservationV1>& resources() const& noexcept {
         return reservation_;
@@ -132,15 +174,18 @@ class OutputAnalysisAttemptV1 final {
     OutputAnalysisAttemptV1(std::shared_ptr<const runtime::ProcessFrame> frame,
                             std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity,
                             std::shared_ptr<const OutputAnalysisReportV1> report,
-                            std::optional<core::Sha256Digest> digest,
+                            std::optional<core::Sha256Digest> digest, OutputPresetV1 preset,
                             OutputAnalysisAttemptTargetV1 target,
+                            OutputAnalysisAttemptDisplayProductsV1 display,
                             std::shared_ptr<ExportResourceReservationV1> reservation) noexcept;
 
     std::shared_ptr<const runtime::ProcessFrame> frame_;
     std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity_;
     std::shared_ptr<const OutputAnalysisReportV1> report_;
     std::optional<core::Sha256Digest> digest_;
+    OutputPresetV1 preset_ = OutputPresetV1::FlatExrRgba32fLinRec709SceneV1;
     OutputAnalysisAttemptTargetV1 target_;
+    OutputAnalysisAttemptDisplayProductsV1 display_;
     std::shared_ptr<ExportResourceReservationV1> reservation_;
 };
 

--- a/src/output/include/bloom/output/output_limits.hpp
+++ b/src/output/include/bloom/output/output_limits.hpp
@@ -11,6 +11,19 @@ inline constexpr std::uint64_t kOutputAnalysisMaximumPixelCountV1 = 67'108'864U;
 inline constexpr std::size_t kOutputAnalysisMaximumProcessPixelBytesV1 = 1'073'741'824U;
 inline constexpr std::size_t kOutputAnalysisDigestMaximumPreimageBytesV1 = 4'194'304U;
 
+// frame-output.md's "Version 1 export limits" table's "retained prepared PNG bytes" row. Only the
+// PNG preset has a prepared display/output buffer at all (EXR exposes the retained process rows
+// directly), so this bounds exactly the one allocation bloom/output/png_export_write.hpp's
+// ColorPreparing stage makes: the straight-RGBA8 stream the writer and reopen verifier then share.
+//
+// Reachability note (see the implementor's report): the closed pixel-count ceiling above is
+// 2^26 pixels and RGBA8 is 4 bytes per pixel, so the largest prepared stream the production
+// pipeline can ever ask for is exactly 268435456 bytes -- exactly at, and therefore never over,
+// this limit ("Values exactly at either limit do not exceed it"). The limit is enforced anyway,
+// and a caller may LOWER it ("a request may lower but not raise them"), which is how the
+// over-limit rejection is exercised.
+inline constexpr std::uint64_t kOutputExportPreparedPngBytesMaximumV1 = 268'435'456ULL;
+
 // frame-output.md's "Version 1 export limits" table names "one encoder or verifier streaming
 // chunk" at 16 MiB but no adapter existed yet to materialize it as a bound. The flat OpenEXR
 // writer/verifier (issue #99) is the first consumer: it caps how many scanlines it touches per

--- a/src/output/include/bloom/output/png_export_write.hpp
+++ b/src/output/include/bloom/output/png_export_write.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <bloom/core/sha256.hpp>
+
+// output_analysis_analyzer.hpp (which declares the real OutputAnalysisReportV1 class) must be
+// visible before png_reopen_verifier.hpp's own header: that G1 header uses
+// std::shared_ptr<const OutputAnalysisReportV1> in verify()'s public signature without including or
+// forward-declaring it itself (out of scope to change -- "consume G1's API as-is"). A blank-line-
+// separated include block (this codebase's .clang-format uses the default IncludeBlocks: Preserve,
+// which sorts alphabetically only WITHIN a block, never across one) keeps this header strictly
+// first regardless of clang-format's usual alphabetical reordering. Identical arrangement to
+// flat_exr_export_write.hpp's own leading block, for the identical reason.
+#include <bloom/output/output_analysis_analyzer.hpp>
+
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/output/output_export_stage.hpp>
+#include <bloom/output/output_limits.hpp>
+#include <bloom/output/png_output_adapter.hpp>
+#include <bloom/output/png_reopen_verifier.hpp>
+#include <bloom/runtime/cancellation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+
+// The PNG counterpart of flat_exr_export_write.hpp, and the one place the approved export job's
+// PNG-specific nodes live (docs/architecture/frame-output.md, "Non-Blocking Execution", node 2:
+// "For PNG, dependent output preparation applies the retained qualified built-in processor on CPU
+// in bounded chunks ... then produces one immutable prepared display/output frame"). It composes,
+// in the doc's own ordered stage vocabulary:
+//
+//   ColorPreparing  -- bloom::runtime::CpuQualifiedDisplayPreparer over the attempt's RETAINED
+//                      qualified processor handle, which itself drives C2's chunked
+//                      color::produceBloomNeutralDisplayFrame/applyBloomNeutralDisplayChunk pair
+//                      with cancellation checked between chunks. This reuses the established
+//                      qualified-display staging seam rather than calling bloom_color_ocio a
+//                      second, differently-bounded way.
+//   PreparingOutput -- the two-field aggregate construction png_output_adapter.hpp's own
+//                      PngRgba8SrgbPreparedStreamV1 comment predicted: dimensions + pixels off the
+//                      prepared display frame, with no reshaping, copy, or stride translation.
+//   Writing         -- G1's PngRgba8SrgbWriterV1.
+//   Verifying       -- G1's PngRgba8SrgbReopenVerifierV1, fed the attempt's retained
+//                      processIdentity, report, expected OCIO revision, and canonical
+//                      DisplayProcessorIdentity (all four of verify()'s existing parameters).
+//   Publishing      -- the shared bounded streaming artifact SHA-256.
+//
+// Like its flat OpenEXR sibling this writes to a caller-owned SCRATCH path outside the publication
+// lease's own staging file (G1's writer/verifier are path-based; StagedArtifactLease exposes only a
+// byte-oriented API and never a filesystem path). The scratch file is never published, never
+// atomically replaces anything, and is not tracked by StagedArtifactCoordinator; the caller
+// (bloom::host::executeExportPublication) streams its bytes into the real lease afterward and
+// discards it. No zlib or OpenColorIO type appears here.
+namespace bloom::output {
+
+enum class PngExportWriteStatusV1 : std::uint8_t {
+    Written,
+    Cancelled,
+    Failed,
+};
+
+enum class PngExportWriteErrorCodeV1 : std::uint8_t {
+    None,
+    // The attempt is not a PNG attempt, or its frame/process identity/report is missing.
+    InvalidAttempt,
+    // A PNG attempt that reached this job without the retained qualified display-processor handle,
+    // canonical identity, and expected OCIO revision the preset's writer/verifier both require.
+    // Unreachable for an APPROVED export (an approvable PNG report exists only when those products
+    // do), but typed rather than assumed.
+    MissingDisplayProducts,
+    // The prepared straight-RGBA8 stream would exceed the effective retained-prepared-PNG-bytes
+    // limit (output_limits.hpp's kOutputExportPreparedPngBytesMaximumV1, or the lower limit this
+    // call was given). Nothing is allocated for the prepared stream and no file is created.
+    PreparedBytesLimitExceeded,
+    // The qualified display processor could not be applied to the retained process frame (a
+    // non-finite sample, an unusable floating-point environment, an allocation failure, or an
+    // incompatible descriptor).
+    ColorPrepareFailed,
+    WriteFailed,
+    VerifyFailed,
+    ArtifactHashFailed,
+    InternalInvariant,
+};
+
+class [[nodiscard]] PngExportWriteResultV1 final {
+  public:
+    [[nodiscard]] static PngExportWriteResultV1 written(core::Sha256Digest semanticDigest,
+                                                        core::Sha256Digest artifactDigest,
+                                                        std::uint64_t artifactByteCount,
+                                                        std::uint64_t preparedByteCount) noexcept;
+    [[nodiscard]] static PngExportWriteResultV1 cancelled() noexcept;
+    [[nodiscard]] static PngExportWriteResultV1
+    failed(PngExportWriteErrorCodeV1 error, PngWriteErrorCodeV1 writeError = {},
+           const PngVerifyDiagnosticV1& verifyDiagnostic = {}) noexcept;
+
+    [[nodiscard]] PngExportWriteStatusV1 status() const noexcept { return status_; }
+    [[nodiscard]] PngExportWriteErrorCodeV1 error() const noexcept { return error_; }
+    [[nodiscard]] PngWriteErrorCodeV1 writeError() const noexcept { return writeError_; }
+    [[nodiscard]] const PngVerifyDiagnosticV1& verifyDiagnostic() const& noexcept {
+        return verifyDiagnostic_;
+    }
+    [[nodiscard]] const PngVerifyDiagnosticV1& verifyDiagnostic() const&& = delete;
+    // Valid only when status() is Written: the kind-1 OutputSemanticIdentity digest G1's verifier
+    // issued from the DECODED reopened scratch file, and the artifact SHA-256 of the scratch file's
+    // complete raw bytes, plus its byte count.
+    [[nodiscard]] const core::Sha256Digest& semanticDigest() const& noexcept {
+        return semanticDigest_;
+    }
+    [[nodiscard]] const core::Sha256Digest& semanticDigest() const&& = delete;
+    [[nodiscard]] const core::Sha256Digest& artifactDigest() const& noexcept {
+        return artifactDigest_;
+    }
+    [[nodiscard]] const core::Sha256Digest& artifactDigest() const&& = delete;
+    [[nodiscard]] std::uint64_t artifactByteCount() const noexcept { return artifactByteCount_; }
+    // The retained prepared straight-RGBA8 byte count this run actually charged. Valid only when
+    // status() is Written.
+    [[nodiscard]] std::uint64_t preparedByteCount() const noexcept { return preparedByteCount_; }
+
+  private:
+    PngExportWriteResultV1() = default;
+
+    PngExportWriteStatusV1 status_ = PngExportWriteStatusV1::Failed;
+    PngExportWriteErrorCodeV1 error_ = PngExportWriteErrorCodeV1::InternalInvariant;
+    PngWriteErrorCodeV1 writeError_ = PngWriteErrorCodeV1::None;
+    PngVerifyDiagnosticV1 verifyDiagnostic_;
+    core::Sha256Digest semanticDigest_;
+    core::Sha256Digest artifactDigest_;
+    std::uint64_t artifactByteCount_ = 0;
+    std::uint64_t preparedByteCount_ = 0;
+};
+
+// The checked byte count of the prepared straight-RGBA8 stream a PNG export of `attempt` would
+// retain (width * height * 4 over the retained process frame's data window). Returns nullopt when
+// the attempt carries no valid frame descriptor or the arithmetic does not fit. Callers use this
+// BEFORE any allocation or file creation, both to expand the job's resource reservation and to
+// reject an over-limit request (frame-output.md: "An insufficient or overflowing reservation
+// rejects the stage before allocation or file creation").
+[[nodiscard]] std::optional<std::uint64_t>
+checkedPngPreparedByteCountV1(const OutputAnalysisAttemptV1& attempt) noexcept;
+
+class PngExportWriterV1 final {
+  public:
+    // Runs ColorPreparing -> PreparingOutput -> Writing -> Verifying -> the artifact hash over
+    // `attempt`'s retained products, staging into `scratchPath` (which must not already exist;
+    // this call creates it). On any non-Written outcome the caller owns removing whatever partial
+    // bytes exist at `scratchPath`, exactly like FlatExrExportWriterV1::run().
+    //
+    // `preparedByteLimit` is the effective retained-prepared-PNG-bytes ceiling. It is clamped down
+    // to kOutputExportPreparedPngBytesMaximumV1 and can never raise it -- frame-output.md's
+    // "Version 1 export limits are closed; a request may lower but not raise them".
+    [[nodiscard]] PngExportWriteResultV1
+    run(const OutputAnalysisAttemptV1& attempt, const std::filesystem::path& scratchPath,
+        const runtime::CancellationToken& cancellation,
+        const OutputExportProgressCallbackV1& progress = {},
+        std::uint64_t preparedByteLimit = kOutputExportPreparedPngBytesMaximumV1) const noexcept;
+};
+
+} // namespace bloom::output

--- a/src/output/output_analysis_attempt.cpp
+++ b/src/output/output_analysis_attempt.cpp
@@ -30,11 +30,12 @@ OutputAnalysisAttemptV1::OutputAnalysisAttemptV1(
     std::shared_ptr<const runtime::ProcessFrame> frame,
     std::shared_ptr<const ProcessFrameSemanticIdentityV1> processIdentity,
     std::shared_ptr<const OutputAnalysisReportV1> report,
-    const std::optional<core::Sha256Digest> digest, OutputAnalysisAttemptTargetV1 target,
+    const std::optional<core::Sha256Digest> digest, const OutputPresetV1 preset,
+    OutputAnalysisAttemptTargetV1 target, OutputAnalysisAttemptDisplayProductsV1 display,
     std::shared_ptr<ExportResourceReservationV1> reservation) noexcept
     : frame_(std::move(frame)), processIdentity_(std::move(processIdentity)),
-      report_(std::move(report)), digest_(digest), target_(std::move(target)),
-      reservation_(std::move(reservation)) {}
+      report_(std::move(report)), digest_(digest), preset_(preset), target_(std::move(target)),
+      display_(std::move(display)), reservation_(std::move(reservation)) {}
 
 namespace {
 
@@ -45,7 +46,8 @@ namespace {
 // this reservation is never an under-count of what Analyzing/digesting can touch).
 [[nodiscard]] std::optional<std::uint64_t>
 checkedAttemptRetainedBytes(const render::Rgba32fImageDescriptor& descriptor,
-                            const OutputAnalysisReportV1& report) noexcept {
+                            const OutputAnalysisReportV1& report,
+                            const OutputAnalysisAttemptDisplayProductsV1& display) noexcept {
     constexpr auto maximum = std::numeric_limits<std::uint64_t>::max();
     std::uint64_t total = descriptor.layout().pixelStorageBytes;
     const auto descriptorBytes = static_cast<std::uint64_t>(report.descriptorByteCount());
@@ -59,7 +61,36 @@ checkedAttemptRetainedBytes(const render::Rgba32fImageDescriptor& descriptor,
         return std::nullopt;
     }
     total += digestPreimageBound;
+    // The PNG display product the completed attempt additionally retains ("including the process
+    // frame, semantic-identity product, report, target state, and PNG processor product"). Only
+    // the canonical identity record has a byte count Bloom can measure: the qualified OCIO CPU
+    // processor behind PreparedCpuDisplayProcessorHandle exposes no allocation size through its
+    // public surface, so its own resident bytes are not charged here (a disclosed under-count of
+    // that one library-owned allocation, not of anything Bloom allocates -- see the implementor's
+    // report).
+    if (display.identity != nullptr) {
+        const auto identityBytes =
+            static_cast<std::uint64_t>(display.identity->canonicalBytes().size());
+        if (identityBytes > maximum - total) {
+            return std::nullopt;
+        }
+        total += identityBytes;
+    }
     return total;
+}
+
+// The report's own preset decides which display products a completed attempt must retain; nothing
+// else may supply or omit them.
+[[nodiscard]] bool displayProductsMatchPreset(const OutputAnalysisReportV1& report,
+                                              const OutputAnalysisAttemptDisplayProductsV1& display,
+                                              const OutputPresetV1 preset) noexcept {
+    if (preset != OutputPresetV1::PngRgba8SrgbV1) {
+        return display.isAbsent();
+    }
+    if (report.approvable()) {
+        return display.isPresent();
+    }
+    return display.isPresent() || display.isAbsent();
 }
 
 } // namespace
@@ -85,13 +116,26 @@ buildOutputAnalysisAttemptV1(OutputAnalysisAttemptBuildInputsV1 inputs,
             OutputAnalysisAttemptErrorCodeV1::InvalidReport);
     }
 
+    const auto preset = inputs.report->view().preset;
+    if (!displayProductsMatchPreset(*inputs.report, inputs.display, preset)) {
+        return OutputAnalysisAttemptBuildResultV1::failure(
+            OutputAnalysisAttemptErrorCodeV1::InvalidDisplayProducts);
+    }
+
     // A nonapprovable report is still a successful, completed attempt (frame-output.md: "A
     // nonapprovable but valid report is a successful analysis attempt"); only an approvable report
-    // gets a digest at all.
+    // gets a digest at all. The PNG dependencies below are the exact retained products
+    // (displayProductsMatchPreset() above already proved they are present for an approvable PNG
+    // report and absent for EXR); computeOutputAnalysisDigestV1 itself re-checks that the expected
+    // revision equals both the identity's embedded revision and the report's own target
+    // external-dependency descriptor.
     std::optional<core::Sha256Digest> digest;
     if (inputs.report->approvable()) {
-        const auto digestResult =
-            computeOutputAnalysisDigestV1(*inputs.processIdentity, inputs.report->view(), {});
+        const OutputAnalysisDigestDependenciesV1 dependencies{
+            .expectedOcioRevision = inputs.display.expectedOcioRevision,
+            .displayProcessorIdentity = inputs.display.identity.get()};
+        const auto digestResult = computeOutputAnalysisDigestV1(
+            *inputs.processIdentity, inputs.report->view(), dependencies);
         if (!digestResult) {
             return OutputAnalysisAttemptBuildResultV1::failure(
                 OutputAnalysisAttemptErrorCodeV1::DigestFailed);
@@ -100,7 +144,8 @@ buildOutputAnalysisAttemptV1(OutputAnalysisAttemptBuildInputsV1 inputs,
     }
 
     const auto* descriptor = inputs.frame->processImage().descriptor();
-    const auto retainedBytes = checkedAttemptRetainedBytes(*descriptor, *inputs.report);
+    const auto retainedBytes =
+        checkedAttemptRetainedBytes(*descriptor, *inputs.report, inputs.display);
     if (!retainedBytes.has_value()) {
         return OutputAnalysisAttemptBuildResultV1::failure(
             OutputAnalysisAttemptErrorCodeV1::ResourceReservationFailed);
@@ -116,7 +161,8 @@ buildOutputAnalysisAttemptV1(OutputAnalysisAttemptBuildInputsV1 inputs,
     try {
         auto attempt = std::shared_ptr<OutputAnalysisAttemptV1>(new OutputAnalysisAttemptV1(
             std::move(inputs.frame), std::move(inputs.processIdentity), std::move(inputs.report),
-            digest, std::move(inputs.target), std::move(reservation)));
+            digest, preset, std::move(inputs.target), std::move(inputs.display),
+            std::move(reservation)));
         return OutputAnalysisAttemptBuildResultV1::success(std::move(attempt));
     } catch (const std::bad_alloc&) {
         return OutputAnalysisAttemptBuildResultV1::failure(

--- a/src/output/output_export_artifact_hash.hpp
+++ b/src/output/output_export_artifact_hash.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+// Private (non-FILE_SET, non-installed) header shared by the two export-write bridges
+// (flat_exr_export_write.cpp and png_export_write.cpp), mirroring flat_exr_preset_contract.hpp /
+// png_preset_contract.hpp's role of keeping a shared rule in one place instead of letting the two
+// preset paths drift apart. It holds exactly the two preset-independent helpers both bridges need:
+// the best-effort progress-callback trampoline, and the bounded streaming artifact SHA-256
+// (docs/architecture/frame-output.md, "Atomic Publication" step 5: "compute the artifact SHA-256").
+// Nothing here is preset-specific, and the flat OpenEXR behavior is byte-for-byte the code that
+// previously lived in flat_exr_export_write.cpp's own anonymous namespace.
+
+#include <bloom/core/sha256.hpp>
+#include <bloom/output/output_export_stage.hpp>
+#include <bloom/output/output_limits.hpp>
+#include <bloom/runtime/cancellation.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <span>
+#include <vector>
+
+namespace bloom::output::detail {
+
+inline void reportExportProgress(const OutputExportProgressCallbackV1& callback,
+                                 const OutputExportProgressV1& progress) noexcept {
+    if (!callback) {
+        return;
+    }
+    try {
+        callback(progress);
+    } catch (...) {
+        return;
+    }
+}
+
+// Streams `path`'s complete raw bytes in bounded chunks, computing their SHA-256. Returns
+// nullopt on I/O failure, allocation failure, or cancellation.
+[[nodiscard]] inline std::optional<core::Sha256Digest> hashExportArtifactFile(
+    const std::filesystem::path& path, const runtime::CancellationToken& cancellation,
+    const OutputExportProgressCallbackV1& progress, std::uint64_t& byteCountOut) noexcept {
+    try {
+        std::ifstream stream(path, std::ios::binary);
+        if (!stream) {
+            return std::nullopt;
+        }
+        std::vector<std::byte> buffer(kOutputAdapterMaximumStreamingChunkBytesV1);
+        core::Sha256Hasher hasher;
+        std::uint64_t total = 0;
+        reportExportProgress(
+            progress, {.stage = OutputExportStageV1::Publishing, .completed = 0, .total = 0});
+        while (stream) {
+            if (cancellation.isCancellationRequested()) {
+                return std::nullopt;
+            }
+            stream.read(reinterpret_cast<char*>(buffer.data()),
+                        static_cast<std::streamsize>(buffer.size()));
+            const auto readCount = static_cast<std::size_t>(stream.gcount());
+            if (readCount == 0) {
+                break;
+            }
+            if (!hasher.update(std::span(buffer).first(readCount))) {
+                return std::nullopt;
+            }
+            total += readCount;
+            reportExportProgress(
+                progress,
+                {.stage = OutputExportStageV1::Publishing, .completed = total, .total = total});
+        }
+        if (stream.bad()) {
+            return std::nullopt;
+        }
+        byteCountOut = total;
+        return hasher.finalize();
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+} // namespace bloom::output::detail

--- a/src/output/png_export_write.cpp
+++ b/src/output/png_export_write.cpp
@@ -1,0 +1,204 @@
+#include <bloom/output/png_export_write.hpp>
+
+#include "output_export_artifact_hash.hpp"
+#include <bloom/render/image_types.hpp>
+#include <bloom/runtime/qualified_display_preparation.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace bloom::output {
+
+PngExportWriteResultV1 PngExportWriteResultV1::written(
+    const core::Sha256Digest semanticDigest, const core::Sha256Digest artifactDigest,
+    const std::uint64_t artifactByteCount, const std::uint64_t preparedByteCount) noexcept {
+    PngExportWriteResultV1 result;
+    result.status_ = PngExportWriteStatusV1::Written;
+    result.error_ = PngExportWriteErrorCodeV1::None;
+    result.semanticDigest_ = semanticDigest;
+    result.artifactDigest_ = artifactDigest;
+    result.artifactByteCount_ = artifactByteCount;
+    result.preparedByteCount_ = preparedByteCount;
+    return result;
+}
+
+PngExportWriteResultV1 PngExportWriteResultV1::cancelled() noexcept {
+    PngExportWriteResultV1 result;
+    result.status_ = PngExportWriteStatusV1::Cancelled;
+    result.error_ = PngExportWriteErrorCodeV1::None;
+    return result;
+}
+
+PngExportWriteResultV1
+PngExportWriteResultV1::failed(const PngExportWriteErrorCodeV1 error,
+                               const PngWriteErrorCodeV1 writeError,
+                               const PngVerifyDiagnosticV1& verifyDiagnostic) noexcept {
+    PngExportWriteResultV1 result;
+    result.status_ = PngExportWriteStatusV1::Failed;
+    result.error_ = error == PngExportWriteErrorCodeV1::None
+                        ? PngExportWriteErrorCodeV1::InternalInvariant
+                        : error;
+    result.writeError_ = writeError;
+    result.verifyDiagnostic_ = verifyDiagnostic;
+    return result;
+}
+
+std::optional<std::uint64_t>
+checkedPngPreparedByteCountV1(const OutputAnalysisAttemptV1& attempt) noexcept {
+    if (attempt.frame() == nullptr) {
+        return std::nullopt;
+    }
+    const auto* descriptor = attempt.frame()->processImage().descriptor();
+    if (descriptor == nullptr) {
+        return std::nullopt;
+    }
+    // The same extent, and the same checked RGBA8 layout arithmetic, the ColorPreparing stage
+    // itself uses (color::produceBloomNeutralDisplayFrame windows its output to the source
+    // process frame's DATA window and sizes it with render::checkedRgba8Layout).
+    const auto layout = render::checkedRgba8Layout(descriptor->dataWindow().extent());
+    if (!layout) {
+        return std::nullopt;
+    }
+    return static_cast<std::uint64_t>(layout.value()->pixelStorageBytes);
+}
+
+namespace {
+
+[[nodiscard]] PngExportWriteErrorCodeV1 translateColorPrepareFailure(
+    const std::vector<runtime::QualifiedDisplayDiagnostic>& diagnostics) noexcept {
+    for (const auto& diagnostic : diagnostics) {
+        if (diagnostic.code ==
+            runtime::QualifiedDisplayDiagnosticCode::PixelStorageBudgetExceeded) {
+            return PngExportWriteErrorCodeV1::PreparedBytesLimitExceeded;
+        }
+    }
+    return PngExportWriteErrorCodeV1::ColorPrepareFailed;
+}
+
+} // namespace
+
+PngExportWriteResultV1 PngExportWriterV1::run(
+    const OutputAnalysisAttemptV1& attempt, const std::filesystem::path& scratchPath,
+    const runtime::CancellationToken& cancellation, const OutputExportProgressCallbackV1& progress,
+    const std::uint64_t preparedByteLimit) const noexcept {
+    if (attempt.preset() != OutputPresetV1::PngRgba8SrgbV1 || attempt.frame() == nullptr ||
+        attempt.processIdentity() == nullptr || attempt.report() == nullptr) {
+        return PngExportWriteResultV1::failed(PngExportWriteErrorCodeV1::InvalidAttempt);
+    }
+    const auto& display = attempt.display();
+    if (!display.isPresent()) {
+        return PngExportWriteResultV1::failed(PngExportWriteErrorCodeV1::MissingDisplayProducts);
+    }
+    // isPresent() above already proves this, but it proves it through a member function call
+    // clang-tidy's bugprone-unchecked-optional-access cannot follow; taking the value out once,
+    // here, with an immediately-adjacent check is this repository's established way to avoid an
+    // unprovable-at-a-distance dereference at the use site below.
+    core::Sha256Digest expectedOcioRevision;
+    if (display.expectedOcioRevision.has_value()) {
+        expectedOcioRevision = *display.expectedOcioRevision;
+    } else {
+        return PngExportWriteResultV1::failed(PngExportWriteErrorCodeV1::MissingDisplayProducts);
+    }
+
+    // Closed-limit clamp: a caller may lower the retained-prepared-PNG-bytes ceiling, never raise
+    // it. Zero would mean "no prepared stream is representable at all", which is a caller error
+    // rather than a resource outcome, so it is rejected as an over-limit request before anything
+    // is allocated.
+    const auto effectiveLimit = std::min(preparedByteLimit, kOutputExportPreparedPngBytesMaximumV1);
+    const auto preparedBytes = checkedPngPreparedByteCountV1(attempt);
+    if (!preparedBytes.has_value()) {
+        return PngExportWriteResultV1::failed(PngExportWriteErrorCodeV1::InvalidAttempt);
+    }
+    if (effectiveLimit == 0 || *preparedBytes > effectiveLimit) {
+        return PngExportWriteResultV1::failed(
+            PngExportWriteErrorCodeV1::PreparedBytesLimitExceeded);
+    }
+
+    // --- ColorPreparing. The preparer drives C2's chunked apply and checks `cancellation` between
+    // chunks; its own budget check is the second enforcement of the same effective limit checked
+    // above (that one rejects before allocation, this one is the allocator's own guard).
+    const runtime::CpuQualifiedDisplayPreparer preparer(*display.processor);
+    const auto colorResult = preparer.prepare(
+        attempt.frame(),
+        {.aggregatePixelStorageByteLimit = static_cast<std::size_t>(effectiveLimit),
+         .chunkPixelCount = runtime::kDefaultQualifiedDisplayChunkPixelCount},
+        cancellation, [&progress](const runtime::QualifiedDisplayProgress& stageProgress) {
+            detail::reportExportProgress(progress, {.stage = OutputExportStageV1::ColorPreparing,
+                                                    .completed = stageProgress.completed,
+                                                    .total = stageProgress.total});
+        });
+    if (colorResult.status() == runtime::QualifiedDisplayPreparationStatus::Cancelled) {
+        return PngExportWriteResultV1::cancelled();
+    }
+    if (colorResult.status() != runtime::QualifiedDisplayPreparationStatus::Prepared ||
+        colorResult.frame() == nullptr) {
+        return PngExportWriteResultV1::failed(
+            translateColorPrepareFailure(colorResult.diagnostics()));
+    }
+
+    // --- PreparingOutput: the two-field aggregate png_output_adapter.hpp predicted.
+    // `preparedFrame` (and therefore this span) stays alive for the whole Writing/Verifying
+    // sequence below, which is exactly what PngRgba8SrgbPreparedStreamV1's non-owning `pixels`
+    // contract requires.
+    const auto& preparedFrame = colorResult.frame()->buffer();
+    const PngRgba8SrgbPreparedStreamV1 prepared{
+        .dimensions = preparedFrame.displayWindow().extent(), .pixels = preparedFrame.pixels()};
+    const auto preparedPixelCount = static_cast<std::uint64_t>(preparedFrame.layout().pixelCount);
+    detail::reportExportProgress(progress, {.stage = OutputExportStageV1::PreparingOutput,
+                                            .completed = preparedPixelCount,
+                                            .total = preparedPixelCount});
+    if (cancellation.isCancellationRequested()) {
+        return PngExportWriteResultV1::cancelled();
+    }
+
+    // --- Writing.
+    const PngRgba8SrgbWriterV1 writer;
+    const auto writeResult = writer.write(
+        prepared, scratchPath, cancellation, [&progress](const PngWriteProgressV1& writeProgress) {
+            detail::reportExportProgress(progress, {.stage = OutputExportStageV1::Writing,
+                                                    .completed = writeProgress.completedRows,
+                                                    .total = writeProgress.totalRows});
+        });
+    if (writeResult.status() == PngWriteStatusV1::Cancelled) {
+        return PngExportWriteResultV1::cancelled();
+    }
+    if (writeResult.status() != PngWriteStatusV1::Written) {
+        return PngExportWriteResultV1::failed(PngExportWriteErrorCodeV1::WriteFailed,
+                                              writeResult.error());
+    }
+
+    // --- Verifying: all four of G1 verify()'s identity-issuance inputs come from the attempt's own
+    // retained products; nothing here reconstructs or substitutes one.
+    const PngRgba8SrgbReopenVerifierV1 verifier;
+    const auto verifyResult = verifier.verify(
+        scratchPath, prepared, attempt.processIdentity(), attempt.report(), expectedOcioRevision,
+        display.identity, cancellation, [&progress](const PngVerifyProgressV1& verifyProgress) {
+            detail::reportExportProgress(progress, {.stage = OutputExportStageV1::Verifying,
+                                                    .completed = verifyProgress.completedRows,
+                                                    .total = verifyProgress.totalRows});
+        });
+    if (verifyResult.status() == PngVerifyStatusV1::Cancelled) {
+        return PngExportWriteResultV1::cancelled();
+    }
+    if (verifyResult.status() != PngVerifyStatusV1::Verified) {
+        return PngExportWriteResultV1::failed(PngExportWriteErrorCodeV1::VerifyFailed, {},
+                                              verifyResult.diagnostic());
+    }
+
+    std::uint64_t artifactByteCount = 0;
+    const auto artifactDigest =
+        detail::hashExportArtifactFile(scratchPath, cancellation, progress, artifactByteCount);
+    if (!artifactDigest.has_value()) {
+        if (cancellation.isCancellationRequested()) {
+            return PngExportWriteResultV1::cancelled();
+        }
+        return PngExportWriteResultV1::failed(PngExportWriteErrorCodeV1::ArtifactHashFailed);
+    }
+
+    return PngExportWriteResultV1::written(verifyResult.digest(), *artifactDigest,
+                                           artifactByteCount, *preparedBytes);
+}
+
+} // namespace bloom::output

--- a/src/output/tests/flat_exr_export_write_tests.cpp
+++ b/src/output/tests/flat_exr_export_write_tests.cpp
@@ -48,7 +48,9 @@ buildAttempt(output::ExportResourceLedgerV1& ledger, support::Fixture fixture) {
          .target = {.targetKey = bloom::core::ArtifactTargetKey::fromRaw(1),
                     .observation = platform::ArtifactTargetObservation::absent(),
                     .targetPath = "/tmp/ignored.exr",
-                    .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace}},
+                    .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace},
+         // EXR has no display product at all (frame-output.md: "EXR has no display product").
+         .display = {}},
         ledger);
     if (!result) {
         std::abort();

--- a/src/output/tests/output_analysis_attempt_tests.cpp
+++ b/src/output/tests/output_analysis_attempt_tests.cpp
@@ -43,7 +43,8 @@ void testBuildSucceedsAndRetainsProducts(Expectations& expectations) {
     auto result = output::buildOutputAnalysisAttemptV1({.frame = source.frame,
                                                         .processIdentity = source.processIdentity,
                                                         .report = source.report,
-                                                        .target = fixtureTarget()},
+                                                        .target = fixtureTarget(),
+                                                        .display = {}},
                                                        ledger);
     expectations.expect(static_cast<bool>(result),
                         "a valid ready EXR source builds a completed attempt");
@@ -71,12 +72,14 @@ void testDigestIsStableAcrossTwoBuilds(Expectations& expectations) {
     auto resultA = output::buildOutputAnalysisAttemptV1({.frame = sourceA.frame,
                                                          .processIdentity = sourceA.processIdentity,
                                                          .report = sourceA.report,
-                                                         .target = fixtureTarget()},
+                                                         .target = fixtureTarget(),
+                                                         .display = {}},
                                                         ledger);
     auto resultB = output::buildOutputAnalysisAttemptV1({.frame = sourceB.frame,
                                                          .processIdentity = sourceB.processIdentity,
                                                          .report = sourceB.report,
-                                                         .target = fixtureTarget()},
+                                                         .target = fixtureTarget(),
+                                                         .display = {}},
                                                         ledger);
     expectations.expect(static_cast<bool>(resultA) && static_cast<bool>(resultB),
                         "both identical-fixture builds succeed");
@@ -96,11 +99,37 @@ void testInvalidTargetIsRejected(Expectations& expectations) {
         {.frame = source.frame,
          .processIdentity = source.processIdentity,
          .report = source.report,
-         .target = {}}, // default-constructed target has an invalid ArtifactTargetKey
+         .target = {}, // default-constructed target has an invalid ArtifactTargetKey
+         .display = {}},
         ledger);
     expectations.expect(!result && result.error() ==
                                        output::OutputAnalysisAttemptErrorCodeV1::InvalidTarget,
                         "an invalid (never-preflighted) target is a typed InvalidTarget failure");
+}
+
+// frame-output.md: "EXR has no display product" and "The EXR preset rejects a nonempty OCIO
+// revision or display identity." A partially-populated display triple is equally structurally
+// invalid for EXR -- it is neither present nor absent -- so it is rejected before any digest is
+// computed rather than silently ignored.
+void testExrRejectsRetainedDisplayProducts(Expectations& expectations) {
+    auto source = support::prepareSource(support::roundTripFixture());
+    output::ExportResourceLedgerV1 ledger;
+    auto result = output::buildOutputAnalysisAttemptV1(
+        {.frame = source.frame,
+         .processIdentity = source.processIdentity,
+         .report = source.report,
+         .target = fixtureTarget(),
+         .display = {.processor = nullptr,
+                     .identity = nullptr,
+                     .expectedOcioRevision = bloom::core::Sha256Digest{}}},
+        ledger);
+    expectations.expect(
+        !result &&
+            result.error() == output::OutputAnalysisAttemptErrorCodeV1::InvalidDisplayProducts,
+        "an EXR attempt carrying any PNG display product is a typed InvalidDisplayProducts "
+        "failure");
+    expectations.expect(ledger.chargedBytes() == 0,
+                        "a refused display-product build charges nothing against the ledger");
 }
 
 void testResourceExhaustionIsTypedWithZeroLeak(Expectations& expectations) {
@@ -109,7 +138,8 @@ void testResourceExhaustionIsTypedWithZeroLeak(Expectations& expectations) {
     auto result = output::buildOutputAnalysisAttemptV1({.frame = source.frame,
                                                         .processIdentity = source.processIdentity,
                                                         .report = source.report,
-                                                        .target = fixtureTarget()},
+                                                        .target = fixtureTarget(),
+                                                        .display = {}},
                                                        ledger);
     expectations.expect(
         !result &&
@@ -126,6 +156,7 @@ int main() {
     testBuildSucceedsAndRetainsProducts(expectations);
     testDigestIsStableAcrossTwoBuilds(expectations);
     testInvalidTargetIsRejected(expectations);
+    testExrRejectsRetainedDisplayProducts(expectations);
     testResourceExhaustionIsTypedWithZeroLeak(expectations);
     return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/output/tests/png_export_write_tests.cpp
+++ b/src/output/tests/png_export_write_tests.cpp
@@ -1,0 +1,345 @@
+// Tests for PngExportWriterV1 (issue #111): the approved export job's PNG half -- ColorPreparing
+// through the retained qualified display processor, PreparingOutput, G1's writer, G1's reopen
+// verifier with all four identity-issuance inputs, and the artifact hash. Mirrors
+// flat_exr_export_write_tests.cpp's shape, plus the PNG-only retained-display-product and
+// prepared-bytes-limit cases flat OpenEXR has no equivalent of.
+
+#include "png_test_support.hpp"
+
+#include <bloom/color/bloom_neutral_builtin.hpp>
+#include <bloom/color/ocio_builtin_registry.hpp>
+#include <bloom/color/ocio_cpu_display_processor.hpp>
+#include <bloom/core/artifact_target_key.hpp>
+#include <bloom/output/output_analysis_attempt.hpp>
+#include <bloom/output/output_export_resource_ledger.hpp>
+#include <bloom/output/png_export_write.hpp>
+#include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace std::chrono_literals;
+namespace color = bloom::color;
+namespace core = bloom::core;
+namespace output = bloom::output;
+namespace platform = bloom::platform;
+namespace runtime = bloom::runtime;
+namespace support = bloom_output_png_test_support;
+
+[[nodiscard]] output::OutputAnalysisAttemptTargetV1 fixtureTarget() {
+    return {.targetKey = core::ArtifactTargetKey::fromRaw(11),
+            .observation = platform::ArtifactTargetObservation::absent(),
+            .targetPath = "/tmp/does-not-matter.png",
+            .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace};
+}
+
+// The real qualified Bloom Neutral CPU display processor, resolved and built exactly the way the
+// attempt's own blocking stage does (C2's in-process registry + processor builder against the
+// embedded payload's frozen expectedRevision). Built once per process: the OCIO config parse is the
+// expensive part of these tests and nothing here mutates the handle.
+[[nodiscard]] std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> qualifiedHandle() {
+    static const std::shared_ptr<const color::PreparedCpuDisplayProcessorHandle> handle = [] {
+        auto resolution = color::resolveBloomNeutralV1BuiltIn(
+            color::OcioConfigLocatorKind::BloomBuiltIn, color::kBloomNeutralV1ConfigUri,
+            color::kBloomNeutralV1ConfigDigest);
+        if (!resolution.ready()) {
+            std::abort();
+        }
+        auto resolved = std::move(resolution).takeResolved();
+        if (!resolved.has_value()) {
+            std::abort();
+        }
+        auto built = color::buildBloomNeutralCpuDisplayProcessor(*resolved);
+        auto handleValue = std::move(built).takeHandle();
+        if (!handleValue.has_value()) {
+            std::abort();
+        }
+        return std::make_shared<const color::PreparedCpuDisplayProcessorHandle>(
+            std::move(*handleValue));
+    }();
+    return handle;
+}
+
+[[nodiscard]] output::OutputAnalysisAttemptDisplayProductsV1 fixtureDisplayProducts() {
+    auto handle = qualifiedHandle();
+    // The aliasing shared_ptr the production runner uses: the identity is the handle's own, never
+    // an independently adopted copy.
+    std::shared_ptr<const color::DisplayProcessorIdentityV1> identity(handle, &handle->identity());
+    return {.processor = std::move(handle),
+            .identity = std::move(identity),
+            .expectedOcioRevision = color::kBloomNeutralV1ConfigDigest};
+}
+
+// Runs the same pre-approval pipeline the production attempt graph runs -- identity preparation,
+// the PNG analyzer with the resolved color state, then buildOutputAnalysisAttemptV1 -- so every
+// test below exercises a genuine retained attempt rather than a hand-assembled stand-in.
+[[nodiscard]] std::shared_ptr<const output::OutputAnalysisAttemptV1>
+buildPngAttempt(support::Expectations& expectations, output::ExportResourceLedgerV1& ledger,
+                const std::uint32_t width, const std::uint32_t height,
+                const output::PngRgba8SrgbColorResolutionStateV1 colorResolution =
+                    output::PngRgba8SrgbColorResolutionStateV1::Ready) {
+    auto frame = support::publish(support::pngShapedFixture(width, height));
+    const output::ProcessFrameSemanticIdentityV1Preparer identityPreparer;
+    const auto identityResult = identityPreparer.prepare(frame, {});
+    if (identityResult.status() !=
+            output::ProcessFrameSemanticIdentityPreparationStatus::Prepared ||
+        identityResult.identity() == nullptr) {
+        expectations.expect(false, "attempt fixture: the process identity prepares");
+        return nullptr;
+    }
+    const auto analyzed = output::analyzePngRgba8SrgbV1(
+        {.process = {.state = output::OutputAnalysisProcessSourceStateV1::Ready,
+                     .readyIdentity = identityResult.identity(),
+                     .missingDescriptor = std::nullopt},
+         .expectedOcioRevision = color::kBloomNeutralV1ConfigDigest,
+         .colorResolution = colorResolution});
+    if (!analyzed.hasReport()) {
+        expectations.expect(false, "attempt fixture: the PNG analyzer produces a report");
+        return nullptr;
+    }
+    const bool ready = colorResolution == output::PngRgba8SrgbColorResolutionStateV1::Ready;
+    auto result = output::buildOutputAnalysisAttemptV1(
+        {.frame = frame,
+         .processIdentity = identityResult.identity(),
+         .report = analyzed.report(),
+         .target = fixtureTarget(),
+         .display =
+             ready ? fixtureDisplayProducts() : output::OutputAnalysisAttemptDisplayProductsV1{}},
+        ledger);
+    expectations.expect(static_cast<bool>(result), "attempt fixture: the PNG attempt builds");
+    return result ? result.attempt() : nullptr;
+}
+
+// -------------------------------------------------------------------------------------------
+
+void testPngExportWriteRoundTripAndIndependentDecode(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("png-export-round-trip");
+    output::ExportResourceLedgerV1 ledger;
+    const auto attempt = buildPngAttempt(expectations, ledger, 5, 3);
+    if (attempt == nullptr) {
+        return;
+    }
+    expectations.expect(attempt->preset() == output::OutputPresetV1::PngRgba8SrgbV1 &&
+                            attempt->approvable() && attempt->display().isPresent(),
+                        "round trip: the PNG attempt is approvable and retains its display "
+                        "products");
+
+    const auto destination = scratch.file("round-trip.png");
+    const output::PngExportWriterV1 writer;
+    const auto result = writer.run(*attempt, destination, {});
+    expectations.expect(result.status() == output::PngExportWriteStatusV1::Written,
+                        "round trip: the PNG export write/verify sequence succeeds");
+    if (result.status() != output::PngExportWriteStatusV1::Written) {
+        return;
+    }
+    expectations.expect(result.preparedByteCount() == std::size_t{5} * 3 * 4,
+                        "round trip: the charged prepared byte count is width * height * 4");
+    expectations.expect(result.artifactByteCount() > 0 &&
+                            result.artifactByteCount() == std::filesystem::file_size(destination),
+                        "round trip: the artifact byte count matches the staged file");
+
+    const auto decoded = support::independentlyDecodePng(destination);
+    expectations.expect(decoded.ok && decoded.everyCrcValid && decoded.everyRowFilterZero,
+                        "round trip: the staged file independently decodes with valid CRCs and "
+                        "zero row filters");
+    expectations.expect(decoded.chunkTypesInOrder ==
+                            std::vector<std::string>{"IHDR", "sRGB", "IDAT", "IEND"},
+                        "round trip: the independent decode sees exactly the closed chunk profile");
+    expectations.expect(decoded.width == 5 && decoded.height == 3 && decoded.bitDepth == 8 &&
+                            decoded.colorType == 6 && decoded.interlaceMethod == 0 &&
+                            decoded.srgbIntent == 0,
+                        "round trip: the independent decode sees the required IHDR/sRGB fields");
+}
+
+void testKind1DigestIsStableAcrossTwoRuns(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("png-export-digest-stability");
+    output::ExportResourceLedgerV1 ledgerA;
+    output::ExportResourceLedgerV1 ledgerB;
+    const auto attemptA = buildPngAttempt(expectations, ledgerA, 4, 4);
+    const auto attemptB = buildPngAttempt(expectations, ledgerB, 4, 4);
+    if (attemptA == nullptr || attemptB == nullptr) {
+        return;
+    }
+    const output::PngExportWriterV1 writer;
+    const auto resultA = writer.run(*attemptA, scratch.file("stable-a.png"), {});
+    const auto resultB = writer.run(*attemptB, scratch.file("stable-b.png"), {});
+    expectations.expect(resultA.status() == output::PngExportWriteStatusV1::Written &&
+                            resultB.status() == output::PngExportWriteStatusV1::Written,
+                        "digest stability: both independent runs write and verify");
+    if (resultA.status() != output::PngExportWriteStatusV1::Written ||
+        resultB.status() != output::PngExportWriteStatusV1::Written) {
+        return;
+    }
+    expectations.expect(resultA.semanticDigest() == resultB.semanticDigest(),
+                        "digest stability: the kind-1 semantic identity digest is identical across "
+                        "two independent runs over the identical fixture");
+}
+
+void testPreparedBytesLimitExceededIsTyped(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("png-export-prepared-limit");
+    output::ExportResourceLedgerV1 ledger;
+    const auto attempt = buildPngAttempt(expectations, ledger, 8, 8);
+    if (attempt == nullptr) {
+        return;
+    }
+    const auto destination = scratch.file("over-limit.png");
+    const output::PngExportWriterV1 writer;
+    // 8 * 8 * 4 = 256 prepared bytes; a lowered ceiling of 255 is one byte under.
+    // frame-output.md's closed 256 MiB ceiling can never itself be EXCEEDED through the production
+    // pipeline (the closed 2^26 pixel-count limit caps prepared bytes at exactly 256 MiB), so the
+    // "a request may lower but not raise them" seam is the only way to reach this rejection --
+    // see output_limits.hpp's own reachability note.
+    const auto result = writer.run(*attempt, destination, {}, {}, 255);
+    expectations.expect(result.status() == output::PngExportWriteStatusV1::Failed &&
+                            result.error() ==
+                                output::PngExportWriteErrorCodeV1::PreparedBytesLimitExceeded,
+                        "prepared-bytes limit: an over-limit prepared stream is a typed "
+                        "PreparedBytesLimitExceeded failure");
+    expectations.expect(!std::filesystem::exists(destination),
+                        "prepared-bytes limit: nothing is written and no file is created");
+
+    const auto atLimit = writer.run(*attempt, scratch.file("at-limit.png"), {}, {}, 256);
+    expectations.expect(atLimit.status() == output::PngExportWriteStatusV1::Written,
+                        "prepared-bytes limit: a prepared stream exactly AT the limit is accepted "
+                        "(values exactly at a limit do not exceed it)");
+}
+
+void testMissingDisplayProductsIsTyped(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("png-export-missing-display");
+    output::ExportResourceLedgerV1 ledger;
+    // A PNG attempt whose color resolution was Missing: it completes (a truthful, non-approvable
+    // report) but retains no display products, so the writer must refuse it typed rather than
+    // dereference a null processor.
+    const auto attempt = buildPngAttempt(expectations, ledger, 4, 4,
+                                         output::PngRgba8SrgbColorResolutionStateV1::Missing);
+    if (attempt == nullptr) {
+        return;
+    }
+    expectations.expect(!attempt->approvable() && attempt->display().isAbsent(),
+                        "missing display: a non-Ready color resolution completes a non-approvable "
+                        "attempt with no display products");
+    const auto destination = scratch.file("missing-display.png");
+    const output::PngExportWriterV1 writer;
+    const auto result = writer.run(*attempt, destination, {});
+    expectations.expect(result.status() == output::PngExportWriteStatusV1::Failed &&
+                            result.error() ==
+                                output::PngExportWriteErrorCodeV1::MissingDisplayProducts,
+                        "missing display: the writer refuses typed MissingDisplayProducts");
+    expectations.expect(!std::filesystem::exists(destination),
+                        "missing display: no file is created");
+}
+
+void testCancellationDuringColorPreparingWritesNothing(support::Expectations& expectations) {
+    const support::ScratchDirectory scratch("png-export-cancel-color");
+    output::ExportResourceLedgerV1 ledger;
+    // 400 * 400 = 160000 pixels spans three of C2's 65536-pixel apply chunks, so this exercises a
+    // genuinely multi-chunk apply. The rendezvous is the ColorPreparing progress report emitted
+    // immediately before that chunk loop (the unique completed==0/total==0 one), which gives a
+    // DETERMINISTIC synchronization point instead of racing a background thread; cancellation is
+    // therefore observed at the loop's first chunk-boundary check. C2's chunk loop exposes no
+    // per-chunk progress hook of its own, so a later boundary cannot be targeted without adding one
+    // -- out of scope here, and immaterial to what this proves: cancellation inside ColorPreparing
+    // packs no pixels, creates no file, and publishes nothing.
+    const auto attempt = buildPngAttempt(expectations, ledger, 400, 400);
+    if (attempt == nullptr) {
+        return;
+    }
+    const auto destination = scratch.file("cancelled.png");
+
+    runtime::TaskSchedulerConfig config = runtime::TaskSchedulerConfig::defaults();
+    config.cpuWorkerCount = 1;
+    config.blockingIoWorkerCount = 1;
+    runtime::TaskScheduler scheduler(config);
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool reachedColorPreparing = false;
+    bool released = false;
+    std::atomic_bool cancelled = false;
+    std::atomic_bool written = false;
+    const output::PngExportWriterV1 writer;
+
+    auto submission = scheduler.submit<void>(
+        runtime::TaskRequest(
+            "PNG export color cancellation",
+            {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)}),
+        [&](runtime::TaskContext& context) {
+            const auto result =
+                writer.run(*attempt, destination, context.cancellation(),
+                           [&](const output::OutputExportProgressV1& progress) {
+                               // The one ColorPreparing report emitted immediately before C2's
+                               // apply loop.
+                               if (progress.stage != output::OutputExportStageV1::ColorPreparing ||
+                                   progress.completed != 0 || progress.total != 0) {
+                                   return;
+                               }
+                               std::unique_lock lock(mutex);
+                               reachedColorPreparing = true;
+                               condition.notify_all();
+                               condition.wait(lock, [&released] { return released; });
+                           });
+            cancelled.store(result.status() == output::PngExportWriteStatusV1::Cancelled,
+                            std::memory_order_release);
+            written.store(result.status() == output::PngExportWriteStatusV1::Written,
+                          std::memory_order_release);
+            return runtime::TaskResult<void>::succeeded();
+        });
+    {
+        std::unique_lock lock(mutex);
+        expectations.expect(
+            submission.accepted() &&
+                condition.wait_for(lock, 10s,
+                                   [&reachedColorPreparing] { return reachedColorPreparing; }),
+            "color cancellation: the fixture reaches the ColorPreparing rendezvous");
+    }
+    submission.handle.cancel();
+    {
+        const std::lock_guard lock(mutex);
+        released = true;
+        condition.notify_all();
+    }
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    std::optional<runtime::TaskResult<void>> taskResult;
+    while (!taskResult.has_value() && std::chrono::steady_clock::now() < deadline) {
+        taskResult = submission.handle.tryTakeResult();
+        std::this_thread::yield();
+    }
+    expectations.expect(cancelled.load(std::memory_order_acquire) &&
+                            !written.load(std::memory_order_acquire),
+                        "color cancellation: the run reports a typed Cancelled result, never "
+                        "Written");
+    expectations.expect(!std::filesystem::exists(destination),
+                        "color cancellation: cancellation during ColorPreparing writes no file at "
+                        "all");
+    scheduler.beginShutdown();
+    while (!scheduler.isQuiescent() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    expectations.expect(scheduler.isQuiescent(), "color cancellation: the fixture shuts down "
+                                                 "cleanly");
+}
+
+} // namespace
+
+int main() {
+    support::Expectations expectations;
+    testPngExportWriteRoundTripAndIndependentDecode(expectations);
+    testKind1DigestIsStableAcrossTwoRuns(expectations);
+    testPreparedBytesLimitExceededIsTyped(expectations);
+    testMissingDisplayProductsIsTyped(expectations);
+    testCancellationDuringColorPreparingWritesNothing(expectations);
+    return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/src/ui/frame_export_controller.cpp
+++ b/src/ui/frame_export_controller.cpp
@@ -13,6 +13,7 @@
 #include <QPushButton>
 #include <QStandardPaths>
 
+#include <cctype>
 #include <system_error>
 #include <utility>
 
@@ -93,6 +94,8 @@ summarizeFacets(const output::OutputAnalysisReportV1View& view) {
     switch (stage) {
     case host::OutputAnalysisAttemptStageV1::Resolving:
         return FrameExportController::tr("resolving the destination");
+    case host::OutputAnalysisAttemptStageV1::ColorPreparing:
+        return FrameExportController::tr("preparing the color transform");
     case host::OutputAnalysisAttemptStageV1::Evaluating:
         return FrameExportController::tr("evaluating the composition");
     case host::OutputAnalysisAttemptStageV1::Identifying:
@@ -109,6 +112,8 @@ summarizeFacets(const output::OutputAnalysisReportV1View& view) {
         return FrameExportController::tr("preflight");
     case host::FrameExportPublicationStageV1::Staging:
         return FrameExportController::tr("staging");
+    case host::FrameExportPublicationStageV1::ColorPreparing:
+        return FrameExportController::tr("preparing the color transform");
     case host::FrameExportPublicationStageV1::Writing:
         return FrameExportController::tr("writing");
     case host::FrameExportPublicationStageV1::Verifying:
@@ -163,16 +168,42 @@ exportFailureOutcome(const host::FrameExportPublicationFailureV1* failure) {
     return FrameExportOutcome::Failed;
 }
 
+// The exact serialized preset ID from the typed-preset table, never a paraphrase. The fallback
+// spellings are unreachable (outputPresetIdentityV1() covers both closed presets) but keep this
+// display path total.
+[[nodiscard]] QString presetDisplayName(const output::OutputPresetV1 preset) {
+    const auto identity = output::outputPresetIdentityV1(preset);
+    if (identity.has_value()) {
+        return QString::fromUtf8(identity->serializedId.data(),
+                                 static_cast<int>(identity->serializedId.size()));
+    }
+    return preset == output::OutputPresetV1::PngRgba8SrgbV1
+               ? QStringLiteral("PngRgba8SrgbV1")
+               : QStringLiteral("FlatExrRgba32fLinRec709SceneV1");
+}
+
 } // namespace
+
+output::OutputPresetV1
+FrameExportController::presetForDestination(const std::filesystem::path& destination) {
+    auto extension = destination.extension().string();
+    for (auto& character : extension) {
+        character = static_cast<char>(std::tolower(static_cast<unsigned char>(character)));
+    }
+    return extension == ".png" ? output::OutputPresetV1::PngRgba8SrgbV1
+                               : output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1;
+}
 
 FrameExportController::FrameExportController(
     CompositionSession& session, runtime::TaskScheduler& scheduler, TaskUiBridge& taskUiBridge,
     const runtime::SnapshotCompiler& compiler, host::PublicationCoordinator& publicationCoordinator,
     platform::StagedArtifactCoordinator& artifactCoordinator,
-    std::filesystem::path scratchDirectory, QObject* parent)
+    std::filesystem::path scratchDirectory,
+    runtime::QualifiedDisplayProcessorProvider* const displayProcessorProvider, QObject* parent)
     : QObject(parent), session_(session), scheduler_(scheduler), taskUiBridge_(taskUiBridge),
       compiler_(compiler), publicationCoordinator_(publicationCoordinator),
       artifactCoordinator_(artifactCoordinator),
+      displayProcessorProvider_(displayProcessorProvider),
       scratchDirectory_(scratchDirectory.empty() ? defaultExportScratchDirectory()
                                                  : std::move(scratchDirectory)) {
     std::error_code error;
@@ -180,9 +211,13 @@ FrameExportController::FrameExportController(
 
     connect(&taskUiBridge_, &TaskUiBridge::snapshotsPolled, this, &FrameExportController::pollOnce);
 
+    // Both closed version 1 presets are offered; the chosen extension -- not the selected filter
+    // entry -- is what actually selects the preset (presetForDestination() above), so a path typed
+    // by hand behaves identically to one picked through a filter. OpenEXR stays first so the
+    // dialog's default selection, and therefore every existing artist habit, is unchanged.
     destinationProvider_ = []() -> std::optional<std::filesystem::path> {
-        const auto chosen =
-            QFileDialog::getSaveFileName(nullptr, tr("Export Frame"), {}, tr("OpenEXR (*.exr)"));
+        const auto chosen = QFileDialog::getSaveFileName(nullptr, tr("Export Frame"), {},
+                                                         tr("OpenEXR (*.exr);;PNG (*.png)"));
         if (chosen.isEmpty()) {
             return std::nullopt;
         }
@@ -295,6 +330,7 @@ void FrameExportController::beginExport(std::filesystem::path destination) {
     }
 
     pendingDestination_ = std::move(destination);
+    pendingPreset_ = presetForDestination(pendingDestination_);
 
     runtime::TaskRequest request(
         "Compile composition for frame export",
@@ -414,7 +450,9 @@ void FrameExportController::handleCompileResult(CompileHandle& compiling) {
                        .pixelStorageByteLimit = kDefaultPreviewPixelStorageByteLimit},
         .targetPath = pendingDestination_,
         .overwritePolicy = platform::ArtifactOverwritePolicy::CreateOrReplace,
-        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)}};
+        .owner = {.kind = runtime::TaskOwnerKind::Export, .id = runtime::TaskOwnerId::fromRaw(1)},
+        .preset = pendingPreset_,
+        .displayProcessorProvider = displayProcessorProvider_};
 
     auto begin = host::beginOutputAnalysisAttemptV1(scheduler_, artifactCoordinator_, ledger_,
                                                     std::move(request));
@@ -490,13 +528,11 @@ void FrameExportController::presentApproval(
             prompt.height = descriptor->displayWindow().extent().height();
         }
     }
-    const auto presetIdentity =
-        output::outputPresetIdentityV1(output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1);
-    prompt.presetName =
-        presetIdentity.has_value()
-            ? QString::fromUtf8(presetIdentity->serializedId.data(),
-                                static_cast<int>(presetIdentity->serializedId.size()))
-            : QStringLiteral("FlatExrRgba32fLinRec709SceneV1");
+    // Read off the completed attempt, which took its preset from the chosen destination extension
+    // -- never re-derived from the path here, so the prompt can never name a different preset from
+    // the one that was actually analyzed.
+    prompt.preset = attempt->preset();
+    prompt.presetName = presetDisplayName(prompt.preset);
     prompt.facets = summarizeFacets(attempt->report()->view());
     const auto digestHex = digest->toLowercaseHex();
     prompt.digestShortForm = QString::fromLatin1(digestHex.data(), 16);
@@ -715,6 +751,10 @@ QString FrameExportController::describeExportFailure(
         return tr("The export ran out of its resource budget during %1; the previous target, if "
                   "any, is unchanged.")
             .arg(jobStageName(failure->stage()));
+    }
+    if (failure->payloadAs<host::FrameExportPreparedBytesExceededV1>() != nullptr) {
+        return tr("This frame's prepared PNG pixels exceed the export size limit; nothing was "
+                  "written and the previous target, if any, is unchanged.");
     }
     return tr("The export failed during %1; the previous target, if any, is unchanged.")
         .arg(jobStageName(failure->stage()));

--- a/src/ui/include/bloom/ui/frame_export_controller.hpp
+++ b/src/ui/include/bloom/ui/frame_export_controller.hpp
@@ -9,6 +9,7 @@
 #include <bloom/output/output_analysis_attempt.hpp>
 #include <bloom/output/output_export_resource_ledger.hpp>
 #include <bloom/platform/staged_artifact.hpp>
+#include <bloom/runtime/qualified_display_processor_provider.hpp>
 #include <bloom/runtime/snapshot_compiler.hpp>
 #include <bloom/runtime/task_scheduler.hpp>
 
@@ -46,8 +47,11 @@ struct FrameExportApprovalPrompt final {
     std::filesystem::path destination;
     std::uint32_t width = 0;
     std::uint32_t height = 0;
+    // The typed preset the chosen destination extension selected, read straight off the completed
+    // attempt (never re-derived from the path at prompt time).
+    output::OutputPresetV1 preset = output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1;
     // The exact serialized preset ID (docs/architecture/frame-output.md's typed-preset table) --
-    // "FlatExrRgba32fLinRec709SceneV1" in version 1, never a paraphrase.
+    // "PngRgba8SrgbV1" or "FlatExrRgba32fLinRec709SceneV1", never a paraphrase.
     QString presetName;
     FrameExportFacetSummary facets;
     // The first 16 lowercase hex characters of attempt->digest()->toLowercaseHex() -- "the digest's
@@ -111,11 +115,21 @@ class FrameExportController final : public QObject {
     // owns ... supersession across saves and exports"). `scratchDirectory`, when non-empty,
     // overrides the default app-private temp location (tests use this to stay inside their own temp
     // fixture); either way the resolved directory is created if missing.
-    FrameExportController(CompositionSession& session, runtime::TaskScheduler& scheduler,
-                          TaskUiBridge& taskUiBridge, const runtime::SnapshotCompiler& compiler,
-                          host::PublicationCoordinator& publicationCoordinator,
-                          platform::StagedArtifactCoordinator& artifactCoordinator,
-                          std::filesystem::path scratchDirectory = {}, QObject* parent = nullptr);
+    // `displayProcessorProvider`, when non-null, must be the SAME application-wide
+    // bloom::runtime::QualifiedDisplayProcessorProvider the viewer's preview pipeline reads, and
+    // must outlive this object. A PNG export then REUSES that already-built qualified processor
+    // instead of resolving and building a second one on its own blocking stage. When it is null
+    // (or still Pending), the PNG attempt builds its own -- a real cost, never a silent fallback
+    // to an unqualified transform. It is a trailing defaulted parameter so the composition root
+    // can adopt it without every existing caller changing.
+    FrameExportController(
+        CompositionSession& session, runtime::TaskScheduler& scheduler, TaskUiBridge& taskUiBridge,
+        const runtime::SnapshotCompiler& compiler,
+        host::PublicationCoordinator& publicationCoordinator,
+        platform::StagedArtifactCoordinator& artifactCoordinator,
+        std::filesystem::path scratchDirectory = {},
+        runtime::QualifiedDisplayProcessorProvider* displayProcessorProvider = nullptr,
+        QObject* parent = nullptr);
     ~FrameExportController() override;
 
     // A composition exists and no export is currently in flight (menu-enabled rule; MainWindow
@@ -131,10 +145,19 @@ class FrameExportController final : public QObject {
     [[nodiscard]] std::uint64_t chargedResourceBytes() const noexcept;
 
     // Seam setters (ProjectHost's decision-4 precedent). Defaults are installed at construction (a
-    // real QFileDialog::getSaveFileName ".exr" filter; a real QMessageBox Export/Cancel prompt), so
+    // real QFileDialog::getSaveFileName offering both closed presets' ".exr"/".png" filters; a real
+    // QMessageBox Export/Cancel prompt naming the selected preset), so
     // offscreen tests can drive the whole flow without a real dialog appearing.
     void setDestinationProvider(FrameExportDestinationProvider provider);
     void setApprovalDecisionProvider(FrameExportApprovalDecisionProvider provider);
+
+    // The typed preset a destination path selects: the closed extension->preset mapping the export
+    // command uses (design decision 3: "the chosen extension selects the preset"). Exactly ".png"
+    // (ASCII case-insensitive) selects PngRgba8SrgbV1; every other extension -- including ".exr",
+    // no extension at all, and an unrecognized one -- keeps the flat OpenEXR preset this command
+    // has always used, so no pre-existing destination changes meaning.
+    [[nodiscard]] static output::OutputPresetV1
+    presetForDestination(const std::filesystem::path& destination);
 
   public slots:
     // "File -> Export Frame..." entry point: refuses while busy or without a composition, else
@@ -180,6 +203,7 @@ class FrameExportController final : public QObject {
     const runtime::SnapshotCompiler& compiler_;
     host::PublicationCoordinator& publicationCoordinator_;
     platform::StagedArtifactCoordinator& artifactCoordinator_;
+    runtime::QualifiedDisplayProcessorProvider* displayProcessorProvider_ = nullptr;
     output::ExportResourceLedgerV1 ledger_;
     std::filesystem::path scratchDirectory_;
 
@@ -188,6 +212,7 @@ class FrameExportController final : public QObject {
 
     FrameExportActivity activity_ = FrameExportActivity::Idle;
     std::filesystem::path pendingDestination_;
+    output::OutputPresetV1 pendingPreset_ = output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1;
 
     std::variant<std::monostate, CompileHandle, host::OutputAnalysisAttemptRunnerV1,
                  ExportJobHandle>

--- a/src/ui/tests/frame_export_controller_tests.cpp
+++ b/src/ui/tests/frame_export_controller_tests.cpp
@@ -39,6 +39,7 @@
 #include <string_view>
 #include <unistd.h>
 #include <utility>
+#include <vector>
 
 // Task F3 (issue #103): drives bloom::ui::FrameExportController's public surface -- "File -> Export
 // Frame..." -- end to end over a REAL bloom::runtime::TaskScheduler, mirroring
@@ -562,6 +563,165 @@ void testExternalModificationConflictSurfacedAsFailure(Expectations& expectation
                         "was");
 }
 
+// -------------------------------------------------------------------------------------------
+// Preset selection by destination extension (issue #111, design decision 3): the chosen extension
+// -- not the dialog's selected filter entry -- selects the preset, so a hand-typed path behaves
+// identically to a filtered one.
+// -------------------------------------------------------------------------------------------
+
+void testDestinationExtensionSelectsPreset(Expectations& expectations) {
+    const auto preset = [](const char* path) {
+        return FrameExportController::presetForDestination(std::filesystem::path(path));
+    };
+    expectations.expect(preset("/tmp/frame.png") == output::OutputPresetV1::PngRgba8SrgbV1,
+                        "extension routing: .png selects the PNG preset");
+    expectations.expect(preset("/tmp/frame.PNG") == output::OutputPresetV1::PngRgba8SrgbV1,
+                        "extension routing: extension matching is ASCII case-insensitive");
+    expectations.expect(preset("/tmp/frame.exr") ==
+                            output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1,
+                        "extension routing: .exr keeps the flat OpenEXR preset");
+    expectations.expect(preset("/tmp/frame") ==
+                            output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1,
+                        "extension routing: no extension keeps the flat OpenEXR preset");
+    expectations.expect(preset("/tmp/frame.tiff") ==
+                            output::OutputPresetV1::FlatExrRgba32fLinRec709SceneV1,
+                        "extension routing: an unrecognized extension keeps the flat OpenEXR "
+                        "preset, never a silently different one");
+}
+
+// -------------------------------------------------------------------------------------------
+// Full PNG drive through the injected destination seam: a .png destination routes to the PNG
+// preset, the approval prompt reports PNG-appropriate facts, and the published file really is a
+// PNG.
+// -------------------------------------------------------------------------------------------
+
+void testPngDestinationRoutesToPngPresetAndPublishes(Expectations& expectations) {
+    Fixture fixture;
+    if (!fixture.setUp(expectations, "png drive: fixture is available")) {
+        return;
+    }
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.25, 0.5, 0.75, 1.0}),
+        "png drive: the solid layer is added");
+
+    const auto target = fixture.directory.path() / "published.png";
+    fixture.controller().setDestinationProvider(
+        [&target]() -> std::optional<std::filesystem::path> { return target; });
+
+    std::optional<FrameExportApprovalPrompt> capturedPrompt;
+    fixture.controller().setApprovalDecisionProvider(
+        [&capturedPrompt](const FrameExportApprovalPrompt& prompt) {
+            capturedPrompt = prompt;
+            return FrameExportApprovalDecision::Export;
+        });
+
+    int finishedCount = 0;
+    FrameExportOutcome outcome = FrameExportOutcome::Refused;
+    QObject::connect(&fixture.controller(), &FrameExportController::exportFinished,
+                     [&](const FrameExportOutcome resultOutcome, const QString&) {
+                         ++finishedCount;
+                         outcome = resultOutcome;
+                     });
+
+    fixture.controller().requestExport();
+    expectations.expect(waitUntil([&] { return finishedCount == 1; }),
+                        "png drive: the export reaches a terminal outcome");
+    expectations.expect(outcome == FrameExportOutcome::Published,
+                        "png drive: the export publishes");
+    expectations.expect(std::filesystem::exists(target),
+                        "png drive: the target file really exists");
+
+    const auto* prompt =
+        require(capturedPrompt, expectations, "png drive: the approval prompt was presented");
+    if (prompt != nullptr) {
+        expectations.expect(prompt->preset == output::OutputPresetV1::PngRgba8SrgbV1,
+                            "png drive: the prompt reports the typed PNG preset the .png "
+                            "destination selected");
+        expectations.expect(prompt->presetName == QStringLiteral("PngRgba8SrgbV1"),
+                            "png drive: the prompt names the exact serialized PNG preset id");
+        expectations.expect(prompt->width == 4 && prompt->height == 4,
+                            "png drive: the prompt names the composition's own resolution");
+        // docs/architecture/frame-output.md's nominal PNG derivation: pixels, precision, color, and
+        // alpha association are Approximated and external dependencies is ExternalReference -- five
+        // non-exact facets; the remaining six are Exact.
+        expectations.expect(prompt->facets.exactFacetCount == 6 &&
+                                prompt->facets.nonExactFacetCount == 5,
+                            "png drive: a nominal PNG export reports six Exact and five non-Exact "
+                            "facets");
+        expectations.expect(
+            prompt->facets.nonExactFacetNames.contains(QStringLiteral("Color")) &&
+                prompt->facets.nonExactFacetNames.contains(QStringLiteral("External Dependencies")),
+            "png drive: the non-exact facet list names the PNG-specific color and "
+            "external-dependency conversions");
+        expectations.expect(prompt->digestShortForm.size() == 16,
+                            "png drive: the digest short form is 16 hex characters");
+    }
+
+    std::ifstream published(target, std::ios::binary);
+    std::array<char, 8> signature{};
+    published.read(signature.data(), 8);
+    static constexpr std::array<unsigned char, 8> kPngSignature{137, 80, 78, 71, 13, 10, 26, 10};
+    bool signatureMatches = published.gcount() == 8;
+    for (std::size_t index = 0; index < signature.size() && signatureMatches; ++index) {
+        signatureMatches =
+            static_cast<unsigned char>(signature.at(index)) == kPngSignature.at(index);
+    }
+    expectations.expect(signatureMatches,
+                        "png drive: the published file carries the exact PNG signature");
+}
+
+// -------------------------------------------------------------------------------------------
+// Both presets from one controller, back to back: the EXR path is unchanged and the PNG path
+// coexists with it under the same one-export-at-a-time bound.
+// -------------------------------------------------------------------------------------------
+
+void testBothPresetsExportBackToBack(Expectations& expectations) {
+    Fixture fixture;
+    if (!fixture.setUp(expectations, "both presets: fixture is available")) {
+        return;
+    }
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.2, 0.4, 0.6, 1.0}),
+        "both presets: the solid layer is added");
+
+    QStringList presetNames;
+    fixture.controller().setApprovalDecisionProvider(
+        [&presetNames](const FrameExportApprovalPrompt& prompt) {
+            presetNames << prompt.presetName;
+            return FrameExportApprovalDecision::Export;
+        });
+
+    int finishedCount = 0;
+    std::vector<FrameExportOutcome> outcomes;
+    QObject::connect(&fixture.controller(), &FrameExportController::exportFinished,
+                     [&](const FrameExportOutcome resultOutcome, const QString&) {
+                         ++finishedCount;
+                         outcomes.push_back(resultOutcome);
+                     });
+
+    const auto exrTarget = fixture.directory.path() / "both.exr";
+    const auto pngTarget = fixture.directory.path() / "both.png";
+    fixture.controller().beginExport(exrTarget);
+    expectations.expect(!fixture.controller().canExport(),
+                        "both presets: the one-export-at-a-time bound holds while the first export "
+                        "is in flight");
+    expectations.expect(waitUntil([&] { return finishedCount == 1; }),
+                        "both presets: the EXR export reaches a terminal outcome");
+    fixture.controller().beginExport(pngTarget);
+    expectations.expect(waitUntil([&] { return finishedCount == 2; }),
+                        "both presets: the PNG export reaches a terminal outcome");
+
+    expectations.expect(outcomes.size() == 2 && outcomes[0] == FrameExportOutcome::Published &&
+                            outcomes[1] == FrameExportOutcome::Published,
+                        "both presets: both exports publish");
+    expectations.expect(std::filesystem::exists(exrTarget) && std::filesystem::exists(pngTarget),
+                        "both presets: both target files exist");
+    expectations.expect(presetNames == QStringList{QStringLiteral("FlatExrRgba32fLinRec709SceneV1"),
+                                                   QStringLiteral("PngRgba8SrgbV1")},
+                        "both presets: each approval prompt named the preset its own destination "
+                        "extension selected");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -573,5 +733,8 @@ int main(int argc, char** argv) {
     testAttemptFailureViaOverLimitCompositionSurfacesDiagnostics(expectations);
     testCancelAtApprovalDiscardsCleanly(expectations);
     testExternalModificationConflictSurfacedAsFailure(expectations);
+    testDestinationExtensionSelectsPreset(expectations);
+    testPngDestinationRoutesToPngPresetAndPublishes(expectations);
+    testBothPresetsExportBackToBack(expectations);
     return expectations.failures() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
Completes the delivery surface — both version 1 presets now export end to end from the app:

- **Attempt**: preset enters the request (EXR default keeps every caller unchanged); PNG runs ColorPreparing on the existing blocking Resolving stage, reusing the app's published qualified processor (falling back to registry resolve+build), with the contract's five `ocio.*` resolution states mapped one-to-one and a resolved-but-unbuildable processor honestly reported as adapter-unavailable. The retained processor identity aliases the handle's own member so the pair can never split.
- **Job**: ColorPreparing (C2 chunked apply, budget-checked, cancellable) → prepared straight-RGBA8 stream → G1 writer → G1 verifier with all four inputs → kind-1 identity; the EXR path is byte-identical with its shared artifact-hash helpers extracted verbatim and pinned by unchanged tests. Prepared-bytes limit enforced pre-allocation via the doc's lower-not-raise seam.
- **Command**: the dialog gains the PNG filter; extension selects the preset via a closed case-insensitive mapping; the approval prompt reads preset facts off the attempt, never re-derived.
- End-to-end tests both presets: independent zlib decode plus independent verifier reproduction of the prepared stream through a freshly built processor, digest equality asserted; cancellation and limit paths publish nothing.
- Honest findings recorded in-code: C2's cancellation-vs-invalid-state conflation, G1's include-ordering nit, and two resolution states mapped despite having no version-1 producer.

Desktop 103/103 and native 88/88 on a fresh prefix, format check clean.

Closes #111.

Implemented by a Claude Opus subagent; reviewed by the supervising session.