### PR TITLE
feat: give Bloom its own window chrome

### DIFF
--- a/apps/bloom/main.cpp
+++ b/apps/bloom/main.cpp
@@ -11,6 +11,7 @@
 #include <bloom/ui/editor_registry.hpp>
 #include <bloom/ui/frame_export_controller.hpp>
 #include <bloom/ui/jobs_editor.hpp>
+#include <bloom/ui/kit/mnemonic_style.hpp>
 #include <bloom/ui/kit/theme.hpp>
 #include <bloom/ui/main_window.hpp>
 #include <bloom/ui/project_host.hpp>
@@ -35,6 +36,17 @@ int main(int argc, char* argv[]) {
     // application stylesheet, and the interface font belong to the application, not to one window,
     // and installing them first means no surface is ever constructed under the default Qt theme.
     bloom::ui::kit::installKinetikTheme(application);
+    // Mnemonic underlines only while Alt is held (task U2, issue #118, decision 2): a small
+    // QProxyStyle installed application-wide, right after the theme's own Fusion style, so every
+    // menu -- title-bar-embedded or classic -- shares the same behavior. QApplication::setStyle()
+    // takes ownership of the style object (Qt's own documented contract); the static analyzer
+    // cannot see through that ownership transfer and reports a path-sensitive "leak" anchored
+    // wherever later in main() its analysis happens to conclude the object is unreachable, not at
+    // this allocation -- hence the function-scoped suppression markers below rather than a
+    // single-line one.
+    // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) -- QApplication::setStyle() owns it.
+    auto* mnemonicStyle = new bloom::ui::kit::AltUnderlineProxyStyle();
+    QApplication::setStyle(mnemonicStyle);
 
     // ProjectHost (task U1, issue #72) replaces the hand-rolled document/command-stack pair: it
     // owns the application's single live bloom::host::ProjectSession and constructs an initial
@@ -125,8 +137,13 @@ int main(int argc, char* argv[]) {
 
     application.setQuitOnLastWindowClosed(false);
     QSettings settings;
+    // Read BEFORE MainWindow is constructed (decision 1): MainWindow's window flags and menu-bar
+    // hosting must be right from the very first construction, not patched in afterward -- the
+    // documented ctor-order trap -- so the chrome mode is a constructor argument, not something
+    // MainWindow discovers for itself post-construction.
+    const auto chromeMode = bloom::ui::chromeModeFromSettings(settings);
     bloom::ui::MainWindow window(editorRegistry, compositionSession, projectHost,
-                                 frameExportController);
+                                 frameExportController, chromeMode);
     (void)window.restoreApplicationState(settings);
     QObject::connect(&shutdownCoordinator,
                      &bloom::ui::ApplicationShutdownCoordinator::shutdownStarted, &window,
@@ -138,5 +155,6 @@ int main(int argc, char* argv[]) {
                      &QApplication::quit);
     window.show();
 
+    // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
     return application.exec();
 }

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -21,12 +21,14 @@ target_sources(
         kit/dropdown_popup.cpp
         kit/fonts.cpp
         kit/icons.cpp
+        kit/mnemonic_style.cpp
         kit/painting.cpp
         kit/radio_group.cpp
         kit/range_selector.cpp
         kit/slider.cpp
         kit/switch_control.cpp
         kit/theme.cpp
+        kit/title_bar.cpp
         kit/tokens.cpp
         kit/value_field.cpp
     PUBLIC
@@ -38,12 +40,14 @@ target_sources(
             include/bloom/ui/kit/dropdown_popup.hpp
             include/bloom/ui/kit/fonts.hpp
             include/bloom/ui/kit/icons.hpp
+            include/bloom/ui/kit/mnemonic_style.hpp
             include/bloom/ui/kit/painting.hpp
             include/bloom/ui/kit/radio_group.hpp
             include/bloom/ui/kit/range_selector.hpp
             include/bloom/ui/kit/slider.hpp
             include/bloom/ui/kit/switch_control.hpp
             include/bloom/ui/kit/theme.hpp
+            include/bloom/ui/kit/title_bar.hpp
             include/bloom/ui/kit/tokens.hpp
             include/bloom/ui/kit/value_field.hpp
 )
@@ -171,6 +175,11 @@ qt_add_resources(bloom_ui_kit "kinetik_fonts"
         kit/third_party/plus-jakarta-sans/PlusJakartaSans-SemiBold.ttf
 )
 
+# Generates the "Open Source Licenses..." embedded catalog (task U2, issue #118, decision 3) BEFORE
+# bloom_ui's sources are declared, so BLOOM_THIRD_PARTY_LICENSE_CATALOG_CPP below names a file that
+# already exists at generate time.
+include("${CMAKE_CURRENT_SOURCE_DIR}/generate_third_party_license_catalog.cmake")
+
 add_library(bloom_ui STATIC)
 
 target_sources(
@@ -184,7 +193,9 @@ target_sources(
         editor_area.cpp
         editor_registry.cpp
         frame_export_controller.cpp
+        frameless_window_support.cpp
         jobs_editor.cpp
+        licenses_window.cpp
         main_window.cpp
         node_editor.cpp
         playback_controller.cpp
@@ -196,6 +207,7 @@ target_sources(
         timeline_ruler.cpp
         viewer_editor.cpp
         workspace_host.cpp
+        "${BLOOM_THIRD_PARTY_LICENSE_CATALOG_CPP}"
     PUBLIC
         FILE_SET HEADERS
         BASE_DIRS include
@@ -208,7 +220,9 @@ target_sources(
             include/bloom/ui/editor_area.hpp
             include/bloom/ui/editor_registry.hpp
             include/bloom/ui/frame_export_controller.hpp
+            include/bloom/ui/frameless_window_support.hpp
             include/bloom/ui/jobs_editor.hpp
+            include/bloom/ui/licenses_window.hpp
             include/bloom/ui/main_window.hpp
             include/bloom/ui/node_editor.hpp
             include/bloom/ui/playback_controller.hpp
@@ -216,6 +230,7 @@ target_sources(
             include/bloom/ui/qualified_display_processor_bootstrap.hpp
             include/bloom/ui/task_monitor_model.hpp
             include/bloom/ui/task_ui_bridge.hpp
+            include/bloom/ui/third_party_license_catalog.hpp
             include/bloom/ui/timeline_frame_math.hpp
             include/bloom/ui/timeline_ruler.hpp
             include/bloom/ui/viewer_editor.hpp

--- a/src/ui/editor_area.cpp
+++ b/src/ui/editor_area.cpp
@@ -4,11 +4,16 @@
 #include <bloom/ui/kit/icons.hpp>
 #include <bloom/ui/kit/tokens.hpp>
 
+#include <QAction>
 #include <QChildEvent>
 #include <QComboBox>
 #include <QEvent>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QMenu>
+#include <QPainterPath>
+#include <QRegion>
+#include <QResizeEvent>
 #include <QSize>
 #include <QSizePolicy>
 #include <QString>
@@ -52,6 +57,15 @@ EditorArea::EditorArea(const EditorRegistry& registry, std::string_view initialE
     editorPicker_ = new QComboBox(header);
     editorPicker_->setObjectName("editorTypePicker");
     editorPicker_->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    // The panel header's title styling (task U2, issue #118, decision 4): UiSmall already IS
+    // "uppercase, +0.07em tracking" (kit::font()'s own recipe for the role), so giving the
+    // switcher this role is the whole job -- no separate title label, no per-character transform.
+    // Stays a QComboBox rather than becoming a KDropdown (decision 4's own named alternative):
+    // this control also carries the "unavailable editor" placeholder path below via
+    // QComboBox::findData()/setItemData(..., Qt::ToolTipRole), neither of which KDropdown exposes,
+    // and switching its type would silently break every existing "editorTypePicker" QComboBox*
+    // test contract outside this task's sanctioned change.
+    editorPicker_->setFont(kit::font(kit::TypeRole::UiSmall));
 
     for (const auto& editor : registry.editors()) {
         editorPicker_->addItem(editor.displayName, QString::fromStdString(editor.id));
@@ -81,18 +95,44 @@ EditorArea::EditorArea(const EditorRegistry& registry, std::string_view initialE
         return button;
     };
 
-    splitLeftRightButton_ = makeHeaderButton(kit::IconId::SplitHorizontal, "Split area left/right",
-                                             "splitLeftRightButton");
-    splitTopBottomButton_ = makeHeaderButton(kit::IconId::SplitVertical, "Split area top/bottom",
-                                             "splitTopBottomButton");
+    // The header context-menu button (task U2, issue #118, decision 4 -- the ONE sanctioned
+    // test-contract change): replaces the separate H/V split QToolButtons with a single
+    // ContextMenu-icon button whose kit-styled QMenu offers all four panel operations under the
+    // SAME signals the old buttons emitted. Maximize and Close stay as their own dedicated
+    // buttons below (unchanged since task U1) -- only the two less-frequent split actions move
+    // into the menu; both are ALSO offered there for a consistent, discoverable, keyboard-
+    // reachable equivalent.
+    contextMenuButton_ =
+        makeHeaderButton(kit::IconId::ContextMenu, "Panel options", "panelContextMenuButton");
+
+    contextMenu_ = new QMenu(contextMenuButton_);
+    contextMenu_->setObjectName("panelOptionsMenu");
+    auto* splitHorizontalAction = contextMenu_->addAction("Split Horizontally");
+    splitHorizontalAction->setObjectName("panelSplitHorizontalAction");
+    connect(splitHorizontalAction, &QAction::triggered, this,
+            [this] { emit splitRequested(this, Qt::Horizontal); });
+    auto* splitVerticalAction = contextMenu_->addAction("Split Vertically");
+    splitVerticalAction->setObjectName("panelSplitVerticalAction");
+    connect(splitVerticalAction, &QAction::triggered, this,
+            [this] { emit splitRequested(this, Qt::Vertical); });
+    contextMenu_->addSeparator();
+    auto* menuMaximizeAction = contextMenu_->addAction("Maximize");
+    menuMaximizeAction->setObjectName("panelMaximizeAction");
+    connect(menuMaximizeAction, &QAction::triggered, this,
+            [this] { emit maximizeRequested(this); });
+    auto* menuCloseAction = contextMenu_->addAction("Close");
+    menuCloseAction->setObjectName("panelCloseAction");
+    connect(menuCloseAction, &QAction::triggered, this, [this] { emit closeRequested(this); });
+    contextMenuButton_->setMenu(contextMenu_);
+    contextMenuButton_->setPopupMode(QToolButton::InstantPopup);
+
     maximizeButton_ =
         makeHeaderButton(kit::IconId::Maximize, "Maximize area", "maximizeAreaButton");
     closeButton_ = makeHeaderButton(kit::IconId::Close, "Close area", "closeAreaButton");
 
     headerLayout->addWidget(editorPicker_);
     headerLayout->addStretch(1);
-    headerLayout->addWidget(splitLeftRightButton_);
-    headerLayout->addWidget(splitTopBottomButton_);
+    headerLayout->addWidget(contextMenuButton_);
     headerLayout->addWidget(maximizeButton_);
     headerLayout->addWidget(closeButton_);
 
@@ -101,10 +141,6 @@ EditorArea::EditorArea(const EditorRegistry& registry, std::string_view initialE
 
     connect(editorPicker_, &QComboBox::currentIndexChanged, this,
             [this](int index) { rebuildEditor(index); });
-    connect(splitLeftRightButton_, &QToolButton::clicked, this,
-            [this] { emit splitRequested(this, Qt::Horizontal); });
-    connect(splitTopBottomButton_, &QToolButton::clicked, this,
-            [this] { emit splitRequested(this, Qt::Vertical); });
     connect(closeButton_, &QToolButton::clicked, this, [this] { emit closeRequested(this); });
     connect(maximizeButton_, &QToolButton::clicked, this, [this] { emit maximizeRequested(this); });
 
@@ -163,11 +199,22 @@ void EditorArea::setAreaActive(bool active) {
 bool EditorArea::isAreaActive() const noexcept { return active_; }
 
 void EditorArea::setSplitEnabled(bool enabled) {
-    splitLeftRightButton_->setEnabled(enabled);
-    splitTopBottomButton_->setEnabled(enabled);
+    // The split actions live in the context menu now (decision 4); the button that opens the menu
+    // stays enabled either way -- Maximize and Close inside it are unaffected by this flag.
+    for (auto* action : {contextMenu_->findChild<QAction*>("panelSplitHorizontalAction"),
+                         contextMenu_->findChild<QAction*>("panelSplitVerticalAction")}) {
+        if (action != nullptr) {
+            action->setEnabled(enabled);
+        }
+    }
 }
 
-void EditorArea::setCloseEnabled(bool enabled) { closeButton_->setEnabled(enabled); }
+void EditorArea::setCloseEnabled(bool enabled) {
+    closeButton_->setEnabled(enabled);
+    if (auto* action = contextMenu_->findChild<QAction*>("panelCloseAction")) {
+        action->setEnabled(enabled);
+    }
+}
 
 void EditorArea::setMaximizedAppearance(bool maximized) {
     maximizeButton_->setIcon(
@@ -236,6 +283,23 @@ void EditorArea::watchForActivation(QWidget* widget) {
     for (auto* descendant : descendants) {
         descendant->installEventFilter(this);
     }
+}
+
+void EditorArea::resizeEvent(QResizeEvent* event) {
+    QFrame::resizeEvent(event);
+    updateRoundedMask();
+}
+
+void EditorArea::updateRoundedMask() {
+    // Radius::Large rounded corners over the Background gutter (task U2, issue #118, decision 4):
+    // a real clip rather than only the stylesheet's own border-radius, so the header's Surface
+    // background and whatever the active editor draws never overhang the panel's rounded corners
+    // -- the QFrame's own CSS border-radius (kinetikStyleSheet()'s QFrame#editorArea rule) only
+    // ever paints the frame's OWN background/border, never its children.
+    QPainterPath path;
+    const int radius = kit::radiusPx(kit::Radius::Large, 0);
+    path.addRoundedRect(rect(), radius, radius);
+    setMask(QRegion(path.toFillPolygon().toPolygon()));
 }
 
 } // namespace bloom::ui

--- a/src/ui/frameless_window_support.cpp
+++ b/src/ui/frameless_window_support.cpp
@@ -1,0 +1,60 @@
+#include <bloom/ui/frameless_window_support.hpp>
+
+#include <QEvent>
+#include <QMainWindow>
+#include <QMouseEvent>
+#include <QWidget>
+#include <QWindow>
+
+namespace bloom::ui {
+
+FramelessEdgeResizer::FramelessEdgeResizer(QMainWindow& window, const int marginPx,
+                                           QObject* parent)
+    : QObject(parent), window_(window), marginPx_(marginPx) {}
+
+bool FramelessEdgeResizer::eventFilter(QObject* watched, QEvent* event) {
+    if (event->type() != QEvent::MouseButtonPress) {
+        return false;
+    }
+    auto* mouseEvent = static_cast<QMouseEvent*>(event);
+    if (mouseEvent->button() != Qt::LeftButton) {
+        return false;
+    }
+    auto* target = qobject_cast<QWidget*>(watched);
+    if (target == nullptr || target->window() != &window_) {
+        return false;
+    }
+    if (window_.isMaximized() || window_.isFullScreen()) {
+        return false;
+    }
+    auto* handle = window_.windowHandle();
+    if (handle == nullptr) {
+        return false;
+    }
+
+    const QPoint local = window_.mapFromGlobal(mouseEvent->globalPosition().toPoint());
+    const QRect bounds = window_.rect();
+    if (!bounds.marginsAdded(QMargins(marginPx_, marginPx_, marginPx_, marginPx_)).contains(local)) {
+        return false;
+    }
+
+    Qt::Edges edges;
+    if (local.x() <= bounds.left() + marginPx_) {
+        edges |= Qt::LeftEdge;
+    } else if (local.x() >= bounds.right() - marginPx_) {
+        edges |= Qt::RightEdge;
+    }
+    if (local.y() <= bounds.top() + marginPx_) {
+        edges |= Qt::TopEdge;
+    } else if (local.y() >= bounds.bottom() - marginPx_) {
+        edges |= Qt::BottomEdge;
+    }
+    if (edges == Qt::Edges{}) {
+        return false;
+    }
+
+    handle->startSystemResize(edges);
+    return true;
+}
+
+} // namespace bloom::ui

--- a/src/ui/frameless_window_support.cpp
+++ b/src/ui/frameless_window_support.cpp
@@ -8,8 +8,7 @@
 
 namespace bloom::ui {
 
-FramelessEdgeResizer::FramelessEdgeResizer(QMainWindow& window, const int marginPx,
-                                           QObject* parent)
+FramelessEdgeResizer::FramelessEdgeResizer(QMainWindow& window, const int marginPx, QObject* parent)
     : QObject(parent), window_(window), marginPx_(marginPx) {}
 
 bool FramelessEdgeResizer::eventFilter(QObject* watched, QEvent* event) {
@@ -34,7 +33,8 @@ bool FramelessEdgeResizer::eventFilter(QObject* watched, QEvent* event) {
 
     const QPoint local = window_.mapFromGlobal(mouseEvent->globalPosition().toPoint());
     const QRect bounds = window_.rect();
-    if (!bounds.marginsAdded(QMargins(marginPx_, marginPx_, marginPx_, marginPx_)).contains(local)) {
+    if (!bounds.marginsAdded(QMargins(marginPx_, marginPx_, marginPx_, marginPx_))
+             .contains(local)) {
         return false;
     }
 

--- a/src/ui/generate_third_party_license_catalog.cmake
+++ b/src/ui/generate_third_party_license_catalog.cmake
@@ -1,0 +1,123 @@
+# Generates bloom::ui::thirdPartyLicenseCatalog() (task U2, issue #118, decision 3) from the real,
+# checked-in license records -- never hand-maintained -- so the "Open Source Licenses..." window
+# always lists exactly what this build actually ships:
+#
+#   * every dependencies/licenses/<component>/LICENSE  (the qualified-prefix superbuild libraries)
+#   * every src/ui/kit/third_party/<component>/LICENSE (the vendored icon/font assets)
+#   * a Qt/ADR-0014 dynamic-LGPL distribution notice, authored here (there is no vendored Qt
+#     LICENSE file in this repository to parse: Bloom links Qt dynamically rather than vendoring
+#     its source -- see docs/decisions/0014-apache-license-and-qt-distribution.md)
+#
+# Technique: mirrors src/color/ocio_builtin_payload.inc.in's file(READ ... HEX) -> "0x..," byte
+# array embed, generalized from one frozen asset to N discovered files, because license text has
+# no fixed byte count to assert against. Runs at CMake configure time; included (not
+# add_subdirectory'd) from src/ui/CMakeLists.txt so relative paths resolve against that file's own
+# CMAKE_CURRENT_SOURCE_DIR/BINARY_DIR. Every source LICENSE file is registered with
+# CMAKE_CONFIGURE_DEPENDS so editing one alone triggers a reconfigure and regeneration.
+
+set(_bloom_license_component_names "")
+set(_bloom_license_component_files "")
+
+file(GLOB _bloom_dependency_license_dirs LIST_DIRECTORIES true
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../dependencies/licenses/*")
+file(GLOB _bloom_kit_license_dirs LIST_DIRECTORIES true
+    "${CMAKE_CURRENT_SOURCE_DIR}/kit/third_party/*")
+
+foreach(_bloom_license_dir IN LISTS _bloom_dependency_license_dirs _bloom_kit_license_dirs)
+    if(IS_DIRECTORY "${_bloom_license_dir}" AND EXISTS "${_bloom_license_dir}/LICENSE")
+        get_filename_component(_bloom_component_name "${_bloom_license_dir}" NAME)
+        list(APPEND _bloom_license_component_names "${_bloom_component_name}")
+        list(APPEND _bloom_license_component_files "${_bloom_license_dir}/LICENSE")
+    endif()
+endforeach()
+
+# The Qt notice: authored text, not parsed from a vendored file (see the file comment above),
+# routed through the same hex-embed path as every other entry by writing it to a generated text
+# file first.
+set(_bloom_qt_notice_text [[Qt 6
+
+Bloom links dynamically against the Qt 6 libraries under the GNU Lesser General Public License,
+version 3 (LGPLv3). Bloom does not modify Qt's source. Community release packages bundle the
+qualified, unmodified Qt runtime libraries and plugins alongside Bloom; artists never install a
+separate Qt SDK or compile Bloom themselves.
+
+Under the LGPLv3, you may relink Bloom against a modified or different compatible version of the
+Qt libraries. Bloom preserves this right by linking dynamically and not imposing technical
+restrictions (such as static linking, or locked or signed libraries that would reject a relinked
+Qt) that would remove it.
+
+Qt is Copyright (C) The Qt Company Ltd. and other contributors, and is licensed under the GNU
+Lesser General Public License, version 3, as published by the Free Software Foundation. The
+complete LGPLv3 text is available at https://www.gnu.org/licenses/lgpl-3.0.html. Qt's own
+licensing terms are documented at https://doc.qt.io/qt-6/licensing.html.
+
+See this repository's docs/decisions/0014-apache-license-and-qt-distribution.md for Bloom's
+complete Qt distribution decision.
+]])
+set(_bloom_qt_notice_path "${CMAKE_CURRENT_BINARY_DIR}/generated/qt6-notice.txt")
+file(WRITE "${_bloom_qt_notice_path}" "${_bloom_qt_notice_text}")
+list(APPEND _bloom_license_component_names "Qt 6")
+list(APPEND _bloom_license_component_files "${_bloom_qt_notice_path}")
+
+list(LENGTH _bloom_license_component_names _bloom_license_component_count)
+if(_bloom_license_component_count EQUAL 0)
+    message(FATAL_ERROR
+        "No third-party license files discovered under dependencies/licenses/*/LICENSE or "
+        "src/ui/kit/third_party/*/LICENSE -- the Open Source Licenses window would ship empty. "
+        "This means the license roots moved or are missing; fix the roots or this script.")
+endif()
+
+set(_bloom_catalog_body "")
+string(APPEND _bloom_catalog_body
+    "// GENERATED FILE -- produced by src/ui/generate_third_party_license_catalog.cmake at CMake\n"
+    "// configure time. Do not edit by hand; edit the source LICENSE files or this script instead.\n"
+    "#include <bloom/ui/third_party_license_catalog.hpp>\n"
+    "\n"
+    "namespace bloom::ui {\n"
+    "namespace {\n"
+    "\n")
+
+set(_bloom_catalog_entries "")
+math(EXPR _bloom_license_last_index "${_bloom_license_component_count} - 1")
+foreach(_bloom_i RANGE 0 ${_bloom_license_last_index})
+    list(GET _bloom_license_component_names ${_bloom_i} _bloom_component_name)
+    list(GET _bloom_license_component_files ${_bloom_i} _bloom_component_file)
+
+    file(READ "${_bloom_component_file}" _bloom_hex HEX)
+    string(LENGTH "${_bloom_hex}" _bloom_hex_length)
+    math(EXPR _bloom_byte_count "${_bloom_hex_length} / 2")
+    string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1," _bloom_bytes "${_bloom_hex}")
+
+    string(REPLACE "\\" "\\\\" _bloom_name_escaped "${_bloom_component_name}")
+    string(REPLACE "\"" "\\\"" _bloom_name_escaped "${_bloom_name_escaped}")
+
+    string(APPEND _bloom_catalog_body
+        "constexpr unsigned char kLicenseBytes${_bloom_i}[] = { ${_bloom_bytes} };\n")
+    string(APPEND _bloom_catalog_entries
+        "    { std::string_view(\"${_bloom_name_escaped}\"), "
+        "std::string_view(reinterpret_cast<const char*>(kLicenseBytes${_bloom_i}), "
+        "${_bloom_byte_count}) },\n")
+endforeach()
+
+string(APPEND _bloom_catalog_body
+    "\n"
+    "const ThirdPartyLicenseEntry kEntries[] = {\n"
+    "${_bloom_catalog_entries}"
+    "};\n"
+    "\n"
+    "} // namespace\n"
+    "\n"
+    "std::span<const ThirdPartyLicenseEntry> thirdPartyLicenseCatalog() {\n"
+    "    return kEntries;\n"
+    "}\n"
+    "\n"
+    "} // namespace bloom::ui\n")
+
+set(BLOOM_THIRD_PARTY_LICENSE_CATALOG_CPP
+    "${CMAKE_CURRENT_BINARY_DIR}/generated/third_party_license_catalog.generated.cpp")
+file(WRITE "${BLOOM_THIRD_PARTY_LICENSE_CATALOG_CPP}" "${_bloom_catalog_body}")
+
+# Reconfigure (and so regenerate) whenever a source LICENSE file -- or this script -- changes.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+    ${_bloom_license_component_files}
+    "${CMAKE_CURRENT_SOURCE_DIR}/generate_third_party_license_catalog.cmake")

--- a/src/ui/include/bloom/ui/editor_area.hpp
+++ b/src/ui/include/bloom/ui/editor_area.hpp
@@ -9,7 +9,9 @@
 
 class QComboBox;
 class QEvent;
+class QMenu;
 class QObject;
+class QResizeEvent;
 class QToolButton;
 class QVBoxLayout;
 
@@ -43,19 +45,21 @@ class EditorArea final : public QFrame {
 
   protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
   private:
     void rebuildEditor(int editorIndex);
     int addUnavailableEditor(std::string_view editorId);
     void watchForActivation(QWidget* widget);
+    void updateRoundedMask();
 
     const EditorRegistry& editorRegistry_;
     QString areaId_;
     QComboBox* editorPicker_ = nullptr;
     QWidget* editorWidget_ = nullptr;
     QVBoxLayout* contentLayout_ = nullptr;
-    QToolButton* splitLeftRightButton_ = nullptr;
-    QToolButton* splitTopBottomButton_ = nullptr;
+    QToolButton* contextMenuButton_ = nullptr;
+    QMenu* contextMenu_ = nullptr;
     QToolButton* closeButton_ = nullptr;
     QToolButton* maximizeButton_ = nullptr;
     bool active_ = false;

--- a/src/ui/include/bloom/ui/frameless_window_support.hpp
+++ b/src/ui/include/bloom/ui/frameless_window_support.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QObject>
+
+class QMainWindow;
+
+namespace bloom::ui {
+
+// Edge-resize for a frameless, custom-chrome top-level window (task U2, issue #118, decision 1).
+// A frameless QMainWindow has no OS-owned border to grab, so this installs an application-wide
+// event filter (the only way to see a mouse press near the window's own edge before whichever
+// child widget sits there -- WorkspaceHost's Background gutter, the TitleBar itself -- claims it)
+// and, for a left-button press that lands within `marginPx` of `window`'s own rectangle, calls
+// QWindow::startSystemResize() for the nearest edge/corner. Native chrome never constructs one:
+// the platform's own border already does this.
+//
+// Wayland-first correctness (issue #118's target session), X11 also supported: both compositors
+// implement QWindow::startSystemResize() through the same Qt platform-integration contract this
+// class calls through, so no platform-specific code path is needed here.
+class FramelessEdgeResizer final : public QObject {
+    Q_OBJECT
+
+  public:
+    FramelessEdgeResizer(QMainWindow& window, int marginPx, QObject* parent = nullptr);
+
+  protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+  private:
+    QMainWindow& window_;
+    int marginPx_;
+};
+
+} // namespace bloom::ui

--- a/src/ui/include/bloom/ui/kit/button.hpp
+++ b/src/ui/include/bloom/ui/kit/button.hpp
@@ -52,6 +52,13 @@ class KButton final : public QAbstractButton {
     void setIconId(std::optional<IconId> icon);
     [[nodiscard]] std::optional<IconId> iconId() const noexcept;
 
+    // Opt-in, Ghost-only: hover/press take the Danger recipe (Error fill, Foreground ink) while
+    // rest/focus stay plain ghost -- the "close button" convention (title bar, panel header) where
+    // the control reads as chrome-weight until the pointer commits to the destructive action, never
+    // Error-colored at rest the way Variant::Danger itself is. False for every other variant.
+    void setDangerOnHover(bool dangerOnHover);
+    [[nodiscard]] bool dangerOnHover() const noexcept;
+
     // The single state this button is in right now, resolved by one rule so that painting and
     // tests can never disagree about it.
     [[nodiscard]] State visualState() const;
@@ -74,10 +81,13 @@ class KButton final : public QAbstractButton {
     [[nodiscard]] int controlExtent() const;
     [[nodiscard]] Size iconBox() const;
 
+    [[nodiscard]] bool paintsAsDanger(State state) const noexcept;
+
     Variant variant_ = Variant::Secondary;
     ControlSize controlSize_ = ControlSize::Default;
     std::optional<IconId> icon_;
     bool hovered_ = false;
+    bool dangerOnHover_ = false;
 };
 
 } // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/kit/mnemonic_style.hpp
+++ b/src/ui/include/bloom/ui/kit/mnemonic_style.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QProxyStyle>
+#include <QString>
+
+class QStyleOption;
+class QWidget;
+
+namespace bloom::ui::kit {
+
+// Mnemonic underlines only while Alt is held (task U2, issue #118): Bloom's menu bar and menus
+// carry "&File"-style mnemonics, but the underline itself must stay hidden until the artist
+// actually presses Alt, matching the platform-standard "hold Alt to reveal access keys"
+// convention rather than showing every underline permanently. Qt's own style hint
+// (QStyle::SH_UnderlineShortcut) decides this, and the platform/Fusion default does not reliably
+// key it to the live Alt state on every platform Bloom ships to, so this proxy overrides exactly
+// that one hint and defers every other style query to its base style unchanged.
+//
+// Scope: installed once, application-wide, in apps/bloom/main.cpp right after
+// installKinetikTheme() -- see that call site's comment. Not a per-widget style.
+class AltUnderlineProxyStyle final : public QProxyStyle {
+    Q_OBJECT
+
+  public:
+    // Wraps a freshly created "Fusion" base style (the same style installKinetikTheme() selects),
+    // so replacing the application style with this proxy never double-frees or aliases the style
+    // object installKinetikTheme() already installed.
+    AltUnderlineProxyStyle();
+    explicit AltUnderlineProxyStyle(QStyle* baseStyle);
+
+    [[nodiscard]] int styleHint(StyleHint hint, const QStyleOption* option = nullptr,
+                                const QWidget* widget = nullptr,
+                                QStyleHintReturn* returnData = nullptr) const override;
+};
+
+// The pure decision AltUnderlineProxyStyle::styleHint() applies for SH_UnderlineShortcut, factored
+// out so both branches (Alt held / Alt not held) are directly unit-testable without depending on
+// real global keyboard state, which an offscreen test cannot reliably drive.
+[[nodiscard]] bool showMnemonicUnderline(Qt::KeyboardModifiers modifiers) noexcept;
+
+} // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/kit/title_bar.hpp
+++ b/src/ui/include/bloom/ui/kit/title_bar.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <QWidget>
+
+class QHBoxLayout;
+class QLabel;
+class QMenuBar;
+class QMouseEvent;
+
+namespace bloom::ui::kit {
+
+class KButton;
+
+// The Kinetik application title bar (task U2, issue #118): a Size::TitleBar-tall row carrying the
+// app title (Type::Title) on the left, an optional embedded QMenuBar (custom chrome shares the
+// SAME QMenuBar instance the native-chrome path would otherwise dock classically -- see
+// MainWindow), and minimize/maximize-or-restore/close ghost buttons on the right.
+//
+// Drag-to-move and double-click-to-maximize are handled here, on the title bar's own empty area:
+// Qt delivers mouse events to this widget only where no child (the label, the menu bar, a button)
+// already claimed them, so no manual hit-testing against those children is needed.
+class TitleBar final : public QWidget {
+    Q_OBJECT
+
+  public:
+    explicit TitleBar(QWidget* parent = nullptr);
+
+    void setTitle(const QString& title);
+
+    // Reparents `menuBar` into the title bar row, right after the title label. Ownership follows
+    // Qt's normal parent-child rule -- the caller must not also parent it elsewhere. Native chrome
+    // never calls this; it keeps the QMenuBar docked classically via QMainWindow::menuBar().
+    void setMenuBar(QMenuBar* menuBar);
+
+    // Swaps the maximize button between its Maximize and Restore glyph/tooltip -- the window owner
+    // (MainWindow) calls this from QWidget::changeEvent(QEvent::WindowStateChange) so every path to
+    // a state change (button, double-click, OS action, keyboard) stays in sync, mirroring
+    // EditorArea::setMaximizedAppearance()'s precedent for the same problem at panel scope.
+    void setMaximized(bool maximized);
+    // Named to avoid shadowing QWidget::isMaximized() (a real window-manager state query this
+    // widget has no opinion on) -- this is only ever the last value setMaximized() was given.
+    [[nodiscard]] bool maximizedAppearance() const noexcept;
+
+  Q_SIGNALS:
+    void minimizeRequested();
+    void maximizeOrRestoreRequested();
+    void closeRequested();
+
+  protected:
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+
+  private:
+    QLabel* titleLabel_ = nullptr;
+    QHBoxLayout* layout_ = nullptr;
+    int menuBarSlot_ = 0;
+    QMenuBar* menuBar_ = nullptr;
+    KButton* minimizeButton_ = nullptr;
+    KButton* maximizeButton_ = nullptr;
+    KButton* closeButton_ = nullptr;
+    bool maximized_ = false;
+};
+
+} // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/licenses_window.hpp
+++ b/src/ui/include/bloom/ui/licenses_window.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QDialog>
+
+class QListWidget;
+class QPlainTextEdit;
+
+namespace bloom::ui {
+
+// "Open Source Licenses..." (task U2, issue #118, decision 3): a read-only, kit-styled dialog
+// listing every shipped third-party component (bloom::ui::thirdPartyLicenseCatalog(), embedded at
+// CMake configure time from the real license records -- see
+// generate_third_party_license_catalog.cmake) with its complete license text. No network access.
+class LicensesWindow final : public QDialog {
+    Q_OBJECT
+
+  public:
+    explicit LicensesWindow(QWidget* parent = nullptr);
+
+  private:
+    QListWidget* componentList_ = nullptr;
+    QPlainTextEdit* licenseText_ = nullptr;
+};
+
+} // namespace bloom::ui

--- a/src/ui/include/bloom/ui/main_window.hpp
+++ b/src/ui/include/bloom/ui/main_window.hpp
@@ -2,21 +2,47 @@
 
 #include <QMainWindow>
 
+#include <cstdint>
+
 class QAction;
 class QCloseEvent;
 class QLabel;
 class QMenu;
+class QMenuBar;
+class QResizeEvent;
 class QSettings;
 class QStackedWidget;
+
+namespace bloom::ui::kit {
+class TitleBar;
+} // namespace bloom::ui::kit
 
 namespace bloom::ui {
 
 class CompositionSession;
 class EditorRegistry;
 class FrameExportController;
+class FramelessEdgeResizer;
 class ProjectHost;
 class WorkspaceHost;
 enum class WorkspaceLayoutRestoreResult;
+
+// Custom window chrome, default on, with a persisted native fallback (task U2, issue #118,
+// decision 1). Read via chromeModeFromSettings() at startup, in apps/bloom/main.cpp, BEFORE
+// MainWindow is constructed -- QSettings can only be read correctly once QCoreApplication's
+// organization/application name is set, and MainWindow's window flags must be right from its very
+// first construction, not patched in afterward, so the mode is a constructor argument rather than
+// something MainWindow discovers for itself.
+enum class ChromeMode : std::uint8_t {
+    Custom,
+    Native,
+};
+
+// "appearance/chrome" = "custom" (default) | "native". Any other or missing value reads as
+// Custom. Shared by apps/bloom/main.cpp's startup read and by MainWindow's own "Use Native Window
+// Frame" View-menu toggle, so both agree on exactly what the setting means.
+[[nodiscard]] ChromeMode chromeModeFromSettings(const QSettings& settings);
+void setChromeModeInSettings(QSettings& settings, ChromeMode mode);
 
 class MainWindow final : public QMainWindow {
     Q_OBJECT
@@ -24,7 +50,7 @@ class MainWindow final : public QMainWindow {
   public:
     MainWindow(const EditorRegistry& editorRegistry, CompositionSession& compositionSession,
                ProjectHost& projectHost, FrameExportController& frameExportController,
-               QWidget* parent = nullptr);
+               ChromeMode chromeMode = ChromeMode::Custom, QWidget* parent = nullptr);
 
     [[nodiscard]] WorkspaceHost* workspaceHost() const noexcept;
     [[nodiscard]] WorkspaceLayoutRestoreResult restoreApplicationState(QSettings& settings);
@@ -35,17 +61,23 @@ class MainWindow final : public QMainWindow {
     // can assert the switch without depending on QWidget::isVisible(), which only reports
     // correctly once the top-level window itself has been shown.
     [[nodiscard]] bool isShowingReadOnlyPlaceholder() const noexcept;
+    [[nodiscard]] ChromeMode chromeMode() const noexcept;
 
   signals:
     void shutdownRequested();
 
   protected:
     void closeEvent(QCloseEvent* event) override;
+    void changeEvent(QEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
   private:
-    void createMenus();
+    void createChrome();
+    void createMenus(QMenuBar& menuBar);
     void createFileMenu(QMenu& fileMenu);
-    void createWorkspaceSwitcher();
+    void createViewMenu(QMenu& viewMenu);
+    void createHelpMenu(QMenu& helpMenu);
+    void createWorkspaceSwitcher(QMenuBar& menuBar);
     void createEditorLayout(const EditorRegistry& editorRegistry);
     void createCentralStack();
     QWidget* createReadOnlyPlaceholderPage();
@@ -57,11 +89,19 @@ class MainWindow final : public QMainWindow {
     void updateExportAction();
     void updateWindowTitle();
     void updateContentSurface();
+    void updateWindowMask();
+    void toggleFullScreen();
+    void toggleMaximizeRestore();
 
     CompositionSession& compositionSession_;
     ProjectHost& projectHost_;
     FrameExportController& frameExportController_;
+    ChromeMode chromeMode_;
+    kit::TitleBar* titleBar_ = nullptr;
+    QMenuBar* menuBar_ = nullptr;
+    FramelessEdgeResizer* edgeResizer_ = nullptr;
     QMenu* windowMenu_ = nullptr;
+    QMenu* viewMenu_ = nullptr;
     QStackedWidget* centralStack_ = nullptr;
     WorkspaceHost* workspaceHost_ = nullptr;
     QWidget* readOnlyPlaceholderPage_ = nullptr;
@@ -79,6 +119,11 @@ class MainWindow final : public QMainWindow {
     QAction* splitTopBottomAction_ = nullptr;
     QAction* closeAreaAction_ = nullptr;
     QAction* maximizeAreaAction_ = nullptr;
+    QAction* viewFullScreenAction_ = nullptr;
+    QAction* viewMaximizePanelAction_ = nullptr;
+    QAction* useNativeFrameAction_ = nullptr;
+    QAction* reportIssueAction_ = nullptr;
+    QAction* openSourceLicensesAction_ = nullptr;
     bool workspaceLayoutWritable_ = true;
     bool shutdownRequested_ = false;
 };

--- a/src/ui/include/bloom/ui/third_party_license_catalog.hpp
+++ b/src/ui/include/bloom/ui/third_party_license_catalog.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <span>
+#include <string_view>
+
+namespace bloom::ui {
+
+// One shipped third-party component's name and complete license text, as embedded at CMake
+// configure time by src/ui/generate_third_party_license_catalog.cmake (task U2, issue #118,
+// decision 3) from the real records: every `dependencies/licenses/*/LICENSE` and
+// `src/ui/kit/third_party/*/LICENSE` file, plus the Qt/ADR-0014 dynamic-LGPL notice. Neither field
+// is ever hand-typed here or in the generated source -- both are byte-for-byte copies of the
+// license roots' own files (or, for the Qt entry, ADR 0014's own decision text).
+struct ThirdPartyLicenseEntry {
+    std::string_view component;
+    std::string_view licenseText;
+};
+
+// The complete catalog, in a stable order (license root traversal order). Defined by the
+// generated translation unit (see the CMake script above); never hand-maintained.
+[[nodiscard]] std::span<const ThirdPartyLicenseEntry> thirdPartyLicenseCatalog();
+
+} // namespace bloom::ui

--- a/src/ui/kit/button.cpp
+++ b/src/ui/kit/button.cpp
@@ -170,13 +170,12 @@ QColor KButton::inkForVisualState(const State state) const {
         case State::Selected:
             return color(Color::Foreground);
         case State::Disabled:
-            return variant_ == Variant::Danger
-                       ? withOpacity(color(Color::Error), kDisabledOpacity)
-                       : inkForState(restingInk(variant_), state);
+            return variant_ == Variant::Danger ? withOpacity(color(Color::Error), kDisabledOpacity)
+                                               : inkForState(restingInk(variant_), state);
         case State::Normal:
         case State::Focused:
             return variant_ == Variant::Danger ? color(Color::Error)
-                                                : inkForState(restingInk(variant_), state);
+                                               : inkForState(restingInk(variant_), state);
         }
     }
     return inkForState(restingInk(variant_), state);

--- a/src/ui/kit/button.cpp
+++ b/src/ui/kit/button.cpp
@@ -87,6 +87,24 @@ void KButton::setIconId(std::optional<IconId> icon) {
 
 std::optional<IconId> KButton::iconId() const noexcept { return icon_; }
 
+void KButton::setDangerOnHover(const bool dangerOnHover) {
+    if (dangerOnHover_ == dangerOnHover) {
+        return;
+    }
+    dangerOnHover_ = dangerOnHover;
+    update();
+}
+
+bool KButton::dangerOnHover() const noexcept { return dangerOnHover_; }
+
+bool KButton::paintsAsDanger(const State state) const noexcept {
+    if (variant_ == Variant::Danger) {
+        return true;
+    }
+    return variant_ == Variant::Ghost && dangerOnHover_ &&
+           (state == State::Hover || state == State::Pressed || state == State::Selected);
+}
+
 State KButton::visualState() const {
     // One rule, consulted by both painting and tests. Order matters: disabled outranks everything,
     // because a disabled control has no hover and no press response at all.
@@ -109,10 +127,7 @@ State KButton::visualState() const {
 }
 
 QColor KButton::fillForState(const State state) const {
-    const bool filled =
-        variant_ == Variant::Primary ||
-        (variant_ == Variant::Danger &&
-         (state == State::Hover || state == State::Pressed || state == State::Selected));
+    const bool filled = variant_ == Variant::Primary || paintsAsDanger(state);
 
     if (variant_ == Variant::Primary) {
         // The accent triple states the recipe outright; nothing derived is needed.
@@ -130,8 +145,8 @@ QColor KButton::fillForState(const State state) const {
         }
     }
     if (filled) {
-        // Danger, once committed: the same rest/hover/press relation the accent triple states,
-        // applied to Error.
+        // Danger, once committed (or Ghost with dangerOnHover, once hovered/pressed): the same
+        // rest/hover/press relation the accent triple states, applied to Error.
         const QColor base = color(Color::Error);
         return state == State::Pressed ? pressedFillFor(base) : hoverFillFor(base);
     }
@@ -148,17 +163,20 @@ QColor KButton::inkForVisualState(const State state) const {
         return state == State::Disabled ? withOpacity(color(Color::Foreground), kDisabledOpacity)
                                         : color(Color::Foreground);
     }
-    if (variant_ == Variant::Danger) {
+    if (variant_ == Variant::Danger || (variant_ == Variant::Ghost && dangerOnHover_)) {
         switch (state) {
         case State::Hover:
         case State::Pressed:
         case State::Selected:
             return color(Color::Foreground);
         case State::Disabled:
-            return withOpacity(color(Color::Error), kDisabledOpacity);
+            return variant_ == Variant::Danger
+                       ? withOpacity(color(Color::Error), kDisabledOpacity)
+                       : inkForState(restingInk(variant_), state);
         case State::Normal:
         case State::Focused:
-            return color(Color::Error);
+            return variant_ == Variant::Danger ? color(Color::Error)
+                                                : inkForState(restingInk(variant_), state);
         }
     }
     return inkForState(restingInk(variant_), state);
@@ -242,7 +260,7 @@ void KButton::paintEvent(QPaintEvent* event) {
 
     const QColor fill = fillForState(state);
     QColor border = color(borderForState(state));
-    if (variant_ == Variant::Primary) {
+    if (variant_ == Variant::Primary || paintsAsDanger(state)) {
         border = fill;
     } else if (variant_ == Variant::Danger &&
                (state == State::Normal || state == State::Focused || state == State::Disabled)) {

--- a/src/ui/kit/mnemonic_style.cpp
+++ b/src/ui/kit/mnemonic_style.cpp
@@ -15,8 +15,7 @@ AltUnderlineProxyStyle::AltUnderlineProxyStyle()
 AltUnderlineProxyStyle::AltUnderlineProxyStyle(QStyle* baseStyle) : QProxyStyle(baseStyle) {}
 
 int AltUnderlineProxyStyle::styleHint(const StyleHint hint, const QStyleOption* option,
-                                      const QWidget* widget,
-                                      QStyleHintReturn* returnData) const {
+                                      const QWidget* widget, QStyleHintReturn* returnData) const {
     if (hint == QStyle::SH_UnderlineShortcut) {
         return showMnemonicUnderline(QGuiApplication::keyboardModifiers()) ? 1 : 0;
     }

--- a/src/ui/kit/mnemonic_style.cpp
+++ b/src/ui/kit/mnemonic_style.cpp
@@ -1,0 +1,26 @@
+#include <bloom/ui/kit/mnemonic_style.hpp>
+
+#include <QGuiApplication>
+#include <QStyleFactory>
+
+namespace bloom::ui::kit {
+
+bool showMnemonicUnderline(const Qt::KeyboardModifiers modifiers) noexcept {
+    return modifiers.testFlag(Qt::AltModifier);
+}
+
+AltUnderlineProxyStyle::AltUnderlineProxyStyle()
+    : AltUnderlineProxyStyle(QStyleFactory::create(QStringLiteral("Fusion"))) {}
+
+AltUnderlineProxyStyle::AltUnderlineProxyStyle(QStyle* baseStyle) : QProxyStyle(baseStyle) {}
+
+int AltUnderlineProxyStyle::styleHint(const StyleHint hint, const QStyleOption* option,
+                                      const QWidget* widget,
+                                      QStyleHintReturn* returnData) const {
+    if (hint == QStyle::SH_UnderlineShortcut) {
+        return showMnemonicUnderline(QGuiApplication::keyboardModifiers()) ? 1 : 0;
+    }
+    return QProxyStyle::styleHint(hint, option, widget, returnData);
+}
+
+} // namespace bloom::ui::kit

--- a/src/ui/kit/theme.cpp
+++ b/src/ui/kit/theme.cpp
@@ -76,6 +76,10 @@ const auto& numberPlaceholders() {
         {QLatin1StringView("radius.ScrollBarThumb"), radiusPx(Radius::Full, px(Size::ScrollBar))},
         {QLatin1StringView("radius.ScrollBarThumbHover"),
          radiusPx(Radius::Full, px(Size::ScrollBarHover))},
+        // The workspace-switcher tab's checked pill (task U2, issue #118, decision 2): Radius::Full
+        // against the menu bar's own Control-height row, the same "pill against its own extent"
+        // technique the scrollbar thumb above uses.
+        {QLatin1StringView("radius.WorkspaceTabPill"), radiusPx(Radius::Full, px(Size::Control))},
         {QLatin1StringView("border.Hairline"), static_cast<int>(kHairlineWidth)},
         {QLatin1StringView("border.Window"), static_cast<int>(kWindowBorderWidth)},
     });
@@ -175,10 +179,22 @@ QMenuBar::item:selected {
 }
 QMenuBar::item:checked {
     background: {color.SurfaceRaised};
-    border-radius: {radius.Small}px;
+    color: {color.Accent};
+    border-radius: {radius.WorkspaceTabPill}px;
 }
 QMenuBar::item:disabled {
     color: {color.DisabledInk};
+}
+QWidget#kinetikTitleBar {
+    background: {color.Surface};
+    border-bottom: {border.Hairline}px solid {color.Border};
+}
+QWidget#kinetikTitleBar QMenuBar {
+    background: {color.Surface};
+    border-bottom: none;
+}
+QLabel#titleBarTitleLabel {
+    color: {color.Foreground};
 }
 QMenu {
     background: {color.SurfaceRaised};
@@ -205,6 +221,7 @@ QMenu::separator {
 QFrame#editorArea {
     background: {color.Background};
     border: {border.Hairline}px solid {color.Border};
+    border-radius: {radius.Large}px;
 }
 QFrame#editorArea[active="true"] {
     border-color: {color.Accent};
@@ -216,6 +233,18 @@ QWidget#editorHeader {
 }
 QLabel#unavailableEditorPlaceholder {
     color: {color.Faint};
+}
+QToolButton#panelContextMenuButton, QToolButton#maximizeAreaButton, QToolButton#closeAreaButton {
+    border: {border.Hairline}px solid {color.Border};
+    border-radius: {radius.Small}px;
+}
+QToolButton#panelContextMenuButton:hover, QToolButton#maximizeAreaButton:hover {
+    border-color: {color.BorderHover};
+}
+QToolButton#closeAreaButton:hover {
+    background: {color.Error};
+    border-color: {color.Error};
+    color: {color.Foreground};
 }
 QWidget#readOnlyPlaceholderPage {
     background: {color.Background};

--- a/src/ui/kit/title_bar.cpp
+++ b/src/ui/kit/title_bar.cpp
@@ -84,8 +84,7 @@ void TitleBar::setMaximized(const bool maximized) {
     }
     maximized_ = maximized;
     maximizeButton_->setIconId(maximized_ ? IconId::Restore : IconId::Maximize);
-    const QString toolTip =
-        maximized_ ? QStringLiteral("Restore") : QStringLiteral("Maximize");
+    const QString toolTip = maximized_ ? QStringLiteral("Restore") : QStringLiteral("Maximize");
     maximizeButton_->setToolTip(toolTip);
     maximizeButton_->setAccessibleName(toolTip);
 }

--- a/src/ui/kit/title_bar.cpp
+++ b/src/ui/kit/title_bar.cpp
@@ -1,0 +1,117 @@
+#include <bloom/ui/kit/title_bar.hpp>
+
+#include <bloom/ui/kit/button.hpp>
+#include <bloom/ui/kit/fonts.hpp>
+#include <bloom/ui/kit/icons.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMenuBar>
+#include <QMouseEvent>
+#include <QSizePolicy>
+#include <QWindow>
+
+namespace bloom::ui::kit {
+namespace {
+
+KButton* makeChromeButton(const IconId iconId, const QString& toolTip, const QString& objectName,
+                          QWidget* parent) {
+    auto* button = new KButton(iconId, QString{}, parent);
+    button->setObjectName(objectName);
+    button->setVariant(KButton::Variant::Ghost);
+    button->setControlSize(KButton::ControlSize::Default);
+    button->setToolTip(toolTip);
+    button->setAccessibleName(toolTip);
+    button->setFocusPolicy(Qt::NoFocus);
+    return button;
+}
+
+} // namespace
+
+TitleBar::TitleBar(QWidget* parent) : QWidget(parent) {
+    setObjectName(QStringLiteral("kinetikTitleBar"));
+    setFixedHeight(px(Size::TitleBar));
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+    titleLabel_ = new QLabel(this);
+    titleLabel_->setObjectName(QStringLiteral("titleBarTitleLabel"));
+    titleLabel_->setFont(kit::font(TypeRole::Title));
+
+    minimizeButton_ = makeChromeButton(IconId::Minimize, QStringLiteral("Minimize"),
+                                       QStringLiteral("titleBarMinimizeButton"), this);
+    maximizeButton_ = makeChromeButton(IconId::Maximize, QStringLiteral("Maximize"),
+                                       QStringLiteral("titleBarMaximizeButton"), this);
+    closeButton_ = makeChromeButton(IconId::Close, QStringLiteral("Close"),
+                                    QStringLiteral("titleBarCloseButton"), this);
+    // Standard convention (decision 1, issue #118): the close control alone commits to Error fill
+    // once hovered, while resting flush with its ghost siblings.
+    closeButton_->setDangerOnHover(true);
+
+    layout_ = new QHBoxLayout(this);
+    layout_->setContentsMargins(px(Spacing::M), 0, px(Spacing::XS), 0);
+    layout_->setSpacing(px(Spacing::S));
+    layout_->addWidget(titleLabel_);
+    menuBarSlot_ = layout_->count();
+    layout_->addStretch(1);
+    layout_->addWidget(minimizeButton_);
+    layout_->addWidget(maximizeButton_);
+    layout_->addWidget(closeButton_);
+
+    connect(minimizeButton_, &KButton::clicked, this, &TitleBar::minimizeRequested);
+    connect(maximizeButton_, &KButton::clicked, this, &TitleBar::maximizeOrRestoreRequested);
+    connect(closeButton_, &KButton::clicked, this, &TitleBar::closeRequested);
+}
+
+void TitleBar::setTitle(const QString& title) { titleLabel_->setText(title); }
+
+void TitleBar::setMenuBar(QMenuBar* menuBar) {
+    if (menuBar_ == menuBar) {
+        return;
+    }
+    if (menuBar_ != nullptr) {
+        layout_->removeWidget(menuBar_);
+    }
+    menuBar_ = menuBar;
+    if (menuBar_ != nullptr) {
+        layout_->insertWidget(menuBarSlot_, menuBar_);
+    }
+}
+
+void TitleBar::setMaximized(const bool maximized) {
+    if (maximized_ == maximized) {
+        return;
+    }
+    maximized_ = maximized;
+    maximizeButton_->setIconId(maximized_ ? IconId::Restore : IconId::Maximize);
+    const QString toolTip =
+        maximized_ ? QStringLiteral("Restore") : QStringLiteral("Maximize");
+    maximizeButton_->setToolTip(toolTip);
+    maximizeButton_->setAccessibleName(toolTip);
+}
+
+bool TitleBar::maximizedAppearance() const noexcept { return maximized_; }
+
+void TitleBar::mousePressEvent(QMouseEvent* event) {
+    // Only ever reached for the empty bar area: the label, the embedded menu bar, and the three
+    // buttons all claim their own mouse events first.
+    if (event->button() == Qt::LeftButton) {
+        if (auto* handle = window()->windowHandle(); handle != nullptr) {
+            handle->startSystemMove();
+        }
+        event->accept();
+        return;
+    }
+    QWidget::mousePressEvent(event);
+}
+
+void TitleBar::mouseDoubleClickEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton) {
+        Q_EMIT maximizeOrRestoreRequested();
+        event->accept();
+        return;
+    }
+    QWidget::mouseDoubleClickEvent(event);
+}
+
+} // namespace bloom::ui::kit

--- a/src/ui/licenses_window.cpp
+++ b/src/ui/licenses_window.cpp
@@ -1,0 +1,62 @@
+#include <bloom/ui/licenses_window.hpp>
+
+#include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/third_party_license_catalog.hpp>
+
+#include <QHBoxLayout>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QPlainTextEdit>
+#include <QString>
+
+namespace bloom::ui {
+namespace {
+
+[[nodiscard]] QString toQString(const std::string_view text) {
+    return QString::fromUtf8(text.data(), static_cast<qsizetype>(text.size()));
+}
+
+} // namespace
+
+LicensesWindow::LicensesWindow(QWidget* parent) : QDialog(parent) {
+    setObjectName(QStringLiteral("licensesWindow"));
+    setWindowTitle(QStringLiteral("Open Source Licenses"));
+    // A whole-dialog default extent, not a chrome token: mirrors MainWindow's own
+    // resize(1600, 1000) precedent for top-level window sizing -- the token vocabulary governs
+    // control chrome (spacing, radii, control heights), not an arbitrary dialog's overall size.
+    resize(760, 520);
+
+    componentList_ = new QListWidget(this);
+    componentList_->setObjectName(QStringLiteral("licensesComponentList"));
+
+    licenseText_ = new QPlainTextEdit(this);
+    licenseText_->setObjectName(QStringLiteral("licensesTextView"));
+    licenseText_->setReadOnly(true);
+    licenseText_->setFont(kit::font(kit::TypeRole::Value));
+
+    for (const auto& entry : thirdPartyLicenseCatalog()) {
+        auto* item = new QListWidgetItem(toQString(entry.component), componentList_);
+        item->setData(Qt::UserRole, toQString(entry.licenseText));
+    }
+
+    connect(componentList_, &QListWidget::currentRowChanged, this, [this](const int row) {
+        if (row < 0) {
+            licenseText_->clear();
+            return;
+        }
+        licenseText_->setPlainText(componentList_->item(row)->data(Qt::UserRole).toString());
+    });
+
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(kit::px(kit::Spacing::M), kit::px(kit::Spacing::M),
+                               kit::px(kit::Spacing::M), kit::px(kit::Spacing::M));
+    layout->setSpacing(kit::px(kit::Spacing::M));
+    layout->addWidget(componentList_, 1);
+    layout->addWidget(licenseText_, 3);
+
+    if (componentList_->count() > 0) {
+        componentList_->setCurrentRow(0);
+    }
+}
+
+} // namespace bloom::ui

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -5,21 +5,33 @@
 #include <bloom/ui/editor_area.hpp>
 #include <bloom/ui/editor_registry.hpp>
 #include <bloom/ui/frame_export_controller.hpp>
+#include <bloom/ui/frameless_window_support.hpp>
+#include <bloom/ui/kit/title_bar.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/licenses_window.hpp>
 #include <bloom/ui/project_host.hpp>
 #include <bloom/ui/workspace_host.hpp>
 
 #include <QAction>
 #include <QActionGroup>
+#include <QApplication>
 #include <QCloseEvent>
+#include <QDesktopServices>
+#include <QEvent>
 #include <QKeySequence>
 #include <QLabel>
+#include <QLatin1StringView>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
+#include <QPainterPath>
+#include <QRegion>
+#include <QResizeEvent>
 #include <QSettings>
 #include <QStackedWidget>
 #include <QStatusBar>
 #include <QStringList>
+#include <QUrl>
 #include <QVBoxLayout>
 
 #include <filesystem>
@@ -28,22 +40,38 @@ namespace {
 
 constexpr auto workspaceLayoutKey = "workspace/compositing/layout";
 constexpr auto windowGeometryKey = "window/main/geometry";
+constexpr auto chromeModeKey = "appearance/chrome";
+constexpr auto issueTrackerUrl = "https://github.com/kinetik-gg/bloom/issues/new";
 
 } // namespace
 
 namespace bloom::ui {
 
+ChromeMode chromeModeFromSettings(const QSettings& settings) {
+    const auto value =
+        settings.value(QLatin1StringView(chromeModeKey), QStringLiteral("custom")).toString();
+    return value.compare(QStringLiteral("native"), Qt::CaseInsensitive) == 0 ? ChromeMode::Native
+                                                                             : ChromeMode::Custom;
+}
+
+void setChromeModeInSettings(QSettings& settings, const ChromeMode mode) {
+    settings.setValue(QLatin1StringView(chromeModeKey),
+                      mode == ChromeMode::Native ? QStringLiteral("native")
+                                                 : QStringLiteral("custom"));
+}
+
 MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession& compositionSession,
                        ProjectHost& projectHost, FrameExportController& frameExportController,
-                       QWidget* parent)
+                       ChromeMode chromeMode, QWidget* parent)
     : QMainWindow(parent), compositionSession_(compositionSession), projectHost_(projectHost),
-      frameExportController_(frameExportController) {
+      frameExportController_(frameExportController), chromeMode_(chromeMode) {
     setObjectName("bloomMainWindow");
     setWindowTitle("Bloom");
     resize(1600, 1000);
 
-    createMenus();
-    createWorkspaceSwitcher();
+    createChrome();
+    createMenus(*menuBar_);
+    createWorkspaceSwitcher(*menuBar_);
     createEditorLayout(editorRegistry);
     createCentralStack();
     createWorkspaceActions();
@@ -167,10 +195,92 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     });
 }
 
-void MainWindow::createMenus() {
-    auto* fileMenu = menuBar()->addMenu("&File");
+void MainWindow::changeEvent(QEvent* event) {
+    QMainWindow::changeEvent(event);
+    // Every path to a maximize/restore state change -- the title bar button, its double-click,
+    // an OS action, a keyboard shortcut -- lands here, so this is the one place that keeps the
+    // TitleBar glyph and the window's own corner rounding in sync (decision 1: "maximize state
+    // switches the icon and drops the window corner radius").
+    if (event->type() == QEvent::WindowStateChange) {
+        if (titleBar_ != nullptr) {
+            titleBar_->setMaximized(isMaximized() || isFullScreen());
+        }
+        updateWindowMask();
+    }
+}
+
+void MainWindow::resizeEvent(QResizeEvent* event) {
+    QMainWindow::resizeEvent(event);
+    updateWindowMask();
+}
+
+void MainWindow::createChrome() {
+    if (chromeMode_ == ChromeMode::Native) {
+        // Classic row: QMainWindow's own menu bar, stock window decorations, everything else
+        // identical (decision 1).
+        menuBar_ = menuBar();
+        return;
+    }
+
+    // Custom chrome (decision 1, default on): frameless main window with a Kinetik TitleBar
+    // whose row hosts the SAME QMenuBar the native path would otherwise dock classically
+    // (decision 2, "share one implementation").
+    setWindowFlag(Qt::FramelessWindowHint, true);
+    titleBar_ = new kit::TitleBar(this);
+    menuBar_ = new QMenuBar();
+    titleBar_->setMenuBar(menuBar_);
+    setMenuWidget(titleBar_);
+
+    connect(titleBar_, &kit::TitleBar::minimizeRequested, this, &QWidget::showMinimized);
+    connect(titleBar_, &kit::TitleBar::maximizeOrRestoreRequested, this,
+            &MainWindow::toggleMaximizeRestore);
+    connect(titleBar_, &kit::TitleBar::closeRequested, this, &QWidget::close);
+
+    // Edge-resize on a thin frameless margin (decision 1): see FramelessEdgeResizer's own header
+    // comment for why an application-wide event filter, rather than reserved dead space, is the
+    // mechanism -- and why it is Wayland/X11-correct through Qt's own platform contract.
+    edgeResizer_ = new FramelessEdgeResizer(*this, kit::px(kit::Spacing::XS), this);
+    qApp->installEventFilter(edgeResizer_);
+
+    updateWindowMask();
+}
+
+void MainWindow::updateWindowMask() {
+    if (chromeMode_ != ChromeMode::Custom) {
+        return;
+    }
+    if (isMaximized() || isFullScreen()) {
+        // A maximized/full-screen frameless window fills the screen; rounded corners there would
+        // poke into the visible desktop, so the mask is dropped entirely (decision 1).
+        clearMask();
+        return;
+    }
+    QPainterPath path;
+    const int radius = kit::radiusPx(kit::Radius::Large, 0);
+    path.addRoundedRect(rect(), radius, radius);
+    setMask(QRegion(path.toFillPolygon().toPolygon()));
+}
+
+void MainWindow::toggleFullScreen() {
+    if (isFullScreen()) {
+        showNormal();
+    } else {
+        showFullScreen();
+    }
+}
+
+void MainWindow::toggleMaximizeRestore() {
+    if (isMaximized()) {
+        showNormal();
+    } else {
+        showMaximized();
+    }
+}
+
+void MainWindow::createMenus(QMenuBar& menuBar) {
+    auto* fileMenu = menuBar.addMenu("&File");
     createFileMenu(*fileMenu);
-    auto* editMenu = menuBar()->addMenu("&Edit");
+    auto* editMenu = menuBar.addMenu("&Edit");
     undoAction_ = editMenu->addAction("Undo");
     undoAction_->setObjectName("undoAction");
     undoAction_->setShortcut(QKeySequence::Undo);
@@ -185,9 +295,65 @@ void MainWindow::createMenus() {
     connect(&compositionSession_, &CompositionSession::historyChanged, this,
             &MainWindow::updateEditActions);
 
-    menuBar()->addMenu("&View");
-    windowMenu_ = menuBar()->addMenu("&Window");
-    menuBar()->addMenu("&Help");
+    viewMenu_ = menuBar.addMenu("&View");
+    createViewMenu(*viewMenu_);
+    windowMenu_ = menuBar.addMenu("&Window");
+    auto* helpMenu = menuBar.addMenu("&Help");
+    createHelpMenu(*helpMenu);
+}
+
+void MainWindow::createViewMenu(QMenu& viewMenu) {
+    // Full Screen (decision 2): F11, plain window fullscreen toggle.
+    viewFullScreenAction_ = viewMenu.addAction("Full Screen");
+    viewFullScreenAction_->setObjectName("viewFullScreenAction");
+    viewFullScreenAction_->setCheckable(true);
+    viewFullScreenAction_->setShortcut(QKeySequence(Qt::Key_F11));
+    viewFullScreenAction_->setShortcutContext(Qt::WindowShortcut);
+    connect(viewFullScreenAction_, &QAction::triggered, this, &MainWindow::toggleFullScreen);
+
+    // Maximize Panel (decision 2): routes to the SAME editor-maximize the Window menu's
+    // "Maximize Active Area" already drives -- wired once workspaceHost_ exists, in
+    // createWorkspaceActions(), which also keeps both actions' checked state in sync.
+    viewMaximizePanelAction_ = viewMenu.addAction("Maximize Panel");
+    viewMaximizePanelAction_->setObjectName("viewMaximizePanelAction");
+    viewMaximizePanelAction_->setCheckable(true);
+
+    viewMenu.addSeparator();
+
+    // "Use Native Window Frame" (decision 1): toggles the persisted chrome setting and explains,
+    // honestly, that this slice never re-chromes a live window -- the artist restarts to see it.
+    useNativeFrameAction_ = viewMenu.addAction("Use Native Window Frame");
+    useNativeFrameAction_->setObjectName("useNativeFrameAction");
+    useNativeFrameAction_->setCheckable(true);
+    useNativeFrameAction_->setChecked(chromeMode_ == ChromeMode::Native);
+    useNativeFrameAction_->setStatusTip(
+        tr("Restart Bloom to apply the window frame change."));
+    connect(useNativeFrameAction_, &QAction::triggered, this, [this](const bool checked) {
+        QSettings settings;
+        setChromeModeInSettings(settings, checked ? ChromeMode::Native : ChromeMode::Custom);
+        statusBar()->showMessage(tr("Restart Bloom to use the %1 window frame.")
+                                     .arg(checked ? tr("native") : tr("custom")),
+                                 6000);
+    });
+}
+
+void MainWindow::createHelpMenu(QMenu& helpMenu) {
+    // "Report an Issue…" (decision 2): opens the repository's issue tracker via QDesktopServices,
+    // whose url handler is Qt's own interception seam for tests (QDesktopServices::setUrlHandler).
+    reportIssueAction_ = helpMenu.addAction("Report an Issue…");
+    reportIssueAction_->setObjectName("reportIssueAction");
+    connect(reportIssueAction_, &QAction::triggered, this,
+            [] { QDesktopServices::openUrl(QUrl(QString::fromLatin1(issueTrackerUrl))); });
+
+    // "Open Source Licenses…" (decision 3): a non-modal LicensesWindow, so triggering the action
+    // never blocks the event loop (or an automated test that fires it synchronously).
+    openSourceLicensesAction_ = helpMenu.addAction("Open Source Licenses…");
+    openSourceLicensesAction_->setObjectName("openSourceLicensesAction");
+    connect(openSourceLicensesAction_, &QAction::triggered, this, [this] {
+        auto* dialog = new LicensesWindow(this);
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        dialog->show();
+    });
 }
 
 void MainWindow::updateEditActions() {
@@ -282,6 +448,12 @@ void MainWindow::updateWindowTitle() {
         path.has_value() ? QString::fromStdString(path->filename().string()) : tr("Untitled");
     setWindowTitle(QStringLiteral("%1[*] — Bloom").arg(name));
     setWindowModified(projectHost_.isDirty());
+    if (titleBar_ != nullptr) {
+        // The TitleBar's own label follows the session the same way (decision 1): "Bloom —
+        // <project name/Untitled>", updated on every dirty/session change alongside the real
+        // OS-level window title above.
+        titleBar_->setTitle(QStringLiteral("Bloom — %1").arg(name));
+    }
 }
 
 void MainWindow::updateContentSurface() {
@@ -310,15 +482,23 @@ void MainWindow::updateContentSurface() {
     centralStack_->setCurrentWidget(readOnlyPlaceholderPage_);
 }
 
-void MainWindow::createWorkspaceSwitcher() {
-    menuBar()->addSeparator();
+void MainWindow::createWorkspaceSwitcher(QMenuBar& menuBar) {
+    menuBar.addSeparator();
 
-    auto* group = new QActionGroup(menuBar());
+    auto* group = new QActionGroup(&menuBar);
     group->setExclusive(true);
 
     const QStringList workspaces = {"Compositing", "Editing", "Grading", "Scripting", "Rendering"};
     for (const QString& workspace : workspaces) {
-        auto* action = menuBar()->addAction(workspace);
+        auto* action = menuBar.addAction(workspace);
+        // Stable per-workspace identity (decision 2: "still actions, same objectNames" -- these
+        // did not carry one before this slice, so each gets one now). The tab-pill restyle itself
+        // (kit::kinetikStyleSheet()'s QMenuBar::item:checked rule) is NOT scoped by this
+        // objectName -- Qt style sheets cannot address one QMenuBar item independently of its
+        // siblings, only the shared subcontrol state -- but these five checkable actions are the
+        // only checkable top-level menu-bar actions this application ever adds, so the shared rule
+        // safely reaches only them.
+        action->setObjectName(QStringLiteral("workspaceSwitcherTab.%1").arg(workspace));
         action->setCheckable(true);
         action->setEnabled(workspace == "Compositing");
         action->setChecked(workspace == "Compositing");
@@ -406,6 +586,11 @@ void MainWindow::createWorkspaceActions() {
     connect(maximizeAreaAction_, &QAction::triggered, workspaceHost_,
             [this] { workspaceHost_->toggleMaximizeActiveArea(); });
 
+    // View menu's "Maximize Panel" (decision 2) routes to the exact same signal -- wired here,
+    // now that workspaceHost_ exists, rather than in createViewMenu().
+    connect(viewMaximizePanelAction_, &QAction::triggered, workspaceHost_,
+            [this] { workspaceHost_->toggleMaximizeActiveArea(); });
+
     windowMenu_->addSeparator();
     auto* resetLayoutAction = windowMenu_->addAction("Reset Compositing Layout");
     resetLayoutAction->setObjectName("resetCompositingLayoutAction");
@@ -433,6 +618,11 @@ void MainWindow::updateWorkspaceActions() {
     maximizeAreaAction_->setChecked(workspaceHost_->isAreaMaximized());
     maximizeAreaAction_->setText(workspaceHost_->isAreaMaximized() ? "Restore Active Area"
                                                                    : "Maximize Active Area");
+    // Kept in lockstep with the Window menu's own action: same underlying state, two menu homes.
+    viewMaximizePanelAction_->setEnabled(hasMultipleAreas);
+    viewMaximizePanelAction_->setChecked(workspaceHost_->isAreaMaximized());
 }
+
+ChromeMode MainWindow::chromeMode() const noexcept { return chromeMode_; }
 
 } // namespace bloom::ui

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -55,9 +55,9 @@ ChromeMode chromeModeFromSettings(const QSettings& settings) {
 }
 
 void setChromeModeInSettings(QSettings& settings, const ChromeMode mode) {
-    settings.setValue(QLatin1StringView(chromeModeKey),
-                      mode == ChromeMode::Native ? QStringLiteral("native")
-                                                 : QStringLiteral("custom"));
+    settings.setValue(QLatin1StringView(chromeModeKey), mode == ChromeMode::Native
+                                                            ? QStringLiteral("native")
+                                                            : QStringLiteral("custom"));
 }
 
 MainWindow::MainWindow(const EditorRegistry& editorRegistry, CompositionSession& compositionSession,
@@ -326,8 +326,7 @@ void MainWindow::createViewMenu(QMenu& viewMenu) {
     useNativeFrameAction_->setObjectName("useNativeFrameAction");
     useNativeFrameAction_->setCheckable(true);
     useNativeFrameAction_->setChecked(chromeMode_ == ChromeMode::Native);
-    useNativeFrameAction_->setStatusTip(
-        tr("Restart Bloom to apply the window frame change."));
+    useNativeFrameAction_->setStatusTip(tr("Restart Bloom to apply the window frame change."));
     connect(useNativeFrameAction_, &QAction::triggered, this, [this](const bool checked) {
         QSettings settings;
         setChromeModeInSettings(settings, checked ? ChromeMode::Native : ChromeMode::Custom);

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -19,6 +19,18 @@ add_executable(bloom_kit_fonts_test
 add_executable(bloom_kit_icons_test
     kit_icons_tests.cpp
 )
+add_executable(bloom_kit_title_bar_test
+    kit_title_bar_tests.cpp
+)
+add_executable(bloom_kit_mnemonic_style_test
+    kit_mnemonic_style_tests.cpp
+)
+add_executable(bloom_third_party_license_catalog_test
+    third_party_license_catalog_tests.cpp
+)
+add_executable(bloom_main_window_chrome_test
+    main_window_chrome_tests.cpp
+)
 add_executable(bloom_kit_range_test
     kit_range_tests.cpp
 )
@@ -98,6 +110,10 @@ target_link_libraries(bloom_kit_choice_test PRIVATE bloom_ui_kit Qt6::Test)
 target_link_libraries(bloom_kit_dropdown_test PRIVATE bloom_ui_kit Qt6::Test)
 target_link_libraries(bloom_kit_fonts_test PRIVATE bloom_ui_kit)
 target_link_libraries(bloom_kit_icons_test PRIVATE bloom_ui_kit)
+target_link_libraries(bloom_kit_title_bar_test PRIVATE bloom_ui_kit Qt6::Test)
+target_link_libraries(bloom_kit_mnemonic_style_test PRIVATE bloom_ui_kit)
+target_link_libraries(bloom_third_party_license_catalog_test PRIVATE bloom_ui)
+target_link_libraries(bloom_main_window_chrome_test PRIVATE bloom_ui Qt6::Test)
 target_link_libraries(bloom_kit_range_test PRIVATE bloom_ui_kit Qt6::Test)
 target_link_libraries(bloom_kit_value_field_test PRIVATE bloom_ui_kit Qt6::Test)
 target_link_libraries(bloom_kit_theme_test PRIVATE bloom_ui_kit)
@@ -124,6 +140,10 @@ bloom_enable_warnings(bloom_kit_choice_test)
 bloom_enable_warnings(bloom_kit_dropdown_test)
 bloom_enable_warnings(bloom_kit_fonts_test)
 bloom_enable_warnings(bloom_kit_icons_test)
+bloom_enable_warnings(bloom_kit_title_bar_test)
+bloom_enable_warnings(bloom_kit_mnemonic_style_test)
+bloom_enable_warnings(bloom_third_party_license_catalog_test)
+bloom_enable_warnings(bloom_main_window_chrome_test)
 bloom_enable_warnings(bloom_kit_range_test)
 bloom_enable_warnings(bloom_kit_value_field_test)
 bloom_enable_warnings(bloom_kit_theme_test)
@@ -199,6 +219,38 @@ bloom_add_test(
     COMMAND bloom_kit_icons_test
     LABELS ui unit kit
     TIMEOUT 60
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.kit_title_bar
+    COMMAND bloom_kit_title_bar_test
+    LABELS ui unit kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.kit_mnemonic_style
+    COMMAND bloom_kit_mnemonic_style_test
+    LABELS ui unit kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.third_party_license_catalog
+    COMMAND bloom_third_party_license_catalog_test --root "${PROJECT_SOURCE_DIR}"
+    LABELS ui unit quality
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.main_window_chrome
+    COMMAND bloom_main_window_chrome_test
+    LABELS ui integration
+    TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )
 

--- a/src/ui/tests/editor_area_chrome_tests.cpp
+++ b/src/ui/tests/editor_area_chrome_tests.cpp
@@ -3,8 +3,10 @@
 #include <bloom/ui/kit/icons.hpp>
 #include <bloom/ui/kit/tokens.hpp>
 
+#include <QAction>
 #include <QApplication>
 #include <QIcon>
+#include <QMenu>
 #include <QSignalSpy>
 #include <QString>
 #include <QToolButton>
@@ -43,36 +45,71 @@ EditorRegistry makeRegistry() {
     return registry;
 }
 
+// task U2, issue #118, decision 4 -- the ONE sanctioned test-contract change: the H/V split
+// QToolButtons (splitLeftRightButton/splitTopBottomButton) are gone, replaced by a single
+// "panelContextMenuButton" QToolButton whose "panelOptionsMenu" QMenu offers four actions
+// (panelSplitHorizontalAction/panelSplitVerticalAction/panelMaximizeAction/panelCloseAction, all
+// new stable objectNames). Maximize and Close keep their original standalone QToolButtons and
+// objectNames unchanged.
+
 void testHeaderControlsAreIconsWithTheirNamesIntact(Expectations& expectations) {
     const EditorRegistry registry = makeRegistry();
     EditorArea area(registry, "bloom.probe", QString{});
+
+    expectations.expect(
+        area.findChild<QToolButton*>(QStringLiteral("splitLeftRightButton")) == nullptr &&
+            area.findChild<QToolButton*>(QStringLiteral("splitTopBottomButton")) == nullptr,
+        "the old split buttons are really gone, not merely relabeled");
 
     struct Contract {
         const char* objectName;
         const char* toolTip;
     };
     for (const auto& [objectName, toolTip] :
-         {Contract{"splitLeftRightButton", "Split area left/right"},
-          Contract{"splitTopBottomButton", "Split area top/bottom"},
+         {Contract{"panelContextMenuButton", "Panel options"},
           Contract{"maximizeAreaButton", "Maximize area"},
           Contract{"closeAreaButton", "Close area"}}) {
         auto* button = area.findChild<QToolButton*>(QString::fromLatin1(objectName));
         expectations.expect(button != nullptr,
-                            std::string{"the header still exposes "} + objectName);
+                            std::string{"the header exposes "} + objectName);
         if (button == nullptr) {
             continue;
         }
         expectations.expect(!button->icon().isNull(),
                             std::string{objectName} + " draws a Kinetik icon");
         expectations.expect(button->text().isEmpty(),
-                            std::string{objectName} + " no longer carries a typed glyph");
+                            std::string{objectName} + " carries no typed glyph");
         expectations.expect(button->toolTip() == QString::fromLatin1(toolTip),
-                            std::string{objectName} + " keeps its tooltip");
+                            std::string{objectName} + " has its tooltip");
         expectations.expect(button->accessibleName() == QString::fromLatin1(toolTip),
-                            std::string{objectName} + " keeps its accessible name: an icon never "
+                            std::string{objectName} + " has its accessible name: an icon never "
                                                       "replaces one");
         expectations.expect(button->iconSize().width() == kit::px(kit::Size::IconSmall),
                             std::string{objectName} + " uses the dense-chrome icon box");
+    }
+
+}
+
+void testTheContextMenuOffersAllFourOperations(Expectations& expectations) {
+    const EditorRegistry registry = makeRegistry();
+    EditorArea area(registry, "bloom.probe", QString{});
+    auto* contextButton =
+        area.findChild<QToolButton*>(QStringLiteral("panelContextMenuButton"));
+    expectations.expect(contextButton != nullptr, "the context-menu button exists");
+    if (contextButton == nullptr) {
+        return;
+    }
+    auto* menu = contextButton->menu();
+    expectations.expect(menu != nullptr && menu->objectName() == QStringLiteral("panelOptionsMenu"),
+                        "the button owns a kit-styled, identifiable QMenu");
+    if (menu == nullptr) {
+        return;
+    }
+    for (const char* objectName :
+         {"panelSplitHorizontalAction", "panelSplitVerticalAction", "panelMaximizeAction",
+          "panelCloseAction"}) {
+        expectations.expect(menu->findChild<QAction*>(QString::fromLatin1(objectName)) != nullptr,
+                            std::string{"the menu offers "} + objectName);
     }
 }
 
@@ -104,35 +141,60 @@ void testMaximizeSwapsIconAndNamesWithoutChangingIdentity(Expectations& expectat
 void testHeaderControlsStillDriveTheirSignals(Expectations& expectations) {
     const EditorRegistry registry = makeRegistry();
     EditorArea area(registry, "bloom.probe", QString{});
+    auto* menu = area.findChild<QMenu*>(QStringLiteral("panelOptionsMenu"));
+    expectations.expect(menu != nullptr, "the panel options menu exists");
+    if (menu == nullptr) {
+        return;
+    }
 
     QSignalSpy splitSpy(&area, &EditorArea::splitRequested);
     QSignalSpy closeSpy(&area, &EditorArea::closeRequested);
     QSignalSpy maximizeSpy(&area, &EditorArea::maximizeRequested);
 
-    area.findChild<QToolButton*>(QStringLiteral("splitLeftRightButton"))->click();
-    area.findChild<QToolButton*>(QStringLiteral("splitTopBottomButton"))->click();
+    // QAction::trigger() fires the same signal a real click on a shown popup would, without
+    // needing to actually open the (offscreen) popup -- the menu's own visibility is not what is
+    // under test here.
+    menu->findChild<QAction*>(QStringLiteral("panelSplitHorizontalAction"))->trigger();
+    menu->findChild<QAction*>(QStringLiteral("panelSplitVerticalAction"))->trigger();
     area.findChild<QToolButton*>(QStringLiteral("closeAreaButton"))->click();
     area.findChild<QToolButton*>(QStringLiteral("maximizeAreaButton"))->click();
+    // The menu's own Maximize/Close actions route to the SAME signals the standalone buttons do.
+    menu->findChild<QAction*>(QStringLiteral("panelMaximizeAction"))->trigger();
+    menu->findChild<QAction*>(QStringLiteral("panelCloseAction"))->trigger();
 
-    // The split controls keep their behavior in this slice: replacing them with a context menu is
-    // a later slice's decision, not a side effect of an icon change.
-    expectations.expect(splitSpy.count() == 2, "both split controls still request a split");
-    expectations.expect(closeSpy.count() == 1, "the close control still requests a close");
-    expectations.expect(maximizeSpy.count() == 1, "the maximize control still requests a maximize");
+    expectations.expect(splitSpy.count() == 2, "both menu split actions request a split");
+    expectations.expect(closeSpy.count() == 2,
+                        "the close button AND the menu's close action request a close");
+    expectations.expect(maximizeSpy.count() == 2,
+                        "the maximize button AND the menu's maximize action request a maximize");
 }
 
 void testSplitAndCloseEnablementIsUnchanged(Expectations& expectations) {
     const EditorRegistry registry = makeRegistry();
     EditorArea area(registry, "bloom.probe", QString{});
+    auto* menu = area.findChild<QMenu*>(QStringLiteral("panelOptionsMenu"));
+    expectations.expect(menu != nullptr, "the panel options menu exists");
+    if (menu == nullptr) {
+        return;
+    }
+
     area.setSplitEnabled(false);
     area.setCloseEnabled(false);
     expectations.expect(
-        !area.findChild<QToolButton*>(QStringLiteral("splitLeftRightButton"))->isEnabled() &&
-            !area.findChild<QToolButton*>(QStringLiteral("splitTopBottomButton"))->isEnabled(),
-        "split enablement still reaches both controls");
+        !menu->findChild<QAction*>(QStringLiteral("panelSplitHorizontalAction"))->isEnabled() &&
+            !menu->findChild<QAction*>(QStringLiteral("panelSplitVerticalAction"))->isEnabled(),
+        "split enablement now reaches the menu's two split actions");
     expectations.expect(
-        !area.findChild<QToolButton*>(QStringLiteral("closeAreaButton"))->isEnabled(),
-        "close enablement still reaches its control");
+        !area.findChild<QToolButton*>(QStringLiteral("closeAreaButton"))->isEnabled() &&
+            !menu->findChild<QAction*>(QStringLiteral("panelCloseAction"))->isEnabled(),
+        "close enablement reaches both the standalone button and the menu's close action");
+
+    area.setSplitEnabled(true);
+    area.setCloseEnabled(true);
+    expectations.expect(
+        menu->findChild<QAction*>(QStringLiteral("panelSplitHorizontalAction"))->isEnabled() &&
+            menu->findChild<QAction*>(QStringLiteral("panelSplitVerticalAction"))->isEnabled(),
+        "and re-enabling reaches them too");
 }
 
 } // namespace
@@ -142,6 +204,7 @@ int main(int argc, char** argv) {
     const QApplication application(argc, argv);
     Expectations expectations;
     testHeaderControlsAreIconsWithTheirNamesIntact(expectations);
+    testTheContextMenuOffersAllFourOperations(expectations);
     testMaximizeSwapsIconAndNamesWithoutChangingIdentity(expectations);
     testHeaderControlsStillDriveTheirSignals(expectations);
     testSplitAndCloseEnablementIsUnchanged(expectations);

--- a/src/ui/tests/editor_area_chrome_tests.cpp
+++ b/src/ui/tests/editor_area_chrome_tests.cpp
@@ -65,13 +65,11 @@ void testHeaderControlsAreIconsWithTheirNamesIntact(Expectations& expectations) 
         const char* objectName;
         const char* toolTip;
     };
-    for (const auto& [objectName, toolTip] :
-         {Contract{"panelContextMenuButton", "Panel options"},
-          Contract{"maximizeAreaButton", "Maximize area"},
-          Contract{"closeAreaButton", "Close area"}}) {
+    for (const auto& [objectName, toolTip] : {Contract{"panelContextMenuButton", "Panel options"},
+                                              Contract{"maximizeAreaButton", "Maximize area"},
+                                              Contract{"closeAreaButton", "Close area"}}) {
         auto* button = area.findChild<QToolButton*>(QString::fromLatin1(objectName));
-        expectations.expect(button != nullptr,
-                            std::string{"the header exposes "} + objectName);
+        expectations.expect(button != nullptr, std::string{"the header exposes "} + objectName);
         if (button == nullptr) {
             continue;
         }
@@ -87,14 +85,12 @@ void testHeaderControlsAreIconsWithTheirNamesIntact(Expectations& expectations) 
         expectations.expect(button->iconSize().width() == kit::px(kit::Size::IconSmall),
                             std::string{objectName} + " uses the dense-chrome icon box");
     }
-
 }
 
 void testTheContextMenuOffersAllFourOperations(Expectations& expectations) {
     const EditorRegistry registry = makeRegistry();
     EditorArea area(registry, "bloom.probe", QString{});
-    auto* contextButton =
-        area.findChild<QToolButton*>(QStringLiteral("panelContextMenuButton"));
+    auto* contextButton = area.findChild<QToolButton*>(QStringLiteral("panelContextMenuButton"));
     expectations.expect(contextButton != nullptr, "the context-menu button exists");
     if (contextButton == nullptr) {
         return;
@@ -105,9 +101,8 @@ void testTheContextMenuOffersAllFourOperations(Expectations& expectations) {
     if (menu == nullptr) {
         return;
     }
-    for (const char* objectName :
-         {"panelSplitHorizontalAction", "panelSplitVerticalAction", "panelMaximizeAction",
-          "panelCloseAction"}) {
+    for (const char* objectName : {"panelSplitHorizontalAction", "panelSplitVerticalAction",
+                                   "panelMaximizeAction", "panelCloseAction"}) {
         expectations.expect(menu->findChild<QAction*>(QString::fromLatin1(objectName)) != nullptr,
                             std::string{"the menu offers "} + objectName);
     }

--- a/src/ui/tests/kit_button_tests.cpp
+++ b/src/ui/tests/kit_button_tests.cpp
@@ -256,7 +256,8 @@ void testGhostDangerOnHoverStaysGhostAtRest(Expectations& expectations) {
 
     expectations.expect(!button.fillForState(kit::State::Normal).isValid(),
                         "still no surface of its own at rest, exactly like plain Ghost");
-    expectations.expect(button.inkForVisualState(kit::State::Normal) == kit::color(kit::Color::Muted),
+    expectations.expect(button.inkForVisualState(kit::State::Normal) ==
+                            kit::color(kit::Color::Muted),
                         "resting ink is still the ordinary ghost muted ink, not Error");
 
     expectations.expect(button.fillForState(kit::State::Hover) ==
@@ -271,8 +272,8 @@ void testGhostDangerOnHoverStaysGhostAtRest(Expectations& expectations) {
 
     // Every other variant ignores the flag entirely: it is a Ghost-only opt-in.
     button.setVariant(kit::KButton::Variant::Secondary);
-    expectations.expect(button.fillForState(kit::State::Hover) != kit::hoverFillFor(kit::color(
-                                                                       kit::Color::Error)),
+    expectations.expect(button.fillForState(kit::State::Hover) !=
+                            kit::hoverFillFor(kit::color(kit::Color::Error)),
                         "dangerOnHover has no effect outside Variant::Ghost");
 }
 

--- a/src/ui/tests/kit_button_tests.cpp
+++ b/src/ui/tests/kit_button_tests.cpp
@@ -244,6 +244,38 @@ void testAnIconButtonRendersBothGlyphAndLabel(Expectations& expectations) {
     expectations.expect(sawAccent, "a Primary button really paints its accent fill");
 }
 
+void testGhostDangerOnHoverStaysGhostAtRest(Expectations& expectations) {
+    // The title bar / panel-header close button convention (task U2, issue #118): flush with its
+    // ghost siblings at rest, Error fill only once the pointer commits.
+    kit::KButton button(kit::IconId::Close, QString{});
+    button.setVariant(kit::KButton::Variant::Ghost);
+    expectations.expect(!button.dangerOnHover(), "dangerOnHover defaults to false");
+
+    button.setDangerOnHover(true);
+    expectations.expect(button.dangerOnHover(), "the flag round-trips");
+
+    expectations.expect(!button.fillForState(kit::State::Normal).isValid(),
+                        "still no surface of its own at rest, exactly like plain Ghost");
+    expectations.expect(button.inkForVisualState(kit::State::Normal) == kit::color(kit::Color::Muted),
+                        "resting ink is still the ordinary ghost muted ink, not Error");
+
+    expectations.expect(button.fillForState(kit::State::Hover) ==
+                            kit::hoverFillFor(kit::color(kit::Color::Error)),
+                        "hover fills with the Error recipe once dangerOnHover is set");
+    expectations.expect(button.inkForVisualState(kit::State::Hover) ==
+                            kit::color(kit::Color::Foreground),
+                        "hover ink is legible on the Error fill");
+    expectations.expect(button.fillForState(kit::State::Pressed) ==
+                            kit::pressedFillFor(kit::color(kit::Color::Error)),
+                        "pressed deepens the same Error recipe Danger itself uses");
+
+    // Every other variant ignores the flag entirely: it is a Ghost-only opt-in.
+    button.setVariant(kit::KButton::Variant::Secondary);
+    expectations.expect(button.fillForState(kit::State::Hover) != kit::hoverFillFor(kit::color(
+                                                                       kit::Color::Error)),
+                        "dangerOnHover has no effect outside Variant::Ghost");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -258,5 +290,6 @@ int main(int argc, char** argv) {
     testDisabledInkIsFortyPercentInEveryVariant(expectations);
     testControlSizesAndTheOutsideFocusRing(expectations);
     testAnIconButtonRendersBothGlyphAndLabel(expectations);
+    testGhostDangerOnHoverStaysGhostAtRest(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/tests/kit_mnemonic_style_tests.cpp
+++ b/src/ui/tests/kit_mnemonic_style_tests.cpp
@@ -62,7 +62,8 @@ void testInstalledProxyRoutesThroughToTheRealStyleHintQuery(Expectations& expect
     // spot-check one hint that has nothing to do with mnemonics.
     const int tabFocus = style.styleHint(QStyle::SH_Widget_ShareActivation);
     const auto* fusion = QStyleFactory::create(QStringLiteral("Fusion"));
-    expectations.expect(fusion != nullptr, "a reference Fusion style is available to compare against");
+    expectations.expect(fusion != nullptr,
+                        "a reference Fusion style is available to compare against");
     if (fusion != nullptr) {
         expectations.expect(tabFocus == fusion->styleHint(QStyle::SH_Widget_ShareActivation),
                             "hints other than SH_UnderlineShortcut fall through to the base style "

--- a/src/ui/tests/kit_mnemonic_style_tests.cpp
+++ b/src/ui/tests/kit_mnemonic_style_tests.cpp
@@ -1,0 +1,83 @@
+#include <bloom/ui/kit/mnemonic_style.hpp>
+
+#include <QApplication>
+#include <QStyle>
+#include <QStyleFactory>
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+// The pure decision both branches: an offscreen test cannot reliably synthesize a real, global
+// Alt-held keyboard state (QGuiApplication::keyboardModifiers() reflects actual hardware/compositor
+// state, not something a unit test can fake by posting an event), so both branches of the
+// SH_UnderlineShortcut decision are asserted directly against kit::showMnemonicUnderline() instead
+// of through a live style-hint query under a simulated key press. Reported per the task's own
+// "say which" guidance.
+void testUnderlineShortcutDecisionBothWays(Expectations& expectations) {
+    expectations.expect(!kit::showMnemonicUnderline(Qt::NoModifier),
+                        "mnemonics stay hidden with no modifier held");
+    expectations.expect(!kit::showMnemonicUnderline(Qt::ShiftModifier | Qt::ControlModifier),
+                        "mnemonics stay hidden for unrelated modifiers");
+    expectations.expect(kit::showMnemonicUnderline(Qt::AltModifier),
+                        "mnemonics reveal while Alt is held");
+    expectations.expect(kit::showMnemonicUnderline(Qt::AltModifier | Qt::ShiftModifier),
+                        "Alt still reveals mnemonics alongside another modifier");
+}
+
+// The real, live keyboard state in an offscreen test process has no Alt held, so the installed
+// proxy's actual styleHint() call is asserted against exactly that one guaranteed branch --
+// confirming the override is really wired to QStyle::styleHint() and not just to the pure helper
+// above.
+void testInstalledProxyRoutesThroughToTheRealStyleHintQuery(Expectations& expectations) {
+    kit::AltUnderlineProxyStyle style;
+    const int hint = style.styleHint(QStyle::SH_UnderlineShortcut);
+    expectations.expect(hint == 0,
+                        "with no Alt held (the only state an offscreen process can guarantee), "
+                        "the installed proxy hides mnemonic underlines");
+
+    // Every other style hint is still delegated to the wrapped base style rather than swallowed:
+    // spot-check one hint that has nothing to do with mnemonics.
+    const int tabFocus = style.styleHint(QStyle::SH_Widget_ShareActivation);
+    const auto* fusion = QStyleFactory::create(QStringLiteral("Fusion"));
+    expectations.expect(fusion != nullptr, "a reference Fusion style is available to compare against");
+    if (fusion != nullptr) {
+        expectations.expect(tabFocus == fusion->styleHint(QStyle::SH_Widget_ShareActivation),
+                            "hints other than SH_UnderlineShortcut fall through to the base style "
+                            "unchanged");
+        delete fusion;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testUnderlineShortcutDecisionBothWays(expectations);
+    testInstalledProxyRoutesThroughToTheRealStyleHintQuery(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/kit_title_bar_tests.cpp
+++ b/src/ui/tests/kit_title_bar_tests.cpp
@@ -1,0 +1,166 @@
+#include <bloom/ui/kit/button.hpp>
+#include <bloom/ui/kit/icons.hpp>
+#include <bloom/ui/kit/title_bar.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+
+#include <QApplication>
+#include <QLabel>
+#include <QMenuBar>
+#include <QPoint>
+#include <QSignalSpy>
+#include <QString>
+#include <QTest>
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+void testTitleBarShapeAndIdentity(Expectations& expectations) {
+    kit::TitleBar titleBar;
+    expectations.expect(titleBar.objectName() == QStringLiteral("kinetikTitleBar"),
+                        "the title bar carries its stable objectName");
+    expectations.expect(titleBar.height() == kit::px(kit::Size::TitleBar),
+                        "the title bar is exactly Size::TitleBar tall");
+
+    auto* minimize = titleBar.findChild<kit::KButton*>(QStringLiteral("titleBarMinimizeButton"));
+    auto* maximize = titleBar.findChild<kit::KButton*>(QStringLiteral("titleBarMaximizeButton"));
+    auto* close = titleBar.findChild<kit::KButton*>(QStringLiteral("titleBarCloseButton"));
+    expectations.expect(minimize != nullptr && maximize != nullptr && close != nullptr,
+                        "all three window-control buttons exist");
+    if (minimize == nullptr || maximize == nullptr || close == nullptr) {
+        return;
+    }
+    expectations.expect(minimize->variant() == kit::KButton::Variant::Ghost &&
+                            maximize->variant() == kit::KButton::Variant::Ghost &&
+                            close->variant() == kit::KButton::Variant::Ghost,
+                        "all three are kit ghost buttons");
+    expectations.expect(close->dangerOnHover(),
+                        "close hover = Error fill, standard convention -- the others do not");
+    expectations.expect(!minimize->dangerOnHover() && !maximize->dangerOnHover(),
+                        "minimize/maximize stay plain ghost on hover");
+    expectations.expect(minimize->iconId() == kit::IconId::Minimize &&
+                            maximize->iconId() == kit::IconId::Maximize &&
+                            close->iconId() == kit::IconId::Close,
+                        "each button carries its semantic icon");
+}
+
+void testTitleFollowsTheProjectName(Expectations& expectations) {
+    kit::TitleBar titleBar;
+    auto* label = titleBar.findChild<QLabel*>(QStringLiteral("titleBarTitleLabel"));
+    expectations.expect(label != nullptr, "the title label exists");
+    if (label == nullptr) {
+        return;
+    }
+    titleBar.setTitle(QStringLiteral("Bloom — Untitled"));
+    expectations.expect(label->text() == QStringLiteral("Bloom — Untitled"),
+                        "the label shows exactly what MainWindow sets");
+    titleBar.setTitle(QStringLiteral("Bloom — My Project"));
+    expectations.expect(label->text() == QStringLiteral("Bloom — My Project"),
+                        "the title tracks a later project name change");
+}
+
+void testButtonsEmitTheirIntents(Expectations& expectations) {
+    kit::TitleBar titleBar;
+    auto* minimize = titleBar.findChild<kit::KButton*>(QStringLiteral("titleBarMinimizeButton"));
+    auto* maximize = titleBar.findChild<kit::KButton*>(QStringLiteral("titleBarMaximizeButton"));
+    auto* close = titleBar.findChild<kit::KButton*>(QStringLiteral("titleBarCloseButton"));
+    expectations.expect(minimize != nullptr && maximize != nullptr && close != nullptr,
+                        "the buttons exist for the signal-wiring assertions");
+    if (minimize == nullptr || maximize == nullptr || close == nullptr) {
+        return;
+    }
+
+    QSignalSpy minimizeSpy(&titleBar, &kit::TitleBar::minimizeRequested);
+    QSignalSpy maximizeSpy(&titleBar, &kit::TitleBar::maximizeOrRestoreRequested);
+    QSignalSpy closeSpy(&titleBar, &kit::TitleBar::closeRequested);
+
+    minimize->click();
+    maximize->click();
+    close->click();
+
+    expectations.expect(minimizeSpy.count() == 1, "the minimize button requests minimize");
+    expectations.expect(maximizeSpy.count() == 1, "the maximize button requests maximize/restore");
+    expectations.expect(closeSpy.count() == 1, "the close button requests close");
+}
+
+void testDoubleClickOnTheEmptyAreaTogglesMaximize(Expectations& expectations) {
+    kit::TitleBar titleBar;
+    titleBar.resize(600, kit::px(kit::Size::TitleBar));
+    QSignalSpy maximizeSpy(&titleBar, &kit::TitleBar::maximizeOrRestoreRequested);
+    // Far to the right of the title label and left of the button cluster: guaranteed empty bar
+    // area regardless of exact button widths, so the event lands on TitleBar itself.
+    QTest::mouseDClick(&titleBar, Qt::LeftButton, Qt::NoModifier, QPoint(300, 17));
+    expectations.expect(maximizeSpy.count() == 1,
+                        "double-clicking the empty bar area requests maximize/restore");
+}
+
+void testMaximizeIconSwapsWithAppearance(Expectations& expectations) {
+    kit::TitleBar titleBar;
+    auto* maximize = titleBar.findChild<kit::KButton*>(QStringLiteral("titleBarMaximizeButton"));
+    expectations.expect(maximize != nullptr, "the maximize button exists");
+    if (maximize == nullptr) {
+        return;
+    }
+    expectations.expect(!titleBar.maximizedAppearance(), "a fresh title bar starts unmaximized");
+    expectations.expect(maximize->iconId() == kit::IconId::Maximize,
+                        "and shows the Maximize glyph at rest");
+
+    titleBar.setMaximized(true);
+    expectations.expect(titleBar.maximizedAppearance(), "setMaximized(true) records the appearance");
+    expectations.expect(maximize->iconId() == kit::IconId::Restore,
+                        "maximizing swaps the glyph to Restore");
+    expectations.expect(maximize->toolTip() == QStringLiteral("Restore"),
+                        "and updates the tooltip to match");
+
+    titleBar.setMaximized(false);
+    expectations.expect(maximize->iconId() == kit::IconId::Maximize,
+                        "restoring swaps the glyph back");
+}
+
+void testMenuBarEmbedsIntoTheRow(Expectations& expectations) {
+    kit::TitleBar titleBar;
+    auto* bar = new QMenuBar();
+    bar->addMenu(QStringLiteral("&File"));
+    titleBar.setMenuBar(bar);
+    expectations.expect(bar->parentWidget() == &titleBar,
+                        "setMenuBar() reparents the menu bar into the title bar's own row");
+    expectations.expect(titleBar.findChild<QMenuBar*>() == bar,
+                        "the embedded menu bar is really a child of the title bar");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testTitleBarShapeAndIdentity(expectations);
+    testTitleFollowsTheProjectName(expectations);
+    testButtonsEmitTheirIntents(expectations);
+    testDoubleClickOnTheEmptyAreaTogglesMaximize(expectations);
+    testMaximizeIconSwapsWithAppearance(expectations);
+    testMenuBarEmbedsIntoTheRow(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/kit_title_bar_tests.cpp
+++ b/src/ui/tests/kit_title_bar_tests.cpp
@@ -128,7 +128,8 @@ void testMaximizeIconSwapsWithAppearance(Expectations& expectations) {
                         "and shows the Maximize glyph at rest");
 
     titleBar.setMaximized(true);
-    expectations.expect(titleBar.maximizedAppearance(), "setMaximized(true) records the appearance");
+    expectations.expect(titleBar.maximizedAppearance(),
+                        "setMaximized(true) records the appearance");
     expectations.expect(maximize->iconId() == kit::IconId::Restore,
                         "maximizing swaps the glyph to Restore");
     expectations.expect(maximize->toolTip() == QStringLiteral("Restore"),

--- a/src/ui/tests/main_window_chrome_tests.cpp
+++ b/src/ui/tests/main_window_chrome_tests.cpp
@@ -245,7 +245,7 @@ void testViewMenuItemsExistAndFire(Expectations& expectations) {
     // Window menu's own action would.
     auto* windowMaximizeAction = window.findChild<QAction*>(QStringLiteral("maximizeAreaAction"));
     expectations.expect(windowMaximizeAction != nullptr, "view menu: the Window menu's own "
-                                                          "Maximize Active Area action exists too");
+                                                         "Maximize Active Area action exists too");
     expectations.expect(maximizePanelAction->isEnabled(),
                         "view menu: Maximize Panel is enabled with the default multi-area layout");
     maximizePanelAction->trigger();

--- a/src/ui/tests/main_window_chrome_tests.cpp
+++ b/src/ui/tests/main_window_chrome_tests.cpp
@@ -1,3 +1,318 @@
-// Placeholder pending MainWindow's chrome-mode integration (task U2, issue #118); filled in once
-// bloom::ui::ChromeMode / chromeModeFromSettings() land in main_window.hpp.
-int main() { return 0; }
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/editor_registry.hpp>
+#include <bloom/ui/frame_export_controller.hpp>
+#include <bloom/ui/kit/title_bar.hpp>
+#include <bloom/ui/licenses_window.hpp>
+#include <bloom/ui/main_window.hpp>
+#include <bloom/ui/project_host.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+#include <bloom/ui/workspace_host.hpp>
+
+#include <QAction>
+#include <QApplication>
+#include <QDesktopServices>
+#include <QDir>
+#include <QLabel>
+#include <QMenuBar>
+#include <QObject>
+#include <QSettings>
+#include <QString>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <QWidget>
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+// QDesktopServices::setUrlHandler() looks its receiver's slot up by name through the meta-object
+// system, which requires a moc-processed QObject. Kept at file scope, outside the anonymous
+// namespace below, because moc cannot reliably generate metadata for a Q_OBJECT class declared
+// inside one.
+class UrlCapture final : public QObject {
+    Q_OBJECT
+
+  public:
+    int callCount = 0;
+    QUrl lastUrl;
+
+  public Q_SLOTS:
+    void capture(const QUrl& url) {
+        ++callCount;
+        lastUrl = url;
+    }
+};
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+[[nodiscard]] bool registerStandInEditors(EditorRegistry& registry) {
+    const auto addTestEditor = [&registry](std::string id, QString name) {
+        return registry.registerEditor(
+            {.id = std::move(id), .displayName = std::move(name), .create = [](QWidget* parent) {
+                 return new QLabel("chrome test editor", parent);
+             }});
+    };
+    return addTestEditor("bloom.viewer", "Compositor") && addTestEditor("bloom.nodes", "Nodes") &&
+           addTestEditor("bloom.timeline", "Timeline") && addTestEditor("bloom.media", "Media") &&
+           addTestEditor("bloom.properties", "Properties");
+}
+
+// A small fixture bundle so each test can build a fresh MainWindow without repeating the whole
+// ProjectHost/CompositionSession/FrameExportController wiring inline -- mirrors tests/ui_smoke.cpp
+// and main_window_readonly_placeholder_tests.cpp's own precedent for this construction.
+struct Fixture final {
+    EditorRegistry registry;
+    bloom::runtime::TaskScheduler scheduler;
+    ProjectHost projectHost{scheduler};
+    CompositionSession compositionSession;
+    bloom::runtime::NodeDefinitionRegistry nodeDefinitions;
+    bloom::runtime::SnapshotCompiler snapshotCompiler{nodeDefinitions};
+    TaskUiBridge taskUiBridge{scheduler};
+    FrameExportController frameExportController;
+
+    explicit Fixture(bool* ok)
+        : compositionSession(*projectHost.liveDocumentAndStack().first,
+                             *projectHost.liveDocumentAndStack().second,
+                             projectHost.lowestCompositionId()),
+          frameExportController(compositionSession, scheduler, taskUiBridge, snapshotCompiler,
+                                projectHost.publicationCoordinator(),
+                                projectHost.artifactCoordinator()) {
+        nodeDefinitions.freeze();
+        *ok = registerStandInEditors(registry);
+    }
+};
+
+void testChromeModeFromSettingsReadsTheInjectedFile(Expectations& expectations) {
+    QTemporaryDir directory;
+    expectations.expect(directory.isValid(), "chrome mode: temp directory is available");
+    if (!directory.isValid()) {
+        return;
+    }
+    const auto path = QDir(directory.path()).filePath("settings.ini");
+
+    {
+        QSettings settings(path, QSettings::IniFormat);
+        expectations.expect(chromeModeFromSettings(settings) == ChromeMode::Custom,
+                            "chrome mode: an absent key defaults to Custom");
+    }
+    {
+        QSettings settings(path, QSettings::IniFormat);
+        settings.setValue("appearance/chrome", "native");
+        settings.sync();
+    }
+    {
+        const QSettings settings(path, QSettings::IniFormat);
+        expectations.expect(chromeModeFromSettings(settings) == ChromeMode::Native,
+                            "chrome mode: an injected \"native\" value reads as Native");
+    }
+    {
+        QSettings settings(path, QSettings::IniFormat);
+        settings.setValue("appearance/chrome", "custom");
+        settings.sync();
+    }
+    {
+        const QSettings settings(path, QSettings::IniFormat);
+        expectations.expect(chromeModeFromSettings(settings) == ChromeMode::Custom,
+                            "chrome mode: an injected \"custom\" value reads as Custom");
+    }
+    {
+        QSettings settings(path, QSettings::IniFormat);
+        settings.setValue("appearance/chrome", "nonsense");
+        settings.sync();
+    }
+    {
+        const QSettings settings(path, QSettings::IniFormat);
+        expectations.expect(chromeModeFromSettings(settings) == ChromeMode::Custom,
+                            "chrome mode: any other value defaults to Custom, not a crash");
+    }
+}
+
+void testCustomChromeBuildsAFramelessTitleBarWindow(Expectations& expectations) {
+    bool ok = false;
+    Fixture fixture(&ok);
+    expectations.expect(ok, "custom chrome: fixture editors registered");
+    if (!ok) {
+        return;
+    }
+
+    MainWindow window(fixture.registry, fixture.compositionSession, fixture.projectHost,
+                      fixture.frameExportController, ChromeMode::Custom);
+    expectations.expect(window.chromeMode() == ChromeMode::Custom,
+                        "custom chrome: chromeMode() reports what it was constructed with");
+    expectations.expect(window.windowFlags().testFlag(Qt::FramelessWindowHint),
+                        "custom chrome: the window is really frameless");
+
+    auto* titleBar = window.findChild<kit::TitleBar*>();
+    expectations.expect(titleBar != nullptr, "custom chrome: a TitleBar exists");
+    if (titleBar == nullptr) {
+        return;
+    }
+    expectations.expect(window.menuWidget() == titleBar,
+                        "custom chrome: the TitleBar is installed as the menu widget");
+    expectations.expect(titleBar->findChild<QMenuBar*>() != nullptr,
+                        "custom chrome: the menu bar is embedded inside the title bar's row");
+
+    // Title follows the session (decision 1): a fresh project shows "Bloom — Untitled".
+    auto* label = titleBar->findChild<QLabel*>(QStringLiteral("titleBarTitleLabel"));
+    expectations.expect(label != nullptr && label->text() == QStringLiteral("Bloom — Untitled"),
+                        "custom chrome: the title bar's label follows the project name");
+
+    // Maximize state propagation: MainWindow::changeEvent syncs the TitleBar's appearance.
+    expectations.expect(!titleBar->maximizedAppearance(), "custom chrome: starts unmaximized");
+    window.setWindowState(window.windowState() | Qt::WindowMaximized);
+    QApplication::sendPostedEvents();
+    expectations.expect(titleBar->maximizedAppearance(),
+                        "custom chrome: a WindowStateChange event syncs the title bar's glyph");
+}
+
+void testNativeChromeKeepsTheClassicMenuBar(Expectations& expectations) {
+    bool ok = false;
+    Fixture fixture(&ok);
+    expectations.expect(ok, "native chrome: fixture editors registered");
+    if (!ok) {
+        return;
+    }
+
+    MainWindow window(fixture.registry, fixture.compositionSession, fixture.projectHost,
+                      fixture.frameExportController, ChromeMode::Native);
+    expectations.expect(window.chromeMode() == ChromeMode::Native,
+                        "native chrome: chromeMode() reports Native");
+    expectations.expect(!window.windowFlags().testFlag(Qt::FramelessWindowHint),
+                        "native chrome: stock decorations, not frameless");
+    expectations.expect(window.findChild<kit::TitleBar*>() == nullptr,
+                        "native chrome: no TitleBar is constructed at all");
+    expectations.expect(window.menuBar() != nullptr && window.menuWidget() == window.menuBar(),
+                        "native chrome: QMainWindow's own classic menu bar is in charge");
+}
+
+void testViewMenuItemsExistAndFire(Expectations& expectations) {
+    bool ok = false;
+    Fixture fixture(&ok);
+    if (!ok) {
+        expectations.expect(false, "view menu: fixture editors registered");
+        return;
+    }
+    MainWindow window(fixture.registry, fixture.compositionSession, fixture.projectHost,
+                      fixture.frameExportController, ChromeMode::Custom);
+
+    auto* fullScreenAction = window.findChild<QAction*>(QStringLiteral("viewFullScreenAction"));
+    auto* maximizePanelAction =
+        window.findChild<QAction*>(QStringLiteral("viewMaximizePanelAction"));
+    auto* nativeFrameAction = window.findChild<QAction*>(QStringLiteral("useNativeFrameAction"));
+    expectations.expect(fullScreenAction != nullptr && maximizePanelAction != nullptr &&
+                            nativeFrameAction != nullptr,
+                        "view menu: Full Screen, Maximize Panel, and Use Native Window Frame all "
+                        "exist");
+    if (fullScreenAction == nullptr || maximizePanelAction == nullptr ||
+        nativeFrameAction == nullptr) {
+        return;
+    }
+
+    expectations.expect(!fullScreenAction->shortcut().isEmpty(),
+                        "view menu: Full Screen carries the F11 shortcut");
+    expectations.expect(!window.isFullScreen(), "view menu: starts out of full screen");
+    fullScreenAction->trigger();
+    expectations.expect(window.isFullScreen(), "view menu: Full Screen really toggles it");
+    fullScreenAction->trigger();
+    expectations.expect(!window.isFullScreen(), "view menu: and toggles back");
+
+    // Maximize Panel routes to the exact same underlying signal the Window menu's own action
+    // does (decision 2). The default compositing layout starts with five areas, so both actions
+    // are enabled from construction; triggering it flips the SAME workspace maximize state the
+    // Window menu's own action would.
+    auto* windowMaximizeAction = window.findChild<QAction*>(QStringLiteral("maximizeAreaAction"));
+    expectations.expect(windowMaximizeAction != nullptr, "view menu: the Window menu's own "
+                                                          "Maximize Active Area action exists too");
+    expectations.expect(maximizePanelAction->isEnabled(),
+                        "view menu: Maximize Panel is enabled with the default multi-area layout");
+    maximizePanelAction->trigger();
+    expectations.expect(window.workspaceHost()->isAreaMaximized(),
+                        "view menu: Maximize Panel really maximizes the active area");
+    if (windowMaximizeAction != nullptr) {
+        expectations.expect(windowMaximizeAction->isChecked(),
+                            "view menu: the Window menu's action reflects the same state Maximize "
+                            "Panel just set");
+    }
+    maximizePanelAction->trigger();
+    expectations.expect(!window.workspaceHost()->isAreaMaximized(),
+                        "view menu: triggering it again restores");
+
+    expectations.expect(nativeFrameAction->isCheckable() && !nativeFrameAction->isChecked(),
+                        "view menu: Use Native Window Frame reflects the Custom chrome it was "
+                        "constructed with");
+}
+
+void testHelpMenuItemsExistAndFire(Expectations& expectations) {
+    bool ok = false;
+    Fixture fixture(&ok);
+    if (!ok) {
+        expectations.expect(false, "help menu: fixture editors registered");
+        return;
+    }
+    MainWindow window(fixture.registry, fixture.compositionSession, fixture.projectHost,
+                      fixture.frameExportController, ChromeMode::Custom);
+
+    auto* reportIssueAction = window.findChild<QAction*>(QStringLiteral("reportIssueAction"));
+    auto* licensesAction = window.findChild<QAction*>(QStringLiteral("openSourceLicensesAction"));
+    expectations.expect(reportIssueAction != nullptr && licensesAction != nullptr,
+                        "help menu: Report an Issue and Open Source Licenses both exist");
+    if (reportIssueAction == nullptr || licensesAction == nullptr) {
+        return;
+    }
+
+    UrlCapture capture;
+    QDesktopServices::setUrlHandler(QStringLiteral("https"), &capture, "capture");
+    reportIssueAction->trigger();
+    QDesktopServices::unsetUrlHandler(QStringLiteral("https"));
+    expectations.expect(capture.callCount == 1,
+                        "help menu: Report an Issue really calls QDesktopServices::openUrl()");
+    expectations.expect(capture.lastUrl.scheme() == QStringLiteral("https") &&
+                            capture.lastUrl.host() == QStringLiteral("github.com"),
+                        "help menu: it opens the repository's issue tracker");
+
+    // Non-modal (LicensesWindow::show(), never exec()): triggering it synchronously must not hang
+    // this test.
+    licensesAction->trigger();
+    auto* licensesWindow = window.findChild<LicensesWindow*>();
+    expectations.expect(licensesWindow != nullptr,
+                        "help menu: Open Source Licenses opens a real LicensesWindow");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testChromeModeFromSettingsReadsTheInjectedFile(expectations);
+    testCustomChromeBuildsAFramelessTitleBarWindow(expectations);
+    testNativeChromeKeepsTheClassicMenuBar(expectations);
+    testViewMenuItemsExistAndFire(expectations);
+    testHelpMenuItemsExistAndFire(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}
+
+#include "main_window_chrome_tests.moc"

--- a/src/ui/tests/main_window_chrome_tests.cpp
+++ b/src/ui/tests/main_window_chrome_tests.cpp
@@ -1,0 +1,3 @@
+// Placeholder pending MainWindow's chrome-mode integration (task U2, issue #118); filled in once
+// bloom::ui::ChromeMode / chromeModeFromSettings() land in main_window.hpp.
+int main() { return 0; }

--- a/src/ui/tests/third_party_license_catalog_tests.cpp
+++ b/src/ui/tests/third_party_license_catalog_tests.cpp
@@ -37,7 +37,8 @@ using namespace bloom::ui;
 
 // The set of component directory names that carry a LICENSE file under one root -- exactly the
 // discovery rule generate_third_party_license_catalog.cmake itself applies.
-[[nodiscard]] std::set<std::string> licensedComponentDirectories(const std::filesystem::path& root) {
+[[nodiscard]] std::set<std::string>
+licensedComponentDirectories(const std::filesystem::path& root) {
     std::set<std::string> names;
     if (!std::filesystem::exists(root)) {
         return names;
@@ -55,7 +56,7 @@ using namespace bloom::ui;
 // because the catalog also carries the synthesized Qt/ADR-0014 notice, which has no LICENSE file
 // of its own to enumerate here.
 void testCatalogCoversEveryLicensedComponentDirectory(Expectations& expectations,
-                                                       const std::filesystem::path& repositoryRoot) {
+                                                      const std::filesystem::path& repositoryRoot) {
     const auto dependencyComponents =
         licensedComponentDirectories(repositoryRoot / "dependencies" / "licenses");
     const auto kitComponents =
@@ -69,9 +70,9 @@ void testCatalogCoversEveryLicensedComponentDirectory(Expectations& expectations
     std::set<std::string> catalogComponents;
     for (const auto& entry : thirdPartyLicenseCatalog()) {
         catalogComponents.emplace(entry.component);
-        expectations.expect(!entry.licenseText.empty(),
-                            std::string{"the catalog entry for "} + std::string{entry.component} +
-                                " has non-empty license text");
+        expectations.expect(!entry.licenseText.empty(), std::string{"the catalog entry for "} +
+                                                            std::string{entry.component} +
+                                                            " has non-empty license text");
     }
 
     for (const auto& name : dependencyComponents) {

--- a/src/ui/tests/third_party_license_catalog_tests.cpp
+++ b/src/ui/tests/third_party_license_catalog_tests.cpp
@@ -1,0 +1,130 @@
+#include <bloom/ui/licenses_window.hpp>
+#include <bloom/ui/third_party_license_catalog.hpp>
+
+#include <QApplication>
+#include <QListWidget>
+#include <QPlainTextEdit>
+#include <QString>
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <set>
+#include <source_location>
+#include <string>
+#include <string_view>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+// The set of component directory names that carry a LICENSE file under one root -- exactly the
+// discovery rule generate_third_party_license_catalog.cmake itself applies.
+[[nodiscard]] std::set<std::string> licensedComponentDirectories(const std::filesystem::path& root) {
+    std::set<std::string> names;
+    if (!std::filesystem::exists(root)) {
+        return names;
+    }
+    for (const auto& entry : std::filesystem::directory_iterator(root)) {
+        if (entry.is_directory() && std::filesystem::exists(entry.path() / "LICENSE")) {
+            names.insert(entry.path().filename().string());
+        }
+    }
+    return names;
+}
+
+// Decision 3 (task U2, issue #118): the catalog lists AT LEAST every component directory present
+// in the two license roots, and shows non-empty text for each. "At least" rather than "exactly"
+// because the catalog also carries the synthesized Qt/ADR-0014 notice, which has no LICENSE file
+// of its own to enumerate here.
+void testCatalogCoversEveryLicensedComponentDirectory(Expectations& expectations,
+                                                       const std::filesystem::path& repositoryRoot) {
+    const auto dependencyComponents =
+        licensedComponentDirectories(repositoryRoot / "dependencies" / "licenses");
+    const auto kitComponents =
+        licensedComponentDirectories(repositoryRoot / "src" / "ui" / "kit" / "third_party");
+    expectations.expect(!dependencyComponents.empty(),
+                        "the dependency license root really has components to require (fixture "
+                        "sanity: a --root miss would silently pass an empty requirement)");
+    expectations.expect(!kitComponents.empty(),
+                        "the kit third-party license root really has components to require");
+
+    std::set<std::string> catalogComponents;
+    for (const auto& entry : thirdPartyLicenseCatalog()) {
+        catalogComponents.emplace(entry.component);
+        expectations.expect(!entry.licenseText.empty(),
+                            std::string{"the catalog entry for "} + std::string{entry.component} +
+                                " has non-empty license text");
+    }
+
+    for (const auto& name : dependencyComponents) {
+        expectations.expect(catalogComponents.contains(name),
+                            "the catalog lists dependency-license component: " + name);
+    }
+    for (const auto& name : kitComponents) {
+        expectations.expect(catalogComponents.contains(name),
+                            "the catalog lists kit third-party component: " + name);
+    }
+    expectations.expect(catalogComponents.contains("Qt 6"),
+                        "the catalog also carries the Qt/ADR-0014 notice");
+}
+
+void testLicensesWindowListsEveryCatalogEntryWithText(Expectations& expectations) {
+    LicensesWindow window;
+    auto* list = window.findChild<QListWidget*>(QStringLiteral("licensesComponentList"));
+    auto* text = window.findChild<QPlainTextEdit*>(QStringLiteral("licensesTextView"));
+    expectations.expect(list != nullptr && text != nullptr,
+                        "the window exposes its list and text panes");
+    if (list == nullptr || text == nullptr) {
+        return;
+    }
+
+    expectations.expect(static_cast<std::size_t>(list->count()) ==
+                            thirdPartyLicenseCatalog().size(),
+                        "the list has exactly one row per catalog entry");
+    expectations.expect(!text->toPlainText().isEmpty(),
+                        "selecting the first component (the default selection) shows its text");
+    expectations.expect(text->isReadOnly(), "the license text is read-only");
+
+    for (int row = 0; row < list->count(); ++row) {
+        list->setCurrentRow(row);
+        expectations.expect(!text->toPlainText().isEmpty(),
+                            "every listed component shows non-empty license text when selected");
+    }
+}
+
+} // namespace
+
+int main(int argumentCount, char** arguments) {
+    std::filesystem::path repositoryRoot = std::filesystem::current_path();
+    for (int index = 1; index < argumentCount; ++index) {
+        const std::string_view argument{arguments[index]};
+        if (argument == "--root" && index + 1 < argumentCount) {
+            repositoryRoot = arguments[++index];
+        }
+    }
+
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argumentCount, arguments);
+    Expectations expectations;
+    testCatalogCoversEveryLicensedComponentDirectory(expectations, repositoryRoot);
+    testLicensesWindowListsEveryCatalogEntryWithText(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The chrome slice of #116 — the window, menu bar, and panel primitive become Kinetik:

- **Custom window chrome by default, native by choice**: frameless window with the Kinetik title bar (project-following title, ghost min/max/close with Error-fill close hover), system move/resize through the platform APIs, rounded corners that drop correctly when maximized, and a persisted `appearance/chrome` setting read before window construction with an honest restart notice on toggle.
- **Menu bar**: kit hover/padding; mnemonic underlines only while Alt is held via a proxy style (both branches asserted directly — offscreen Alt simulation is unreliable and the report says so); View gains Full Screen and Maximize Panel; Help gains Report an Issue (interception-tested via Qt's URL-handler seam) and **Open Source Licenses — generated at configure time from the repository's real license records** (all 16 components plus the Qt LGPL notice), rendered read-only in the mono face.
- **Panel primitive**: rounded panels over visible gutters; the H/V split buttons replaced by a header context menu routing to the same signals (the one sanctioned test-contract change, fully enumerated); bordered maximize/close with Error-fill close hover; workspace tabs restyled as checked pills.
- Disclosed judgment calls: panel switcher stays a styled QComboBox per the package's own escape hatch; edge-resize uses the standard event-filter technique, not yet verified on live compositors; licenses window is non-modal.

Desktop 119/119 and native 88/88, quality checks clean.

Closes #118.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.