### PR TITLE
feat: lay out properties as a Kinetik field grid

### DIFF
--- a/src/ui/composition_editors.cpp
+++ b/src/ui/composition_editors.cpp
@@ -4,7 +4,13 @@
 #include <bloom/ui/timeline_frame_math.hpp>
 #include <bloom/ui/timeline_ruler.hpp>
 
+#include <bloom/ui/kit/icons.hpp>
+#include <bloom/ui/kit/painting.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/kit/value_field.hpp>
+
 #include <bloom/core/color.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
 #include <bloom/core/rational_time.hpp>
 #include <bloom/document/composition_settings.hpp>
 #include <bloom/document/graph.hpp>
@@ -14,14 +20,16 @@
 #include <QAbstractItemView>
 #include <QAction>
 #include <QApplication>
-#include <QDoubleSpinBox>
-#include <QFormLayout>
+#include <QEnterEvent>
+#include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QKeySequence>
 #include <QLabel>
 #include <QListWidget>
 #include <QMenu>
+#include <QPainter>
+#include <QPalette>
 #include <QSignalBlocker>
 #include <QToolButton>
 #include <QTreeWidget>
@@ -32,6 +40,7 @@
 #include <array>
 #include <charconv>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <optional>
@@ -249,6 +258,213 @@ frameContextFor(const CompositionSession& session) {
         .arg(scaledFraction, kDecimalPlaces, 10, QChar('0'));
 }
 
