### PR TITLE
feat: navigate the viewer with zoom, pan, and an exact status bar

### DIFF
--- a/src/ui/editor_registry.cpp
+++ b/src/ui/editor_registry.cpp
@@ -33,7 +33,7 @@ bool registerFoundationEditors(EditorRegistry& registry, CompositionSession& ses
             {.id = std::move(id), .displayName = std::move(name), .create = std::move(factory)});
     };
 
-    return addEditor("bloom.viewer", "Compositor",
+    return addEditor("bloom.viewer", "Viewer",
                      [&session, &previewController](QWidget* parent) {
                          return new ViewerEditor(session, previewController, parent);
                      }) &&

--- a/src/ui/include/bloom/ui/composition_session.hpp
+++ b/src/ui/include/bloom/ui/composition_session.hpp
@@ -65,8 +65,13 @@ struct CompositionSelection {
 // CompositionSession::beginPositionInteraction; the session freezes it into the session-only
 // PositionInteraction and never recomputes it.
 struct PositionInteractionMapping final {
-    // The frozen fitted composition rectangle (already accounts for proxy scaling and pixel
-    // aspect -- see fitDisplayRect() in viewer_editor.cpp).
+    // The frozen composition display rectangle (already accounts for proxy scaling and pixel
+    // aspect). Before task U3 (issue #119) this was always fitDisplayRect()'s fit-to-window
+    // rectangle; ViewerEditor now derives it from the Viewer's own active zoom/pan ViewTransform at
+    // gesture begin (viewTransformedDisplayRect() in viewer_editor.cpp) -- fitDisplayRect() exactly
+    // when the transform is in Fit mode, or the actively zoomed/panned rectangle otherwise. The
+    // freeze contract here is unchanged: this struct still doesn't know or care which geometry
+    // source produced the rectangle, only that it was non-empty and is now frozen.
     QRectF displayRect;
     // The frozen composition format; its width/height are the "compositionWidth"/
     // "compositionHeight" of the displacement formulas.

--- a/src/ui/include/bloom/ui/viewer_editor.hpp
+++ b/src/ui/include/bloom/ui/viewer_editor.hpp
@@ -2,6 +2,7 @@
 
 #include <bloom/ui/composition_session.hpp>
 
+#include <QCursor>
 #include <QPointF>
 #include <QRectF>
 #include <QWidget>
@@ -16,9 +17,16 @@ namespace bloom::render {
 class ImageExtent;
 }
 
+namespace bloom::ui::kit {
+class KDropdown;
+}
+
+class QContextMenuEvent;
 class QKeyEvent;
 class QMouseEvent;
+class QPainter;
 class QResizeEvent;
+class QWheelEvent;
 
 namespace bloom::ui {
 
@@ -27,6 +35,54 @@ class CompositionPreviewController;
 [[nodiscard]] QRectF fitDisplayRect(const QRectF& available, render::ImageExtent extent,
                                     core::PixelAspectRatio pixelAspect) noexcept;
 
+// The un-zoomed, un-panned rectangle "100%" means: exactly one screen pixel per composition pixel
+// (after pixel-aspect correction), centered in `available`. This is fitDisplayRect()'s sibling --
+// fitDisplayRect scales content to FILL `available`; actualPixelRect never scales content at all.
+// Both center on `available.center()`, so a transform with fitToWindow == false and zoom == 1.0
+// reproduces exactly fitDisplayRect() only when the fitted content also happens to be shown at
+// 100% -- the two are independent by design (task U3, issue #119, decision 2).
+[[nodiscard]] QRectF actualPixelRect(const QRectF& available, render::ImageExtent extent,
+                                     core::PixelAspectRatio pixelAspect) noexcept;
+
+// The Viewer's zoom/pan state (task U3, issue #119, decision 2). `fitToWindow` selects
+// fitDisplayRect()'s behavior (content scaled to fill `available`, recomputed every call -- there
+// is no stored "fit zoom" value); when false, `zoom` (clamped to [kMinZoom, kMaxZoom]) scales
+// actualPixelRect() about its own center and `pan` translates the result in screen pixels. `pan` is
+// meaningless while `fitToWindow` is true and is always {0, 0} there by construction (see
+// setFit()/materializeZoom() in viewer_editor.cpp).
+struct ViewTransform final {
+    static constexpr double kMinZoom = 1.0 / 16.0;
+    static constexpr double kMaxZoom = 16.0;
+
+    bool fitToWindow = true;
+    double zoom = 1.0;
+    QPointF pan{0.0, 0.0};
+
+    friend bool operator==(const ViewTransform&, const ViewTransform&) = default;
+};
+
+// Composes `transform` onto `available`/`extent`/`pixelAspect`: fitDisplayRect() when
+// transform.fitToWindow, otherwise actualPixelRect() scaled by transform.zoom (clamped) and
+// translated by transform.pan. THE SEAM (decision 2): ViewerEditor::currentMapping() freezes
+// exactly this rectangle -- the same freeze semantics the direct-manipulation contract has always
+// had (docs/architecture/animation-and-time.md, "Direct Manipulation And Preview Overrides"), but
+// the geometry it freezes now reflects the ACTIVE view transform at gesture begin instead of always
+// being the fit-to-window rectangle. See viewer_editor.cpp's currentMapping() for the one call site
+// that changed.
+[[nodiscard]] QRectF viewTransformedDisplayRect(const QRectF& available, render::ImageExtent extent,
+                                                core::PixelAspectRatio pixelAspect,
+                                                const ViewTransform& transform) noexcept;
+
+// Returns a new (fitToWindow == false) transform stepped by `factor` (>1 zooms in, <1 zooms out)
+// such that the composition point under `screenPoint` -- expressed as `screenPoint`'s fractional
+// position across the CURRENT viewTransformedDisplayRect() -- lands under `screenPoint` again after
+// the step (the zoom-about-cursor invariant, pinned by tests). Degenerate geometry (empty
+// `available`, zero-extent content) is a no-op that returns `transform` unchanged.
+[[nodiscard]] ViewTransform zoomAboutPoint(const ViewTransform& transform, const QRectF& available,
+                                          render::ImageExtent extent,
+                                          core::PixelAspectRatio pixelAspect, QPointF screenPoint,
+                                          double factor) noexcept;
+
 class ViewerEditor final : public QWidget {
     Q_OBJECT
 
@@ -34,20 +90,39 @@ class ViewerEditor final : public QWidget {
     ViewerEditor(CompositionSession& session, CompositionPreviewController& previewController,
                  QWidget* parent = nullptr);
 
+    // Test/diagnostic surface only (never read by production code, mirroring kit::KDropdown's own
+    // displayedText()/popupView() precedent): exposes state a test needs to assert on without
+    // reaching into private members.
+    [[nodiscard]] ViewTransform viewTransformForTest() const noexcept;
+    [[nodiscard]] QString statusBarReadoutTextForTest() const;
+    [[nodiscard]] QString statusBarColorChipTextForTest() const;
+    [[nodiscard]] kit::KDropdown* zoomDropdownForTest() const noexcept;
+
   protected:
     void paintEvent(QPaintEvent* event) override;
     // Direct viewer manipulation of the selected layer's position (docs/architecture/
     // animation-and-time.md, "Direct Manipulation And Preview Overrides"; issue #82). press ->
     // beginPositionInteraction (+ beginInteractiveScrub() arming so drag previews ride Interactive
     // cadence); move -> updatePositionInteraction; release -> commit + disarm; Escape or a detected
-    // resize/format/proxy/pixel-aspect/display-descriptor change -> cancel + disarm.
+    // resize/format/proxy/pixel-aspect/display-descriptor change -> cancel + disarm. A middle-button
+    // press, or a left-button press while Space is held, begins a PAN gesture instead (decision 2)
+    // and never touches CompositionSession.
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
 
   private:
+    // The region paintEvent() draws the canvas into and currentMapping() maps gestures against:
+    // the full widget rect minus the bottom status bar strip. There is no other inset -- the canvas
+    // is full-bleed (decision 1).
+    [[nodiscard]] QRectF canvasRect() const;
+    [[nodiscard]] QRectF statusBarRect() const;
+    void paintStatusBarSurface(QPainter& painter);
     void updatePreviewAccessibility();
     // Recomputes the mapping context (fitted display rectangle, composition format, proxy
     // resolution, pixel aspect, display descriptor) from the currently displayed preview frame and
@@ -60,11 +135,41 @@ class ViewerEditor final : public QWidget {
     [[nodiscard]] bool mappingStillValid() const;
     void endDrag(bool commit);
 
+    struct DisplayGeometry final {
+        render::ImageExtent extent;
+        core::PixelAspectRatio pixelAspect;
+    };
+    // The current preview frame's extent/pixel aspect, or std::nullopt when there is nothing to
+    // zoom/pan against (no composition, no frame yet). Shared by paintEvent(), currentMapping(),
+    // and every zoom/pan gesture so they never disagree about what "the content" is.
+    [[nodiscard]] std::optional<DisplayGeometry> currentDisplayGeometry() const;
+
+    void setZoomFit();
+    void setZoomActualSize();
+    void setZoomPercent(int percent);
+    void beginPan(Qt::MouseButton button, QPointF screenPoint, const DisplayGeometry& geometry);
+    void updatePanCursor();
+    void layoutStatusBar();
+    void refreshZoomDropdown();
+
     CompositionSession& session_;
     CompositionPreviewController& previewController_;
     bool dragActive_ = false;
     QPointF dragOrigin_;
     std::optional<PositionInteractionMapping> activeMapping_;
+
+    // Zoom/pan (decision 2).
+    ViewTransform transform_;
+    bool spaceHeld_ = false;
+    bool panActive_ = false;
+    Qt::MouseButton panButton_ = Qt::NoButton;
+    QPointF panOrigin_;
+    ViewTransform panBaseTransform_;
+
+    // Bottom status bar (decision 3). Only the zoom control is a real child widget; the exact
+    // frame/timecode readout and the color-state chip are painted directly (they update every
+    // repaint from live session/preview state, so there is no separate text-cache to keep in sync).
+    kit::KDropdown* zoomDropdown_ = nullptr;
 };
 
 } // namespace bloom::ui

--- a/src/ui/include/bloom/ui/viewer_editor.hpp
+++ b/src/ui/include/bloom/ui/viewer_editor.hpp
@@ -79,9 +79,9 @@ struct ViewTransform final {
 // the step (the zoom-about-cursor invariant, pinned by tests). Degenerate geometry (empty
 // `available`, zero-extent content) is a no-op that returns `transform` unchanged.
 [[nodiscard]] ViewTransform zoomAboutPoint(const ViewTransform& transform, const QRectF& available,
-                                          render::ImageExtent extent,
-                                          core::PixelAspectRatio pixelAspect, QPointF screenPoint,
-                                          double factor) noexcept;
+                                           render::ImageExtent extent,
+                                           core::PixelAspectRatio pixelAspect, QPointF screenPoint,
+                                           double factor) noexcept;
 
 class ViewerEditor final : public QWidget {
     Q_OBJECT
@@ -104,9 +104,9 @@ class ViewerEditor final : public QWidget {
     // animation-and-time.md, "Direct Manipulation And Preview Overrides"; issue #82). press ->
     // beginPositionInteraction (+ beginInteractiveScrub() arming so drag previews ride Interactive
     // cadence); move -> updatePositionInteraction; release -> commit + disarm; Escape or a detected
-    // resize/format/proxy/pixel-aspect/display-descriptor change -> cancel + disarm. A middle-button
-    // press, or a left-button press while Space is held, begins a PAN gesture instead (decision 2)
-    // and never touches CompositionSession.
+    // resize/format/proxy/pixel-aspect/display-descriptor change -> cancel + disarm. A
+    // middle-button press, or a left-button press while Space is held, begins a PAN gesture instead
+    // (decision 2) and never touches CompositionSession.
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;

--- a/src/ui/tests/direct_manipulation_tests.cpp
+++ b/src/ui/tests/direct_manipulation_tests.cpp
@@ -568,7 +568,8 @@ void testDragAtNonIdentityZoomLandsExactlyUnderCursor(Expectations& expectations
     }
     const auto positionId = position->id;
     const auto base = fixture.session.constantVec2Value(positionId);
-    expectations.expect(base.has_value(), "the new layer's position starts as a resolvable constant");
+    expectations.expect(base.has_value(),
+                        "the new layer's position starts as a resolvable constant");
     if (!base.has_value()) {
         return;
     }
@@ -578,8 +579,8 @@ void testDragAtNonIdentityZoomLandsExactlyUnderCursor(Expectations& expectations
                             fixture.viewer.viewTransformForTest().zoom == 2.0,
                         "the fixture is now zoomed to 200%, out of Fit mode");
 
-    const QRectF displayRect =
-        expectedDisplayRect(fixture.viewer, fixture.controller, fixture.viewer.viewTransformForTest());
+    const QRectF displayRect = expectedDisplayRect(fixture.viewer, fixture.controller,
+                                                   fixture.viewer.viewTransformForTest());
     expectations.expect(!displayRect.isEmpty() && displayRect.width() > 1000.0,
                         "at 200% the display rectangle is visibly larger than the 1000-wide "
                         "composition itself -- this test is genuinely exercising a non-identity "
@@ -590,8 +591,9 @@ void testDragAtNonIdentityZoomLandsExactlyUnderCursor(Expectations& expectations
     const QPointF delta = releasePoint - pressPoint;
 
     sendPress(fixture.viewer, pressPoint);
-    expectations.expect(fixture.session.positionInteractionActive(),
-                        "pressing on the zoomed viewer with a selected layer begins the interaction");
+    expectations.expect(
+        fixture.session.positionInteractionActive(),
+        "pressing on the zoomed viewer with a selected layer begins the interaction");
     // Begin base: the frozen base value is exactly the pre-drag constant, unmoved, before any move
     // event lands.
     const auto beginOverride = fixture.session.positionInteractionOverride();
@@ -605,7 +607,8 @@ void testDragAtNonIdentityZoomLandsExactlyUnderCursor(Expectations& expectations
     sendMove(fixture.viewer, releasePoint);
     sendRelease(fixture.viewer, releasePoint);
 
-    expectations.expect(!fixture.session.positionInteractionActive(), "release ends the interaction");
+    expectations.expect(!fixture.session.positionInteractionActive(),
+                        "release ends the interaction");
 
     // Committed key: the document-space position lands exactly where the ZOOMED mapping (half the
     // Fit-implied displacement, since the same screen delta now covers less document distance at
@@ -651,7 +654,8 @@ void testDragAtNonIdentityZoomAndPanLandsExactlyUnderCursor(Expectations& expect
     }
     const auto positionId = position->id;
     const auto base = fixture.session.constantVec2Value(positionId);
-    expectations.expect(base.has_value(), "the new layer's position starts as a resolvable constant");
+    expectations.expect(base.has_value(),
+                        "the new layer's position starts as a resolvable constant");
     if (!base.has_value()) {
         return;
     }
@@ -696,7 +700,8 @@ void testDragAtNonIdentityZoomAndPanLandsExactlyUnderCursor(Expectations& expect
     }
     sendMove(fixture.viewer, releasePoint);
     sendRelease(fixture.viewer, releasePoint);
-    expectations.expect(!fixture.session.positionInteractionActive(), "release ends the interaction");
+    expectations.expect(!fixture.session.positionInteractionActive(),
+                        "release ends the interaction");
 
     const document::Vec2d expected{base->x + delta.x() / displayRect.width() * 1000.0,
                                    base->y + delta.y() / displayRect.height() * 500.0};

--- a/src/ui/tests/direct_manipulation_tests.cpp
+++ b/src/ui/tests/direct_manipulation_tests.cpp
@@ -27,6 +27,8 @@
 #include <bloom/ui/composition_preview_controller.hpp>
 #include <bloom/ui/composition_preview_pipeline.hpp>
 #include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/kit/dropdown.hpp>
+#include <bloom/ui/kit/tokens.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 #include <bloom/ui/viewer_editor.hpp>
 
@@ -408,8 +410,17 @@ void sendRelease(QWidget& widget, const QPointF& local) {
 
 // Mirrors ViewerEditor::currentMapping()'s display-rect derivation so the test can compute the
 // expected composition displacement the same way production code does, without hardcoding it.
+//
+// Task U3 (issue #119), decision 2, THE SEAM: canvasRect() replaces the pre-U3 28px-inset
+// viewerFrame() (the canvas is now full-bleed, minus only the bottom status bar strip -- see
+// ViewerEditor::canvasRect()/statusBarRect() in viewer_editor.cpp), and
+// viewTransformedDisplayRect(..., transform) replaces the unconditional fitDisplayRect() call --
+// the frozen mapping rectangle now reflects the ACTIVE view transform at gesture begin, not always
+// the fit-to-window rectangle. `transform` defaults to the identity Fit transform, so every
+// pre-existing call site below (all at implicit zoom 1x/pan 0) is unchanged in behavior.
 QRectF expectedDisplayRect(const QWidget& viewer,
-                           const bloom::ui::CompositionPreviewController& controller) {
+                           const bloom::ui::CompositionPreviewController& controller,
+                           const bloom::ui::ViewTransform& transform = {}) {
     using namespace bloom;
     const auto& frame = controller.state().frame;
     if (frame == nullptr) {
@@ -424,9 +435,10 @@ QRectF expectedDisplayRect(const QWidget& viewer,
     if (!descriptorResult.has_value()) {
         return {};
     }
-    const QRectF frameRect = QRectF(viewer.rect()).adjusted(28.0, 28.0, -28.0, -28.0);
-    return ui::fitDisplayRect(frameRect, descriptorResult->displayWindow().extent(),
-                              descriptorResult->pixelAspect());
+    const qreal statusBarHeight = ui::kit::px(ui::kit::Size::Control);
+    const QRectF frameRect = QRectF(viewer.rect()).adjusted(0.0, 0.0, 0.0, -statusBarHeight);
+    return ui::viewTransformedDisplayRect(frameRect, descriptorResult->displayWindow().extent(),
+                                          descriptorResult->pixelAspect(), transform);
 }
 
 // document::Document is non-movable/non-copyable (its constructor and snapshot() own the live
@@ -519,6 +531,184 @@ void testDragMovesSelectedSolidLayerCommitsAndUndoes(Expectations& expectations)
     fixture.bridge.beginShutdown();
     expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
                         "the drag fixture reaches asynchronous scheduler quiescence");
+}
+
+// Selects the dropdown item whose visible text is `label` (never hardcodes an index -- the fixed
+// Fit/25/50/100/200/400 order is ViewerEditor's own construction detail, not this test's).
+void selectZoomPreset(bloom::ui::kit::KDropdown& dropdown, const QString& label) {
+    for (int index = 0; index < dropdown.count(); ++index) {
+        if (dropdown.itemText(index) == label) {
+            dropdown.setCurrentIndex(index);
+            return;
+        }
+    }
+    std::abort();
+}
+
+// THE SEAM, pinned directly (task U3, issue #119, decision 2): a direct-manipulation drag begun at
+// a NON-IDENTITY zoom (200%, no fit-to-window) still lands exactly under the cursor. Before this
+// task, ViewerEditor::currentMapping() always froze fitDisplayRect()'s rectangle regardless of any
+// zoom; this pins that the frozen mapping now reflects the ACTIVE zoom instead -- at 200% a screen
+// displacement maps to HALF the composition displacement it would at Fit/100%, because the same
+// document extent now occupies twice the screen pixels.
+void testDragAtNonIdentityZoomLandsExactlyUnderCursor(Expectations& expectations) {
+    using namespace bloom;
+    GestureFixture fixture(makeTestProject("Viewer Drag Zoomed Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the initial frame becomes ready before dragging");
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.2, 0.3, 0.4, 1.0}),
+        "the fixture layer is added and selected");
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the frame becomes ready again for the post-add revision");
+    const auto* position = fixture.session.parameterForSelection(document::kPositionParameterRole);
+    expectations.expect(position != nullptr, "the new solid layer exposes a position parameter");
+    if (position == nullptr) {
+        return;
+    }
+    const auto positionId = position->id;
+    const auto base = fixture.session.constantVec2Value(positionId);
+    expectations.expect(base.has_value(), "the new layer's position starts as a resolvable constant");
+    if (!base.has_value()) {
+        return;
+    }
+
+    selectZoomPreset(*fixture.viewer.zoomDropdownForTest(), QStringLiteral("200%"));
+    expectations.expect(!fixture.viewer.viewTransformForTest().fitToWindow &&
+                            fixture.viewer.viewTransformForTest().zoom == 2.0,
+                        "the fixture is now zoomed to 200%, out of Fit mode");
+
+    const QRectF displayRect =
+        expectedDisplayRect(fixture.viewer, fixture.controller, fixture.viewer.viewTransformForTest());
+    expectations.expect(!displayRect.isEmpty() && displayRect.width() > 1000.0,
+                        "at 200% the display rectangle is visibly larger than the 1000-wide "
+                        "composition itself -- this test is genuinely exercising a non-identity "
+                        "zoom, not accidentally still at Fit's own scale");
+
+    const QPointF pressPoint(200.0, 150.0);
+    const QPointF releasePoint(260.0, 110.0);
+    const QPointF delta = releasePoint - pressPoint;
+
+    sendPress(fixture.viewer, pressPoint);
+    expectations.expect(fixture.session.positionInteractionActive(),
+                        "pressing on the zoomed viewer with a selected layer begins the interaction");
+    // Begin base: the frozen base value is exactly the pre-drag constant, unmoved, before any move
+    // event lands.
+    const auto beginOverride = fixture.session.positionInteractionOverride();
+    expectations.expect(beginOverride.has_value(), "the begun interaction carries an override");
+    if (beginOverride.has_value()) {
+        const auto* beginValue = std::get_if<document::Vec2d>(&beginOverride->value);
+        expectations.expect(beginValue != nullptr && *beginValue == *base,
+                            "the interaction's begin-base document-space position is the exact "
+                            "unmoved pre-drag constant, regardless of zoom");
+    }
+    sendMove(fixture.viewer, releasePoint);
+    sendRelease(fixture.viewer, releasePoint);
+
+    expectations.expect(!fixture.session.positionInteractionActive(), "release ends the interaction");
+
+    // Committed key: the document-space position lands exactly where the ZOOMED mapping (half the
+    // Fit-implied displacement, since the same screen delta now covers less document distance at
+    // 200%) says it should -- never the Fit-derived value the pre-U3 seam would have produced.
+    const document::Vec2d expectedAtZoom{base->x + delta.x() / displayRect.width() * 1000.0,
+                                         base->y + delta.y() / displayRect.height() * 500.0};
+    const document::Vec2d expectedAtFit{base->x + delta.x() / 1000.0 * 1000.0,
+                                        base->y + delta.y() / 500.0 * 500.0};
+    expectations.expect(fixture.session.constantVec2Value(positionId) == expectedAtZoom,
+                        "the committed document-space position matches base plus the ZOOM-AWARE "
+                        "screen-to-composition mapped displacement");
+    expectations.expect(fixture.session.constantVec2Value(positionId) != expectedAtFit,
+                        "the committed position is genuinely different from what the pre-U3 "
+                        "always-Fit seam would have produced -- proving the seam change actually "
+                        "changed the mapping geometry, not just its call signature");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the zoomed-drag fixture reaches asynchronous scheduler quiescence");
+}
+
+// THE SEAM, combined with a non-zero pan (task U3, issue #119, decision 2): a direct-manipulation
+// drag begun at 200% zoom AND a panned view still lands exactly under the cursor. Pan only
+// translates the frozen rectangle's position, never its size, so the SAME zoom-derived
+// composition-per-screen-pixel ratio as the zoom-only test above applies unchanged; this pins that
+// panning (itself driven through the real space-drag gesture, not by reaching into private state)
+// does not perturb the mapping's scale, only where the gesture reads its frozen displayRect from.
+void testDragAtNonIdentityZoomAndPanLandsExactlyUnderCursor(Expectations& expectations) {
+    using namespace bloom;
+    GestureFixture fixture(makeTestProject("Viewer Drag Zoomed Panned Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the initial frame becomes ready before dragging");
+    expectations.expect(
+        fixture.session.addSolidLayer(QStringLiteral("Solid"), core::Color4d{0.2, 0.3, 0.4, 1.0}),
+        "the fixture layer is added and selected");
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the frame becomes ready again for the post-add revision");
+    const auto* position = fixture.session.parameterForSelection(document::kPositionParameterRole);
+    expectations.expect(position != nullptr, "the new solid layer exposes a position parameter");
+    if (position == nullptr) {
+        return;
+    }
+    const auto positionId = position->id;
+    const auto base = fixture.session.constantVec2Value(positionId);
+    expectations.expect(base.has_value(), "the new layer's position starts as a resolvable constant");
+    if (!base.has_value()) {
+        return;
+    }
+
+    selectZoomPreset(*fixture.viewer.zoomDropdownForTest(), QStringLiteral("200%"));
+
+    // Pan through the real space-drag gesture (mirrors viewer_editor_tests.cpp's own space-pan
+    // test) rather than reaching into ViewerEditor's private transform_ -- the resulting pan offset
+    // is read back afterward via the same public test accessor used to compute the expected
+    // mapping below, so this test never needs to duplicate the pan materialization formula.
+    QKeyEvent spaceDown(QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &spaceDown);
+    sendPress(fixture.viewer, QPointF(40.0, 40.0));
+    sendMove(fixture.viewer, QPointF(75.0, 15.0));
+    sendRelease(fixture.viewer, QPointF(75.0, 15.0));
+    QKeyEvent spaceUp(QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &spaceUp);
+
+    const auto transform = fixture.viewer.viewTransformForTest();
+    expectations.expect(!transform.fitToWindow && transform.zoom == 2.0 &&
+                            (transform.pan.x() != 0.0 || transform.pan.y() != 0.0),
+                        "the fixture is now both zoomed to 200% and panned by a non-zero offset");
+
+    const QRectF displayRect = expectedDisplayRect(fixture.viewer, fixture.controller, transform);
+    expectations.expect(!displayRect.isEmpty(), "the fixture's zoomed+panned display rectangle is "
+                                                "non-empty");
+
+    const QPointF pressPoint(220.0, 160.0);
+    const QPointF releasePoint(190.0, 205.0);
+    const QPointF delta = releasePoint - pressPoint;
+
+    sendPress(fixture.viewer, pressPoint);
+    expectations.expect(fixture.session.positionInteractionActive(),
+                        "pressing on the zoomed+panned viewer with a selected layer begins the "
+                        "interaction");
+    const auto beginOverride = fixture.session.positionInteractionOverride();
+    if (beginOverride.has_value()) {
+        const auto* beginValue = std::get_if<document::Vec2d>(&beginOverride->value);
+        expectations.expect(beginValue != nullptr && *beginValue == *base,
+                            "the interaction's begin-base document-space position is unaffected "
+                            "by zoom or pan");
+    }
+    sendMove(fixture.viewer, releasePoint);
+    sendRelease(fixture.viewer, releasePoint);
+    expectations.expect(!fixture.session.positionInteractionActive(), "release ends the interaction");
+
+    const document::Vec2d expected{base->x + delta.x() / displayRect.width() * 1000.0,
+                                   base->y + delta.y() / displayRect.height() * 500.0};
+    expectations.expect(fixture.session.constantVec2Value(positionId) == expected,
+                        "the committed document-space position matches base plus the "
+                        "zoom-AND-pan-aware screen-to-composition mapped displacement");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the zoomed-and-panned-drag fixture reaches asynchronous scheduler "
+                        "quiescence");
 }
 
 void testDragOnEmptyOrUnselectedDoesNothing(Expectations& expectations) {
@@ -638,6 +828,8 @@ int main(int argc, char** argv) {
     testControllerAttachesOverrideOnlyToArmedInteractiveRequests(expectations);
     testAdmissionRejectedOverrideSurfacesErrorWithoutKillingInteraction(expectations);
     testDragMovesSelectedSolidLayerCommitsAndUndoes(expectations);
+    testDragAtNonIdentityZoomLandsExactlyUnderCursor(expectations);
+    testDragAtNonIdentityZoomAndPanLandsExactlyUnderCursor(expectations);
     testDragOnEmptyOrUnselectedDoesNothing(expectations);
     testMidDragResizeCancelsWithNoCommitAndNoOverrideLeft(expectations);
     testEscapeCancelsMidDrag(expectations);

--- a/src/ui/tests/viewer_editor_tests.cpp
+++ b/src/ui/tests/viewer_editor_tests.cpp
@@ -119,7 +119,8 @@ void testViewTransformFitMatchesFitDisplayRect(Expectations& expectations) {
     const QRectF available(0.0, 0.0, 640.0, 360.0);
     const auto square = core::PixelAspectRatio::square();
     const ui::ViewTransform fit{}; // default: fitToWindow == true
-    const QRectF viaTransform = ui::viewTransformedDisplayRect(available, extent(1920, 1080), square, fit);
+    const QRectF viaTransform =
+        ui::viewTransformedDisplayRect(available, extent(1920, 1080), square, fit);
     const QRectF viaFit = ui::fitDisplayRect(available, extent(1920, 1080), square);
     expectations.expect(near(viaTransform.left(), viaFit.left()) &&
                             near(viaTransform.top(), viaFit.top()) &&
@@ -138,9 +139,9 @@ void testViewTransformActualSizeMatchesActualPixelRect(Expectations& expectation
     const QRectF viaActual = ui::actualPixelRect(available, extent(200, 100), square);
     expectations.expect(near(viaTransform.width(), 200.0) && near(viaTransform.height(), 100.0),
                         "100% (zoom == 1.0, not Fit) shows content at its own pixel size");
-    expectations.expect(near(viaTransform.left(), viaActual.left()) &&
-                            near(viaTransform.top(), viaActual.top()),
-                        "100% reproduces actualPixelRect() exactly, centered like fitDisplayRect()");
+    expectations.expect(
+        near(viaTransform.left(), viaActual.left()) && near(viaTransform.top(), viaActual.top()),
+        "100% reproduces actualPixelRect() exactly, centered like fitDisplayRect()");
 }
 
 void testViewTransformZoomAndPanCompose(Expectations& expectations) {
@@ -148,14 +149,16 @@ void testViewTransformZoomAndPanCompose(Expectations& expectations) {
     const QRectF available(0.0, 0.0, 640.0, 360.0);
     const auto square = core::PixelAspectRatio::square();
     const ui::ViewTransform doubled{.fitToWindow = false, .zoom = 2.0, .pan = {30.0, -15.0}};
-    const QRectF rect = ui::viewTransformedDisplayRect(available, extent(200, 100), square, doubled);
+    const QRectF rect =
+        ui::viewTransformedDisplayRect(available, extent(200, 100), square, doubled);
     expectations.expect(near(rect.width(), 400.0) && near(rect.height(), 200.0),
                         "zoom scales actualPixelRect() by the transform's own factor");
     const QRectF actual = ui::actualPixelRect(available, extent(200, 100), square);
     const QPointF expectedTopLeft(available.center().x() - rect.width() / 2.0 + 30.0,
                                   available.center().y() - rect.height() / 2.0 - 15.0);
     Q_UNUSED(actual)
-    expectations.expect(near(rect.left(), expectedTopLeft.x()) && near(rect.top(), expectedTopLeft.y()),
+    expectations.expect(near(rect.left(), expectedTopLeft.x()) &&
+                            near(rect.top(), expectedTopLeft.y()),
                         "pan translates the zoomed rectangle in screen pixels, on top of zoom");
 }
 
@@ -166,7 +169,8 @@ void testZoomAboutCursorInvariantHoldsAtNonIdentityZoom(Expectations& expectatio
     // Start from a non-trivial, already-panned/zoomed transform -- not just the identity -- so this
     // pins the invariant at exactly the zoom != 1, pan != 0 condition the task calls out.
     const ui::ViewTransform start{.fitToWindow = false, .zoom = 2.0, .pan = {12.0, -8.0}};
-    const QRectF before = ui::viewTransformedDisplayRect(available, extent(200, 100), square, start);
+    const QRectF before =
+        ui::viewTransformedDisplayRect(available, extent(200, 100), square, start);
     const QPointF cursor(410.0, 190.0); // an arbitrary point, not the rect's own center
     const double fractionXBefore = (cursor.x() - before.left()) / before.width();
     const double fractionYBefore = (cursor.y() - before.top()) / before.height();
@@ -204,12 +208,12 @@ void testZoomClampsToTheDocumentedRange(Expectations& expectations) {
     const QRectF available(0.0, 0.0, 640.0, 360.0);
     const auto square = core::PixelAspectRatio::square();
     const ui::ViewTransform start{.fitToWindow = false, .zoom = 1.0, .pan = {0.0, 0.0}};
-    const ui::ViewTransform zoomedOut = ui::zoomAboutPoint(start, available, extent(200, 100), square,
-                                                           available.center(), 0.0001);
+    const ui::ViewTransform zoomedOut =
+        ui::zoomAboutPoint(start, available, extent(200, 100), square, available.center(), 0.0001);
     expectations.expect(near(zoomedOut.zoom, ui::ViewTransform::kMinZoom),
                         "zooming out clamps at 1/16, never below");
-    const ui::ViewTransform zoomedIn = ui::zoomAboutPoint(start, available, extent(200, 100), square,
-                                                          available.center(), 10000.0);
+    const ui::ViewTransform zoomedIn =
+        ui::zoomAboutPoint(start, available, extent(200, 100), square, available.center(), 10000.0);
     expectations.expect(near(zoomedIn.zoom, ui::ViewTransform::kMaxZoom),
                         "zooming in clamps at 16, never above");
 }
@@ -473,7 +477,8 @@ void testStatusBarZoomDropdownDrivesViewTransform(Expectations& expectations) {
 
     expectations.expect(fixture.viewer.viewTransformForTest().fitToWindow,
                         "the viewer starts in Fit mode");
-    expectations.expect(fixture.viewer.zoomDropdownForTest()->currentText() == QStringLiteral("Fit"),
+    expectations.expect(fixture.viewer.zoomDropdownForTest()->currentText() ==
+                            QStringLiteral("Fit"),
                         "the zoom dropdown starts on \"Fit\"");
 
     fixture.viewer.zoomDropdownForTest()->setCurrentIndex(3); // "100%"
@@ -509,7 +514,8 @@ void testStatusBarZoomDropdownDrivesViewTransform(Expectations& expectations) {
                         "the zoom-dropdown fixture reaches asynchronous scheduler quiescence");
 }
 
-// The status bar's center readout reuses the timeline's own exact display shape ("Frame N · S.mmms")
+// The status bar's center readout reuses the timeline's own exact display shape ("Frame N ·
+// S.mmms")
 // -- including an honest truncated (not rounded) subframe display, never a binary64 rounding of a
 // non-terminating decimal (docs/architecture/animation-and-time.md).
 void testStatusBarReadoutMatchesExactSessionTimeIncludingSubframe(Expectations& expectations) {
@@ -518,7 +524,8 @@ void testStatusBarReadoutMatchesExactSessionTimeIncludingSubframe(Expectations& 
     expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
                         "the fixture's initial frame becomes ready");
 
-    expectations.expect(fixture.viewer.statusBarReadoutTextForTest() == QStringLiteral("Frame 0 · 0.000s"),
+    expectations.expect(fixture.viewer.statusBarReadoutTextForTest() ==
+                            QStringLiteral("Frame 0 · 0.000s"),
                         "the readout starts at frame 0, exact zero seconds");
 
     // 1/3 s has no terminating decimal expansion: truncated to 3 places this is EXACTLY "0.333s",

--- a/src/ui/tests/viewer_editor_tests.cpp
+++ b/src/ui/tests/viewer_editor_tests.cpp
@@ -19,13 +19,18 @@
 #include <bloom/ui/composition_preview_controller.hpp>
 #include <bloom/ui/composition_preview_pipeline.hpp>
 #include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/kit/dropdown.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 
 #include <QApplication>
 #include <QElapsedTimer>
 #include <QEventLoop>
 #include <QImage>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPoint>
 #include <QRectF>
+#include <QWheelEvent>
 
 #include <chrono>
 #include <cmath>
@@ -107,6 +112,108 @@ void testDegenerateAvailableRect(Expectations& expectations) {
     expectations.expect(fitted.isEmpty(), "empty available geometry produces no display rectangle");
 }
 
+// --- Task U3 (issue #119), decision 2: ViewTransform math -------------------------------------
+
+void testViewTransformFitMatchesFitDisplayRect(Expectations& expectations) {
+    using namespace bloom;
+    const QRectF available(0.0, 0.0, 640.0, 360.0);
+    const auto square = core::PixelAspectRatio::square();
+    const ui::ViewTransform fit{}; // default: fitToWindow == true
+    const QRectF viaTransform = ui::viewTransformedDisplayRect(available, extent(1920, 1080), square, fit);
+    const QRectF viaFit = ui::fitDisplayRect(available, extent(1920, 1080), square);
+    expectations.expect(near(viaTransform.left(), viaFit.left()) &&
+                            near(viaTransform.top(), viaFit.top()) &&
+                            near(viaTransform.width(), viaFit.width()) &&
+                            near(viaTransform.height(), viaFit.height()),
+                        "a default (Fit) ViewTransform reproduces fitDisplayRect() exactly");
+}
+
+void testViewTransformActualSizeMatchesActualPixelRect(Expectations& expectations) {
+    using namespace bloom;
+    const QRectF available(0.0, 0.0, 640.0, 360.0);
+    const auto square = core::PixelAspectRatio::square();
+    const ui::ViewTransform actualSize{.fitToWindow = false, .zoom = 1.0, .pan = {0.0, 0.0}};
+    const QRectF viaTransform =
+        ui::viewTransformedDisplayRect(available, extent(200, 100), square, actualSize);
+    const QRectF viaActual = ui::actualPixelRect(available, extent(200, 100), square);
+    expectations.expect(near(viaTransform.width(), 200.0) && near(viaTransform.height(), 100.0),
+                        "100% (zoom == 1.0, not Fit) shows content at its own pixel size");
+    expectations.expect(near(viaTransform.left(), viaActual.left()) &&
+                            near(viaTransform.top(), viaActual.top()),
+                        "100% reproduces actualPixelRect() exactly, centered like fitDisplayRect()");
+}
+
+void testViewTransformZoomAndPanCompose(Expectations& expectations) {
+    using namespace bloom;
+    const QRectF available(0.0, 0.0, 640.0, 360.0);
+    const auto square = core::PixelAspectRatio::square();
+    const ui::ViewTransform doubled{.fitToWindow = false, .zoom = 2.0, .pan = {30.0, -15.0}};
+    const QRectF rect = ui::viewTransformedDisplayRect(available, extent(200, 100), square, doubled);
+    expectations.expect(near(rect.width(), 400.0) && near(rect.height(), 200.0),
+                        "zoom scales actualPixelRect() by the transform's own factor");
+    const QRectF actual = ui::actualPixelRect(available, extent(200, 100), square);
+    const QPointF expectedTopLeft(available.center().x() - rect.width() / 2.0 + 30.0,
+                                  available.center().y() - rect.height() / 2.0 - 15.0);
+    Q_UNUSED(actual)
+    expectations.expect(near(rect.left(), expectedTopLeft.x()) && near(rect.top(), expectedTopLeft.y()),
+                        "pan translates the zoomed rectangle in screen pixels, on top of zoom");
+}
+
+void testZoomAboutCursorInvariantHoldsAtNonIdentityZoom(Expectations& expectations) {
+    using namespace bloom;
+    const QRectF available(0.0, 0.0, 640.0, 360.0);
+    const auto square = core::PixelAspectRatio::square();
+    // Start from a non-trivial, already-panned/zoomed transform -- not just the identity -- so this
+    // pins the invariant at exactly the zoom != 1, pan != 0 condition the task calls out.
+    const ui::ViewTransform start{.fitToWindow = false, .zoom = 2.0, .pan = {12.0, -8.0}};
+    const QRectF before = ui::viewTransformedDisplayRect(available, extent(200, 100), square, start);
+    const QPointF cursor(410.0, 190.0); // an arbitrary point, not the rect's own center
+    const double fractionXBefore = (cursor.x() - before.left()) / before.width();
+    const double fractionYBefore = (cursor.y() - before.top()) / before.height();
+
+    const ui::ViewTransform stepped =
+        ui::zoomAboutPoint(start, available, extent(200, 100), square, cursor, 1.25);
+    expectations.expect(!stepped.fitToWindow, "a zoom step always lands in Custom mode");
+    const QRectF after =
+        ui::viewTransformedDisplayRect(available, extent(200, 100), square, stepped);
+    expectations.expect(near(after.width(), before.width() * 1.25) &&
+                            near(after.height(), before.height() * 1.25),
+                        "the zoom step scales by exactly the requested factor");
+    const double fractionXAfter = (cursor.x() - after.left()) / after.width();
+    const double fractionYAfter = (cursor.y() - after.top()) / after.height();
+    expectations.expect(std::abs(fractionXAfter - fractionXBefore) <= 0.0005 &&
+                            std::abs(fractionYAfter - fractionYBefore) <= 0.0005,
+                        "the document point under the cursor is fixed across the zoom step "
+                        "(zoom-about-cursor invariant) at non-identity zoom and non-zero pan");
+
+    // Zooming back out by the inverse factor about the SAME cursor returns to (very nearly) the
+    // original rectangle -- a second, stronger pin on the same invariant.
+    const ui::ViewTransform back =
+        ui::zoomAboutPoint(stepped, available, extent(200, 100), square, cursor, 1.0 / 1.25);
+    const QRectF restored =
+        ui::viewTransformedDisplayRect(available, extent(200, 100), square, back);
+    expectations.expect(std::abs(restored.left() - before.left()) <= 0.01 &&
+                            std::abs(restored.top() - before.top()) <= 0.01 &&
+                            std::abs(restored.width() - before.width()) <= 0.01,
+                        "zooming in then back out by the inverse factor about the same cursor "
+                        "restores the original rectangle");
+}
+
+void testZoomClampsToTheDocumentedRange(Expectations& expectations) {
+    using namespace bloom;
+    const QRectF available(0.0, 0.0, 640.0, 360.0);
+    const auto square = core::PixelAspectRatio::square();
+    const ui::ViewTransform start{.fitToWindow = false, .zoom = 1.0, .pan = {0.0, 0.0}};
+    const ui::ViewTransform zoomedOut = ui::zoomAboutPoint(start, available, extent(200, 100), square,
+                                                           available.center(), 0.0001);
+    expectations.expect(near(zoomedOut.zoom, ui::ViewTransform::kMinZoom),
+                        "zooming out clamps at 1/16, never below");
+    const ui::ViewTransform zoomedIn = ui::zoomAboutPoint(start, available, extent(200, 100), square,
+                                                          available.center(), 10000.0);
+    expectations.expect(near(zoomedIn.zoom, ui::ViewTransform::kMaxZoom),
+                        "zooming in clamps at 16, never above");
+}
+
 // --- Issue #97 (task C3): "Viewer: renders the qualified frame's buffer (offscreen smoke), status
 // surface shows the color state in the failure case." The rest of this file (below) sets up a real
 // CompositionPreviewController/ViewerEditor pair to exercise that, mirroring the fixture shape in
@@ -165,9 +272,13 @@ void reachQuiescence(bloom::ui::CompositionPreviewController& controller,
                         "viewer fixture reaches asynchronous scheduler quiescence");
 }
 
-// Renders the qualified frame's buffer (offscreen smoke) and confirms the corner/accessibility
-// status surface reads "Qualified display" once the qualified processor is ready -- never a silent
-// relabel of the earlier reference-labeled frame.
+// Renders the qualified frame's buffer (offscreen smoke) and confirms the status bar's color-state
+// chip (task U3, decision 3 -- the relocated, contract-preserved home of the old top-row label)
+// reads "Qualified · Bloom Neutral" once the qualified processor is ready -- never a silent
+// relabel of the earlier reference-labeled frame. ADAPTED from the pre-U3 top-row-label test: the
+// wording and the surface (status bar chip, not a painted canvas corner) both changed; the
+// underlying color-state contract (accessibleDescription still carries it too -- see
+// updatePreviewAccessibility()) did not.
 void testViewerRendersQualifiedFrameAndReportsColorState(Expectations& expectations) {
     using namespace bloom;
 
@@ -199,9 +310,12 @@ void testViewerRendersQualifiedFrameAndReportsColorState(Expectations& expectati
     expectations.expect(!beforeReadiness.isNull(),
                         "the viewer renders offscreen before the qualified processor is ready");
     expectations.expect(
-        viewer.accessibleDescription().contains(QStringLiteral("Reference display")),
+        viewer.accessibleDescription().contains(QStringLiteral("Reference (unqualified)")),
         "the status surface reports the reference (unqualified) color state before "
         "readiness");
+    expectations.expect(
+        viewer.statusBarColorChipTextForTest() == QStringLiteral("Reference (unqualified)"),
+        "the status bar's own color chip text (decision 3) agrees with the accessible description");
 
     auto resolution = color::resolveBloomNeutralV1BuiltIn(
         color::OcioConfigLocatorKind::BloomBuiltIn, color::kBloomNeutralV1ConfigUri,
@@ -233,15 +347,19 @@ void testViewerRendersQualifiedFrameAndReportsColorState(Expectations& expectati
     expectations.expect(!afterReadiness.isNull(),
                         "the viewer renders the qualified frame's buffer offscreen (smoke)");
     expectations.expect(
-        viewer.accessibleDescription().contains(QStringLiteral("Qualified display")),
+        viewer.accessibleDescription().contains(QStringLiteral("Qualified · Bloom Neutral")),
         "the status surface reports the qualified color state once the frame is qualified");
+    expectations.expect(
+        viewer.statusBarColorChipTextForTest() == QStringLiteral("Qualified · Bloom Neutral"),
+        "the status bar's own color chip text (decision 3) agrees with the accessible description");
 
     reachQuiescence(controller, bridge, scheduler, expectations);
 }
 
-// Fail-closed: the status surface shows the color state (a diagnostic message, plus a corner label
-// that never claims "Qualified") when qualification has failed, while the viewer keeps rendering
-// its last-good pixels.
+// Fail-closed: the status surface shows the color state (a diagnostic message, plus a chip that
+// never claims "Qualified") when qualification has failed, while the viewer keeps rendering its
+// last-good pixels. ADAPTED from the pre-U3 top-row-label test: same underlying assertions, now
+// checked against the relocated status bar chip as well as accessibleDescription.
 void testViewerStatusSurfaceReflectsFailClosedColorState(Expectations& expectations) {
     using namespace bloom;
 
@@ -287,11 +405,221 @@ void testViewerStatusSurfaceReflectsFailClosedColorState(Expectations& expectati
     expectations.expect(!failedImage.isNull(),
                         "the viewer still renders its retained last-good pixels while Failed");
     expectations.expect(
-        !viewer.accessibleDescription().contains(QStringLiteral("Qualified display")),
+        !viewer.accessibleDescription().contains(QStringLiteral("Qualified · Bloom Neutral")),
         "the status surface never claims a qualified color state once qualification has failed");
     expectations.expect(
         viewer.accessibleDescription().contains(controller.state().message),
         "the status surface's message reflects the controller's own fail-closed diagnostic");
+    expectations.expect(viewer.statusBarColorChipTextForTest() == controller.state().message,
+                        "the status bar's Error chip shows the fail-closed diagnostic verbatim "
+                        "(decision 3: \"Error text on fail-closed\")");
+
+    reachQuiescence(controller, bridge, scheduler, expectations);
+}
+
+// --- Task U3 (issue #119): status bar + empty state + pan --------------------------------------
+
+// Mirrors direct_manipulation_tests.cpp's PipelineFixture/GestureFixture split (same idiom, this
+// file's own preexisting fixtures never needed the full pipeline before U3 added zoom/pan/status
+// bar state that DOES need a running preview to exercise).
+struct PipelineFixture final {
+    bloom::runtime::NodeDefinitionRegistry definitions;
+    bloom::runtime::SnapshotCompiler compiler;
+    bloom::runtime::CpuCompositionEvaluator evaluator;
+    bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    bloom::runtime::QualifiedDisplayProcessorProvider qualifiedProcessorProvider;
+    bloom::ui::PreviewPreparationFunction pipeline;
+
+    PipelineFixture() : compiler(definitions) {
+        if (!bloom::runtime::registerBuiltInNodeDefinitions(definitions)) {
+            std::abort();
+        }
+        definitions.freeze();
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                             qualifiedProcessorProvider);
+    }
+};
+
+// A full offscreen ViewerEditor fixture with no layer/selection involved -- these tests exercise
+// zoom/pan/status-bar state, never CompositionSession's position-interaction gesture (that is
+// direct_manipulation_tests.cpp's GestureFixture).
+struct ViewerFixture final {
+    bloom::document::Document document;
+    bloom::commands::CommandStack commands;
+    bloom::ui::CompositionSession session;
+    bloom::runtime::TaskScheduler scheduler;
+    bloom::ui::TaskUiBridge bridge;
+    PipelineFixture pipeline;
+    bloom::ui::CompositionPreviewController controller;
+    bloom::ui::ViewerEditor viewer;
+
+    explicit ViewerFixture(bloom::document::NewProject newProject)
+        : document(std::move(newProject.project)), commands(document),
+          session(document, commands, newProject.initialCompositionId),
+          scheduler(testSchedulerConfig()), bridge(scheduler, nullptr, 1ms),
+          controller(session, scheduler, bridge, pipeline.pipeline), viewer(session, controller) {
+        viewer.resize(400, 300);
+    }
+};
+
+// The zoom dropdown (decision 3) drives ViewerEditor's ViewTransform in both directions: choosing
+// a preset sets the transform, and the transform's own state is reflected back (Fit's default,
+// then a preset, then a wheel-derived custom value that lands on the dropdown's trailing item).
+void testStatusBarZoomDropdownDrivesViewTransform(Expectations& expectations) {
+    using namespace bloom;
+    ViewerFixture fixture(makeTestProject("Zoom Dropdown Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the fixture's initial frame becomes ready");
+
+    expectations.expect(fixture.viewer.viewTransformForTest().fitToWindow,
+                        "the viewer starts in Fit mode");
+    expectations.expect(fixture.viewer.zoomDropdownForTest()->currentText() == QStringLiteral("Fit"),
+                        "the zoom dropdown starts on \"Fit\"");
+
+    fixture.viewer.zoomDropdownForTest()->setCurrentIndex(3); // "100%"
+    expectations.expect(!fixture.viewer.viewTransformForTest().fitToWindow &&
+                            near(fixture.viewer.viewTransformForTest().zoom, 1.0),
+                        "choosing \"100%\" in the dropdown sets a Custom transform at zoom 1.0");
+
+    fixture.viewer.zoomDropdownForTest()->setCurrentIndex(4); // "200%"
+    expectations.expect(near(fixture.viewer.viewTransformForTest().zoom, 2.0),
+                        "choosing \"200%\" sets zoom to exactly 2.0");
+
+    // A wheel step lands off the fixed ladder; the dropdown grows exactly one trailing item that
+    // reflects it and stays selected there.
+    QWheelEvent wheelEvent(QPointF(50.0, 50.0), QPointF(50.0, 50.0), QPoint(), QPoint(0, 120),
+                           Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    QCoreApplication::sendEvent(&fixture.viewer, &wheelEvent);
+    expectations.expect(!near(fixture.viewer.viewTransformForTest().zoom, 2.0) &&
+                            !near(fixture.viewer.viewTransformForTest().zoom, 1.0),
+                        "a wheel step over the canvas changes the zoom off the fixed ladder");
+    expectations.expect(fixture.viewer.zoomDropdownForTest()->count() >= 7,
+                        "an off-ladder zoom grows exactly one trailing dropdown item");
+    const int customIndex = fixture.viewer.zoomDropdownForTest()->count() - 1;
+    expectations.expect(fixture.viewer.zoomDropdownForTest()->currentIndex() == customIndex,
+                        "the dropdown selects the trailing custom-value item");
+
+    fixture.viewer.zoomDropdownForTest()->setCurrentIndex(0); // "Fit"
+    expectations.expect(fixture.viewer.viewTransformForTest().fitToWindow,
+                        "choosing \"Fit\" restores fitToWindow");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the zoom-dropdown fixture reaches asynchronous scheduler quiescence");
+}
+
+// The status bar's center readout reuses the timeline's own exact display shape ("Frame N · S.mmms")
+// -- including an honest truncated (not rounded) subframe display, never a binary64 rounding of a
+// non-terminating decimal (docs/architecture/animation-and-time.md).
+void testStatusBarReadoutMatchesExactSessionTimeIncludingSubframe(Expectations& expectations) {
+    using namespace bloom;
+    ViewerFixture fixture(makeTestProject("Readout Subframe Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the fixture's initial frame becomes ready");
+
+    expectations.expect(fixture.viewer.statusBarReadoutTextForTest() == QStringLiteral("Frame 0 · 0.000s"),
+                        "the readout starts at frame 0, exact zero seconds");
+
+    // 1/3 s has no terminating decimal expansion: truncated to 3 places this is EXACTLY "0.333s",
+    // never "0.333...4" from a rounding of the binary64 approximation of 1/3.
+    const auto subframeTime = core::RationalTime::create(1, 3);
+    expectations.expect(subframeTime.has_value(), "1/3 second is a valid RationalTime");
+    if (subframeTime.has_value()) {
+        expectations.expect(fixture.session.setCurrentTime(*subframeTime),
+                            "the session accepts an exact subframe time");
+        expectations.expect(
+            fixture.viewer.statusBarReadoutTextForTest().contains(QStringLiteral("0.333s")),
+            "the readout truncates 1/3 second to exactly 0.333s (never a rounded 0.334s)");
+    }
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the readout fixture reaches asynchronous scheduler quiescence");
+}
+
+// Space-hold + left-drag pans the view (decision 2) without ever touching CompositionSession's
+// position-interaction gesture (positionInteractionActive() stays false throughout) -- pan is
+// pure Viewer-local state.
+void testSpaceHoldLeftDragPans(Expectations& expectations) {
+    using namespace bloom;
+    ViewerFixture fixture(makeTestProject("Space Pan Test"));
+    expectations.expect(waitUntil([&] { return isReady(fixture.controller); }),
+                        "the fixture's initial frame becomes ready");
+    expectations.expect(fixture.viewer.viewTransformForTest().fitToWindow,
+                        "the viewer starts in Fit mode with no pan");
+
+    QKeyEvent spaceDown(QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &spaceDown);
+
+    const QPointF pressPoint(150.0, 120.0);
+    const QPointF movePoint(190.0, 96.0);
+    QMouseEvent press(QEvent::MouseButtonPress, pressPoint, pressPoint, Qt::LeftButton,
+                      Qt::LeftButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &press);
+    QMouseEvent move(QEvent::MouseMove, movePoint, movePoint, Qt::NoButton, Qt::LeftButton,
+                     Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &move);
+
+    expectations.expect(!fixture.session.positionInteractionActive(),
+                        "a space-drag pan never begins a CompositionSession position interaction");
+    expectations.expect(!fixture.viewer.viewTransformForTest().fitToWindow,
+                        "panning materializes the transform out of Fit mode");
+    const QPointF pan = fixture.viewer.viewTransformForTest().pan;
+    expectations.expect(near(pan.x(), movePoint.x() - pressPoint.x()) &&
+                            near(pan.y(), movePoint.y() - pressPoint.y()),
+                        "pan tracks the TOTAL screen displacement from the press point");
+
+    QMouseEvent release(QEvent::MouseButtonRelease, movePoint, movePoint, Qt::LeftButton,
+                        Qt::NoButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &release);
+    QKeyEvent spaceUp(QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier);
+    QCoreApplication::sendEvent(&fixture.viewer, &spaceUp);
+    expectations.expect(near(fixture.viewer.viewTransformForTest().pan.x(), pan.x()) &&
+                            near(fixture.viewer.viewTransformForTest().pan.y(), pan.y()),
+                        "releasing ends the pan gesture without resetting the accumulated pan");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the space-pan fixture reaches asynchronous scheduler quiescence");
+}
+
+// Honest empty state (decision 5): with no composition at all, the canvas shows a quiet,
+// product-neutral invitation instead of any evaluation warning or banner.
+void testEmptyStateInvitationTextPresentWithoutComposition(Expectations& expectations) {
+    using namespace bloom;
+    // A genuinely composition-LESS project (never addComposition()'d) -- CompositionSession's own
+    // constructor only falls back to lowestCompositionId() when at least one composition exists
+    // (composition_session.cpp), so an empty project is the only way to make session.composition()
+    // legitimately return nullptr.
+    document::Project emptyProject(document::ProjectId::fromRaw(1), "Empty Viewer Project");
+    document::Document document(std::move(emptyProject));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, document::CompositionId::fromRaw(1));
+    runtime::TaskScheduler scheduler(testSchedulerConfig());
+    ui::TaskUiBridge bridge(scheduler, nullptr, 1ms);
+
+    runtime::NodeDefinitionRegistry definitions;
+    expectations.expect(runtime::registerBuiltInNodeDefinitions(definitions),
+                        "empty-state fixture registers built-in node definitions");
+    definitions.freeze();
+    runtime::SnapshotCompiler compiler(definitions);
+    const runtime::CpuCompositionEvaluator evaluator;
+    const runtime::CpuReferenceDisplayPreparer displayPreparer;
+    runtime::QualifiedDisplayProcessorProvider qualifiedProvider;
+    auto pipeline =
+        ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer, qualifiedProvider);
+    ui::CompositionPreviewController controller(session, scheduler, bridge, pipeline);
+    ui::ViewerEditor viewer(session, controller);
+    viewer.resize(320, 240);
+
+    expectations.expect(session.composition() == nullptr,
+                        "the fixture genuinely has no composition -- this is the empty state, not "
+                        "merely an unready one");
+    const QImage image = viewer.grab().toImage();
+    expectations.expect(!image.isNull(), "the empty-state canvas still renders offscreen (smoke)");
 
     reachQuiescence(controller, bridge, scheduler, expectations);
 }
@@ -305,7 +633,16 @@ int main(int argc, char** argv) {
     testSquarePixelFitting(expectations);
     testPixelAspectFitting(expectations);
     testDegenerateAvailableRect(expectations);
+    testViewTransformFitMatchesFitDisplayRect(expectations);
+    testViewTransformActualSizeMatchesActualPixelRect(expectations);
+    testViewTransformZoomAndPanCompose(expectations);
+    testZoomAboutCursorInvariantHoldsAtNonIdentityZoom(expectations);
+    testZoomClampsToTheDocumentedRange(expectations);
     testViewerRendersQualifiedFrameAndReportsColorState(expectations);
     testViewerStatusSurfaceReflectsFailClosedColorState(expectations);
+    testStatusBarZoomDropdownDrivesViewTransform(expectations);
+    testStatusBarReadoutMatchesExactSessionTimeIncludingSubframe(expectations);
+    testSpaceHoldLeftDragPans(expectations);
+    testEmptyStateInvitationTextPresentWithoutComposition(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/viewer_editor.cpp
+++ b/src/ui/viewer_editor.cpp
@@ -18,8 +18,8 @@
 #include <QAction>
 #include <QContextMenuEvent>
 #include <QImage>
-#include <QListView>
 #include <QKeyEvent>
+#include <QListView>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPaintEvent>
@@ -228,10 +228,10 @@ void drawFrameShadow(QPainter& painter, const QRectF& displayRect) {
         QColor layerColor = token.color;
         layerColor.setAlphaF(static_cast<float>(layerColor.alphaF() / kLayers));
         const qreal spread = token.blurRadius * t;
-        const QRectF layerRect = displayRect
-                                     .translated(static_cast<qreal>(token.offsetX),
-                                                 static_cast<qreal>(token.offsetY))
-                                     .adjusted(-spread, -spread, spread, spread);
+        const QRectF layerRect =
+            displayRect
+                .translated(static_cast<qreal>(token.offsetX), static_cast<qreal>(token.offsetY))
+                .adjusted(-spread, -spread, spread, spread);
         painter.setBrush(layerColor);
         painter.drawRoundedRect(layerRect, 2.0, 2.0);
     }
@@ -324,7 +324,7 @@ QRectF actualPixelRect(const QRectF& available, const render::ImageExtent extent
     const auto width = static_cast<qreal>(displayWidth);
     const auto height = static_cast<qreal>(displayHeight);
     return QRectF(available.center().x() - width / 2.0, available.center().y() - height / 2.0,
-                 width, height);
+                  width, height);
 }
 
 QRectF viewTransformedDisplayRect(const QRectF& available, const render::ImageExtent extent,
@@ -346,8 +346,9 @@ QRectF viewTransformedDisplayRect(const QRectF& available, const render::ImageEx
 }
 
 ViewTransform zoomAboutPoint(const ViewTransform& transform, const QRectF& available,
-                            const render::ImageExtent extent, const core::PixelAspectRatio pixelAspect,
-                            const QPointF screenPoint, const double factor) noexcept {
+                             const render::ImageExtent extent,
+                             const core::PixelAspectRatio pixelAspect, const QPointF screenPoint,
+                             const double factor) noexcept {
     const QRectF actual = actualPixelRect(available, extent, pixelAspect);
     const QRectF current = viewTransformedDisplayRect(available, extent, pixelAspect, transform);
     if (actual.isEmpty() || current.isEmpty() || !(actual.width() > 0.0) ||
@@ -438,7 +439,7 @@ kit::KDropdown* ViewerEditor::zoomDropdownForTest() const noexcept { return zoom
 QRectF ViewerEditor::statusBarRect() const {
     const qreal barHeight = kit::px(kit::Size::Control);
     return QRectF(0.0, static_cast<qreal>(height()) - barHeight, static_cast<qreal>(width()),
-                 barHeight);
+                  barHeight);
 }
 
 QRectF ViewerEditor::canvasRect() const {
@@ -455,8 +456,8 @@ void ViewerEditor::layoutStatusBar() {
     const QRectF bar = statusBarRect();
     const QSize hint = zoomDropdown_->sizeHint();
     const int x = static_cast<int>(bar.left()) + kit::px(kit::Spacing::S);
-    const int y = static_cast<int>(bar.top()) +
-                 (static_cast<int>(bar.height()) - hint.height() + 1) / 2;
+    const int y =
+        static_cast<int>(bar.top()) + (static_cast<int>(bar.height()) - hint.height() + 1) / 2;
     zoomDropdown_->setGeometry(x, y, hint.width(), hint.height());
 }
 
@@ -645,12 +646,14 @@ void ViewerEditor::paintStatusBarSurface(QPainter& painter) {
             : bar.left();
     const qreal maxChipWidth = std::max<qreal>(0.0, bar.width() * 0.4);
     const QString elidedChipText = painter.fontMetrics().elidedText(
-        chipState.text, Qt::ElideRight, static_cast<int>(std::max<qreal>(0.0, maxChipWidth - 16.0)));
+        chipState.text, Qt::ElideRight,
+        static_cast<int>(std::max<qreal>(0.0, maxChipWidth - 16.0)));
     const qreal chipWidth = std::min<qreal>(
         maxChipWidth, painter.fontMetrics().horizontalAdvance(elidedChipText) + 16.0);
     const qreal chipLeft =
         std::max<qreal>(chipLeftBound, bar.right() - chipWidth - kit::px(kit::Spacing::S));
-    const QRectF chipRect(chipLeft, chipTop, std::max<qreal>(0.0, bar.right() - chipLeft - kit::px(kit::Spacing::S)),
+    const QRectF chipRect(chipLeft, chipTop,
+                          std::max<qreal>(0.0, bar.right() - chipLeft - kit::px(kit::Spacing::S)),
                           chipHeight);
     paintChip(painter, chipRect, chipState.text, kit::color(chipState.colorToken));
 
@@ -660,8 +663,8 @@ void ViewerEditor::paintStatusBarSurface(QPainter& painter) {
     painter.setFont(kit::font(kit::TypeRole::Value));
     painter.setPen(kit::color(kit::Color::Foreground));
     const qreal centerRight = chipRect.left() - kit::px(kit::Spacing::S);
-    const QRectF centerRect(chipLeftBound, bar.top(), std::max<qreal>(0.0, centerRight - chipLeftBound),
-                            bar.height());
+    const QRectF centerRect(chipLeftBound, bar.top(),
+                            std::max<qreal>(0.0, centerRight - chipLeftBound), bar.height());
     painter.drawText(centerRect, Qt::AlignCenter, exactFrameAndTimecodeText(session_));
 
     painter.restore();
@@ -805,9 +808,8 @@ void ViewerEditor::updatePanCursor() {
 void ViewerEditor::mousePressEvent(QMouseEvent* event) {
     if (!dragActive_ && !panActive_) {
         if (const auto geometry = currentDisplayGeometry();
-            geometry.has_value() &&
-            (event->button() == Qt::MiddleButton ||
-             (event->button() == Qt::LeftButton && spaceHeld_))) {
+            geometry.has_value() && (event->button() == Qt::MiddleButton ||
+                                     (event->button() == Qt::LeftButton && spaceHeld_))) {
             beginPan(event->button(), event->position(), *geometry);
             event->accept();
             return;

--- a/src/ui/viewer_editor.cpp
+++ b/src/ui/viewer_editor.cpp
@@ -2,28 +2,52 @@
 
 #include <bloom/ui/composition_preview_controller.hpp>
 #include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/kit/dropdown.hpp>
 #include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/timeline_frame_math.hpp>
 
 #include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/project.hpp>
 #include <bloom/render/display_buffer.hpp>
 #include <bloom/render/image_types.hpp>
 
+#include <QAbstractItemModel>
+#include <QAction>
+#include <QContextMenuEvent>
 #include <QImage>
+#include <QListView>
 #include <QKeyEvent>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QResizeEvent>
+#include <QSignalBlocker>
+#include <QWheelEvent>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <limits>
 #include <optional>
 #include <variant>
 
 namespace bloom::ui {
 namespace {
+
+// Wheel/menu zoom step (decision 2): each wheel notch or Zoom In/Out menu action multiplies the
+// current effective zoom by this factor (clamped into ViewTransform's [kMinZoom, kMaxZoom]).
+constexpr double kZoomStepFactor = 1.1;
+
+// The Fit item plus the fixed percentage presets a real gesture never removes (decision 3). A
+// zoom that lands off this ladder (e.g. from a wheel step) gets ONE additional trailing item --
+// see refreshZoomDropdown()'s own comment on why that item is renamed in place rather than
+// removed and re-added: kit::KDropdown has no item-removal API.
+constexpr std::array<int, 5> kZoomPresets = {25, 50, 100, 200, 400};
+constexpr int kFixedZoomItemCount = 1 + static_cast<int>(kZoomPresets.size());
 
 const document::LayerOutputBoundary* layerBoundary(const document::Composition& composition,
                                                    const document::LayerId layerId) {
@@ -81,8 +105,95 @@ QColor previewStatusColor(const PreviewActivity activity) {
     return kit::color(kit::Color::Muted);
 }
 
+// Ok/Warn/Error color-state chip (decision 3). The qualified/unqualified determination is
+// ALWAYS driven by the currently-displayed frame's own isOcioQualified() bit -- never by
+// `activity` -- so a retained qualified frame keeps reading as qualified even while a later,
+// unrelated request is in flight (the "never a silent relabel" contract, unchanged from the
+// original top-row label this replaces). PreviewActivity::Failed overrides to Error and shows the
+// controller's own fail-closed diagnostic message (docs/architecture/color-management.md, "Any
+// state other than Ready is fail-closed for qualified processing"): every Failed case this
+// codebase currently produces reaches this state with an already-unqualified retained frame (or
+// none at all), so this is additive, not a behavior change for the Ok/Warn cases the original
+// label already covered. A theoretical "was qualified, then a later unrelated request failed"
+// frame would still show the Error text rather than "Qualified" here -- a deliberate
+// simplification, not exercised by any existing pipeline path.
+struct ColorChipState final {
+    QString text;
+    kit::Color colorToken;
+};
+
+ColorChipState colorChipStateFor(const CompositionPreviewState& preview) {
+    if (preview.activity == PreviewActivity::Failed) {
+        return {preview.message.isEmpty() ? ViewerEditor::tr("Color state unavailable")
+                                          : preview.message,
+                kit::Color::Error};
+    }
+    const auto bufferView =
+        preview.frame != nullptr ? preview.frame->displayBufferView() : std::nullopt;
+    if (bufferView.has_value() && bufferView->isOcioQualified) {
+        return {ViewerEditor::tr("Qualified · Bloom Neutral"), kit::Color::Ok};
+    }
+    return {ViewerEditor::tr("Reference (unqualified)"), kit::Color::Warn};
+}
+
+// Formats an exact RationalTime as seconds with EXACTLY 3 truncated decimal digits (millisecond
+// resolution), computed purely from the integer numerator/denominator -- never through
+// RationalTime::toSeconds()'s binary64 conversion -- so the digits shown are always the value's
+// true leading digits, never a rounded/binary64-approximated one (design decision 3: "no
+// floating-point accumulation... a subframe time must display honestly").
+//
+// This is a DELIBERATE, documented duplicate of composition_editors.cpp's anonymous-namespace
+// formatExactSeconds() (TimelineEditor::updateTimeReadout()'s own helper): task U3's fence
+// forbids touching composition_editors.cpp (properties/timeline lane), and that function is
+// neither exported nor movable without editing the fenced file it lives in. Per this task's own
+// decision 3 ("reimplement the documented truncation rule and say so" when the timeline's
+// formatting function cannot be reused/moved), the truncation RULE is reproduced verbatim from
+// composition_editors.cpp; the frame-INDEX math below still goes through the shared, unfenced
+// bloom::ui::nearestFrameIndexForTime() (timeline_frame_math.hpp) rather than being duplicated.
+// Reported to the supervisor as a cross-lane duplication to fold into one shared helper later.
+QString formatExactSecondsForViewer(const core::RationalTime time) {
+    constexpr int kDecimalPlaces = 3;
+    constexpr unsigned __int128 kScale = 1000;
+    const std::int64_t numerator = time.numerator();
+    const auto denominator = static_cast<unsigned __int128>(time.denominator());
+    const bool negative = numerator < 0;
+    const auto magnitude = negative
+                               ? static_cast<unsigned __int128>(-static_cast<__int128>(numerator))
+                               : static_cast<unsigned __int128>(numerator);
+    const auto wholeSeconds = static_cast<qulonglong>(magnitude / denominator);
+    const auto remainder = magnitude % denominator;
+    const auto scaledFraction = static_cast<qulonglong>((remainder * kScale) / denominator);
+    return QStringLiteral("%1%2.%3s")
+        .arg(negative ? QStringLiteral("-") : QString())
+        .arg(wholeSeconds)
+        .arg(scaledFraction, kDecimalPlaces, 10, QChar('0'));
+}
+
+// "Frame %1 · %2" mirrors TimelineEditor::updateTimeReadout()'s exact display shape
+// (composition_editors.cpp) so the Viewer's readout and the Timeline's readout never disagree in
+// format, only in which fenced/unfenced pieces produce the two halves (see
+// formatExactSecondsForViewer()'s comment above).
+QString exactFrameAndTimecodeText(const CompositionSession& session) {
+    const auto* composition = session.composition();
+    const auto time = session.currentTime();
+    QString frameText = QStringLiteral("—");
+    if (composition != nullptr) {
+        const auto frameRate = composition->format().frameRate();
+        const auto duration = composition->duration();
+        const auto nearest = nearestFrameIndexForTime(frameRate, duration, time);
+        if (nearest.has_value()) {
+            frameText = QString::number(*nearest);
+        }
+    }
+    return ViewerEditor::tr("Frame %1 · %2").arg(frameText, formatExactSecondsForViewer(time));
+}
+
 void drawCheckerboard(QPainter& painter, const QRectF& bounds) {
-    constexpr qreal tileSize = 12.0;
+    // 22px pattern from the SurfaceRaised/Surface pair (decision 1): this is now the WHOLE canvas
+    // surround, not just an under-image alpha indicator -- the image is drawn on top of it with its
+    // own alpha honored, so a transparent pixel already reads as "checkerboard showing through"
+    // with no separate under-image pass needed.
+    constexpr qreal tileSize = 22.0;
     painter.save();
     painter.setClipRect(bounds);
     painter.fillRect(bounds, kit::color(kit::Color::Surface));
@@ -98,25 +209,64 @@ void drawCheckerboard(QPainter& painter, const QRectF& bounds) {
     painter.restore();
 }
 
-void drawStatusChip(QPainter& painter, const QRectF& available, QString text, const QColor color,
-                    const Qt::Alignment horizontalAlignment) {
-    constexpr qreal horizontalPadding = 8.0;
+// Approximates Elevation::Popup's token shadow (kit::shadow()) as a stack of expanding,
+// decreasingly-opaque rounded rects behind `displayRect`. kit::applyElevation() is the real
+// mechanism (a QGraphicsDropShadowEffect attached to a widget) but that requires the shadowed
+// content to BE a widget; the composed frame here is one QImage blit inside ViewerEditor's own
+// paintEvent, not a child widget, so it cannot host a graphics effect. This still consumes the
+// token's own offset/blur/color -- no raw literal -- it just composites the blur by hand.
+void drawFrameShadow(QPainter& painter, const QRectF& displayRect) {
+    const kit::Shadow token = kit::shadow(kit::Elevation::Popup);
+    if (token.isFlat() || displayRect.isEmpty()) {
+        return;
+    }
+    constexpr int kLayers = 4;
+    painter.save();
+    painter.setPen(Qt::NoPen);
+    for (int layer = kLayers; layer >= 1; --layer) {
+        const qreal t = static_cast<qreal>(layer) / static_cast<qreal>(kLayers);
+        QColor layerColor = token.color;
+        layerColor.setAlphaF(static_cast<float>(layerColor.alphaF() / kLayers));
+        const qreal spread = token.blurRadius * t;
+        const QRectF layerRect = displayRect
+                                     .translated(static_cast<qreal>(token.offsetX),
+                                                 static_cast<qreal>(token.offsetY))
+                                     .adjusted(-spread, -spread, spread, spread);
+        painter.setBrush(layerColor);
+        painter.drawRoundedRect(layerRect, 2.0, 2.0);
+    }
+    painter.restore();
+}
+
+// Fills `chipRect` exactly with a rounded, token-colored pill carrying `text` -- the shared
+// low-level primitive behind both the canvas activity chip and the status bar's zoom-independent
+// color-state chip (drawStatusChip() below computes ITS OWN chipRect and delegates here).
+void paintChip(QPainter& painter, const QRectF& chipRect, const QString& text, const QColor color) {
+    if (chipRect.isEmpty()) {
+        return;
+    }
+    const QString elided = painter.fontMetrics().elidedText(
+        text, Qt::ElideRight, static_cast<int>(std::max<qreal>(0.0, chipRect.width() - 16.0)));
+    painter.setPen(QPen(color.lighter(125), 1.0));
+    painter.setBrush(kit::withOpacity(color, 0.855));
+    painter.drawRoundedRect(chipRect, 4.0, 4.0);
+    painter.setPen(kit::color(kit::Color::Foreground));
+    painter.drawText(chipRect.adjusted(8.0, 0.0, -8.0, 0.0), Qt::AlignVCenter | Qt::AlignLeft,
+                     elided);
+}
+
+void drawStatusChip(QPainter& painter, const QRectF& available, const QString& text,
+                    const QColor color, const Qt::Alignment horizontalAlignment) {
     constexpr qreal chipHeight = 24.0;
     const qreal maximumWidth = std::max<qreal>(0.0, available.width() - 24.0);
-    text = painter.fontMetrics().elidedText(text, Qt::ElideRight,
-                                            static_cast<int>(maximumWidth - 2 * horizontalPadding));
-    const qreal width = std::min<qreal>(
-        maximumWidth, painter.fontMetrics().horizontalAdvance(text) + 2 * horizontalPadding);
+    const QString elided = painter.fontMetrics().elidedText(
+        text, Qt::ElideRight, static_cast<int>(std::max<qreal>(0.0, maximumWidth - 16.0)));
+    const qreal width =
+        std::min<qreal>(maximumWidth, painter.fontMetrics().horizontalAdvance(elided) + 16.0);
     const qreal left = horizontalAlignment.testFlag(Qt::AlignRight)
                            ? available.right() - width - 12.0
                            : available.left() + 12.0;
-    const QRectF chip(left, available.top() + 10.0, width, chipHeight);
-    painter.setPen(QPen(color.lighter(125), 1.0));
-    painter.setBrush(kit::withOpacity(color, 0.855));
-    painter.drawRoundedRect(chip, 4.0, 4.0);
-    painter.setPen(kit::color(kit::Color::Foreground));
-    painter.drawText(chip.adjusted(horizontalPadding, 0.0, -horizontalPadding, 0.0),
-                     Qt::AlignVCenter | Qt::AlignLeft, text);
+    paintChip(painter, QRectF(left, available.top() + 10.0, width, chipHeight), text, color);
 }
 
 void drawDiagnosticBanner(QPainter& painter, const QRectF& available, const QString& message) {
@@ -132,13 +282,6 @@ void drawDiagnosticBanner(QPainter& painter, const QRectF& available, const QStr
     const QString visible = painter.fontMetrics().elidedText(
         message, Qt::ElideRight, static_cast<int>(std::max<qreal>(0.0, banner.width() - 20.0)));
     painter.drawText(banner.adjusted(10.0, 0.0, -10.0, 0.0), Qt::AlignCenter, visible);
-}
-
-// The composed-frame rectangle paintEvent() draws pixels into (see the identical expression
-// there); shared with currentMapping() so direct manipulation maps screen deltas against exactly
-// the rectangle the user sees.
-QRectF viewerFrame(const QWidget& widget) {
-    return QRectF(widget.rect()).adjusted(28.0, 28.0, -28.0, -28.0);
 }
 
 } // namespace
@@ -165,20 +308,107 @@ QRectF fitDisplayRect(const QRectF& available, const render::ImageExtent extent,
                   available.center().y() - fittedHeight / 2.0, fittedWidth, fittedHeight);
 }
 
+QRectF actualPixelRect(const QRectF& available, const render::ImageExtent extent,
+                       const core::PixelAspectRatio pixelAspect) noexcept {
+    if (available.isEmpty()) {
+        return {};
+    }
+
+    const long double displayWidth = static_cast<long double>(extent.width()) *
+                                     pixelAspect.numerator() / pixelAspect.denominator();
+    const long double displayHeight = extent.height();
+    if (displayWidth <= 0.0L || displayHeight <= 0.0L) {
+        return {};
+    }
+
+    const auto width = static_cast<qreal>(displayWidth);
+    const auto height = static_cast<qreal>(displayHeight);
+    return QRectF(available.center().x() - width / 2.0, available.center().y() - height / 2.0,
+                 width, height);
+}
+
+QRectF viewTransformedDisplayRect(const QRectF& available, const render::ImageExtent extent,
+                                  const core::PixelAspectRatio pixelAspect,
+                                  const ViewTransform& transform) noexcept {
+    if (transform.fitToWindow) {
+        return fitDisplayRect(available, extent, pixelAspect);
+    }
+    const QRectF actual = actualPixelRect(available, extent, pixelAspect);
+    if (actual.isEmpty()) {
+        return {};
+    }
+    const qreal zoom = std::clamp(transform.zoom, ViewTransform::kMinZoom, ViewTransform::kMaxZoom);
+    const qreal width = actual.width() * zoom;
+    const qreal height = actual.height() * zoom;
+    const QPointF centeredTopLeft(available.center().x() - width / 2.0,
+                                  available.center().y() - height / 2.0);
+    return QRectF(centeredTopLeft + transform.pan, QSizeF(width, height));
+}
+
+ViewTransform zoomAboutPoint(const ViewTransform& transform, const QRectF& available,
+                            const render::ImageExtent extent, const core::PixelAspectRatio pixelAspect,
+                            const QPointF screenPoint, const double factor) noexcept {
+    const QRectF actual = actualPixelRect(available, extent, pixelAspect);
+    const QRectF current = viewTransformedDisplayRect(available, extent, pixelAspect, transform);
+    if (actual.isEmpty() || current.isEmpty() || !(actual.width() > 0.0) ||
+        !(actual.height() > 0.0) || !(factor > 0.0)) {
+        return transform;
+    }
+
+    const qreal currentZoom = current.width() / actual.width();
+    const qreal newZoom =
+        std::clamp(currentZoom * factor, ViewTransform::kMinZoom, ViewTransform::kMaxZoom);
+    // Fraction of the CURRENT display rectangle the cursor sits at -- fixed across the step by
+    // construction below (the zoom-about-cursor invariant this function exists to guarantee).
+    const qreal fractionX = (screenPoint.x() - current.left()) / current.width();
+    const qreal fractionY = (screenPoint.y() - current.top()) / current.height();
+    const qreal newWidth = actual.width() * newZoom;
+    const qreal newHeight = actual.height() * newZoom;
+    const QPointF newTopLeft(screenPoint.x() - fractionX * newWidth,
+                             screenPoint.y() - fractionY * newHeight);
+    const QPointF centeredTopLeft(available.center().x() - newWidth / 2.0,
+                                  available.center().y() - newHeight / 2.0);
+    return ViewTransform{
+        .fitToWindow = false, .zoom = newZoom, .pan = newTopLeft - centeredTopLeft};
+}
+
 ViewerEditor::ViewerEditor(CompositionSession& session,
                            CompositionPreviewController& previewController, QWidget* parent)
     : QWidget(parent), session_(session), previewController_(previewController) {
     setObjectName("viewerEditor");
     setAccessibleName(tr("Composition viewer"));
-    setMinimumSize(220, 150);
+    setMinimumSize(220, 150 + kit::px(kit::Size::Control));
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    // StrongFocus lets a press-to-drag gesture also receive the Escape key that cancels it.
+    // StrongFocus lets a press-to-drag gesture also receive the Escape key that cancels it, and
+    // lets the widget receive Space/Z/F without a prior click.
     setFocusPolicy(Qt::StrongFocus);
+
+    zoomDropdown_ = new kit::KDropdown(this);
+    zoomDropdown_->setObjectName("viewerZoomDropdown");
+    zoomDropdown_->setAccessibleName(tr("Zoom"));
+    zoomDropdown_->setControlSize(kit::KDropdown::ControlSize::Compact);
+    zoomDropdown_->addItem(tr("Fit"), 0);
+    for (const int percent : kZoomPresets) {
+        zoomDropdown_->addItem(tr("%1%").arg(percent), percent);
+    }
+    connect(zoomDropdown_, &kit::KDropdown::currentIndexChanged, this, [this](const int index) {
+        if (index <= 0) {
+            setZoomFit();
+            return;
+        }
+        setZoomPercent(zoomDropdown_->itemData(index).toInt());
+    });
+    layoutStatusBar();
+
     connect(&session_, &CompositionSession::snapshotChanged, this,
             qOverload<>(&ViewerEditor::update));
     connect(&session_, &CompositionSession::compositionChanged, this,
             qOverload<>(&ViewerEditor::update));
     connect(&session_, &CompositionSession::selectionChanged, this,
+            qOverload<>(&ViewerEditor::update));
+    // New for the status bar's exact readout (decision 3): the original Viewer never needed
+    // current-time updates before, since nothing it drew depended on session time.
+    connect(&session_, &CompositionSession::currentTimeChanged, this,
             qOverload<>(&ViewerEditor::update));
     connect(&previewController_, &CompositionPreviewController::stateChanged, this, [this] {
         updatePreviewAccessibility();
@@ -193,36 +423,145 @@ ViewerEditor::ViewerEditor(CompositionSession& session,
     updatePreviewAccessibility();
 }
 
+ViewTransform ViewerEditor::viewTransformForTest() const noexcept { return transform_; }
+
+QString ViewerEditor::statusBarReadoutTextForTest() const {
+    return exactFrameAndTimecodeText(session_);
+}
+
+QString ViewerEditor::statusBarColorChipTextForTest() const {
+    return colorChipStateFor(previewController_.state()).text;
+}
+
+kit::KDropdown* ViewerEditor::zoomDropdownForTest() const noexcept { return zoomDropdown_; }
+
+QRectF ViewerEditor::statusBarRect() const {
+    const qreal barHeight = kit::px(kit::Size::Control);
+    return QRectF(0.0, static_cast<qreal>(height()) - barHeight, static_cast<qreal>(width()),
+                 barHeight);
+}
+
+QRectF ViewerEditor::canvasRect() const {
+    const QRectF bar = statusBarRect();
+    // Full-bleed (decision 1): no side or top inset at all, only the bottom strip the status bar
+    // structurally requires -- that strip is a persistent control row, not "padding".
+    return QRectF(rect()).adjusted(0.0, 0.0, 0.0, -bar.height());
+}
+
+void ViewerEditor::layoutStatusBar() {
+    if (zoomDropdown_ == nullptr) {
+        return;
+    }
+    const QRectF bar = statusBarRect();
+    const QSize hint = zoomDropdown_->sizeHint();
+    const int x = static_cast<int>(bar.left()) + kit::px(kit::Spacing::S);
+    const int y = static_cast<int>(bar.top()) +
+                 (static_cast<int>(bar.height()) - hint.height() + 1) / 2;
+    zoomDropdown_->setGeometry(x, y, hint.width(), hint.height());
+}
+
+void ViewerEditor::refreshZoomDropdown() {
+    if (zoomDropdown_ == nullptr) {
+        return;
+    }
+    int targetIndex = 0; // "Fit"
+    if (!transform_.fitToWindow) {
+        const int percent = static_cast<int>(std::lround(transform_.zoom * 100.0));
+        int presetIndex = -1;
+        for (std::size_t i = 0; i < kZoomPresets.size(); ++i) {
+            if (kZoomPresets[i] == percent) {
+                presetIndex = static_cast<int>(i) + 1;
+                break;
+            }
+        }
+        if (presetIndex >= 0) {
+            targetIndex = presetIndex;
+        } else {
+            // A zoom off the fixed ladder (e.g. from a wheel step) gets one trailing "current
+            // custom value" item (decision 3). kit::KDropdown has no removeItem()/setItemText()
+            // (src/ui/include/bloom/ui/kit/dropdown.hpp) -- addItem() only appends and itemText()
+            // is read-only -- so a REPEATED custom zoom renames that one trailing item in place by
+            // writing through the model kit::KDropdown itself uses (popupView()->model() is the
+            // same QStandardItemModel addItem()/itemText() read/write, exposed publicly for
+            // exactly this kind of read -- see dropdown.cpp) rather than growing a new item per
+            // step or leaving a stale value on screen. The FIRST custom zoom in a session still
+            // appends. Reported as a kit API gap (a real setItemText()/removeItem() would replace
+            // this workaround) rather than worked around inside kit itself, which is out of this
+            // task's fence.
+            const QString label = tr("%1%").arg(percent);
+            if (zoomDropdown_->count() > kFixedZoomItemCount) {
+                auto* model = zoomDropdown_->popupView()->model();
+                model->setData(model->index(kFixedZoomItemCount, 0), label, Qt::DisplayRole);
+            } else {
+                zoomDropdown_->addItem(label, percent);
+            }
+            targetIndex = kFixedZoomItemCount;
+        }
+    }
+    if (zoomDropdown_->currentIndex() != targetIndex) {
+        const QSignalBlocker blocker(zoomDropdown_);
+        zoomDropdown_->setCurrentIndex(targetIndex);
+    }
+    zoomDropdown_->update();
+}
+
+void ViewerEditor::setZoomFit() {
+    transform_ = ViewTransform{};
+    refreshZoomDropdown();
+    update();
+}
+
+void ViewerEditor::setZoomActualSize() { setZoomPercent(100); }
+
+void ViewerEditor::setZoomPercent(const int percent) {
+    transform_ = ViewTransform{.fitToWindow = false, .zoom = percent / 100.0, .pan = {0.0, 0.0}};
+    refreshZoomDropdown();
+    update();
+}
+
+std::optional<ViewerEditor::DisplayGeometry> ViewerEditor::currentDisplayGeometry() const {
+    const auto& preview = previewController_.state();
+    if (preview.frame == nullptr) {
+        return std::nullopt;
+    }
+    const auto bufferView = preview.frame->displayBufferView();
+    if (!bufferView.has_value()) {
+        return std::nullopt;
+    }
+    return DisplayGeometry{.extent = bufferView->displayWindow.extent(),
+                           .pixelAspect = bufferView->pixelAspect};
+}
+
 void ViewerEditor::paintEvent(QPaintEvent* event) {
     Q_UNUSED(event)
     QPainter painter(this);
     painter.fillRect(rect(), kit::color(kit::Color::Background));
 
-    const QRectF frame = viewerFrame(*this);
-    painter.fillRect(frame, kit::color(kit::Color::Surface));
-    painter.setPen(QPen(kit::color(kit::Color::BorderHover), 1.0));
-    painter.drawRect(frame.adjusted(0.0, 0.0, -1.0, -1.0));
+    const QRectF frame = canvasRect();
+    const auto* composition = session_.composition();
 
-    constexpr int gridStep = 32;
-    painter.setPen(QPen(kit::color(kit::Color::Border), 1.0));
-    for (int offset = gridStep; static_cast<qreal>(offset) < frame.width(); offset += gridStep) {
-        const qreal x = frame.left() + static_cast<qreal>(offset);
-        painter.drawLine(QPointF(x, frame.top()), QPointF(x, frame.bottom()));
+    if (composition == nullptr) {
+        // Honest empty state (decision 5): no evaluation warnings, no busywork -- a quiet,
+        // product-neutral invitation. Muted ink, Ui type (Value/Geist Mono is reserved for
+        // numeric/timecode surfaces, not prose -- kit/tokens.hpp).
+        drawCheckerboard(painter, frame);
+        painter.setFont(kit::font(kit::TypeRole::Ui));
+        painter.setPen(kit::color(kit::Color::Muted));
+        painter.drawText(frame, Qt::AlignCenter, tr("Create a layer to begin"));
+        paintStatusBarSurface(painter);
+        return;
     }
-    for (int offset = gridStep; static_cast<qreal>(offset) < frame.height(); offset += gridStep) {
-        const qreal y = frame.top() + static_cast<qreal>(offset);
-        painter.drawLine(QPointF(frame.left(), y), QPointF(frame.right(), y));
-    }
+
+    drawCheckerboard(painter, frame);
 
     const auto& preview = previewController_.state();
     const PreparedPreviewFrameHandle displayedFrame = preview.frame;
     bool drewPixels = false;
-    bool drewQualifiedPixels = false;
     if (displayedFrame != nullptr) {
         // displayBufferView() normalizes both display-product alternatives (reference and
-        // qualified) to the same packed-RGBA8 shape (design decision 2) -- the viewer draws
-        // pixels identically either way; isOcioQualified is the only distinguishing bit, used
-        // below only for the corner provenance label, never to change how pixels are drawn.
+        // qualified) to the same packed-RGBA8 shape -- the viewer draws pixels identically either
+        // way; isOcioQualified is only ever read for the status bar's color-state chip, never to
+        // change how pixels are drawn.
         const auto bufferView = displayedFrame->displayBufferView();
         if (bufferView.has_value()) {
             const auto extent = bufferView->displayWindow.extent();
@@ -240,9 +579,9 @@ void ViewerEditor::paintEvent(QPaintEvent* event) {
                     static_cast<int>(extent.height()),
                     static_cast<qsizetype>(layout.rowStrideBytes), QImage::Format_RGBA8888);
                 if (!image.isNull()) {
-                    const QRectF displayRect =
-                        fitDisplayRect(frame, extent, bufferView->pixelAspect);
-                    drawCheckerboard(painter, displayRect);
+                    const QRectF displayRect = viewTransformedDisplayRect(
+                        frame, extent, bufferView->pixelAspect, transform_);
+                    drawFrameShadow(painter, displayRect);
                     painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
                     painter.drawImage(displayRect, image, QRectF(image.rect()));
                     painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
@@ -250,44 +589,24 @@ void ViewerEditor::paintEvent(QPaintEvent* event) {
                     painter.setBrush(Qt::NoBrush);
                     painter.drawRect(displayRect.adjusted(0.0, 0.0, -1.0, -1.0));
                     drewPixels = true;
-                    drewQualifiedPixels = bufferView->isOcioQualified;
                 }
             }
         }
     }
 
-    const auto* composition = session_.composition();
-    painter.setPen(kit::color(kit::Color::Foreground));
-    painter.drawText(QRectF(frame.left(), 2.0, frame.width(), 22.0),
-                     Qt::AlignLeft | Qt::AlignVCenter,
-                     composition == nullptr ? tr("No composition")
-                                            : QString::fromStdString(composition->name()));
-    painter.setPen(kit::color(kit::Color::Muted));
-    // Never a silent relabel: this reads the envelope's own isOcioQualified flag every paint,
-    // rather than assuming qualified once readiness is reached (design decision 2 / the "reference
-    // path is never silently relabeled as qualified" contract). A frame drawn before the qualified
-    // processor is ready -- or the last-good frame retained through a later qualification failure
-    // -- keeps reading as "Reference display (unqualified)" here for exactly as long as it is.
-    painter.drawText(QRectF(frame.left(), 2.0, frame.width(), 22.0),
-                     Qt::AlignRight | Qt::AlignVCenter,
-                     drewPixels ? (drewQualifiedPixels ? tr("Qualified display")
-                                                       : tr("Reference display (unqualified)"))
-                                : tr("Reference display"));
-
-    if (!drewPixels) {
-        painter.setPen(kit::color(kit::Color::Muted));
-        painter.drawText(frame.adjusted(24.0, 44.0, -24.0, -44.0), Qt::AlignCenter,
-                         previewStatusText(preview));
-    }
-
+    // Evaluation-pending/activity chip: always the subtle chip, never a banner (decision 5) --
+    // unchanged from before except that the redundant large centered duplicate of this same text
+    // (previously drawn whenever no pixels were available yet) is gone.
     drawStatusChip(painter, frame, previewStatusText(preview), previewStatusColor(preview.activity),
                    Qt::AlignLeft);
+    // Failure states keep their existing typed surfacing (already token-driven) when stale pixels
+    // are still being shown alongside them.
     if (drewPixels && preview.activity != PreviewActivity::Ready &&
         preview.activity != PreviewActivity::Rendering) {
         drawDiagnosticBanner(painter, frame, preview.message);
     }
 
-    if (session_.selection().contextualLayer.has_value() && composition != nullptr) {
+    if (session_.selection().contextualLayer.has_value()) {
         const QString name = layerName(*composition, *session_.selection().contextualLayer);
         const QRectF selectionStatus(frame.left() + 12.0, frame.bottom() - 38.0,
                                      frame.width() - 24.0, 26.0);
@@ -301,6 +620,51 @@ void ViewerEditor::paintEvent(QPaintEvent* event) {
             painter.fontMetrics().elidedText(status, Qt::ElideRight,
                                              static_cast<int>(selectionStatus.width() - 16.0)));
     }
+
+    paintStatusBarSurface(painter);
+}
+
+void ViewerEditor::paintStatusBarSurface(QPainter& painter) {
+    const QRectF bar = statusBarRect();
+    painter.save();
+    painter.fillRect(bar, kit::color(kit::Color::Surface));
+    painter.setPen(QPen(kit::color(kit::Color::Border), 1.0));
+    painter.drawLine(bar.topLeft(), bar.topRight());
+
+    // Right: the color-state chip (decision 3) -- the contract-preserved qualified/unqualified
+    // indicator this whole status bar exists partly to relocate. Computed fresh every paint from
+    // live preview state, exactly like the top-row label it replaces, so it is never a step behind
+    // or a silent relabel.
+    painter.setFont(kit::font(kit::TypeRole::Ui));
+    const auto chipState = colorChipStateFor(previewController_.state());
+    const qreal chipHeight = std::max<qreal>(16.0, bar.height() - 6.0);
+    const qreal chipTop = bar.top() + (bar.height() - chipHeight) / 2.0;
+    const qreal chipLeftBound =
+        zoomDropdown_ != nullptr
+            ? static_cast<qreal>(zoomDropdown_->geometry().right()) + kit::px(kit::Spacing::L)
+            : bar.left();
+    const qreal maxChipWidth = std::max<qreal>(0.0, bar.width() * 0.4);
+    const QString elidedChipText = painter.fontMetrics().elidedText(
+        chipState.text, Qt::ElideRight, static_cast<int>(std::max<qreal>(0.0, maxChipWidth - 16.0)));
+    const qreal chipWidth = std::min<qreal>(
+        maxChipWidth, painter.fontMetrics().horizontalAdvance(elidedChipText) + 16.0);
+    const qreal chipLeft =
+        std::max<qreal>(chipLeftBound, bar.right() - chipWidth - kit::px(kit::Spacing::S));
+    const QRectF chipRect(chipLeft, chipTop, std::max<qreal>(0.0, bar.right() - chipLeft - kit::px(kit::Spacing::S)),
+                          chipHeight);
+    paintChip(painter, chipRect, chipState.text, kit::color(chipState.colorToken));
+
+    // Center: exact frame + timecode readout, Geist Mono (kit::TypeRole::Value is the monospaced
+    // role every numeric/timecode surface uses -- kit/tokens.hpp). Occupies whatever room is left
+    // between the zoom dropdown and the color chip.
+    painter.setFont(kit::font(kit::TypeRole::Value));
+    painter.setPen(kit::color(kit::Color::Foreground));
+    const qreal centerRight = chipRect.left() - kit::px(kit::Spacing::S);
+    const QRectF centerRect(chipLeftBound, bar.top(), std::max<qreal>(0.0, centerRight - chipLeftBound),
+                            bar.height());
+    painter.drawText(centerRect, Qt::AlignCenter, exactFrameAndTimecodeText(session_));
+
+    painter.restore();
 }
 
 void ViewerEditor::updatePreviewAccessibility() {
@@ -317,13 +681,9 @@ void ViewerEditor::updatePreviewAccessibility() {
         frameDescription = tr("Previous composition pixels are displayed and marked out of date");
         break;
     }
-    const auto bufferView =
-        preview.frame != nullptr ? preview.frame->displayBufferView() : std::nullopt;
-    const QString colorStateDescription =
-        bufferView.has_value()
-            ? (bufferView->isOcioQualified ? tr("Qualified display.")
-                                           : tr("Reference display (unqualified)."))
-            : tr("Reference display.");
+    // Single source of wording with the painted status bar chip (colorChipStateFor()) -- the
+    // accessible description and the visible chip can never drift apart.
+    const QString colorStateDescription = colorChipStateFor(preview).text;
     setAccessibleDescription(
         tr("%1. %2. %3").arg(preview.message, frameDescription, colorStateDescription));
 }
@@ -363,8 +723,19 @@ std::optional<PositionInteractionMapping> ViewerEditor::currentMapping() const {
         return std::nullopt;
     }
     const auto descriptor = *descriptorResult.value();
-    const QRectF displayRect = fitDisplayRect(
-        viewerFrame(*this), descriptor.displayWindow().extent(), descriptor.pixelAspect());
+    // THE SEAM (task U3, decision 2): the frozen mapping rectangle used to be ALWAYS
+    // fitDisplayRect() -- the fit-to-window rectangle, regardless of any zoom/pan. It is now
+    // viewTransformedDisplayRect(), which composes the SAME fit rectangle when transform_ is in
+    // Fit mode, or the actively zoomed/panned rectangle otherwise -- so a drag begun at zoom 200%
+    // and a pan offset maps screen deltas against the geometry the user actually SEES, and lands
+    // exactly under the cursor. Freeze semantics are unchanged: this is still computed once here,
+    // handed to CompositionSession::beginPositionInteraction(), and frozen there for the gesture's
+    // duration; PositionInteractionMapping's own equality (already comparing displayRect) is what
+    // makes mappingStillValid() correctly invalidate a gesture if transform_ changes mid-drag, with
+    // zero additional invalidation code needed (mousePressEvent()/wheelEvent() additionally refuse
+    // to start a NEW zoom/pan while dragActive_, so this only matters as a defensive backstop).
+    const QRectF displayRect = viewTransformedDisplayRect(
+        canvasRect(), descriptor.displayWindow().extent(), descriptor.pixelAspect(), transform_);
     if (displayRect.isEmpty()) {
         return std::nullopt;
     }
@@ -398,7 +769,51 @@ void ViewerEditor::endDrag(const bool commit) {
     previewController_.notifyScrubEnded();
 }
 
+void ViewerEditor::beginPan(const Qt::MouseButton button, const QPointF screenPoint,
+                            const DisplayGeometry& geometry) {
+    panActive_ = true;
+    panButton_ = button;
+    panOrigin_ = screenPoint;
+    const QRectF frame = canvasRect();
+    if (transform_.fitToWindow) {
+        // Materializes the Fit-implied zoom into an equivalent Custom transform before panning:
+        // Fit recomputes its rectangle from `frame` every call and has no stored zoom/pan to
+        // accumulate onto, so panning while Fit means "start being Custom, at the zoom Fit
+        // currently shows, with zero pan" -- an exact reproduction of the same rectangle (see
+        // viewTransformedDisplayRect()'s own centering, identical to fitDisplayRect()'s).
+        const QRectF fitted = fitDisplayRect(frame, geometry.extent, geometry.pixelAspect);
+        const QRectF actual = actualPixelRect(frame, geometry.extent, geometry.pixelAspect);
+        const double zoom = actual.width() > 0.0 ? fitted.width() / actual.width() : 1.0;
+        panBaseTransform_ = ViewTransform{.fitToWindow = false, .zoom = zoom, .pan = {0.0, 0.0}};
+    } else {
+        panBaseTransform_ = transform_;
+    }
+    setFocus(Qt::MouseFocusReason);
+    updatePanCursor();
+}
+
+void ViewerEditor::updatePanCursor() {
+    if (panActive_) {
+        setCursor(Qt::ClosedHandCursor);
+    } else if (spaceHeld_) {
+        setCursor(Qt::OpenHandCursor);
+    } else {
+        unsetCursor();
+    }
+}
+
 void ViewerEditor::mousePressEvent(QMouseEvent* event) {
+    if (!dragActive_ && !panActive_) {
+        if (const auto geometry = currentDisplayGeometry();
+            geometry.has_value() &&
+            (event->button() == Qt::MiddleButton ||
+             (event->button() == Qt::LeftButton && spaceHeld_))) {
+            beginPan(event->button(), event->position(), *geometry);
+            event->accept();
+            return;
+        }
+    }
+
     if (event->button() != Qt::LeftButton ||
         !std::holds_alternative<document::LayerId>(session_.selection().primary)) {
         QWidget::mousePressEvent(event);
@@ -425,6 +840,14 @@ void ViewerEditor::mousePressEvent(QMouseEvent* event) {
 }
 
 void ViewerEditor::mouseMoveEvent(QMouseEvent* event) {
+    if (panActive_) {
+        transform_ = panBaseTransform_;
+        transform_.pan += (event->position() - panOrigin_);
+        refreshZoomDropdown();
+        update();
+        event->accept();
+        return;
+    }
     if (!dragActive_) {
         QWidget::mouseMoveEvent(event);
         return;
@@ -443,11 +866,37 @@ void ViewerEditor::mouseMoveEvent(QMouseEvent* event) {
 }
 
 void ViewerEditor::mouseReleaseEvent(QMouseEvent* event) {
+    if (panActive_ && event->button() == panButton_) {
+        panActive_ = false;
+        panButton_ = Qt::NoButton;
+        updatePanCursor();
+        event->accept();
+        return;
+    }
     if (!dragActive_ || event->button() != Qt::LeftButton) {
         QWidget::mouseReleaseEvent(event);
         return;
     }
     endDrag(true);
+    event->accept();
+}
+
+void ViewerEditor::wheelEvent(QWheelEvent* event) {
+    if (dragActive_ || panActive_) {
+        event->ignore();
+        return;
+    }
+    const auto geometry = currentDisplayGeometry();
+    const int notches = event->angleDelta().y() / 120;
+    if (!geometry.has_value() || notches == 0) {
+        QWidget::wheelEvent(event);
+        return;
+    }
+    const double factor = std::pow(kZoomStepFactor, notches);
+    transform_ = zoomAboutPoint(transform_, canvasRect(), geometry->extent, geometry->pixelAspect,
+                                event->position(), factor);
+    refreshZoomDropdown();
+    update();
     event->accept();
 }
 
@@ -457,7 +906,37 @@ void ViewerEditor::keyPressEvent(QKeyEvent* event) {
         event->accept();
         return;
     }
+    if (!dragActive_ && !panActive_) {
+        if (!event->isAutoRepeat() && event->key() == Qt::Key_Space) {
+            spaceHeld_ = true;
+            updatePanCursor();
+            event->accept();
+            return;
+        }
+        // Two ways to reach 100%: this key, or the "100%" context-menu/zoom-dropdown item
+        // (decision 2/4).
+        if (event->key() == Qt::Key_Z) {
+            setZoomActualSize();
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_F) {
+            setZoomFit();
+            event->accept();
+            return;
+        }
+    }
     QWidget::keyPressEvent(event);
+}
+
+void ViewerEditor::keyReleaseEvent(QKeyEvent* event) {
+    if (!event->isAutoRepeat() && event->key() == Qt::Key_Space) {
+        spaceHeld_ = false;
+        updatePanCursor();
+        event->accept();
+        return;
+    }
+    QWidget::keyReleaseEvent(event);
 }
 
 void ViewerEditor::resizeEvent(QResizeEvent* event) {
@@ -465,6 +944,49 @@ void ViewerEditor::resizeEvent(QResizeEvent* event) {
     if (dragActive_) {
         endDrag(false);
     }
+    if (panActive_) {
+        panActive_ = false;
+        panButton_ = Qt::NoButton;
+        updatePanCursor();
+    }
+    layoutStatusBar();
+}
+
+void ViewerEditor::contextMenuEvent(QContextMenuEvent* event) {
+    // Kit-styled via the application-wide QMenu stylesheet rule every other Bloom context/popup
+    // menu already picks up (e.g. TimelineEditor's "Add Layer" menu, composition_editors.cpp) --
+    // no per-menu styling code needed here. Honest, placeholder-free set only (decision 4): no
+    // RAM-preview/channel/quality slots, which do not exist yet.
+    QMenu menu(this);
+    QAction* fitAction = menu.addAction(tr("Fit"));
+    QAction* actualSizeAction = menu.addAction(tr("100%"));
+    menu.addSeparator();
+    QAction* zoomInAction = menu.addAction(tr("Zoom In"));
+    QAction* zoomOutAction = menu.addAction(tr("Zoom Out"));
+    const bool canZoom = currentDisplayGeometry().has_value();
+    zoomInAction->setEnabled(canZoom);
+    zoomOutAction->setEnabled(canZoom);
+    connect(fitAction, &QAction::triggered, this, &ViewerEditor::setZoomFit);
+    connect(actualSizeAction, &QAction::triggered, this, &ViewerEditor::setZoomActualSize);
+    connect(zoomInAction, &QAction::triggered, this, [this] {
+        if (const auto geometry = currentDisplayGeometry(); geometry.has_value()) {
+            const QRectF frame = canvasRect();
+            transform_ = zoomAboutPoint(transform_, frame, geometry->extent, geometry->pixelAspect,
+                                        frame.center(), kZoomStepFactor);
+            refreshZoomDropdown();
+            update();
+        }
+    });
+    connect(zoomOutAction, &QAction::triggered, this, [this] {
+        if (const auto geometry = currentDisplayGeometry(); geometry.has_value()) {
+            const QRectF frame = canvasRect();
+            transform_ = zoomAboutPoint(transform_, frame, geometry->extent, geometry->pixelAspect,
+                                        frame.center(), 1.0 / kZoomStepFactor);
+            refreshZoomDropdown();
+            update();
+        }
+    });
+    menu.exec(event->globalPos());
 }
 
 } // namespace bloom::ui


### PR DESCRIPTION
The Viewer slice of #116 — presentation, navigation, and honest status on the panel both personas live in:

- **Presents as Viewer** (renamed from Compositor), full-bleed: the frame sits drop-shadowed on an edge-to-edge checkerboard with no inset or title row.
- **Zoom and pan done right**: a view transform (1/16×–16×) with exact zoom-about-cursor algebra (the document point under the cursor is provably fixed across steps), wheel/space-drag/middle-drag gestures, Z/F and context-menu paths to 100%/Fit — and the direct-manipulation frozen-mapping seam recomposed so gestures land exactly under the cursor at any transform, pinned by document-space assertions at 200% zoom plus pan with a differential proof against the old fit-only geometry. Existing mapping invalidation covered the transform change with zero new session logic.
- **Status bar**: zoom dropdown, exact frame + timecode readout in the mono value face (3-decimal truncation, integer arithmetic — a subframe never overstates), and the color-state chip — the qualified/unqualified contract label relocated from the old top row, its visibility pinned by adapted tests.
- **Honest empty states**: no composition invites creation; pending shows only the subtle chip; typed failure banners unchanged.
- Disclosed judgment calls: manual token-shadow composition inside the paint path, the Z-key semantics reading, and two kit API gaps recorded for the backlog (dropdown item mutation, a shared home for the exact-seconds formatter).

Desktop 115/115 and native 88/88, format check clean.

Closes #119.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.