+// Issue #120 (task U5), decisions 1/2: the properties panel's kit field grid. A row is
+// [right-aligned Muted label][optional gold/dimmed Keyframe indicator][value widget], and every
+// row lives inside a PropertiesRow so hovering anywhere across the row -- label, indicator, or
+// value -- paints the SAME States-recipe highlight (docs/ux/visual-language.md, "State": "Hover:
+// one surface step up, plus BorderHover"). Qt delivers Enter/Leave to the common ancestor of the
+// previously- and newly-hovered leaf widgets only when that ancestor's OWN membership in the
+// "currently entered" chain changes, so moving the pointer between a row's own label and its value
+// cell never toggles this row's hover off: the row is entered once and left once, exactly as a
+// single hoverable unit.
+class PropertiesRow final : public QWidget {
+  public:
+    explicit PropertiesRow(QWidget* parent) : QWidget(parent) {
+        setObjectName(QStringLiteral("propertiesRow"));
+        setMinimumHeight(kit::px(kit::Size::Control));
+    }
+
+  protected:
+    void enterEvent(QEnterEvent* event) override {
+        hovered_ = true;
+        update();
+        QWidget::enterEvent(event);
+    }
+
+    void leaveEvent(QEvent* event) override {
+        hovered_ = false;
+        update();
+        QWidget::leaveEvent(event);
+    }
+
+    void paintEvent(QPaintEvent* event) override {
+        Q_UNUSED(event)
+        if (!hovered_) {
+            return;
+        }
+        QPainter painter(this);
+        // The panel itself paints no surface of its own (PropertiesEditor sits directly on the
+        // editor area's Background), so the row's resting surface for the recipe is Background --
+        // hover steps it to Surface, exactly one step up the ladder.
+        kit::fillRoundedSurface(
+            painter, rect(),
+            kit::color(kit::surfaceForState(kit::Color::Background, kit::State::Hover)),
+            kit::color(kit::borderForState(kit::State::Hover)), kit::Radius::Small);
+    }
+
+  private:
+    bool hovered_ = false;
+};
+
+// The fixed right-aligned label column every row in the panel shares (decision 1), sized once from
+// the widest label this panel can ever show rather than a spelled pixel width -- KValueField's own
+// internal sub-label column (kLabelColumnWidth in value_field.cpp) is private to that widget and
+// exists for a narrower purpose (a field-local "X"/"Y" prefix inside the cell itself), so the row's
+// OUTER label column, which names the whole parameter, is measured independently here.
+int propertyLabelColumnWidth() {
+    static const std::array<QString, 10> kLabels{
+        PropertiesEditor::tr("Position"), PropertiesEditor::tr("Opacity"),
+        PropertiesEditor::tr("RGBA"),     PropertiesEditor::tr("Alpha"),
+        PropertiesEditor::tr("Encoding"), PropertiesEditor::tr("Name"),
+        PropertiesEditor::tr("Format"),   PropertiesEditor::tr("Frame Rate"),
+        PropertiesEditor::tr("Duration"), PropertiesEditor::tr("Pixel Aspect"),
+    };
+    const QFontMetrics metrics(kit::font(kit::TypeRole::Ui));
+    int widest = 0;
+    for (const auto& label : kLabels) {
+        widest = std::max(widest, metrics.horizontalAdvance(label));
+    }
+    return widest;
+}
+
+QLabel* makePropertyRowLabel(const QString& text, const int columnWidth, QWidget* parent) {
+    auto* label = new QLabel(text, parent);
+    label->setObjectName(QStringLiteral("propertiesRowLabel"));
+    label->setFont(kit::font(kit::TypeRole::Ui));
+    QPalette palette = label->palette();
+    palette.setColor(QPalette::WindowText, kit::color(kit::Color::Muted));
+    label->setPalette(palette);
+    label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    label->setFixedWidth(columnWidth);
+    return label;
+}
+
+QLabel* makeKeyframeIndicator(QWidget* parent) {
+    auto* indicator = new QLabel(parent);
+    indicator->setObjectName(QStringLiteral("propertiesKeyframeIndicator"));
+    indicator->setFixedSize(kit::px(kit::Size::IconSmall), kit::px(kit::Size::IconSmall));
+    return indicator;
+}
+
+// A read-only value cell's text: `role` is Value (Geist Mono) for numeric-looking content --
+// RGBA, format, frame rate, duration, pixel aspect -- and Ui for prose -- the alpha association
+// sentence, the composition name. None of these are editable through the current session API
+// (issue #120, decision 1's read-only carve-out: "do not add editing capability that doesn't
+// exist today"), so they stay plain selectable text rather than kit::KValueField, which has no way
+// to carry a string and would otherwise misrepresent them as steppable controls.
+QLabel* makeReadOnlyValueLabel(const kit::TypeRole role, QWidget* parent) {
+    auto* label = new QLabel(parent);
+    label->setFont(kit::font(role));
+    QPalette palette = label->palette();
+    palette.setColor(QPalette::WindowText, kit::color(kit::Color::Foreground));
+    label->setPalette(palette);
+    label->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+    return label;
+}
+
+// Wraps `label` (+ optional `indicator`) and `value` in one PropertiesRow, added to `section`'s
+// layout. `section` also parents label/indicator/value at construction, but QBoxLayout::addWidget
+// below reparents each into the row -- the same "construct with `this`, let the layout reparent"
+// idiom the rest of this file already uses for its form rows.
+PropertiesRow* addPropertyRow(QVBoxLayout* section, QWidget* sectionParent, QLabel* label,
+                              QLabel* indicator, QWidget* value) {
+    auto* row = new PropertiesRow(sectionParent);
+    auto* layout = new QHBoxLayout(row);
+    layout->setContentsMargins(kit::px(kit::Spacing::XS), kit::px(kit::Spacing::XXS),
+                               kit::px(kit::Spacing::XS), kit::px(kit::Spacing::XXS));
+    layout->setSpacing(kit::px(kit::Spacing::S));
+    layout->addWidget(label);
+    if (indicator != nullptr) {
+        layout->addWidget(indicator);
+    }
+    layout->addWidget(value, 1);
+    section->addWidget(row);
+    return row;
+}
+
+// A UISmall uppercase group header (decision 1: "Transform", "Appearance", a source-specific
+// group) plus its hairline divider (decision 1: "section dividers as hairlines"), appended to
+// `section`.
+void addSectionHeader(QVBoxLayout* section, QWidget* parent, const QString& title) {
+    // "editorSectionTitle" already names TimelineEditor's "Layers" title and MediaEditor's
+    // "Project" title (unchanged by this task): reused here rather than a new name so every group
+    // header in the workspace -- Transform/Appearance/Solid Source included -- is the same logical
+    // widget kind, per decision 4's "existing objectNames preserved."
+    auto* header = new QLabel(title.toUpper(), parent);
+    header->setObjectName(QStringLiteral("editorSectionTitle"));
+    header->setFont(kit::font(kit::TypeRole::UiSmall));
+    QPalette headerPalette = header->palette();
+    headerPalette.setColor(QPalette::WindowText, kit::color(kit::Color::Muted));
+    header->setPalette(headerPalette);
+    section->addWidget(header);
+
+    auto* divider = new QWidget(parent);
+    divider->setObjectName(QStringLiteral("propertiesSectionDivider"));
+    divider->setFixedHeight(static_cast<int>(std::lround(kit::kHairlineWidth)));
+    QPalette dividerPalette = divider->palette();
+    dividerPalette.setColor(QPalette::Window, kit::color(kit::Color::Border));
+    divider->setPalette(dividerPalette);
+    divider->setAutoFillBackground(true);
+    section->addWidget(divider);
+}
+
+// True when `parameter` carries an animation curve source (issue #120, decision 2: "truth from
+// the session snapshot, no new session API") -- the same std::holds_alternative check
+// sourceDescription() above already uses to report "Animated", read directly rather than by
+// string-comparing that tooltip text.
+bool isAnimatedParameter(const document::ParameterRecord* parameter) {
+    return parameter != nullptr &&
+           std::holds_alternative<document::AnimationCurveSource>(parameter->source);
+}
+
+// Paints `indicator` gold-filled when `parameter` is animation-sourced, Muted-dimmed-outline
+// otherwise (decision 2). The dim opacity reuses tokens::kDisabledOpacity rather than a new
+// literal: "dimmed" and "disabled ink" are the same fade recipe applied to a different ink. The
+// weight switch follows docs/ux/visual-language.md's own iconography rule verbatim ("regular is
+// the default visual weight and fill for selected or toggled states"): an animated parameter is
+// this indicator's "on" state, so it takes the solid diamond-fill glyph rather than the outline
+// one static rows show.
+void updateKeyframeIndicator(QLabel* indicator, const document::ParameterRecord* parameter) {
+    const bool animated = isAnimatedParameter(parameter);
+    const QColor tint =
+        animated ? kit::color(kit::Color::Keyframe)
+                 : kit::withOpacity(kit::color(kit::Color::Muted), kit::kDisabledOpacity);
+    const auto weight = animated ? kit::IconWeight::Fill : kit::IconWeight::Regular;
+    indicator->setPixmap(
+        kit::iconPixmap(kit::IconId::Keyframe, kit::Size::IconSmall, tint, 0.0, weight));
+    indicator->setToolTip(animated ? PropertiesEditor::tr("Animated")
+                                   : PropertiesEditor::tr("Static"));
+}
+
+// Frame rate as an exact rational (decision 3: "exact rational shown honestly"): numerator and
+// denominator are exact std::uint32_t, so this never rounds -- it only omits the denominator when
+// it is exactly 1 (the common whole-fps case) rather than always spelling "24/1 fps".
+QString formatFrameRate(const document::FrameRate rate) {
+    if (rate.denominator() == 1) {
+        return PropertiesEditor::tr("%1 fps").arg(rate.numerator());
+    }
+    return PropertiesEditor::tr("%1/%2 fps").arg(rate.numerator()).arg(rate.denominator());
+}
+
+QString formatPixelAspect(const core::PixelAspectRatio pixelAspect) {
+    return QStringLiteral("%1:%2").arg(pixelAspect.numerator()).arg(pixelAspect.denominator());
+}
+
+QString formatCompositionFormat(const document::CompositionFormat format) {
+    return PropertiesEditor::tr("%1 × %2 px").arg(format.width()).arg(format.height());
+}
+
+// Duration as frame count + exact seconds (decision 3: "duration (frames + seconds via the exact
+// formatting rule)"), reusing formatExactSeconds() above verbatim -- the SAME truncated-rational
+// formatter TimelineEditor::updateTimeReadout() uses for the current-time readout, rather than a
+// second, possibly-inconsistent formatting rule for duration. Frame count is maxFrameIndex + 1
+// (the greatest valid index is 0-based).
+QString formatDuration(const TimelineFrameContext& context) {
+    return PropertiesEditor::tr("%1 frames · %2")
+        .arg(context.maxFrameIndexValue + 1)
+        .arg(formatExactSeconds(context.duration));
+}
+
 } // namespace
 
 TimelineEditor::TimelineEditor(CompositionSession& session,
@@ -368,10 +584,16 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
 
     // Frame-stepping shortcuts (issue #108, decisions 1/2), mirroring playPauseAction's own
     // WindowShortcut idiom exactly (same setObjectName/setShortcut/setShortcutContext/addAction
-    // shape, same reliance on Qt's ShortcutOverride mechanism to let a focused text-entry widget --
-    // e.g. PropertiesEditor's QDoubleSpinBox editors, verified with a standalone Qt harness to
-    // accept ShortcutOverride for Left/Right/Home/End exactly like QLineEdit does -- win over these
-    // shortcuts without any bespoke check here).
+    // shape, same reliance on Qt's ShortcutOverride mechanism to let a focused text-entry widget
+    // win over these shortcuts without any bespoke check here). This relied on PropertiesEditor's
+    // Position X/Y editors being QDoubleSpinBox, whose embedded QLineEdit accepts ShortcutOverride
+    // for Left/Right/Home/End. Issue #120 (task U5) replaced those editors with
+    // kit::KValueField, which has no line edit and does NOT accept ShortcutOverride for those
+    // keys -- so Left/Right/Home/End typed while a Position field has focus now ALSO fires these
+    // WindowShortcut actions, unlike before. Task U5's own fence forbids touching TimelineEditor
+    // beyond what shared code forces, so this is flagged in that task's raw report rather than
+    // fixed here; the fix belongs to whoever next owns either kit::KValueField's key handling or
+    // this focusChanged reconciliation below.
     stepBackwardAction_ = new QAction(tr("Step Back One Frame"), this);
     stepBackwardAction_->setObjectName("stepBackwardAction");
     stepBackwardAction_->setShortcut(QKeySequence(Qt::Key_Left));
@@ -412,8 +634,11 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     // action fires otherwise. Implemented by disabling these four actions outright while layers_
     // holds keyboard focus -- a disabled QAction never claims ShortcutOverride, so the key event
     // reaches layers_ and its native navigation runs completely unchanged; every other focus
-    // location (including no focus, the ruler, the keyframe panel, or a QDoubleSpinBox that itself
-    // already wins via ShortcutOverride) leaves the actions enabled and the step fires.
+    // location (including no focus, the ruler, and the keyframe panel) leaves the actions enabled
+    // and the step fires. That "every other focus location" list no longer includes
+    // PropertiesEditor's Position X/Y fields without a side effect -- see the stepBackwardAction_
+    // construction comment above (issue #120, task U5): kit::KValueField does not win
+    // Left/Right/Home/End via ShortcutOverride the way the QDoubleSpinBox it replaced did.
     connect(qApp, &QApplication::focusChanged, this, [this](QWidget*, QWidget* now) {
         const bool layersFocused = (now == layers_);
         stepBackwardAction_->setEnabled(!layersFocused);
@@ -619,97 +844,171 @@ PropertiesEditor::PropertiesEditor(CompositionSession& session, QWidget* parent)
     setAccessibleName(tr("Properties editor"));
 
     auto* layout = new QVBoxLayout(this);
-    layout->setContentsMargins(12, 10, 12, 12);
-    layout->setSpacing(10);
+    layout->setContentsMargins(kit::px(kit::Spacing::M), kit::px(kit::Spacing::M),
+                               kit::px(kit::Spacing::M), kit::px(kit::Spacing::M));
+    layout->setSpacing(kit::px(kit::Spacing::S));
 
     selectionLabel_ = new QLabel(this);
     selectionLabel_->setObjectName("propertiesSelectionTitle");
     selectionLabel_->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(selectionLabel_);
 
-    auto* transformForm = new QFormLayout;
-    transformForm->setContentsMargins(0, 0, 0, 0);
-    transformForm->setHorizontalSpacing(10);
-    transformForm->setVerticalSpacing(7);
+    // Issue #120 (task U5), decision 1: the kit field grid. Every row's label lives in ONE fixed,
+    // right-aligned column shared across the whole panel -- Transform, Appearance, the
+    // source-specific group, and the no-selection Composition group alike -- computed once from
+    // the widest label text this panel can ever show (propertyLabelColumnWidth() above), not from
+    // a spelled pixel width.
+    const int labelColumnWidth = propertyLabelColumnWidth();
 
-    positionX_ = new QDoubleSpinBox(this);
-    positionY_ = new QDoubleSpinBox(this);
-    opacity_ = new QDoubleSpinBox(this);
-    for (auto* editor : {positionX_, positionY_}) {
-        editor->setRange(-1'000'000.0, 1'000'000.0);
-        editor->setDecimals(2);
-        editor->setSingleStep(1.0);
+    // --- Selection-driven groups (Transform / Appearance / source-specific) --------------------
+    selectionSection_ = new QWidget(this);
+    selectionSection_->setObjectName(QStringLiteral("propertiesSelectionSection"));
+    auto* selectionLayout = new QVBoxLayout(selectionSection_);
+    selectionLayout->setContentsMargins(0, 0, 0, 0);
+    selectionLayout->setSpacing(kit::px(kit::Spacing::XS));
+
+    addSectionHeader(selectionLayout, selectionSection_, tr("Transform"));
+
+    positionX_ = new kit::KValueField(selectionSection_);
+    positionY_ = new kit::KValueField(selectionSection_);
+    for (auto* field : {positionX_, positionY_}) {
+        field->setRange(-1'000'000.0, 1'000'000.0);
+        field->setDecimals(2);
+        field->setSingleStep(1.0);
+        field->setUnit(QStringLiteral("px"));
     }
     positionX_->setObjectName("positionXEditor");
     positionX_->setAccessibleName(tr("Position X"));
+    positionX_->setLabel(QStringLiteral("X"));
     positionY_->setObjectName("positionYEditor");
     positionY_->setAccessibleName(tr("Position Y"));
+    positionY_->setLabel(QStringLiteral("Y"));
+
+    auto* positionFields = new QWidget(selectionSection_);
+    positionFields->setObjectName(QStringLiteral("positionFieldGroup"));
+    auto* positionFieldsLayout = new QHBoxLayout(positionFields);
+    positionFieldsLayout->setContentsMargins(0, 0, 0, 0);
+    positionFieldsLayout->setSpacing(kit::px(kit::Spacing::S));
+    positionFieldsLayout->addWidget(positionX_);
+    positionFieldsLayout->addWidget(positionY_);
+
+    positionKeyframe_ = makeKeyframeIndicator(selectionSection_);
+    addPropertyRow(selectionLayout, selectionSection_,
+                   makePropertyRowLabel(tr("Position"), labelColumnWidth, selectionSection_),
+                   positionKeyframe_, positionFields);
+
+    addSectionHeader(selectionLayout, selectionSection_, tr("Appearance"));
+
+    opacity_ = new kit::KValueField(selectionSection_);
     opacity_->setObjectName("opacityEditor");
     opacity_->setAccessibleName(tr("Opacity"));
     opacity_->setRange(0.0, 100.0);
     opacity_->setDecimals(1);
     opacity_->setSingleStep(1.0);
-    opacity_->setSuffix(QStringLiteral(" %"));
+    opacity_->setUnit(QStringLiteral("%"));
 
-    auto* position = new QWidget(this);
-    auto* positionLayout = new QHBoxLayout(position);
-    positionLayout->setContentsMargins(0, 0, 0, 0);
-    positionLayout->setSpacing(5);
-    positionLayout->addWidget(new QLabel(QStringLiteral("X"), position));
-    positionLayout->addWidget(positionX_);
-    positionLayout->addWidget(new QLabel(QStringLiteral("Y"), position));
-    positionLayout->addWidget(positionY_);
+    opacityKeyframe_ = makeKeyframeIndicator(selectionSection_);
+    addPropertyRow(selectionLayout, selectionSection_,
+                   makePropertyRowLabel(tr("Opacity"), labelColumnWidth, selectionSection_),
+                   opacityKeyframe_, opacity_);
 
-    transformForm->addRow(tr("Position"), position);
-    transformForm->addRow(tr("Opacity"), opacity_);
-    layout->addLayout(transformForm);
-
-    solidColorPanel_ = new QWidget(this);
+    solidColorPanel_ = new QWidget(selectionSection_);
     solidColorPanel_->setObjectName("solidColorProperties");
     auto* solidColorLayout = new QVBoxLayout(solidColorPanel_);
-    solidColorLayout->setContentsMargins(0, 4, 0, 0);
-    solidColorLayout->setSpacing(7);
-    auto* solidColorTitle = new QLabel(tr("Solid Source"), solidColorPanel_);
-    solidColorTitle->setObjectName("editorSectionTitle");
-    solidColorLayout->addWidget(solidColorTitle);
+    solidColorLayout->setContentsMargins(0, 0, 0, 0);
+    solidColorLayout->setSpacing(kit::px(kit::Spacing::XS));
+    addSectionHeader(solidColorLayout, solidColorPanel_, tr("Solid Source"));
 
-    auto* solidColorForm = new QFormLayout;
-    solidColorForm->setContentsMargins(0, 0, 0, 0);
-    solidColorForm->setHorizontalSpacing(10);
-    solidColorForm->setVerticalSpacing(7);
-    solidColorValue_ = new QLabel(solidColorPanel_);
+    solidColorValue_ = makeReadOnlyValueLabel(kit::TypeRole::Value, solidColorPanel_);
     solidColorValue_->setObjectName("solidColorValue");
     solidColorValue_->setAccessibleName(tr("Solid RGBA value"));
-    solidColorValue_->setTextInteractionFlags(Qt::TextSelectableByMouse |
-                                              Qt::TextSelectableByKeyboard);
     solidColorValue_->setWordWrap(true);
-    solidAlphaAssociation_ = new QLabel(solidColorPanel_);
+    solidColorKeyframe_ = makeKeyframeIndicator(solidColorPanel_);
+    addPropertyRow(solidColorLayout, solidColorPanel_,
+                   makePropertyRowLabel(tr("RGBA"), labelColumnWidth, solidColorPanel_),
+                   solidColorKeyframe_, solidColorValue_);
+
+    solidAlphaAssociation_ = makeReadOnlyValueLabel(kit::TypeRole::Ui, solidColorPanel_);
     solidAlphaAssociation_->setObjectName("solidAlphaAssociation");
     solidAlphaAssociation_->setAccessibleName(tr("Solid alpha association"));
-    solidAlphaAssociation_->setTextInteractionFlags(Qt::TextSelectableByMouse |
-                                                    Qt::TextSelectableByKeyboard);
-    solidColorEncoding_ = new QLabel(solidColorPanel_);
+    addPropertyRow(solidColorLayout, solidColorPanel_,
+                   makePropertyRowLabel(tr("Alpha"), labelColumnWidth, solidColorPanel_), nullptr,
+                   solidAlphaAssociation_);
+
+    solidColorEncoding_ = makeReadOnlyValueLabel(kit::TypeRole::Ui, solidColorPanel_);
     solidColorEncoding_->setObjectName("solidColorEncoding");
     solidColorEncoding_->setAccessibleName(tr("Solid color encoding"));
-    solidColorEncoding_->setTextInteractionFlags(Qt::TextSelectableByMouse |
-                                                 Qt::TextSelectableByKeyboard);
-    solidColorForm->addRow(tr("RGBA"), solidColorValue_);
-    solidColorForm->addRow(tr("Alpha"), solidAlphaAssociation_);
-    solidColorForm->addRow(tr("Encoding"), solidColorEncoding_);
-    solidColorLayout->addLayout(solidColorForm);
-    layout->addWidget(solidColorPanel_);
-    layout->addStretch(1);
+    addPropertyRow(solidColorLayout, solidColorPanel_,
+                   makePropertyRowLabel(tr("Encoding"), labelColumnWidth, solidColorPanel_),
+                   nullptr, solidColorEncoding_);
+
+    selectionLayout->addWidget(solidColorPanel_);
+    selectionLayout->addStretch(1);
+    layout->addWidget(selectionSection_);
+
+    // --- No-selection document/composition view (decision 3) ----------------------------------
+    documentSection_ = new QWidget(this);
+    documentSection_->setObjectName(QStringLiteral("propertiesDocumentSection"));
+    auto* documentLayout = new QVBoxLayout(documentSection_);
+    documentLayout->setContentsMargins(0, 0, 0, 0);
+    documentLayout->setSpacing(kit::px(kit::Spacing::XS));
+    addSectionHeader(documentLayout, documentSection_, tr("Composition"));
+
+    documentName_ = makeReadOnlyValueLabel(kit::TypeRole::Ui, documentSection_);
+    documentName_->setObjectName(QStringLiteral("documentName"));
+    documentName_->setAccessibleName(tr("Composition name"));
+    addPropertyRow(documentLayout, documentSection_,
+                   makePropertyRowLabel(tr("Name"), labelColumnWidth, documentSection_), nullptr,
+                   documentName_);
+
+    documentFormat_ = makeReadOnlyValueLabel(kit::TypeRole::Value, documentSection_);
+    documentFormat_->setObjectName(QStringLiteral("documentFormat"));
+    documentFormat_->setAccessibleName(tr("Composition format"));
+    addPropertyRow(documentLayout, documentSection_,
+                   makePropertyRowLabel(tr("Format"), labelColumnWidth, documentSection_), nullptr,
+                   documentFormat_);
+
+    documentFrameRate_ = makeReadOnlyValueLabel(kit::TypeRole::Value, documentSection_);
+    documentFrameRate_->setObjectName(QStringLiteral("documentFrameRate"));
+    documentFrameRate_->setAccessibleName(tr("Composition frame rate"));
+    addPropertyRow(documentLayout, documentSection_,
+                   makePropertyRowLabel(tr("Frame Rate"), labelColumnWidth, documentSection_),
+                   nullptr, documentFrameRate_);
+
+    documentDuration_ = makeReadOnlyValueLabel(kit::TypeRole::Value, documentSection_);
+    documentDuration_->setObjectName(QStringLiteral("documentDuration"));
+    documentDuration_->setAccessibleName(tr("Composition duration"));
+    addPropertyRow(documentLayout, documentSection_,
+                   makePropertyRowLabel(tr("Duration"), labelColumnWidth, documentSection_),
+                   nullptr, documentDuration_);
+
+    documentPixelAspect_ = makeReadOnlyValueLabel(kit::TypeRole::Value, documentSection_);
+    documentPixelAspect_->setObjectName(QStringLiteral("documentPixelAspect"));
+    documentPixelAspect_->setAccessibleName(tr("Composition pixel aspect ratio"));
+    addPropertyRow(documentLayout, documentSection_,
+                   makePropertyRowLabel(tr("Pixel Aspect"), labelColumnWidth, documentSection_),
+                   nullptr, documentPixelAspect_);
+
+    // Color settings (process space + config name) are read from ProjectSession, not from
+    // anything CompositionSession exposes (src/host/include/bloom/host/project_session.hpp) --
+    // document::Composition/Snapshot carry no ColorSettings at all (verified: grep finds
+    // ColorSettings only under src/host and src/project, never src/document). Per decision 3 ("if
+    // a listed fact is not reachable via existing read-only API, omit it and report rather than
+    // adding API"), the color settings summary row is omitted here; see this task's raw report.
+
+    documentLayout->addStretch(1);
+    layout->addWidget(documentSection_);
 
     const auto commitPosition = [this] {
         if (!rebuilding_) {
             (void)session_.setSelectedPosition(positionX_->value(), positionY_->value());
         }
     };
-    connect(positionX_, &QDoubleSpinBox::editingFinished, this, commitPosition);
-    connect(positionY_, &QDoubleSpinBox::editingFinished, this, commitPosition);
-    connect(opacity_, &QDoubleSpinBox::editingFinished, this, [this] {
+    connect(positionX_, &kit::KValueField::valueChanged, this, commitPosition);
+    connect(positionY_, &kit::KValueField::valueChanged, this, commitPosition);
+    connect(opacity_, &kit::KValueField::valueChanged, this, [this](const double value) {
         if (!rebuilding_) {
-            (void)session_.setSelectedOpacity(opacity_->value() / 100.0);
+            (void)session_.setSelectedOpacity(value / 100.0);
         }
     });
     connect(&session_, &CompositionSession::snapshotChanged, this, &PropertiesEditor::rebuild);
@@ -723,6 +1022,14 @@ void PropertiesEditor::rebuild() {
     rebuilding_ = true;
     selectionLabel_->setText(selectionName(session_));
 
+    configurePosition();
+    configureOpacity();
+    configureSolidColor();
+    configureDocumentProperties();
+    rebuilding_ = false;
+}
+
+void PropertiesEditor::configurePosition() {
     const auto* position = session_.parameterForSelection(document::kPositionParameterRole);
     const auto positionValue =
         position == nullptr ? std::nullopt : session_.constantVec2Value(position->id);
@@ -740,10 +1047,7 @@ void PropertiesEditor::rebuild() {
                                     : sourceDescription(*position);
     positionX_->setToolTip(positionTip);
     positionY_->setToolTip(positionTip);
-
-    configureOpacity();
-    configureSolidColor();
-    rebuilding_ = false;
+    updateKeyframeIndicator(positionKeyframe_, position);
 }
 
 void PropertiesEditor::configureOpacity() {
@@ -754,6 +1058,7 @@ void PropertiesEditor::configureOpacity() {
     opacity_->setValue(value.has_value() ? *value * 100.0 : 100.0);
     opacity_->setToolTip(parameter == nullptr ? tr("Opacity is not exposed by this selection")
                                               : sourceDescription(*parameter));
+    updateKeyframeIndicator(opacityKeyframe_, parameter);
 }
 
 void PropertiesEditor::configureSolidColor() {
@@ -768,6 +1073,7 @@ void PropertiesEditor::configureSolidColor() {
         return;
     }
 
+    updateKeyframeIndicator(solidColorKeyframe_, parameter);
     const auto value = session_.constantColorValue(parameter->id);
     solidColorValue_->setText(value.has_value() ? exactColor(*value)
                                                 : sourceDescription(*parameter));
@@ -777,6 +1083,26 @@ void PropertiesEditor::configureSolidColor() {
     solidColorEncoding_->setText(
         QString::fromUtf8(document::kSolidColorEncoding.data(),
                           static_cast<qsizetype>(document::kSolidColorEncoding.size())));
+}
+
+void PropertiesEditor::configureDocumentProperties() {
+    const auto* composition = session_.composition();
+    const bool hasSelection = !std::holds_alternative<std::monostate>(session_.selection().primary);
+    const bool showDocument = composition != nullptr && !hasSelection;
+    documentSection_->setVisible(showDocument);
+    selectionSection_->setVisible(!showDocument);
+    if (!showDocument) {
+        return;
+    }
+
+    documentName_->setText(QString::fromStdString(composition->name()));
+    const auto format = composition->format();
+    documentFormat_->setText(formatCompositionFormat(format));
+    documentFrameRate_->setText(formatFrameRate(format.frameRate()));
+    documentPixelAspect_->setText(formatPixelAspect(format.pixelAspect()));
+    const auto context = frameContextFor(session_);
+    documentDuration_->setText(context.has_value() ? formatDuration(*context)
+                                                   : QStringLiteral("—"));
 }
 
 MediaEditor::MediaEditor(CompositionSession& session, QWidget* parent)

--- a/src/ui/include/bloom/ui/composition_editors.hpp
+++ b/src/ui/include/bloom/ui/composition_editors.hpp
@@ -5,7 +5,6 @@
 #include <QWidget>
 
 class QAction;
-class QDoubleSpinBox;
 class QLabel;
 class QListWidget;
 class QToolButton;
@@ -17,6 +16,10 @@ class CompositionPreviewController;
 class CompositionSession;
 class TimelineKeyframePanel;
 class TimelineRuler;
+
+namespace kit {
+class KValueField;
+} // namespace kit
 
 class TimelineEditor final : public QWidget {
     Q_OBJECT
@@ -78,18 +81,41 @@ class PropertiesEditor final : public QWidget {
 
   private:
     void rebuild();
+    void configurePosition();
     void configureOpacity();
     void configureSolidColor();
+    // Issue #120, decision 3: composition/document properties shown in place of an empty panel
+    // when nothing is selected. Toggles documentSection_/selectionSection_ visibility and fills
+    // documentSection_'s rows from composition()'s own read-only format/duration -- never a new
+    // CompositionSession API.
+    void configureDocumentProperties();
 
     CompositionSession& session_;
     QLabel* selectionLabel_ = nullptr;
-    QDoubleSpinBox* positionX_ = nullptr;
-    QDoubleSpinBox* positionY_ = nullptr;
-    QDoubleSpinBox* opacity_ = nullptr;
+
+    // The selection-driven groups (Transform/Appearance/source-specific), shown together and
+    // hidden as one unit whenever configureDocumentProperties() shows documentSection_ instead
+    // (issue #120, decision 3).
+    QWidget* selectionSection_ = nullptr;
+    kit::KValueField* positionX_ = nullptr;
+    kit::KValueField* positionY_ = nullptr;
+    QLabel* positionKeyframe_ = nullptr;
+    kit::KValueField* opacity_ = nullptr;
+    QLabel* opacityKeyframe_ = nullptr;
     QWidget* solidColorPanel_ = nullptr;
+    QLabel* solidColorKeyframe_ = nullptr;
     QLabel* solidColorValue_ = nullptr;
     QLabel* solidAlphaAssociation_ = nullptr;
     QLabel* solidColorEncoding_ = nullptr;
+
+    // The no-selection document/composition view (issue #120, decision 3).
+    QWidget* documentSection_ = nullptr;
+    QLabel* documentName_ = nullptr;
+    QLabel* documentFormat_ = nullptr;
+    QLabel* documentFrameRate_ = nullptr;
+    QLabel* documentDuration_ = nullptr;
+    QLabel* documentPixelAspect_ = nullptr;
+
     bool rebuilding_ = false;
 };
 

--- a/src/ui/include/bloom/ui/kit/value_field.hpp
+++ b/src/ui/include/bloom/ui/kit/value_field.hpp
@@ -65,6 +65,7 @@ class KValueField final : public QWidget {
     void mousePressEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
+    bool event(QEvent* event) override;
     void enterEvent(QEnterEvent* event) override;
     void leaveEvent(QEvent* event) override;
     void changeEvent(QEvent* event) override;

--- a/src/ui/kit/value_field.cpp
+++ b/src/ui/kit/value_field.cpp
@@ -174,6 +174,31 @@ void KValueField::wheelEvent(QWheelEvent* event) {
     event->accept();
 }
 
+bool KValueField::event(QEvent* event) {
+    // A focused value field owns its editing keys the way a spin box does: claim the
+    // ShortcutOverride so window-level shortcuts (frame stepping, transport jumps) stay inert
+    // while the artist is adjusting a value. Left/Right/Home/End are claimed for parity with the
+    // spin-box widgets this field replaces even though only Up/Down/Page currently step.
+    if (event->type() == QEvent::ShortcutOverride && hasFocus()) {
+        auto* key = static_cast<QKeyEvent*>(event);
+        switch (key->key()) {
+        case Qt::Key_Up:
+        case Qt::Key_Down:
+        case Qt::Key_PageUp:
+        case Qt::Key_PageDown:
+        case Qt::Key_Left:
+        case Qt::Key_Right:
+        case Qt::Key_Home:
+        case Qt::Key_End:
+            event->accept();
+            return true;
+        default:
+            break;
+        }
+    }
+    return QWidget::event(event);
+}
+
 void KValueField::keyPressEvent(QKeyEvent* event) {
     switch (event->key()) {
     case Qt::Key_Up:

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -34,6 +34,9 @@ add_executable(bloom_kit_tokens_test
 add_executable(bloom_composition_projection_test
     composition_projection_test.cpp
 )
+add_executable(bloom_properties_editor_test
+    properties_editor_tests.cpp
+)
 add_executable(bloom_composition_preview_controller_test
     composition_preview_controller_tests.cpp
 )
@@ -103,6 +106,7 @@ target_link_libraries(bloom_kit_value_field_test PRIVATE bloom_ui_kit Qt6::Test)
 target_link_libraries(bloom_kit_theme_test PRIVATE bloom_ui_kit)
 target_link_libraries(bloom_kit_tokens_test PRIVATE bloom_ui_kit)
 target_link_libraries(bloom_composition_projection_test PRIVATE bloom_ui)
+target_link_libraries(bloom_properties_editor_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_preview_controller_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_session_animation_test PRIVATE bloom_ui)
 target_link_libraries(bloom_composition_session_rebind_test PRIVATE bloom_ui)
@@ -129,6 +133,7 @@ bloom_enable_warnings(bloom_kit_value_field_test)
 bloom_enable_warnings(bloom_kit_theme_test)
 bloom_enable_warnings(bloom_kit_tokens_test)
 bloom_enable_warnings(bloom_composition_projection_test)
+bloom_enable_warnings(bloom_properties_editor_test)
 bloom_enable_warnings(bloom_composition_preview_controller_test)
 bloom_enable_warnings(bloom_composition_session_animation_test)
 bloom_enable_warnings(bloom_composition_session_rebind_test)
@@ -237,6 +242,14 @@ bloom_add_test(
 bloom_add_test(
     NAME bloom.ui.composition_projection
     COMMAND bloom_composition_projection_test
+    LABELS ui integration
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.properties_editor
+    COMMAND bloom_properties_editor_test
     LABELS ui integration
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"

--- a/src/ui/tests/composition_projection_test.cpp
+++ b/src/ui/tests/composition_projection_test.cpp
@@ -15,13 +15,13 @@
 #include <bloom/ui/composition_preview_pipeline.hpp>
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/kit/value_field.hpp>
 #include <bloom/ui/node_editor.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 #include <bloom/ui/viewer_editor.hpp>
 
 #include <QAction>
 #include <QApplication>
-#include <QDoubleSpinBox>
 #include <QElapsedTimer>
 #include <QEventLoop>
 #include <QGraphicsItem>
@@ -279,9 +279,9 @@ parameterForRole(const bloom::document::Composition& composition,
     }
     session.selectLayer(layerId);
 
-    auto* positionX = properties.findChild<QDoubleSpinBox*>("positionXEditor");
-    auto* positionY = properties.findChild<QDoubleSpinBox*>("positionYEditor");
-    auto* opacity = properties.findChild<QDoubleSpinBox*>("opacityEditor");
+    auto* positionX = properties.findChild<ui::kit::KValueField*>("positionXEditor");
+    auto* positionY = properties.findChild<ui::kit::KValueField*>("positionYEditor");
+    auto* opacity = properties.findChild<ui::kit::KValueField*>("opacityEditor");
     if (!require(positionX != nullptr && positionY != nullptr && opacity != nullptr,
                  "properties exposes transform editors") ||
         !require(positionX->isEnabled() && positionY->isEnabled() && opacity->isEnabled(),

--- a/src/ui/tests/kit_value_field_tests.cpp
+++ b/src/ui/tests/kit_value_field_tests.cpp
@@ -203,6 +203,31 @@ void testTheStateMachineAndDisabledField(Expectations& expectations) {
 
 } // namespace
 
+void testAFocusedFieldClaimsEditingKeyOverrides(Expectations& expectations) {
+    QWidget host;
+    auto* layout = new QVBoxLayout(&host);
+    auto& field = *new kit::KValueField(&host);
+    layout->addWidget(&field);
+    host.show();
+    host.activateWindow();
+    QCoreApplication::processEvents();
+    QCoreApplication::processEvents();
+
+    field.setFocus(Qt::OtherFocusReason);
+    QCoreApplication::processEvents();
+    QKeyEvent leftOverride(QEvent::ShortcutOverride, Qt::Key_Left, Qt::NoModifier);
+    QCoreApplication::sendEvent(&field, &leftOverride);
+    expectations.expect(leftOverride.isAccepted(),
+                        "a focused field claims Left so window shortcuts stay inert");
+
+    field.clearFocus();
+    QKeyEvent unfocusedOverride(QEvent::ShortcutOverride, Qt::Key_Left, Qt::NoModifier);
+    unfocusedOverride.ignore();
+    QCoreApplication::sendEvent(&field, &unfocusedOverride);
+    expectations.expect(!unfocusedOverride.isAccepted(),
+                        "an unfocused field leaves window shortcuts alone");
+}
+
 int main(int argc, char** argv) {
     qputenv("QT_QPA_PLATFORM", "offscreen");
     QApplication application(argc, argv);
@@ -214,5 +239,6 @@ int main(int argc, char** argv) {
     testSteppersAndKeysStepTheValue(expectations);
     testTheWheelIsIgnoredUntilTheFieldIsFocused(expectations);
     testTheStateMachineAndDisabledField(expectations);
+    testAFocusedFieldClaimsEditingKeyOverrides(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/tests/properties_editor_tests.cpp
+++ b/src/ui/tests/properties_editor_tests.cpp
@@ -1,0 +1,401 @@
+// Issue #120 (task U5): PropertiesEditor's kit field grid, hover recipe, keyframe indicator, and
+// no-selection document view. Every expectation here is presentation-only -- it asserts VALUES,
+// UNITS, and STATE RECIPES the redesigned panel now shows, not any editing capability beyond what
+// composition_projection_test.cpp already exercises (setSelectedPosition/setSelectedOpacity
+// directly through CompositionSession, unchanged by this task).
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/commands/operations.hpp>
+#include <bloom/commands/transaction.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/pixel_aspect_ratio.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/composition_settings.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/ui/composition_editors.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/kit/painting.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/kit/value_field.hpp>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QEnterEvent>
+#include <QImage>
+#include <QLabel>
+#include <QPixmap>
+#include <QPointF>
+#include <QWidget>
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+#include <variant>
+
+namespace {
+
+using namespace bloom;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] bool near(const QColor& left, const QColor& right, const int tolerance) {
+    return std::abs(left.red() - right.red()) <= tolerance &&
+           std::abs(left.green() - right.green()) <= tolerance &&
+           std::abs(left.blue() - right.blue()) <= tolerance;
+}
+
+[[nodiscard]] core::RationalTime time(const std::int64_t numerator,
+                                      const std::int64_t denominator = 1) {
+    const auto result = core::RationalTime::create(numerator, denominator);
+    if (!result.has_value()) {
+        std::cerr << "properties editor test: test time must be valid\n";
+        std::exit(1);
+    }
+    return *result;
+}
+
+struct LayerIds final {
+    document::LayerId layer;
+    document::ParameterId position;
+    document::ParameterId opacity;
+    document::ParameterId color;
+};
+
+// Mirrors composition_session_animation_tests.cpp's addSolidLayer() fixture exactly (same
+// AddSolidLayer transaction, same stable-ID output extraction), plus the color parameter output
+// this file also needs.
+[[nodiscard]] LayerIds addSolidLayer(document::Document& document, commands::CommandStack& stack) {
+    commands::Transaction transaction("Add test layer", document.snapshot().revision());
+    transaction.emplace<commands::AddSolidLayer>(
+        document.snapshot().project().compositions().front().id(), "Solid",
+        core::Color4d{0.2, 0.3, 0.4, 1.0}, document::Vec2d{10.0, 20.0});
+    const auto result = stack.execute(std::move(transaction));
+    const auto layer = result.outputId<document::LayerId>(commands::kAddSolidLayerLayerOutput);
+    const auto position =
+        result.outputId<document::ParameterId>(commands::kAddSolidLayerPositionParameterOutput);
+    const auto opacity =
+        result.outputId<document::ParameterId>(commands::kAddSolidLayerOpacityParameterOutput);
+    const auto color =
+        result.outputId<document::ParameterId>(commands::kAddSolidLayerColorParameterOutput);
+    if (!(result.changed() && layer.has_value() && position.has_value() && opacity.has_value() &&
+          color.has_value())) {
+        std::cerr << "properties editor test: solid layer command must expose its stable IDs\n";
+        std::exit(1);
+    }
+    return {*layer, *position, *opacity, *color};
+}
+
+// Mirrors composition_session_animation_tests.cpp's animateParameter() fixture exactly.
+[[nodiscard]] document::AnimationCurveId
+animateParameter(document::Document& document, commands::CommandStack& stack,
+                 const document::CompositionId compositionId,
+                 const document::ParameterId parameterId) {
+    commands::Transaction transaction("Animate test parameter", document.snapshot().revision());
+    transaction.emplace<commands::CreateAnimationForParameter>(compositionId, parameterId, time(0));
+    const auto result = stack.execute(std::move(transaction));
+    const auto curve = result.outputId<document::AnimationCurveId>(commands::kAnimationCurveOutput);
+    if (!(result.changed() && curve.has_value())) {
+        std::cerr << "properties editor test: animation command must expose its curve ID\n";
+        std::exit(1);
+    }
+    return *curve;
+}
+
+// A row's keyframe indicator paints IconId::Keyframe tinted either Color::Keyframe (animated) or
+// a dimmed Color::Muted (static) -- resolve which one is actually on-screen by grabbing the
+// indicator and comparing its dominant non-transparent pixel against both candidate tints.
+[[nodiscard]] bool indicatorLooksAnimated(QLabel& indicator) {
+    const QImage image = indicator.grab().toImage();
+    const QColor gold = ui::kit::color(ui::kit::Color::Keyframe);
+    for (int y = 0; y < image.height(); ++y) {
+        for (int x = 0; x < image.width(); ++x) {
+            const QColor pixel = image.pixelColor(x, y);
+            if (pixel.alpha() > 0 && near(pixel, gold, 24)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void testSelectionShowsGroupedRowsWithValuesAndUnits(Expectations& expectations) {
+    auto newProject = document::makeNewProject("Grid Test", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+    ui::PropertiesEditor properties(session);
+
+    auto* positionX = properties.findChild<ui::kit::KValueField*>("positionXEditor");
+    auto* positionY = properties.findChild<ui::kit::KValueField*>("positionYEditor");
+    auto* opacity = properties.findChild<ui::kit::KValueField*>("opacityEditor");
+    expectations.expect(positionX != nullptr && positionY != nullptr && opacity != nullptr,
+                        "the Transform/Appearance rows expose kit::KValueField cells");
+    if (positionX == nullptr || positionY == nullptr || opacity == nullptr) {
+        return;
+    }
+    expectations.expect(positionX->value() == 10.0 && positionY->value() == 20.0,
+                        "the Position row reads the solid's exact constant value");
+    expectations.expect(positionX->unit() == QStringLiteral("px") &&
+                            positionY->unit() == QStringLiteral("px"),
+                        "Position cells carry the px unit suffix");
+    expectations.expect(positionX->label() == QStringLiteral("X") &&
+                            positionY->label() == QStringLiteral("Y"),
+                        "Position cells carry their own X/Y sub-labels");
+    expectations.expect(opacity->value() == 100.0 && opacity->unit() == QStringLiteral("%"),
+                        "the Opacity row reads the default constant value with a % unit");
+
+    auto* solidPanel = properties.findChild<QWidget*>("solidColorProperties");
+    auto* solidColorValue = properties.findChild<QLabel*>("solidColorValue");
+    expectations.expect(solidPanel != nullptr && !solidPanel->isHidden() &&
+                            solidColorValue != nullptr &&
+                            solidColorValue->text() == QStringLiteral("R 0.2  G 0.3  B 0.4  A 1"),
+                        "the Solid Source group shows the exact RGBA text unchanged in content");
+
+    auto* documentSection = properties.findChild<QWidget*>("propertiesDocumentSection");
+    expectations.expect(documentSection != nullptr && documentSection->isHidden(),
+                        "a real selection hides the no-selection document view");
+}
+
+void testAnimatedParameterShowsGoldStaticShowsDim(Expectations& expectations) {
+    auto newProject = document::makeNewProject("Animation Test", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack);
+    (void)animateParameter(document, stack, compositionId, ids.opacity);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+    ui::PropertiesEditor properties(session);
+    properties.resize(properties.sizeHint());
+
+    auto* opacityField = properties.findChild<ui::kit::KValueField*>("opacityEditor");
+    auto* positionField = properties.findChild<ui::kit::KValueField*>("positionXEditor");
+    expectations.expect(opacityField != nullptr && positionField != nullptr,
+                        "both parameter rows resolve their value cells");
+    if (opacityField == nullptr || positionField == nullptr) {
+        return;
+    }
+    auto* opacityRow = opacityField->parentWidget();
+    auto* positionRow = positionField->parentWidget()->parentWidget();
+    expectations.expect(opacityRow != nullptr && positionRow != nullptr, "rows resolve");
+    if (opacityRow == nullptr || positionRow == nullptr) {
+        return;
+    }
+    auto* opacityIndicator = opacityRow->findChild<QLabel*>("propertiesKeyframeIndicator");
+    auto* positionIndicator = positionRow->findChild<QLabel*>("propertiesKeyframeIndicator");
+    expectations.expect(opacityIndicator != nullptr && positionIndicator != nullptr,
+                        "both rows carry a keyframe indicator");
+    if (opacityIndicator == nullptr || positionIndicator == nullptr) {
+        return;
+    }
+    opacityIndicator->resize(opacityIndicator->sizeHint());
+    positionIndicator->resize(positionIndicator->sizeHint());
+
+    expectations.expect(indicatorLooksAnimated(*opacityIndicator),
+                        "the animated Opacity parameter paints the gold Keyframe indicator");
+    expectations.expect(!indicatorLooksAnimated(*positionIndicator),
+                        "the still-constant Position parameter paints the dimmed indicator");
+}
+
+void testHoverPaintsTheStatesRecipeOnARow(Expectations& expectations) {
+    auto newProject = document::makeNewProject("Hover Test", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto ids = addSolidLayer(document, stack);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    session.selectLayer(ids.layer);
+    ui::PropertiesEditor properties(session);
+
+    auto* opacityField = properties.findChild<ui::kit::KValueField*>("opacityEditor");
+    expectations.expect(opacityField != nullptr, "the Opacity row resolves for the hover check");
+    if (opacityField == nullptr) {
+        return;
+    }
+    auto* row = opacityField->parentWidget();
+    expectations.expect(row != nullptr && row->objectName() == QStringLiteral("propertiesRow"),
+                        "the Opacity value cell's immediate parent is its PropertiesRow container");
+    if (row == nullptr) {
+        return;
+    }
+    row->resize(row->sizeHint());
+
+    const QColor restBackground = row->grab().toImage().pixelColor(1, 1);
+    const QColor hoverExpected =
+        ui::kit::color(ui::kit::surfaceForState(ui::kit::Color::Background, ui::kit::State::Hover));
+    expectations.expect(!near(restBackground, hoverExpected, 4),
+                        "a row at rest does not already paint the hover fill");
+
+    QEnterEvent enter(QPointF(1.0, 1.0), QPointF(1.0, 1.0), QPointF(1.0, 1.0));
+    QCoreApplication::sendEvent(row, &enter);
+
+    const QImage hovered = row->grab().toImage();
+    bool sawHoverFill = false;
+    for (int y = 0; y < hovered.height() && !sawHoverFill; ++y) {
+        for (int x = 0; x < hovered.width(); ++x) {
+            if (near(hovered.pixelColor(x, y), hoverExpected, 4)) {
+                sawHoverFill = true;
+                break;
+            }
+        }
+    }
+    expectations.expect(sawHoverFill,
+                        "hovering the row paints the States recipe: Background stepped to "
+                        "Hover's surface, i.e. Surface");
+
+    QEvent leave(QEvent::Leave);
+    QCoreApplication::sendEvent(row, &leave);
+    const QColor afterLeave = row->grab().toImage().pixelColor(1, 1);
+    expectations.expect(!near(afterLeave, hoverExpected, 4),
+                        "leaving the row clears the hover fill");
+}
+
+void testNoSelectionShowsDocumentProperties(Expectations& expectations) {
+    const auto frameRate = document::FrameRate::create(24000, 1001);
+    if (!frameRate.has_value()) {
+        expectations.expect(false, "the fractional test frame rate must be valid");
+        return;
+    }
+    const auto format = document::CompositionFormat::create(
+        1920, 1080, core::PixelAspectRatio::square(), *frameRate);
+    if (!format.has_value()) {
+        expectations.expect(false, "the fractional-rate test format must be valid");
+        return;
+    }
+    // 240 exact frames at 24000/1001 fps -- long enough to prove the frame count and the
+    // millisecond-truncated seconds text are both derived from the SAME exact rational
+    // arithmetic composition_editors.cpp's formatExactSeconds()/frameContextFor() already use for
+    // the timeline readout, not a second, possibly-diverging formatting rule.
+    constexpr std::int64_t kFrameCount = 240;
+    constexpr std::int64_t kFrameRateDenominator = 1001;
+    auto newProject = document::makeNewProject(
+        "Document Test", "Main", time(kFrameCount * kFrameRateDenominator, 24000), *format);
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    ui::PropertiesEditor properties(session);
+
+    auto* selectionSection = properties.findChild<QWidget*>("propertiesSelectionSection");
+    auto* documentSection = properties.findChild<QWidget*>("propertiesDocumentSection");
+    expectations.expect(selectionSection != nullptr && documentSection != nullptr &&
+                            !documentSection->isHidden() && selectionSection->isHidden(),
+                        "no selection shows the document view and hides the selection groups");
+
+    auto* name = properties.findChild<QLabel*>("documentName");
+    auto* formatLabel = properties.findChild<QLabel*>("documentFormat");
+    auto* frameRateLabel = properties.findChild<QLabel*>("documentFrameRate");
+    auto* durationLabel = properties.findChild<QLabel*>("documentDuration");
+    auto* pixelAspectLabel = properties.findChild<QLabel*>("documentPixelAspect");
+    expectations.expect(name != nullptr && formatLabel != nullptr && frameRateLabel != nullptr &&
+                            durationLabel != nullptr && pixelAspectLabel != nullptr,
+                        "the document view exposes every reachable composition fact");
+    if (name == nullptr || formatLabel == nullptr || frameRateLabel == nullptr ||
+        durationLabel == nullptr || pixelAspectLabel == nullptr) {
+        return;
+    }
+    expectations.expect(name->text() == QStringLiteral("Main"),
+                        "the document view names the exact composition");
+    expectations.expect(formatLabel->text() == QStringLiteral("1920 × 1080 px"),
+                        "the document view shows the exact composition format");
+    expectations.expect(frameRateLabel->text() == QStringLiteral("24000/1001 fps"),
+                        "a fractional frame rate is shown as the exact rational, never rounded");
+    expectations.expect(durationLabel->text() == QStringLiteral("240 frames · 10.010s"),
+                        "duration shows the exact frame count and the truncated exact seconds");
+    expectations.expect(pixelAspectLabel->text() == QStringLiteral("1:1"),
+                        "square pixel aspect is shown as an exact ratio");
+}
+
+void testSelectionSwapUpdatesRows(Expectations& expectations) {
+    auto newProject = document::makeNewProject("Swap Test", "Main", time(10));
+    const auto compositionId = newProject.initialCompositionId;
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack stack(document);
+    const auto first = addSolidLayer(document, stack);
+
+    ui::CompositionSession session(document, stack, compositionId);
+    ui::PropertiesEditor properties(session);
+
+    auto* documentSection = properties.findChild<QWidget*>("propertiesDocumentSection");
+    auto* selectionSection = properties.findChild<QWidget*>("propertiesSelectionSection");
+    expectations.expect(documentSection != nullptr && !documentSection->isHidden() &&
+                            selectionSection != nullptr && selectionSection->isHidden(),
+                        "constructing with no selection starts on the document view");
+
+    session.selectLayer(first.layer);
+    expectations.expect(documentSection->isHidden() && !selectionSection->isHidden(),
+                        "selecting a layer swaps to the selection groups");
+
+    constexpr core::Color4d secondColor{0.9, 0.1, 0.5, 1.0};
+    expectations.expect(session.addSolidLayer(QStringLiteral("Second"), secondColor),
+                        "a second solid layer can be added for the swap");
+    const auto* secondLayerId = std::get_if<document::LayerId>(&session.selection().primary);
+    expectations.expect(secondLayerId != nullptr, "the new solid becomes the primary selection");
+    if (secondLayerId == nullptr) {
+        return;
+    }
+
+    auto* positionX = properties.findChild<ui::kit::KValueField*>("positionXEditor");
+    auto* solidColorValue = properties.findChild<QLabel*>("solidColorValue");
+    expectations.expect(positionX != nullptr && solidColorValue != nullptr, "rows still resolve");
+    if (positionX == nullptr || solidColorValue == nullptr) {
+        return;
+    }
+    // CompositionSession::addSolidLayer() defaults a new solid's position to the composition's
+    // own center (960, 540 for the default 1920x1080 format -- composition_session.cpp's
+    // compositionCenter()), distinct from the first layer's explicit (10, 20): proves the row
+    // actually re-read the new selection rather than keeping stale values across the swap.
+    expectations.expect(positionX->value() == 960.0,
+                        "the swapped-to layer's own position value replaces the previous row");
+    expectations.expect(solidColorValue->text() == QStringLiteral("R 0.9  G 0.1  B 0.5  A 1"),
+                        "the swapped-to layer's own solid color replaces the previous row");
+
+    session.clearSelection();
+    expectations.expect(!documentSection->isHidden() && selectionSection->isHidden(),
+                        "clearing the selection swaps back to the document view");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testSelectionShowsGroupedRowsWithValuesAndUnits(expectations);
+    testAnimatedParameterShowsGoldStaticShowsDim(expectations);
+    testHoverPaintsTheStatesRecipeOnARow(expectations);
+    testNoSelectionShowsDocumentProperties(expectations);
+    testSelectionSwapUpdatesRows(expectations);
+    if (expectations.failures() > 0) {
+        std::cerr << expectations.failures() << " properties editor expectation(s) failed\n";
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
The Properties slice of #116 — presentation redesign at strict behavior parity:

- **Field grid**: right-aligned label column, KValueField cells for the editable Position/Opacity (same session commits as before), token-styled mono cells for read-only content, grouped sections with uppercase headers and hairline dividers, spacing-scale padding throughout.
- **States**: row-level hover painting the States recipe (pixel-asserted); inline keyframe indicator — gold filled diamond for animated parameters, dimmed outline for static — following the visual-language fill-for-active icon rule.
- **No selection**: document/composition properties replace the empty panel — name, format, exact rational frame rate (24000/1001 shown honestly), truncated-exact duration, pixel aspect. Color-settings summary omitted honestly: it is not reachable from the session's read-only surface, and no API was added.
- **Kit fix folded in on review**: focused value fields now claim their editing-key ShortcutOverride like the spin boxes they replaced, keeping window-level frame stepping inert while adjusting a value — the one regression this slice surfaced, pinned both ways by test.
- Exactly three test adaptations, all type-only lookups; every value-string assertion byte-identical.

Desktop 116/116 and native 88/88, quality checks clean.

Closes #120.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.