### PR TITLE
feat: restyle the timeline as Kinetik tracks and lanes

### DIFF
--- a/src/ui/composition_editors.cpp
+++ b/src/ui/composition_editors.cpp
@@ -37,8 +37,8 @@
 #include <QSignalBlocker>
 #include <QSize>
 #include <QStyle>
-#include <QStyledItemDelegate>
 #include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
 #include <QToolButton>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
@@ -135,14 +135,14 @@ QString layerKind(const CompositionSession& session, const document::LayerId lay
 // audio -- that this project has no import pipeline for yet (verified: no media-backed layer type
 // exists anywhere in src/document). Mapping a Solid or Text layer to one of those roles (e.g.
 // "Solid = DataClip green", the literal example this task's own decision explicitly rejects) would
-// misrepresent a generated, composition-local layer as referenced media it is not. `DataComposition`
-// is the one palette entry that is NOT about referenced media: its own stated meaning is
-// "Compositions" -- content that is authored/evaluated INSIDE a project rather than referenced from
-// an external asset, exactly the property every layer kind Bloom has today (Solid, Text) shares.
-// This is therefore ONE mapping applied uniformly to every layer kind that exists right now, not a
-// per-kind table -- there is nothing to honestly differentiate yet. A future media-backed layer
-// (image/clip/sequence/audio import) would take its own, more specific Data* token when that
-// feature ships; this function is the one place that day's change would land.
+// misrepresent a generated, composition-local layer as referenced media it is not.
+// `DataComposition` is the one palette entry that is NOT about referenced media: its own stated
+// meaning is "Compositions" -- content that is authored/evaluated INSIDE a project rather than
+// referenced from an external asset, exactly the property every layer kind Bloom has today (Solid,
+// Text) shares. This is therefore ONE mapping applied uniformly to every layer kind that exists
+// right now, not a per-kind table -- there is nothing to honestly differentiate yet. A future
+// media-backed layer (image/clip/sequence/audio import) would take its own, more specific Data*
+// token when that feature ships; this function is the one place that day's change would land.
 [[nodiscard]] kit::Color layerLaneColorToken() { return kit::Color::DataComposition; }
 
 qulonglong nextLayerNumber(const CompositionSession& session, const std::string_view typeId,
@@ -315,7 +315,7 @@ class TimelineTrackRowDelegate final : public QStyledItemDelegate {
     }
 
     void paint(QPainter* painter, const QStyleOptionViewItem& option,
-              const QModelIndex& index) const override {
+               const QModelIndex& index) const override {
         painter->save();
         const bool selected = (option.state & QStyle::State_Selected) != 0;
         // "Row striping via surface ladder": odd rows step one rung up from Background, the same
@@ -625,8 +625,7 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     // Decision 5: "Add menu restyled" -- the Add glyph itself; menu entries stay plain text (no
     // Data* token honestly names a generic structured layer the way Add names the action).
     addButton_->setIcon(kit::icon(kit::IconId::Add, kit::Size::IconMedium));
-    addButton_->setIconSize(
-        QSize(kit::px(kit::Size::IconMedium), kit::px(kit::Size::IconMedium)));
+    addButton_->setIconSize(QSize(kit::px(kit::Size::IconMedium), kit::px(kit::Size::IconMedium)));
     addButton_->setPopupMode(QToolButton::InstantPopup);
     addButton_->setToolTip(tr("Add a structured layer"));
     auto* addMenu = new QMenu(tr("Add Layer"), addButton_);
@@ -653,10 +652,9 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     playPauseButton_ = makeToolButton(tr("Play"), tr("Toggle playback"), controls);
     playPauseButton_->setObjectName("playPauseButton");
     playPauseButton_->setCheckable(true);
-    stepForwardButton_ =
-        makeIconToolButton(kit::IconId::StepForward, tr("Step forward one frame (Right)"),
-                          tr("Step forward one frame"),
-                          QStringLiteral("timelineStepForwardButton"), controls);
+    stepForwardButton_ = makeIconToolButton(
+        kit::IconId::StepForward, tr("Step forward one frame (Right)"),
+        tr("Step forward one frame"), QStringLiteral("timelineStepForwardButton"), controls);
     // Loop indicator (decision 5): non-interactive status glyph, not a button -- playback always
     // loops (PlaybackController::tick()'s exact modulo wrap) and there is no command to disable it,
     // so a clickable control here would dishonestly imply a toggle that does not exist.
@@ -704,8 +702,8 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     // Header text stays attached to its LOGICAL column below regardless of the visual reorder
     // (moveSection() a few lines down): text(kNameColumn)/text(kKindColumn) remain the pinned test
     // contract's exact logical columns 0/1.
-    layers_->setHeaderLabels({tr("Name"), tr("Kind"), tr("Visible"), tr("Blending"), tr("Parent"),
-                             tr("Lane")});
+    layers_->setHeaderLabels(
+        {tr("Name"), tr("Kind"), tr("Visible"), tr("Blending"), tr("Parent"), tr("Lane")});
     layers_->setRootIsDecorated(false);
     // Striping now comes from TimelineTrackRowDelegate's own surface-ladder recipe (decision 1),
     // not Qt's native AlternateBase.
@@ -914,9 +912,9 @@ void TimelineEditor::rebuild() {
             // icon with a tooltip that says exactly why, never a toggle that would silently do
             // nothing. Reported in this task's raw report.
             row->setIcon(kVisibilityColumn,
-                        QIcon(kit::iconPixmap(
-                            kit::IconId::Visible, kit::Size::IconSmall,
-                            kit::withOpacity(kit::color(kit::Color::Muted), kit::kDisabledOpacity))));
+                         QIcon(kit::iconPixmap(kit::IconId::Visible, kit::Size::IconSmall,
+                                               kit::withOpacity(kit::color(kit::Color::Muted),
+                                                                kit::kDisabledOpacity))));
             row->setToolTip(kVisibilityColumn,
                             tr("Layer visibility has no command yet -- every layer renders"));
 
@@ -925,20 +923,19 @@ void TimelineEditor::rebuild() {
             // (no audio-layer kind, no solo concept, no lock field anywhere in src/document), so
             // three permanently-inert icons crammed into this already-dense 34px row would read as
             // broken chrome rather than an honest "reserved" placeholder. Justification recorded in
-            // this task's raw report per decision 1's own "omitted entirely... YOUR call, justified"
-            // allowance.
+            // this task's raw report per decision 1's own "omitted entirely... YOUR call,
+            // justified" allowance.
 
             // Blending / Parent (decision 1): one always-disabled dropdown per row, each carrying
             // its single honest value.
-            layers_->setItemWidget(
-                row, kBlendingColumn,
-                makeDisabledPlaceholderDropdown(
-                    tr("Normal"), tr("Blend modes are not implemented yet"),
-                    QStringLiteral("layerBlendingDropdown"), layers_));
-            layers_->setItemWidget(
-                row, kParentColumn,
-                makeDisabledPlaceholderDropdown(tr("None"), tr("Layer parenting does not exist yet"),
-                                                QStringLiteral("layerParentDropdown"), layers_));
+            layers_->setItemWidget(row, kBlendingColumn,
+                                   makeDisabledPlaceholderDropdown(
+                                       tr("Normal"), tr("Blend modes are not implemented yet"),
+                                       QStringLiteral("layerBlendingDropdown"), layers_));
+            layers_->setItemWidget(row, kParentColumn,
+                                   makeDisabledPlaceholderDropdown(
+                                       tr("None"), tr("Layer parenting does not exist yet"),
+                                       QStringLiteral("layerParentDropdown"), layers_));
 
             // Lane bar (decision 2): one type-color-coded bar per row, spanning this column's full
             // width (see TimelineLaneBar's own honesty disclosure comment above).

--- a/src/ui/composition_editors.cpp
+++ b/src/ui/composition_editors.cpp
@@ -4,6 +4,7 @@
 #include <bloom/ui/timeline_frame_math.hpp>
 #include <bloom/ui/timeline_ruler.hpp>
 
+#include <bloom/ui/kit/dropdown.hpp>
 #include <bloom/ui/kit/icons.hpp>
 #include <bloom/ui/kit/painting.hpp>
 #include <bloom/ui/kit/tokens.hpp>
@@ -20,17 +21,24 @@
 #include <QAbstractItemView>
 #include <QAction>
 #include <QApplication>
+#include <QBrush>
 #include <QEnterEvent>
 #include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QHeaderView>
+#include <QIcon>
 #include <QKeySequence>
 #include <QLabel>
 #include <QListWidget>
 #include <QMenu>
+#include <QModelIndex>
 #include <QPainter>
 #include <QPalette>
 #include <QSignalBlocker>
+#include <QSize>
+#include <QStyle>
+#include <QStyledItemDelegate>
+#include <QStyleOptionViewItem>
 #include <QToolButton>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
@@ -68,19 +76,6 @@ const document::LayerOutputBoundary* layerBoundary(const document::Composition& 
     const auto found = std::ranges::find_if(
         boundaries, [layerId](const auto& candidate) { return candidate.layerId == layerId; });
     return found == boundaries.end() ? nullptr : &*found;
-}
-
-const document::ParameterRecord* nodeParameter(const document::Composition& composition,
-                                               const document::NodeId nodeId,
-                                               const std::string_view role) {
-    const auto* node = composition.graph().findNode(nodeId);
-    if (node == nullptr) {
-        return nullptr;
-    }
-    const auto binding = std::ranges::find_if(
-        node->parameters, [role](const auto& candidate) { return candidate.role == role; });
-    return binding == node->parameters.end() ? nullptr
-                                             : composition.parameters().find(binding->parameterId);
 }
 
 QString sourceDescription(const document::ParameterRecord& parameter) {
@@ -134,6 +129,21 @@ QString layerKind(const CompositionSession& session, const document::LayerId lay
     }
     return TimelineEditor::tr("Layer");
 }
+
+// Lane bar color mapping (task U7, issue #122, decision 2). Bloom's data-type palette
+// (kit::Color::Data*) identifies external MEDIA kinds -- image sequences, clips, still images,
+// audio -- that this project has no import pipeline for yet (verified: no media-backed layer type
+// exists anywhere in src/document). Mapping a Solid or Text layer to one of those roles (e.g.
+// "Solid = DataClip green", the literal example this task's own decision explicitly rejects) would
+// misrepresent a generated, composition-local layer as referenced media it is not. `DataComposition`
+// is the one palette entry that is NOT about referenced media: its own stated meaning is
+// "Compositions" -- content that is authored/evaluated INSIDE a project rather than referenced from
+// an external asset, exactly the property every layer kind Bloom has today (Solid, Text) shares.
+// This is therefore ONE mapping applied uniformly to every layer kind that exists right now, not a
+// per-kind table -- there is nothing to honestly differentiate yet. A future media-backed layer
+// (image/clip/sequence/audio import) would take its own, more specific Data* token when that
+// feature ships; this function is the one place that day's change would land.
+[[nodiscard]] kit::Color layerLaneColorToken() { return kit::Color::DataComposition; }
 
 qulonglong nextLayerNumber(const CompositionSession& session, const std::string_view typeId,
                            const std::uint32_t schemaVersion) {
@@ -192,6 +202,26 @@ QString selectionName(const CompositionSession& session) {
 QToolButton* makeToolButton(const QString& text, const QString& accessibleName, QWidget* parent) {
     auto* button = new QToolButton(parent);
     button->setText(text);
+    button->setAccessibleName(accessibleName);
+    button->setAutoRaise(true);
+    return button;
+}
+
+// Task U7 (issue #122), decision 5: transport controls get their kit icon glyph via the SAME
+// "plain QToolButton + kit::icon()" idiom EditorArea's own header chrome already uses
+// (editor_area.cpp's makeHeaderButton) -- not kit::KButton, which is not a QToolButton and would
+// break every existing findChild<QToolButton*>("playPauseButton") test contract
+// (composition_projection_test.cpp, playback_controller_tests.cpp). An icon never replaces an
+// accessible name (ADR 0010; docs/ux/visual-language.md's Iconography section), so every call site
+// still sets both a tooltip and setAccessibleName().
+QToolButton* makeIconToolButton(const kit::IconId iconId, const QString& toolTip,
+                                const QString& accessibleName, const QString& objectName,
+                                QWidget* parent) {
+    auto* button = new QToolButton(parent);
+    button->setObjectName(objectName);
+    button->setIcon(kit::icon(iconId, kit::Size::IconMedium));
+    button->setIconSize(QSize(kit::px(kit::Size::IconMedium), kit::px(kit::Size::IconMedium)));
+    button->setToolTip(toolTip);
     button->setAccessibleName(accessibleName);
     button->setAutoRaise(true);
     return button;
@@ -256,6 +286,110 @@ frameContextFor(const CompositionSession& session) {
         .arg(negative ? QStringLiteral("-") : QString())
         .arg(wholeSeconds)
         .arg(scaledFraction, kDecimalPlaces, 10, QChar('0'));
+}
+
+// The 2px inset selection edge (task U7, issue #122, decision 1: "selection = Accent inset edge
+// per States" -- docs/ux/visual-language.md's "Selected: an Accent fill, or a 2px inset accent edge
+// where a fill would hide content"; a full fill would hide this row's own name/kind text, so the
+// edge variant applies).
+constexpr qreal kTrackRowSelectionEdgeWidth = 2.0;
+
+// Restyles layerStackView's rows (decision 1: "Row striping via surface ladder; selection = Accent
+// inset edge per States") without touching a single byte of QTreeWidgetItem's own model data --
+// text()/icon()/toolTip()/isSelected() and every existing test reading them through
+// findChild<QTreeWidget*>("layerStackView") are completely untouched. Only sizeHint() (row height,
+// decision 1's TimelineRow token) and paint() (background + selection) are overridden; the base
+// QStyledItemDelegate::paint() still draws each column's own icon/text/embedded item-widget
+// afterward, using whatever font/foreground QTreeWidgetItem::setFont()/setForeground() were given
+// at row-build time (see TimelineEditor::rebuild()) -- so this delegate owns none of the actual ink
+// color decisions, only the shared background/selection recipe every column sits on.
+class TimelineTrackRowDelegate final : public QStyledItemDelegate {
+  public:
+    explicit TimelineTrackRowDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
+
+    [[nodiscard]] QSize sizeHint(const QStyleOptionViewItem& option,
+                                 const QModelIndex& index) const override {
+        QSize hint = QStyledItemDelegate::sizeHint(option, index);
+        hint.setHeight(kit::px(kit::Size::TimelineRow));
+        return hint;
+    }
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+              const QModelIndex& index) const override {
+        painter->save();
+        const bool selected = (option.state & QStyle::State_Selected) != 0;
+        // "Row striping via surface ladder": odd rows step one rung up from Background, the same
+        // ladder the rest of the interface steps hover/press states along.
+        const auto surfaceToken = (index.row() % 2) != 0
+                                      ? kit::surfaceStep(kit::Color::Background, 1)
+                                      : kit::Color::Background;
+        painter->fillRect(option.rect, kit::color(surfaceToken));
+        if (selected) {
+            const qreal inset = kTrackRowSelectionEdgeWidth / 2.0;
+            painter->setPen(QPen(kit::color(kit::Color::Accent), kTrackRowSelectionEdgeWidth));
+            painter->setBrush(Qt::NoBrush);
+            painter->drawRect(QRectF(option.rect).adjusted(inset, inset, -inset, -inset));
+        }
+        painter->restore();
+
+        // Suppress Qt's own native full-cell selection fill (already replaced above by the inset
+        // edge) before delegating icon/text painting to the base implementation.
+        QStyleOptionViewItem plain(option);
+        plain.state &= ~QStyle::State_Selected;
+        plain.showDecorationSelected = false;
+        QStyledItemDelegate::paint(painter, plain, index);
+    }
+};
+
+// The per-row lane bar (decision 2): a single rounded, type-color-coded bar filling its ENTIRE
+// allotted width. There is no trim/range feature (no in/out point exists in the document model at
+// all), so "spans the full composition duration honestly" is true by construction here -- the bar
+// is never partial, because nothing in this widget can express a partial state.
+//
+// Honesty disclosure (this task's raw report): this bar's width is the layerStackView TREE
+// COLUMN's own width, not literally the same pixel-space TimelineRuler/TimelineKeyframePanel use --
+// those are separate, independently-scrollable widgets from the layer list, and pixel-perfect
+// cross-widget time-axis alignment between a QTreeWidget column and the ruler was never a wired
+// feature before this task. Building that alignment is a genuine architecture change outside a
+// restyle task's fence, so this bar honestly represents "this layer's content, for its entire
+// duration" within its own dedicated column rather than pretending to share the ruler's exact
+// scroll/zoom state.
+class TimelineLaneBar final : public QWidget {
+  public:
+    explicit TimelineLaneBar(const kit::Color colorToken, QWidget* parent)
+        : QWidget(parent), colorToken_(colorToken) {
+        setObjectName(QStringLiteral("layerLaneBar"));
+        setMinimumHeight(kit::px(kit::Size::TimelineRow) - 2 * kit::px(kit::Spacing::XXS));
+    }
+
+  protected:
+    void paintEvent(QPaintEvent* event) override {
+        Q_UNUSED(event)
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        const QRectF bounds =
+            QRectF(rect()).adjusted(0.0, static_cast<qreal>(kit::px(kit::Spacing::XXS)), 0.0,
+                                    -static_cast<qreal>(kit::px(kit::Spacing::XXS)));
+        kit::fillRoundedSurface(painter, bounds, kit::color(colorToken_), QColor(),
+                                kit::Radius::Small);
+    }
+
+  private:
+    kit::Color colorToken_;
+};
+
+// Blending/Parent (decision 1): one always-disabled KDropdown per row, each carrying its single
+// honest value ("Normal" / "None") -- no blend-mode breadth and no parenting feature exist yet, so
+// there is nothing else to offer, and the tooltip says so rather than the control merely looking
+// unresponsive.
+kit::KDropdown* makeDisabledPlaceholderDropdown(const QString& value, const QString& toolTip,
+                                                const QString& objectName, QWidget* parent) {
+    auto* dropdown = new kit::KDropdown(parent);
+    dropdown->setObjectName(objectName);
+    dropdown->addItem(value);
+    dropdown->setEnabled(false);
+    dropdown->setToolTip(toolTip);
+    return dropdown;
 }
 
 // Issue #120 (task U5), decisions 1/2: the properties panel's kit field grid. A row is
@@ -480,13 +614,19 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     auto* controls = new QWidget(this);
     controls->setObjectName("timelineControls");
     auto* controlsLayout = new QHBoxLayout(controls);
-    controlsLayout->setContentsMargins(8, 5, 8, 5);
-    controlsLayout->setSpacing(4);
+    controlsLayout->setContentsMargins(kit::px(kit::Spacing::S), kit::px(kit::Spacing::XS),
+                                       kit::px(kit::Spacing::S), kit::px(kit::Spacing::XS));
+    controlsLayout->setSpacing(kit::px(kit::Spacing::XS));
 
     auto* title = new QLabel(tr("Layers"), controls);
     title->setObjectName("editorSectionTitle");
     addButton_ = makeToolButton(tr("Add"), tr("Add layer"), controls);
     addButton_->setObjectName("addLayerButton");
+    // Decision 5: "Add menu restyled" -- the Add glyph itself; menu entries stay plain text (no
+    // Data* token honestly names a generic structured layer the way Add names the action).
+    addButton_->setIcon(kit::icon(kit::IconId::Add, kit::Size::IconMedium));
+    addButton_->setIconSize(
+        QSize(kit::px(kit::Size::IconMedium), kit::px(kit::Size::IconMedium)));
     addButton_->setPopupMode(QToolButton::InstantPopup);
     addButton_->setToolTip(tr("Add a structured layer"));
     auto* addMenu = new QMenu(tr("Add Layer"), addButton_);
@@ -500,29 +640,58 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     addTextAction->setObjectName("addTextLayerAction");
     addTextAction->setToolTip(tr("Add a text layer"));
     addButton_->setMenu(addMenu);
-    // Playback transport (issue #105, decision 4): a play/pause toggle beside the ruler, using the
-    // same makeToolButton() idiom as Add/Undo/Redo. Owned per-panel (see the header's comment on
-    // playback_) -- constructed here, directly beside the ruler it drives.
+
+    // Playback transport (issue #105, decision 4; restyled task U7, issue #122, decision 5): a
+    // StepBack/Play-Pause/StepForward/Loop row. playPauseButton_ MUST stay a QToolButton with its
+    // existing text()/isChecked() contract (playback_controller_tests.cpp,
+    // composition_projection_test.cpp both read it by exactly that type/objectName) -- only its
+    // icon changes here; updatePlaybackButton() below swaps the icon alongside the existing
+    // text/tooltip swap.
+    stepBackButton_ = makeIconToolButton(kit::IconId::StepBack, tr("Step back one frame (Left)"),
+                                         tr("Step back one frame"),
+                                         QStringLiteral("timelineStepBackButton"), controls);
     playPauseButton_ = makeToolButton(tr("Play"), tr("Toggle playback"), controls);
     playPauseButton_->setObjectName("playPauseButton");
     playPauseButton_->setCheckable(true);
+    stepForwardButton_ =
+        makeIconToolButton(kit::IconId::StepForward, tr("Step forward one frame (Right)"),
+                          tr("Step forward one frame"),
+                          QStringLiteral("timelineStepForwardButton"), controls);
+    // Loop indicator (decision 5): non-interactive status glyph, not a button -- playback always
+    // loops (PlaybackController::tick()'s exact modulo wrap) and there is no command to disable it,
+    // so a clickable control here would dishonestly imply a toggle that does not exist.
+    loopIndicator_ = new QLabel(controls);
+    loopIndicator_->setObjectName(QStringLiteral("timelineLoopIndicator"));
+    loopIndicator_->setAccessibleName(tr("Playback loops continuously"));
+    loopIndicator_->setToolTip(tr("Playback always loops; there is no command to disable it yet"));
+    loopIndicator_->setPixmap(kit::iconPixmap(kit::IconId::Loop, kit::Size::IconMedium,
+                                              kit::Color::Accent, kit::State::Normal,
+                                              kit::IconWeight::Fill));
     // Current time readout (issue #108, decision 3): a small label beside the transport, matching
     // PropertiesEditor::selectionLabel_'s plain-QLabel idiom (setObjectName + selectable text, no
-    // bespoke styling). Text is set by updateTimeReadout() below, not here.
+    // bespoke styling). Text is set by updateTimeReadout() below, not here. Restyled (decision 5:
+    // "frame/time readout stays the exact formatter, Geist Mono") to the Value type role -- the
+    // FORMATTER (formatExactSeconds(), updateTimeReadout()'s own "Frame %1 · %2" shape) is
+    // completely unchanged, only the font.
     timeReadout_ = new QLabel(controls);
     timeReadout_->setObjectName("timelineTimeReadout");
     timeReadout_->setAccessibleName(tr("Current frame and time"));
     timeReadout_->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    timeReadout_->setFont(kit::font(kit::TypeRole::Value));
     undoButton_ = makeToolButton(tr("Undo"), tr("Undo last edit"), controls);
     redoButton_ = makeToolButton(tr("Redo"), tr("Redo last edit"), controls);
     controlsLayout->addWidget(title);
     controlsLayout->addWidget(addButton_);
+    controlsLayout->addWidget(stepBackButton_);
     controlsLayout->addWidget(playPauseButton_);
+    controlsLayout->addWidget(stepForwardButton_);
+    controlsLayout->addWidget(loopIndicator_);
     controlsLayout->addWidget(timeReadout_);
     controlsLayout->addStretch(1);
     controlsLayout->addWidget(undoButton_);
     controlsLayout->addWidget(redoButton_);
 
+    workArea_ = new TimelineWorkAreaStrip(session_, this);
     ruler_ = new TimelineRuler(session_, previewController, this);
     keyframes_ = new TimelineKeyframePanel(session_, this);
     playback_ = new PlaybackController(session_, previewController, &std::chrono::steady_clock::now,
@@ -531,17 +700,34 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     layers_ = new QTreeWidget(this);
     layers_->setObjectName("layerStackView");
     layers_->setAccessibleName(tr("Composition layers"));
-    layers_->setColumnCount(3);
-    layers_->setHeaderLabels({tr("Name"), tr("Kind"), tr("Opacity")});
+    layers_->setColumnCount(kColumnCount);
+    // Header text stays attached to its LOGICAL column below regardless of the visual reorder
+    // (moveSection() a few lines down): text(kNameColumn)/text(kKindColumn) remain the pinned test
+    // contract's exact logical columns 0/1.
+    layers_->setHeaderLabels({tr("Name"), tr("Kind"), tr("Visible"), tr("Blending"), tr("Parent"),
+                             tr("Lane")});
     layers_->setRootIsDecorated(false);
-    layers_->setAlternatingRowColors(true);
+    // Striping now comes from TimelineTrackRowDelegate's own surface-ladder recipe (decision 1),
+    // not Qt's native AlternateBase.
+    layers_->setAlternatingRowColors(false);
     layers_->setSelectionMode(QAbstractItemView::SingleSelection);
     layers_->setUniformRowHeights(true);
-    layers_->header()->setSectionResizeMode(0, QHeaderView::Stretch);
-    layers_->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
-    layers_->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    layers_->setItemDelegate(new TimelineTrackRowDelegate(layers_));
+    layers_->header()->setSectionResizeMode(kNameColumn, QHeaderView::Interactive);
+    layers_->header()->setSectionResizeMode(kKindColumn, QHeaderView::ResizeToContents);
+    layers_->header()->setSectionResizeMode(kVisibilityColumn, QHeaderView::ResizeToContents);
+    layers_->header()->setSectionResizeMode(kBlendingColumn, QHeaderView::ResizeToContents);
+    layers_->header()->setSectionResizeMode(kParentColumn, QHeaderView::ResizeToContents);
+    layers_->header()->setSectionResizeMode(kLaneColumn, QHeaderView::Stretch);
+    // Decision 1's left-to-right narrative order (visibility, then name, kind, blending, parent,
+    // with the lane body trailing) is a VISUAL reorder only -- QHeaderView::moveSection() moves
+    // visual position, never logical index, so text(kNameColumn)/text(kKindColumn) and every
+    // setItemWidget(item, kBlendingColumn/...) call below keep addressing the same logical columns
+    // regardless of where the header paints them.
+    layers_->header()->moveSection(kVisibilityColumn, 0);
 
     layout->addWidget(controls);
+    layout->addWidget(workArea_);
     layout->addWidget(ruler_);
     layout->addWidget(keyframes_);
     layout->addWidget(layers_, 1);
@@ -600,6 +786,10 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     stepBackwardAction_->setShortcutContext(Qt::WindowShortcut);
     addAction(stepBackwardAction_);
     connect(stepBackwardAction_, &QAction::triggered, this, [this] { stepFrame(-1); });
+    // Task U7 (issue #122), decision 5: the visible stepBackButton_ triggers this SAME action --
+    // one behavior, two entry points (keyboard shortcut, mouse click) -- rather than a parallel
+    // stepFrame(-1) call site.
+    connect(stepBackButton_, &QToolButton::clicked, stepBackwardAction_, &QAction::trigger);
 
     stepForwardAction_ = new QAction(tr("Step Forward One Frame"), this);
     stepForwardAction_->setObjectName("stepForwardAction");
@@ -607,6 +797,7 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     stepForwardAction_->setShortcutContext(Qt::WindowShortcut);
     addAction(stepForwardAction_);
     connect(stepForwardAction_, &QAction::triggered, this, [this] { stepFrame(1); });
+    connect(stepForwardButton_, &QToolButton::clicked, stepForwardAction_, &QAction::trigger);
 
     stepToStartAction_ = new QAction(tr("Go To Start"), this);
     stepToStartAction_->setObjectName("stepToStartAction");
@@ -645,6 +836,12 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
         stepForwardAction_->setEnabled(!layersFocused);
         stepToStartAction_->setEnabled(!layersFocused);
         stepToEndAction_->setEnabled(!layersFocused);
+        // The visible stepBackButton_/stepForwardButton_ mirror their action's enabled state
+        // exactly (task U7, issue #122, decision 5), so the same reconciliation this comment
+        // block already documents for the keyboard shortcuts is visible on the mouse affordance
+        // too rather than showing a clickable button that would silently do nothing.
+        stepBackButton_->setEnabled(!layersFocused);
+        stepForwardButton_->setEnabled(!layersFocused);
     });
 
     connect(layers_, &QTreeWidget::itemSelectionChanged, this, [this] {
@@ -686,32 +883,67 @@ void TimelineEditor::rebuild() {
     const auto* composition = session_.composition();
     if (composition != nullptr) {
         for (const auto& entry : composition->graph().layerStack().entries()) {
-            const auto* boundary = layerBoundary(*composition, entry.layerId);
             const QString name = layerName(*composition, entry.layerId);
             const QString kind = layerKind(session_, entry.layerId);
-            QString opacity = QStringLiteral("—");
-            if (boundary != nullptr) {
-                if (const auto* parameter = nodeParameter(*composition, boundary->nodeId,
-                                                          document::kOpacityParameterRole)) {
-                    const auto* constant =
-                        std::get_if<document::ConstantValueSource>(&parameter->source);
-                    if (constant != nullptr) {
-                        if (const auto* value = std::get_if<double>(&constant->value)) {
-                            opacity = QStringLiteral("%1%").arg(*value * 100.0, 0, 'f', 0);
-                        }
-                    } else {
-                        opacity = sourceDescription(*parameter);
-                    }
-                }
-            }
 
-            auto* row = new QTreeWidgetItem(layers_, {name, kind, opacity});
+            // kNameColumn/kKindColumn stay exactly the pinned text() contract
+            // (composition_projection_test.cpp, playback_controller_tests.cpp); the row's OTHER
+            // columns are new (task U7, issue #122, decision 1) and carry no text of their own
+            // (icon+tooltip or an embedded item widget instead), so this constructor still only
+            // ever receives two strings.
+            auto* row = new QTreeWidgetItem(layers_, {name, kind});
+            row->setFont(kNameColumn, kit::font(kit::TypeRole::Ui));
+            row->setForeground(kNameColumn, QBrush(kit::color(kit::Color::Foreground)));
+            row->setFont(kKindColumn, kit::font(kit::TypeRole::Ui));
+            row->setForeground(kKindColumn, QBrush(kit::color(kit::Color::Muted)));
             row->setData(0, kTimelineLayerIdRole,
                          QVariant::fromValue<qulonglong>(entry.layerId.value()));
             row->setData(0, kTimelineSlotIdRole,
                          QVariant::fromValue<qulonglong>(entry.slotId.value()));
             row->setToolTip(
-                0, tr("Layer %1 · Slot %2").arg(entry.layerId.value()).arg(entry.slotId.value()));
+                kNameColumn,
+                tr("Layer %1 · Slot %2").arg(entry.layerId.value()).arg(entry.slotId.value()));
+
+            // Visibility (decision 1): NO user-facing visibility command exists anywhere in
+            // src/commands today (verified by reading src/commands/include/bloom/commands/
+            // operations.hpp -- AddSolidLayer, AddTextLayer, SetParameterSource, MoveLayerBefore,
+            // and the SetProjectName/SetCompositionName/SetCompositionDuration/
+            // SetCompositionFormat document-settings ops are the complete list; no per-layer
+            // visibility flag exists in the document model at all, layer_graph_model.md included).
+            // The honesty rule therefore applies verbatim: a permanently dimmed, non-interactive
+            // icon with a tooltip that says exactly why, never a toggle that would silently do
+            // nothing. Reported in this task's raw report.
+            row->setIcon(kVisibilityColumn,
+                        QIcon(kit::iconPixmap(
+                            kit::IconId::Visible, kit::Size::IconSmall,
+                            kit::withOpacity(kit::color(kit::Color::Muted), kit::kDisabledOpacity))));
+            row->setToolTip(kVisibilityColumn,
+                            tr("Layer visibility has no command yet -- every layer renders"));
+
+            // Reserved audio-mute/solo/lock columns (decision 1) are deliberately OMITTED, not
+            // rendered as disabled ghost icons: none of the three has ANY model presence today
+            // (no audio-layer kind, no solo concept, no lock field anywhere in src/document), so
+            // three permanently-inert icons crammed into this already-dense 34px row would read as
+            // broken chrome rather than an honest "reserved" placeholder. Justification recorded in
+            // this task's raw report per decision 1's own "omitted entirely... YOUR call, justified"
+            // allowance.
+
+            // Blending / Parent (decision 1): one always-disabled dropdown per row, each carrying
+            // its single honest value.
+            layers_->setItemWidget(
+                row, kBlendingColumn,
+                makeDisabledPlaceholderDropdown(
+                    tr("Normal"), tr("Blend modes are not implemented yet"),
+                    QStringLiteral("layerBlendingDropdown"), layers_));
+            layers_->setItemWidget(
+                row, kParentColumn,
+                makeDisabledPlaceholderDropdown(tr("None"), tr("Layer parenting does not exist yet"),
+                                                QStringLiteral("layerParentDropdown"), layers_));
+
+            // Lane bar (decision 2): one type-color-coded bar per row, spanning this column's full
+            // width (see TimelineLaneBar's own honesty disclosure comment above).
+            layers_->setItemWidget(row, kLaneColumn,
+                                   new TimelineLaneBar(layerLaneColorToken(), layers_));
         }
     }
     updateSelection();
@@ -752,7 +984,13 @@ void TimelineEditor::updateHistoryActions() {
 void TimelineEditor::updatePlaybackButton(const PlaybackState state) {
     const bool playing = state == PlaybackState::Playing;
     playPauseButton_->setChecked(playing);
+    // text()/isChecked() stay the pinned test contract verbatim (playback_controller_tests.cpp);
+    // the icon swap (task U7, issue #122, decision 5: "Play/Pause swap") is purely additive.
     playPauseButton_->setText(playing ? tr("Pause") : tr("Play"));
+    playPauseButton_->setIcon(
+        kit::icon(playing ? kit::IconId::Pause : kit::IconId::Play, kit::Size::IconMedium));
+    playPauseButton_->setIconSize(
+        QSize(kit::px(kit::Size::IconMedium), kit::px(kit::Size::IconMedium)));
     playPauseButton_->setToolTip(playing ? tr("Pause playback (Space)")
                                          : tr("Play from the current time (Space)"));
 }

--- a/src/ui/include/bloom/ui/composition_editors.hpp
+++ b/src/ui/include/bloom/ui/composition_editors.hpp
@@ -16,6 +16,7 @@ class CompositionPreviewController;
 class CompositionSession;
 class TimelineKeyframePanel;
 class TimelineRuler;
+class TimelineWorkAreaStrip;
 
 namespace kit {
 class KValueField;
@@ -27,6 +28,21 @@ class TimelineEditor final : public QWidget {
   public:
     TimelineEditor(CompositionSession& session, CompositionPreviewController& previewController,
                    QWidget* parent = nullptr);
+
+    // Track row column layout (task U7, issue #122, decision 1). Logical column indices are a
+    // stable test contract (composition_projection_test.cpp and playback_controller_tests.cpp
+    // already read text(kNameColumn)/text(kKindColumn) and topLevelItem() by these positions), so
+    // Name/Kind stay logical columns 0/1 exactly as before this task; the new decision-1 columns
+    // are appended after them and reordered to paint LEFTMOST via QHeaderView::moveSection() in
+    // the .cpp, which moves visual position only -- QTreeWidgetItem::text()/icon()/toolTip() and
+    // QHeaderView::logicalIndex() are completely unaffected by that visual reorder.
+    static constexpr int kNameColumn = 0;
+    static constexpr int kKindColumn = 1;
+    static constexpr int kVisibilityColumn = 2;
+    static constexpr int kBlendingColumn = 3;
+    static constexpr int kParentColumn = 4;
+    static constexpr int kLaneColumn = 5;
+    static constexpr int kColumnCount = 6;
 
   private:
     void rebuild();
@@ -48,6 +64,7 @@ class TimelineEditor final : public QWidget {
     void updateTimeReadout();
 
     CompositionSession& session_;
+    TimelineWorkAreaStrip* workArea_ = nullptr;
     TimelineRuler* ruler_ = nullptr;
     TimelineKeyframePanel* keyframes_ = nullptr;
     QTreeWidget* layers_ = nullptr;
@@ -60,7 +77,20 @@ class TimelineEditor final : public QWidget {
     // enabled state) is already independently driven off the shared CompositionSession/
     // CompositionPreviewController rather than a single cross-panel singleton.
     PlaybackController* playback_ = nullptr;
+    // Task U7 (issue #122), decision 5: clickable mouse affordances for the SAME
+    // stepBackwardAction_/stepForwardAction_ QActions the Left/Right shortcuts already trigger --
+    // wired by connecting the button's clicked() straight to the action's trigger() rather than
+    // QToolButton::setDefaultAction(), so this button's own icon/tooltip/objectName stay under
+    // this class's control instead of mirroring the action's text. Their enabled state is kept in
+    // lockstep with the actions by the SAME focusChanged reconciliation lambda that already
+    // disables the actions while layers_ holds keyboard focus (see the constructor).
+    QToolButton* stepBackButton_ = nullptr;
+    QToolButton* stepForwardButton_ = nullptr;
     QToolButton* playPauseButton_ = nullptr;
+    // Non-interactive (decision 5: "non-interactive if loop isn't toggleable"): playback always
+    // loops (PlaybackController::tick()'s exact modulo wrap) with no command to disable it, so this
+    // is a status glyph, never a button that would falsely imply a click could turn looping off.
+    QLabel* loopIndicator_ = nullptr;
     // Current frame index / exact time readout (design decision 3), living beside playPauseButton_
     // in the same controls row.
     QLabel* timeReadout_ = nullptr;

--- a/src/ui/include/bloom/ui/timeline_ruler.hpp
+++ b/src/ui/include/bloom/ui/timeline_ruler.hpp
@@ -58,8 +58,9 @@ class TimelineRuler final : public QWidget {
 };
 
 // The honest "work area" strip (task U7, issue #122, decision 3): a thin Accent-dim band spanning
-// the FULL [0, duration) composition range, painted directly above TimelineRuler in TimelineEditor's
-// layout. Bloom has no range-editing feature yet -- there is no separate in/out point to visualize
+// the FULL [0, duration) composition range, painted directly above TimelineRuler in
+// TimelineEditor's layout. Bloom has no range-editing feature yet -- there is no separate in/out
+// point to visualize
 // -- so this band always spans the entire width by construction; it is deliberately
 // non-interactive (no mouse handling at all) rather than pretend a click could narrow it.
 class TimelineWorkAreaStrip final : public QWidget {

--- a/src/ui/include/bloom/ui/timeline_ruler.hpp
+++ b/src/ui/include/bloom/ui/timeline_ruler.hpp
@@ -2,6 +2,7 @@
 
 #include <bloom/document/ids.hpp>
 
+#include <QRectF>
 #include <QWidget>
 
 #include <vector>
@@ -20,6 +21,13 @@ class CompositionSession;
 // priority through the controller's trailing cadence (CompositionPreviewController::
 // beginInteractiveScrub()/notifyScrubEnded()). Projection and scrub only: no direct Viewer
 // manipulation, no playback transport, no key-editing gestures.
+//
+// Kinetik restyle (task U7, issue #122, decision 3): labeled MAJOR ticks are density-adaptive --
+// the step between them is chosen from the ruler's own width and the widest label this axis could
+// ever paint (its own FONT metrics, not a guessed pixel budget) so adjacent major labels can never
+// collide; unlabeled MINOR ticks fill in at a denser, purely visual grid. The pixel<->frame axis
+// math itself (TimelineAxis, private to the .cpp) is completely unchanged -- this only changes
+// which ticks get a text label and how far apart they are.
 class TimelineRuler final : public QWidget {
     Q_OBJECT
 
@@ -36,9 +44,35 @@ class TimelineRuler final : public QWidget {
   private:
     void scrubToPixel(int pixelX);
 
+  public:
+    // Exposed purely for tests (mirrors ViewerEditor::zoomDropdownForTest()'s precedent): the
+    // exact major-tick label rects paintEvent would draw at the ruler's CURRENT width/composition,
+    // so a collision test can assert disjointness without re-deriving the density math or
+    // rasterizing a QImage to find text.
+    [[nodiscard]] std::vector<QRectF> majorTickLabelRectsForTest() const;
+
+  private:
     CompositionSession& session_;
     CompositionPreviewController& previewController_;
     bool scrubbing_ = false;
+};
+
+// The honest "work area" strip (task U7, issue #122, decision 3): a thin Accent-dim band spanning
+// the FULL [0, duration) composition range, painted directly above TimelineRuler in TimelineEditor's
+// layout. Bloom has no range-editing feature yet -- there is no separate in/out point to visualize
+// -- so this band always spans the entire width by construction; it is deliberately
+// non-interactive (no mouse handling at all) rather than pretend a click could narrow it.
+class TimelineWorkAreaStrip final : public QWidget {
+    Q_OBJECT
+
+  public:
+    explicit TimelineWorkAreaStrip(CompositionSession& session, QWidget* parent = nullptr);
+
+  protected:
+    void paintEvent(QPaintEvent* event) override;
+
+  private:
+    CompositionSession& session_;
 };
 
 // One row per animated parameter of the current selection's layer (position/opacity only in

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -106,6 +106,13 @@ add_executable(bloom_main_window_readonly_placeholder_test
     main_window_readonly_placeholder_tests.cpp
 )
 
+# Task U7 (issue #122): TimelineEditor track-row/transport Kinetik restyle tests, appended rather
+# than folded into timeline_ruler_tests.cpp (which owns the ruler/keyframe-panel interaction
+# contract this task must keep byte-equivalent).
+add_executable(bloom_timeline_editor_style_test
+    timeline_editor_style_tests.cpp
+)
+
 target_link_libraries(bloom_editor_area_chrome_test PRIVATE bloom_ui Qt6::Test)
 target_link_libraries(bloom_kinetik_baseline_test PRIVATE bloom_ui)
 target_link_libraries(bloom_kit_button_test PRIVATE bloom_ui_kit)
@@ -137,6 +144,7 @@ target_link_libraries(bloom_direct_manipulation_test PRIVATE bloom_ui)
 target_link_libraries(bloom_frame_export_controller_test PRIVATE bloom_ui)
 target_link_libraries(bloom_main_window_readonly_placeholder_test PRIVATE bloom_ui ZLIB::ZLIB)
 target_link_libraries(bloom_playback_controller_test PRIVATE bloom_ui Qt6::Test)
+target_link_libraries(bloom_timeline_editor_style_test PRIVATE bloom_ui)
 bloom_enable_warnings(bloom_editor_area_chrome_test)
 bloom_enable_warnings(bloom_kinetik_baseline_test)
 bloom_enable_warnings(bloom_kit_button_test)
@@ -168,6 +176,7 @@ bloom_enable_warnings(bloom_direct_manipulation_test)
 bloom_enable_warnings(bloom_frame_export_controller_test)
 bloom_enable_warnings(bloom_main_window_readonly_placeholder_test)
 bloom_enable_warnings(bloom_playback_controller_test)
+bloom_enable_warnings(bloom_timeline_editor_style_test)
 
 include(BloomTesting)
 
@@ -415,6 +424,14 @@ bloom_add_test(
     NAME bloom.ui.playback_controller
     COMMAND bloom_playback_controller_test
     LABELS ui integration animation
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.timeline_editor_style
+    COMMAND bloom_timeline_editor_style_test
+    LABELS ui integration kit
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
 )

--- a/src/ui/tests/timeline_editor_style_tests.cpp
+++ b/src/ui/tests/timeline_editor_style_tests.cpp
@@ -1,0 +1,419 @@
+// Task U7 (issue #122): Kinetik restyle tests for TimelineEditor's track rows and transport,
+// covering the decisions timeline_ruler_tests.cpp does not (that file owns the ruler/keyframe-panel
+// interaction contract; this file owns the layer-row chrome and transport restyle). Offscreen,
+// matching every other widget test in this suite.
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/runtime/cpu_composition_evaluator.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/runtime/reference_display_preparation.hpp>
+#include <bloom/runtime/snapshot_compiler.hpp>
+#include <bloom/runtime/task_scheduler.hpp>
+#include <bloom/ui/composition_editors.hpp>
+#include <bloom/ui/composition_preview_controller.hpp>
+#include <bloom/ui/composition_preview_pipeline.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/kit/dropdown.hpp>
+#include <bloom/ui/kit/icons.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/task_ui_bridge.hpp>
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QImage>
+#include <QLabel>
+#include <QPixmap>
+#include <QString>
+#include <QToolButton>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] bool near(const QColor& left, const QColor& right, const int tolerance) {
+    return std::abs(left.red() - right.red()) <= tolerance &&
+           std::abs(left.green() - right.green()) <= tolerance &&
+           std::abs(left.blue() - right.blue()) <= tolerance;
+}
+
+bloom::runtime::TaskSchedulerConfig testSchedulerConfig() {
+    return {.cpuWorkerCount = 1,
+            .blockingIoWorkerCount = 1,
+            .cpuQueueCapacity = 16,
+            .blockingIoQueueCapacity = 4,
+            .terminalHistoryCapacity = 32,
+            .diagnosticsPerTask = 8,
+            .groupRegistryCapacity = 8};
+}
+
+bloom::document::CompositionFormat smallFormat() {
+    const auto format = bloom::document::CompositionFormat::create(4, 3);
+    if (!format.has_value()) {
+        std::abort();
+    }
+    return *format;
+}
+
+[[nodiscard]] bloom::core::RationalTime time(const std::int64_t numerator) {
+    const auto value = bloom::core::RationalTime::create(numerator, 1);
+    if (!value.has_value()) {
+        std::abort();
+    }
+    return *value;
+}
+
+bloom::document::NewProject makeTestProject(std::string projectName) {
+    return bloom::document::makeNewProject(std::move(projectName), "Main", time(10), smallFormat());
+}
+
+// Mirrors timeline_ruler_tests.cpp's own PipelineFixture/SessionFixture exactly -- no shared test
+// fixture header exists in this suite (every widget test file in src/ui/tests owns a private copy,
+// e.g. composition_projection_test.cpp, playback_controller_tests.cpp), so this duplication follows
+// the established per-file idiom rather than inventing a new cross-file dependency.
+struct PipelineFixture final {
+    bloom::runtime::NodeDefinitionRegistry definitions;
+    bloom::runtime::SnapshotCompiler compiler;
+    bloom::runtime::CpuCompositionEvaluator evaluator;
+    bloom::runtime::CpuReferenceDisplayPreparer displayPreparer;
+    bloom::runtime::QualifiedDisplayProcessorProvider qualifiedProcessorProvider;
+    bloom::ui::PreviewPreparationFunction pipeline;
+
+    PipelineFixture() : compiler(definitions) {
+        if (!bloom::runtime::registerBuiltInNodeDefinitions(definitions)) {
+            std::abort();
+        }
+        definitions.freeze();
+        pipeline = bloom::ui::makeCompositionPreviewPipeline(compiler, evaluator, displayPreparer,
+                                                             qualifiedProcessorProvider);
+    }
+};
+
+struct SessionFixture final {
+    bloom::document::Document document;
+    bloom::commands::CommandStack commands;
+    bloom::ui::CompositionSession session;
+    bloom::runtime::TaskScheduler scheduler;
+    bloom::ui::TaskUiBridge bridge;
+    PipelineFixture pipeline;
+    bloom::ui::CompositionPreviewController controller;
+
+    explicit SessionFixture(bloom::document::NewProject newProject)
+        : document(std::move(newProject.project)), commands(document),
+          session(document, commands, newProject.initialCompositionId),
+          scheduler(testSchedulerConfig()), bridge(scheduler, nullptr, 1ms),
+          controller(session, scheduler, bridge, pipeline.pipeline) {}
+};
+
+void finishFixture(SessionFixture& fixture) {
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    QElapsedTimer timer;
+    timer.start();
+    while (!fixture.scheduler.isQuiescent() && timer.elapsed() < 4'000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    }
+}
+
+// Forces the tree's real item-widget/column geometry to materialize (setItemWidget() sizes are
+// only assigned once the view actually lays itself out), the same "show a real top-level window,
+// pump events" idiom playback_controller_tests.cpp's tree-focus test already uses.
+void layoutTree(QWidget& host) {
+    host.resize(720, 320);
+    host.show();
+    host.activateWindow();
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+}
+
+// Decision 1's honesty rule: no user-facing layer-visibility command exists anywhere in
+// src/commands (verified by reading operations.hpp), so the eye column must render a permanently
+// dimmed, non-interactive icon with a tooltip that says exactly why -- never a toggle that would
+// silently do nothing.
+void testVisibilityColumnRendersDisabledWithHonestTooltip(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Visibility Column Test"));
+    (void)fixture.session.addSolidLayer(QStringLiteral("A"), core::Color4d{0.2, 0.3, 0.4, 1.0});
+
+    ui::TimelineEditor editor(fixture.session, fixture.controller);
+    auto* tree = editor.findChild<QTreeWidget*>("layerStackView");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 1,
+                        "the layer row exists");
+    if (tree == nullptr || tree->topLevelItemCount() != 1) {
+        finishFixture(fixture);
+        return;
+    }
+    auto* row = tree->topLevelItem(0);
+
+    const auto dimmedIcon = ui::kit::iconPixmap(
+        ui::kit::IconId::Visible, ui::kit::Size::IconSmall,
+        ui::kit::withOpacity(ui::kit::color(ui::kit::Color::Muted), ui::kit::kDisabledOpacity));
+    const auto brightIcon = ui::kit::iconPixmap(ui::kit::IconId::Visible, ui::kit::Size::IconSmall,
+                                                ui::kit::color(ui::kit::Color::Muted));
+    expectations.expect(dimmedIcon.toImage() != brightIcon.toImage(),
+                        "the fixture's own dimmed/bright renderings are genuinely different (test "
+                        "sanity)");
+
+    const auto rowIcon = row->icon(ui::TimelineEditor::kVisibilityColumn);
+    expectations.expect(!rowIcon.isNull(), "the visibility column carries an icon");
+    expectations.expect(
+        rowIcon.pixmap(dimmedIcon.size()).toImage() == dimmedIcon.toImage(),
+        "the visibility icon is the SAME permanently dimmed rendering, not the bright/active one");
+
+    const auto toolTip = row->toolTip(ui::TimelineEditor::kVisibilityColumn);
+    expectations.expect(!toolTip.isEmpty() && toolTip.contains(QStringLiteral("no command"),
+                                                                Qt::CaseInsensitive),
+                        "the tooltip honestly explains there is no visibility command yet");
+
+    finishFixture(fixture);
+}
+
+// Decision 1: Blending shows "Normal" disabled, Parent shows "None" disabled -- one honest value,
+// no fake choices, because neither feature exists.
+void testBlendingAndParentColumnsAreDisabledPlaceholders(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Blending Parent Column Test"));
+    (void)fixture.session.addSolidLayer(QStringLiteral("A"), core::Color4d{0.2, 0.3, 0.4, 1.0});
+
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    QWidget host;
+    auto* layout = new QVBoxLayout(&host);
+    layout->addWidget(editor);
+    layoutTree(host);
+
+    auto* tree = editor->findChild<QTreeWidget*>("layerStackView");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 1,
+                        "the layer row exists");
+    if (tree == nullptr || tree->topLevelItemCount() != 1) {
+        finishFixture(fixture);
+        return;
+    }
+    auto* row = tree->topLevelItem(0);
+
+    auto* blending =
+        qobject_cast<ui::kit::KDropdown*>(tree->itemWidget(row, ui::TimelineEditor::kBlendingColumn));
+    auto* parent =
+        qobject_cast<ui::kit::KDropdown*>(tree->itemWidget(row, ui::TimelineEditor::kParentColumn));
+    expectations.expect(blending != nullptr && parent != nullptr,
+                        "the Blending and Parent columns each carry a KDropdown");
+    if (blending == nullptr || parent == nullptr) {
+        finishFixture(fixture);
+        return;
+    }
+
+    expectations.expect(!blending->isEnabled() && blending->currentText() == QStringLiteral("Normal"),
+                        "Blending shows the one honest value \"Normal\", disabled");
+    expectations.expect(!blending->toolTip().isEmpty(), "Blending's disabled state is explained");
+    expectations.expect(!parent->isEnabled() && parent->currentText() == QStringLiteral("None"),
+                        "Parent shows the one honest value \"None\", disabled");
+    expectations.expect(!parent->toolTip().isEmpty(), "Parent's disabled state is explained");
+
+    finishFixture(fixture);
+}
+
+// Decision 2: the lane bar's color comes from the ONE documented data-type-palette mapping
+// (layerLaneColorToken() in composition_editors.cpp: DataComposition, for every layer kind that
+// exists today).
+void testLaneBarUsesTheDocumentedDataTypeColor(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Lane Bar Color Test"));
+    (void)fixture.session.addSolidLayer(QStringLiteral("A"), core::Color4d{0.2, 0.3, 0.4, 1.0});
+    (void)fixture.session.addTextLayer(QStringLiteral("B"), QStringLiteral("Text"));
+
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    QWidget host;
+    auto* layout = new QVBoxLayout(&host);
+    layout->addWidget(editor);
+    layoutTree(host);
+
+    auto* tree = editor->findChild<QTreeWidget*>("layerStackView");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 2,
+                        "both layer rows exist");
+    if (tree == nullptr || tree->topLevelItemCount() != 2) {
+        finishFixture(fixture);
+        return;
+    }
+
+    const QColor expected = ui::kit::color(ui::kit::Color::DataComposition);
+    for (int index = 0; index < 2; ++index) {
+        auto* row = tree->topLevelItem(index);
+        auto* bar = tree->itemWidget(row, ui::TimelineEditor::kLaneColumn);
+        expectations.expect(bar != nullptr && bar->width() > 4 && bar->height() > 4,
+                            "the lane bar widget exists with real geometry");
+        if (bar == nullptr || bar->width() <= 4 || bar->height() <= 4) {
+            continue;
+        }
+        const QImage image = bar->grab().toImage();
+        const QColor sampled = image.pixelColor(bar->width() / 2, bar->height() / 2);
+        expectations.expect(near(sampled, expected, 6),
+                            "the lane bar's interior paints the documented DataComposition color, "
+                            "for both a Solid and a Text layer alike (one uniform honest mapping)");
+    }
+
+    finishFixture(fixture);
+}
+
+// Decision 1: "selection = Accent inset edge per States" -- a 2px Accent border on the selected
+// row, not a full fill (a fill would hide the row's own name/kind text).
+void testSelectedRowPaintsAccentInsetEdgeNotAFill(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Selection Edge Test"));
+    (void)fixture.session.addSolidLayer(QStringLiteral("A"), core::Color4d{0.2, 0.3, 0.4, 1.0});
+    (void)fixture.session.addSolidLayer(QStringLiteral("B"), core::Color4d{0.2, 0.3, 0.4, 1.0});
+
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    QWidget host;
+    auto* layout = new QVBoxLayout(&host);
+    layout->addWidget(editor);
+    layoutTree(host);
+
+    auto* tree = editor->findChild<QTreeWidget*>("layerStackView");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 2, "both rows exist");
+    if (tree == nullptr || tree->topLevelItemCount() != 2) {
+        finishFixture(fixture);
+        return;
+    }
+    // addSolidLayer selects the newly added layer, so row 1 ("B") is already selected; row 0 ("A")
+    // is not.
+    const auto selectedRect = tree->visualItemRect(tree->topLevelItem(1));
+    const auto unselectedRect = tree->visualItemRect(tree->topLevelItem(0));
+    expectations.expect(tree->topLevelItem(1)->isSelected() && !tree->topLevelItem(0)->isSelected(),
+                        "row 1 is selected, row 0 is not (test precondition)");
+    expectations.expect(selectedRect.height() > 4 && unselectedRect.height() > 4,
+                        "both rows have real painted geometry");
+    if (selectedRect.height() <= 4 || unselectedRect.height() <= 4) {
+        finishFixture(fixture);
+        return;
+    }
+
+    const QImage viewport = tree->viewport()->grab().toImage();
+    const QColor accent = ui::kit::color(ui::kit::Color::Accent);
+    const int sampleX = selectedRect.left() + 12;
+    const QColor selectedTopEdge = viewport.pixelColor(sampleX, selectedRect.top() + 1);
+    const QColor unselectedTopEdge =
+        viewport.pixelColor(unselectedRect.left() + 12, unselectedRect.top() + 1);
+    expectations.expect(near(selectedTopEdge, accent, 24),
+                        "the selected row's top edge paints the Accent inset border");
+    expectations.expect(!near(unselectedTopEdge, accent, 24),
+                        "an unselected row's own top edge does NOT paint the Accent border");
+
+    // The interior (well below the 2px edge) is the striped background, never a full Accent fill --
+    // this is what "inset edge, not a fill" means concretely.
+    const QColor selectedInterior =
+        viewport.pixelColor(sampleX, selectedRect.top() + selectedRect.height() / 2);
+    expectations.expect(!near(selectedInterior, accent, 24),
+                        "the selected row's INTERIOR is not accent-filled -- only the inset edge is");
+
+    finishFixture(fixture);
+}
+
+// Decision 5: the play/pause button's ICON swaps alongside its already-pinned text()/isChecked()
+// contract (playback_controller_tests.cpp owns that contract byte-for-byte; this test adds the
+// icon assertion on top of the SAME public API/idiom rather than duplicating the whole contract).
+void testPlayPauseButtonIconSwapsWithState(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Play Pause Icon Test"));
+
+    auto* editor = new ui::TimelineEditor(fixture.session, fixture.controller);
+    auto* button = editor->findChild<QToolButton*>("playPauseButton");
+    expectations.expect(button != nullptr, "the play/pause button is reachable by name");
+    if (button == nullptr) {
+        delete editor;
+        finishFixture(fixture);
+        return;
+    }
+
+    const auto playIcon = ui::kit::icon(ui::kit::IconId::Play, ui::kit::Size::IconMedium);
+    const auto pauseIcon = ui::kit::icon(ui::kit::IconId::Pause, ui::kit::Size::IconMedium);
+    const auto size = QSize(ui::kit::px(ui::kit::Size::IconMedium),
+                            ui::kit::px(ui::kit::Size::IconMedium));
+    expectations.expect(
+        button->icon().pixmap(size).toImage() == playIcon.pixmap(size).toImage(),
+        "the button starts showing the Play glyph");
+
+    button->click();
+    expectations.expect(button->isChecked() && button->text() == QStringLiteral("Pause"),
+                        "the existing text()/isChecked() contract still flips on click");
+    expectations.expect(
+        button->icon().pixmap(size).toImage() == pauseIcon.pixmap(size).toImage(),
+        "clicking swaps the icon to Pause alongside the text");
+
+    button->click();
+    expectations.expect(
+        button->icon().pixmap(size).toImage() == playIcon.pixmap(size).toImage(),
+        "clicking again swaps the icon back to Play");
+
+    delete editor;
+    finishFixture(fixture);
+}
+
+// Non-goal guard (decision 5): the loop indicator is a status glyph, never a clickable control --
+// playback always loops with no command to disable it, so a QToolButton here would dishonestly
+// imply a toggle that does not exist.
+void testLoopIndicatorIsNonInteractiveAndHonest(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Loop Indicator Test"));
+
+    ui::TimelineEditor editor(fixture.session, fixture.controller);
+    auto* indicator = editor.findChild<QLabel*>("timelineLoopIndicator");
+    expectations.expect(indicator != nullptr, "the loop indicator exists");
+    if (indicator == nullptr) {
+        finishFixture(fixture);
+        return;
+    }
+    expectations.expect(editor.findChild<QToolButton*>("timelineLoopIndicator") == nullptr,
+                        "the loop indicator is a QLabel, never a clickable QToolButton");
+    expectations.expect(!indicator->pixmap().isNull(), "the loop indicator carries a glyph");
+    expectations.expect(indicator->toolTip().contains(QStringLiteral("loop"), Qt::CaseInsensitive),
+                        "the tooltip honestly names the always-on looping behavior");
+
+    finishFixture(fixture);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testVisibilityColumnRendersDisabledWithHonestTooltip(expectations);
+    testBlendingAndParentColumnsAreDisabledPlaceholders(expectations);
+    testLaneBarUsesTheDocumentedDataTypeColor(expectations);
+    testSelectedRowPaintsAccentInsetEdgeNotAFill(expectations);
+    testPlayPauseButtonIconSwapsWithState(expectations);
+    testLoopIndicatorIsNonInteractiveAndHonest(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/timeline_editor_style_tests.cpp
+++ b/src/ui/tests/timeline_editor_style_tests.cpp
@@ -170,8 +170,7 @@ void testVisibilityColumnRendersDisabledWithHonestTooltip(Expectations& expectat
 
     ui::TimelineEditor editor(fixture.session, fixture.controller);
     auto* tree = editor.findChild<QTreeWidget*>("layerStackView");
-    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 1,
-                        "the layer row exists");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 1, "the layer row exists");
     if (tree == nullptr || tree->topLevelItemCount() != 1) {
         finishFixture(fixture);
         return;
@@ -194,8 +193,8 @@ void testVisibilityColumnRendersDisabledWithHonestTooltip(Expectations& expectat
         "the visibility icon is the SAME permanently dimmed rendering, not the bright/active one");
 
     const auto toolTip = row->toolTip(ui::TimelineEditor::kVisibilityColumn);
-    expectations.expect(!toolTip.isEmpty() && toolTip.contains(QStringLiteral("no command"),
-                                                                Qt::CaseInsensitive),
+    expectations.expect(!toolTip.isEmpty() &&
+                            toolTip.contains(QStringLiteral("no command"), Qt::CaseInsensitive),
                         "the tooltip honestly explains there is no visibility command yet");
 
     finishFixture(fixture);
@@ -215,16 +214,15 @@ void testBlendingAndParentColumnsAreDisabledPlaceholders(Expectations& expectati
     layoutTree(host);
 
     auto* tree = editor->findChild<QTreeWidget*>("layerStackView");
-    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 1,
-                        "the layer row exists");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 1, "the layer row exists");
     if (tree == nullptr || tree->topLevelItemCount() != 1) {
         finishFixture(fixture);
         return;
     }
     auto* row = tree->topLevelItem(0);
 
-    auto* blending =
-        qobject_cast<ui::kit::KDropdown*>(tree->itemWidget(row, ui::TimelineEditor::kBlendingColumn));
+    auto* blending = qobject_cast<ui::kit::KDropdown*>(
+        tree->itemWidget(row, ui::TimelineEditor::kBlendingColumn));
     auto* parent =
         qobject_cast<ui::kit::KDropdown*>(tree->itemWidget(row, ui::TimelineEditor::kParentColumn));
     expectations.expect(blending != nullptr && parent != nullptr,
@@ -234,7 +232,8 @@ void testBlendingAndParentColumnsAreDisabledPlaceholders(Expectations& expectati
         return;
     }
 
-    expectations.expect(!blending->isEnabled() && blending->currentText() == QStringLiteral("Normal"),
+    expectations.expect(!blending->isEnabled() &&
+                            blending->currentText() == QStringLiteral("Normal"),
                         "Blending shows the one honest value \"Normal\", disabled");
     expectations.expect(!blending->toolTip().isEmpty(), "Blending's disabled state is explained");
     expectations.expect(!parent->isEnabled() && parent->currentText() == QStringLiteral("None"),
@@ -260,8 +259,7 @@ void testLaneBarUsesTheDocumentedDataTypeColor(Expectations& expectations) {
     layoutTree(host);
 
     auto* tree = editor->findChild<QTreeWidget*>("layerStackView");
-    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 2,
-                        "both layer rows exist");
+    expectations.expect(tree != nullptr && tree->topLevelItemCount() == 2, "both layer rows exist");
     if (tree == nullptr || tree->topLevelItemCount() != 2) {
         finishFixture(fixture);
         return;
@@ -334,8 +332,9 @@ void testSelectedRowPaintsAccentInsetEdgeNotAFill(Expectations& expectations) {
     // this is what "inset edge, not a fill" means concretely.
     const QColor selectedInterior =
         viewport.pixelColor(sampleX, selectedRect.top() + selectedRect.height() / 2);
-    expectations.expect(!near(selectedInterior, accent, 24),
-                        "the selected row's INTERIOR is not accent-filled -- only the inset edge is");
+    expectations.expect(
+        !near(selectedInterior, accent, 24),
+        "the selected row's INTERIOR is not accent-filled -- only the inset edge is");
 
     finishFixture(fixture);
 }
@@ -358,23 +357,20 @@ void testPlayPauseButtonIconSwapsWithState(Expectations& expectations) {
 
     const auto playIcon = ui::kit::icon(ui::kit::IconId::Play, ui::kit::Size::IconMedium);
     const auto pauseIcon = ui::kit::icon(ui::kit::IconId::Pause, ui::kit::Size::IconMedium);
-    const auto size = QSize(ui::kit::px(ui::kit::Size::IconMedium),
-                            ui::kit::px(ui::kit::Size::IconMedium));
-    expectations.expect(
-        button->icon().pixmap(size).toImage() == playIcon.pixmap(size).toImage(),
-        "the button starts showing the Play glyph");
+    const auto size =
+        QSize(ui::kit::px(ui::kit::Size::IconMedium), ui::kit::px(ui::kit::Size::IconMedium));
+    expectations.expect(button->icon().pixmap(size).toImage() == playIcon.pixmap(size).toImage(),
+                        "the button starts showing the Play glyph");
 
     button->click();
     expectations.expect(button->isChecked() && button->text() == QStringLiteral("Pause"),
                         "the existing text()/isChecked() contract still flips on click");
-    expectations.expect(
-        button->icon().pixmap(size).toImage() == pauseIcon.pixmap(size).toImage(),
-        "clicking swaps the icon to Pause alongside the text");
+    expectations.expect(button->icon().pixmap(size).toImage() == pauseIcon.pixmap(size).toImage(),
+                        "clicking swaps the icon to Pause alongside the text");
 
     button->click();
-    expectations.expect(
-        button->icon().pixmap(size).toImage() == playIcon.pixmap(size).toImage(),
-        "clicking again swaps the icon back to Play");
+    expectations.expect(button->icon().pixmap(size).toImage() == playIcon.pixmap(size).toImage(),
+                        "clicking again swaps the icon back to Play");
 
     delete editor;
     finishFixture(fixture);

--- a/src/ui/tests/timeline_ruler_tests.cpp
+++ b/src/ui/tests/timeline_ruler_tests.cpp
@@ -952,11 +952,10 @@ void testDoubleClickInsertClampsToBoundaryValuesBeforeFirstAndAfterLastKey(
 void testRulerMajorTickLabelsNeverCollideAtTwoWidths(Expectations& expectations) {
     using namespace bloom;
     SessionFixture fixture(makeTestProject("Ruler Density Test", time(999, 24)));
-    expectations.expect(waitUntil([&] {
-                            return fixture.controller.state().activity !=
-                                   ui::PreviewActivity::Rendering;
-                        }),
-                        "the initial preview leaves the Rendering activity before measuring labels");
+    expectations.expect(
+        waitUntil(
+            [&] { return fixture.controller.state().activity != ui::PreviewActivity::Rendering; }),
+        "the initial preview leaves the Rendering activity before measuring labels");
 
     ui::TimelineRuler ruler(fixture.session, fixture.controller);
     for (const int width : {180, 1600}) {

--- a/src/ui/tests/timeline_ruler_tests.cpp
+++ b/src/ui/tests/timeline_ruler_tests.cpp
@@ -15,18 +15,22 @@
 #include <bloom/ui/composition_preview_controller.hpp>
 #include <bloom/ui/composition_preview_pipeline.hpp>
 #include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/kit/tokens.hpp>
 #include <bloom/ui/task_ui_bridge.hpp>
 #include <bloom/ui/timeline_ruler.hpp>
 
 #include <QApplication>
 #include <QElapsedTimer>
 #include <QEventLoop>
+#include <QImage>
 #include <QKeyEvent>
 #include <QMouseEvent>
 #include <QPointF>
+#include <QRectF>
 #include <QString>
 
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
@@ -930,6 +934,120 @@ void testDoubleClickInsertClampsToBoundaryValuesBeforeFirstAndAfterLastKey(
         "undo leaves exactly the original two keys in place");
 }
 
+[[nodiscard]] bool near(const QColor& left, const QColor& right, const int tolerance) {
+    return std::abs(left.red() - right.red()) <= tolerance &&
+           std::abs(left.green() - right.green()) <= tolerance &&
+           std::abs(left.blue() - right.blue()) <= tolerance;
+}
+
+[[nodiscard]] bool disjoint(const QRectF& left, const QRectF& right) {
+    return !left.intersects(right);
+}
+
+// Task U7 (issue #122), decision 3: "majors every N frames chosen from zoom/width so labels never
+// collide." Two widths -- one where a single-density ruler would have crammed a label every few
+// frames, one where it would have been far sparser -- both need every major label's own rect
+// disjoint from every other. A long composition (999 frames, so the widest label is 3 digits) makes
+// the collision risk concrete rather than trivially avoided by a short duration.
+void testRulerMajorTickLabelsNeverCollideAtTwoWidths(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Ruler Density Test", time(999, 24)));
+    expectations.expect(waitUntil([&] {
+                            return fixture.controller.state().activity !=
+                                   ui::PreviewActivity::Rendering;
+                        }),
+                        "the initial preview leaves the Rendering activity before measuring labels");
+
+    ui::TimelineRuler ruler(fixture.session, fixture.controller);
+    for (const int width : {180, 1600}) {
+        ruler.resize(width, 26);
+        const auto rects = ruler.majorTickLabelRectsForTest();
+        expectations.expect(!rects.empty(), "at least one major label is chosen at every width");
+        for (std::size_t i = 0; i < rects.size(); ++i) {
+            for (std::size_t j = i + 1; j < rects.size(); ++j) {
+                expectations.expect(disjoint(rects[i], rects[j]),
+                                    "two major label rects never overlap, at width " +
+                                        std::to_string(width));
+            }
+        }
+    }
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the density fixture reaches asynchronous scheduler quiescence");
+}
+
+// Decision 4: "Accent 2px line with a head marker... spanning ruler + lanes." Playhead PIXEL MATH
+// itself is unchanged (pinned by testRulerScrubLandsOnExactFrameTimesIncludingATie above via
+// scrubbing); this pins the RESTYLED presentation -- the line at the playhead's exact pixel is
+// Accent-colored across the ruler's full height.
+void testRulerPlayheadPaintsAnAccentLine(Expectations& expectations) {
+    using namespace bloom;
+    SessionFixture fixture(makeTestProject("Ruler Playhead Color Test", time(1)));
+    expectations.expect(waitUntil([&] {
+                            return fixture.controller.state().activity !=
+                                   ui::PreviewActivity::Rendering;
+                        }),
+                        "the initial preview leaves the Rendering activity before sampling");
+
+    ui::TimelineRuler ruler(fixture.session, fixture.controller);
+    ruler.resize(200, 26);
+    sendClick(ruler, 100.0);
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+
+    const QImage image = ruler.grab().toImage();
+    const int playheadX = image.width() / 2;
+    const QColor accent = ui::kit::color(ui::kit::Color::Accent);
+    bool sawAccent = false;
+    for (int y = ruler.height() / 3; y < ruler.height(); ++y) {
+        if (near(image.pixelColor(playheadX, y), accent, 24)) {
+            sawAccent = true;
+            break;
+        }
+    }
+    expectations.expect(sawAccent, "the playhead paints an Accent-colored line at its exact pixel");
+
+    fixture.controller.beginShutdown();
+    fixture.bridge.beginShutdown();
+    expectations.expect(waitUntil([&] { return fixture.scheduler.isQuiescent(); }),
+                        "the playhead color fixture reaches asynchronous scheduler quiescence");
+}
+
+// Decision 3: the honest work-area strip spans the WHOLE [0, duration) width by construction (no
+// range-editing feature exists to make it partial) and is a dim Accent band, sampled at both edges
+// to prove it is not a fake partial trim.
+void testWorkAreaStripSpansFullWidthWithDimAccentBand(Expectations& expectations) {
+    using namespace bloom;
+    auto newProject = makeTestProject("Work Area Strip Test", time(4));
+    document::Document document(std::move(newProject.project));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, newProject.initialCompositionId);
+
+    ui::TimelineWorkAreaStrip strip(session);
+    strip.resize(300, strip.sizeHint().height() > 0 ? strip.sizeHint().height() : 4);
+
+    const QImage image = strip.grab().toImage();
+    const QColor surface = ui::kit::color(ui::kit::Color::Surface);
+    const QColor accent = ui::kit::color(ui::kit::Color::Accent);
+    const QColor expected(
+        static_cast<int>(std::lround(accent.red() * ui::kit::kDisabledOpacity +
+                                     surface.red() * (1.0 - ui::kit::kDisabledOpacity))),
+        static_cast<int>(std::lround(accent.green() * ui::kit::kDisabledOpacity +
+                                     surface.green() * (1.0 - ui::kit::kDisabledOpacity))),
+        static_cast<int>(std::lround(accent.blue() * ui::kit::kDisabledOpacity +
+                                     surface.blue() * (1.0 - ui::kit::kDisabledOpacity))));
+
+    const int y = image.height() / 2;
+    expectations.expect(near(image.pixelColor(4, y), expected, 20),
+                        "the dim Accent band reaches the LEFT edge (time 0)");
+    expectations.expect(near(image.pixelColor(image.width() - 4, y), expected, 20),
+                        "the dim Accent band reaches the RIGHT edge (just before duration) -- the "
+                        "whole [0, duration) span, never a partial/trimmed band");
+    expectations.expect(!near(image.pixelColor(4, y), accent, 6),
+                        "the band is DIM, not a solid opaque Accent fill");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -943,5 +1061,8 @@ int main(int argc, char** argv) {
     testDragMoveGestureSnapsCommitsUndoesAndRefuses(expectations);
     testDoubleClickInsertsWithSampledValueSelectsAndRefusesOccupiedTime(expectations);
     testDoubleClickInsertClampsToBoundaryValuesBeforeFirstAndAfterLastKey(expectations);
+    testRulerMajorTickLabelsNeverCollideAtTwoWidths(expectations);
+    testRulerPlayheadPaintsAnAccentLine(expectations);
+    testWorkAreaStripSpansFullWidthWithDimAccentBand(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/timeline_ruler.cpp
+++ b/src/ui/timeline_ruler.cpp
@@ -734,7 +734,8 @@ void TimelineWorkAreaStrip::paintEvent(QPaintEvent* event) {
     // kDisabledOpacity as the "dim" fraction (the same "dimmed ink and disabled ink are the same
     // fade recipe" precedent PropertiesEditor's updateKeyframeIndicator() already uses) rather than
     // inventing a new opacity literal.
-    painter.fillRect(rect(), kit::withOpacity(kit::color(kit::Color::Accent), kit::kDisabledOpacity));
+    painter.fillRect(rect(),
+                     kit::withOpacity(kit::color(kit::Color::Accent), kit::kDisabledOpacity));
 }
 
 TimelineKeyframePanel::TimelineKeyframePanel(CompositionSession& session, QWidget* parent)

--- a/src/ui/timeline_ruler.cpp
+++ b/src/ui/timeline_ruler.cpp
@@ -4,6 +4,9 @@
 #include <bloom/ui/composition_session.hpp>
 #include <bloom/ui/timeline_frame_math.hpp>
 
+#include <bloom/ui/kit/painting.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+
 #include <bloom/document/animation.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/parameter.hpp>
@@ -29,11 +32,31 @@
 namespace bloom::ui {
 namespace {
 
-constexpr int kRulerHeight = 26;
-constexpr int kKeyframeRowHeight = 24;
+// Ruler/lane extents (task U7, issue #122, decisions 1/3): TimelineRow (34px) is the token every
+// track row -- header AND lane -- now shares; the ruler keeps its own extent (no dedicated
+// "ruler height" token exists) but is still resolved from Control (26px) rather than a bare
+// literal, matching this file's own prior 26px value exactly.
+const int kRulerHeight = kit::px(kit::Size::Control);
+const int kKeyframeRowHeight = kit::px(kit::Size::TimelineRow);
+// The honest work-area strip (decision 3): thin, using the smallest spacing token rather than an
+// invented pixel gap.
+const int kWorkAreaStripHeight = kit::px(kit::Spacing::XS);
 constexpr qreal kKeyDiamondRadius = 4.5;
 constexpr qreal kKeyHitToleranceLogicalPixels = 6.0;
-constexpr qreal kMinimumPixelsPerTick = 28.0;
+// Minor ticks are a dense, purely visual grid (decision 3: "minors as subtle ticks"); majors are
+// re-derived per paint from the axis's OWN font metrics so adjacent labels can never collide (see
+// majorTickStepFrames() below) rather than reusing this fixed minor-tick pixel budget for labels
+// the way the pre-restyle single-density ruler did.
+constexpr qreal kMinimumPixelsPerMinorTick = 6.0;
+// Extra breathing room between two adjacent major labels, beyond their own widest possible text
+// width -- keeps the collision-avoidance math from packing labels edge-to-edge.
+constexpr qreal kMajorLabelGapPixels = 10.0;
+constexpr qreal kTickLabelInsetPixels = 3.0;
+constexpr qreal kMinorTickHeight = 4.0;
+constexpr qreal kMajorTickHeight = 8.0;
+// "Accent 2px line" (decision 4), shared by the ruler's own playhead and every keyframe lane row's
+// playhead segment so the line reads as one continuous stroke down through the whole panel.
+constexpr qreal kPlayheadLineWidth = 2.0;
 
 // Maps this widget's pixel-space x axis onto composition frame indices/time using
 // bloom::ui::maxFrameIndex()/frameTimeForIndex() (src/ui/include/bloom/ui/timeline_frame_math.hpp),
@@ -100,16 +123,50 @@ struct TimelineAxis final {
     }
 };
 
-[[nodiscard]] std::uint64_t tickStepFrames(const TimelineAxis& axis) {
+// The dense, unlabeled minor grid (decision 3: "minors as subtle ticks"): the smallest frame step
+// whose pixel spacing is still at least kMinimumPixelsPerMinorTick apart.
+[[nodiscard]] std::uint64_t minorTickStepFrames(const TimelineAxis& axis) {
     if (axis.maxIndex == 0 || axis.widthPixels <= 1) {
         return 1;
     }
     const double pixelsPerFrame =
         static_cast<double>(axis.widthPixels - 1) / static_cast<double>(axis.maxIndex);
-    if (pixelsPerFrame >= kMinimumPixelsPerTick) {
+    if (pixelsPerFrame >= kMinimumPixelsPerMinorTick) {
         return 1;
     }
-    return static_cast<std::uint64_t>(std::ceil(kMinimumPixelsPerTick / pixelsPerFrame));
+    return static_cast<std::uint64_t>(std::ceil(kMinimumPixelsPerMinorTick / pixelsPerFrame));
+}
+
+// The labeled major grid (decision 3: "majors every N frames chosen from zoom/width so labels
+// never collide"). `widestLabelPixels` is the ACTUAL rendered width of this axis's widest possible
+// label (its own maxIndex, in the SAME font paintEvent uses) rather than a guessed pixel budget --
+// see the caller. The step is kept an exact multiple of `minorStep` so every major tick lands on a
+// minor tick rather than an off-grid position.
+//
+// Proof of disjointness (pinned by testRulerMajorTickLabelsNeverCollideAtTwoWidths): for two
+// adjacent major indices i < j = i + majorStep, their left-aligned label rects start at
+// pixelForTime(i) + inset and pixelForTime(j) + inset respectively, each at most widestLabelPixels
+// wide (every in-range label's digit count is <= maxIndex's, and this font's digit glyphs are
+// monospaced-within-a-weight so a shorter number never renders wider). The major step guarantees
+// pixelForTime(j) - pixelForTime(i) >= widestLabelPixels + kMajorLabelGapPixels, so label i's
+// right edge (start + width <= start + widestLabelPixels) sits strictly left of label j's left
+// edge (start + widestLabelPixels + kMajorLabelGapPixels), for any pair of consecutive majors --
+// and by induction, every non-adjacent pair too.
+[[nodiscard]] std::uint64_t majorTickStepFrames(const TimelineAxis& axis,
+                                                const qreal widestLabelPixels,
+                                                const std::uint64_t minorStep) {
+    const std::uint64_t flooredMinor = std::max<std::uint64_t>(minorStep, 1);
+    if (axis.maxIndex == 0 || axis.widthPixels <= 1) {
+        return flooredMinor;
+    }
+    const double pixelsPerFrame =
+        static_cast<double>(axis.widthPixels - 1) / static_cast<double>(axis.maxIndex);
+    const double neededPixels = static_cast<double>(widestLabelPixels) + kMajorLabelGapPixels;
+    std::uint64_t step = flooredMinor;
+    while (static_cast<double>(step) * pixelsPerFrame < neededPixels) {
+        step += flooredMinor;
+    }
+    return step;
 }
 
 QString titleCase(const std::string_view role) {
@@ -125,6 +182,43 @@ struct KeyEntry final {
     document::KeyframeId id;
     core::RationalTime time;
 };
+
+// The Geist Mono tick/label font (decision 3), sized down slightly the same way the pre-restyle
+// ruler already scaled its tick font -- ticks are secondary chrome, not a Value-role readout.
+[[nodiscard]] QFont tickFont() {
+    QFont font = kit::font(kit::TypeRole::Value);
+    font.setPointSizeF(font.pointSizeF() * 0.9);
+    return font;
+}
+
+struct MajorTickLabel final {
+    std::uint64_t index = 0;
+    QRectF rect;
+};
+
+// The single source of major-tick label geometry: paintEvent() and
+// TimelineRuler::majorTickLabelRectsForTest() both call this, so a test can never observe a
+// different collision-avoidance decision than what actually gets painted.
+[[nodiscard]] std::vector<MajorTickLabel> computeMajorTickLabels(const TimelineAxis& axis,
+                                                                 const qreal labelAreaHeight) {
+    std::vector<MajorTickLabel> labels;
+    const QFontMetrics metrics(tickFont());
+    const qreal widestLabelPixels = metrics.horizontalAdvance(QString::number(axis.maxIndex));
+    const auto minorStep = minorTickStepFrames(axis);
+    const auto majorStep = majorTickStepFrames(axis, widestLabelPixels, minorStep);
+    for (std::uint64_t index = 0; index <= axis.maxIndex; index += majorStep) {
+        const auto time = frameTimeForIndex(axis.frameRate, axis.duration, index);
+        if (!time.has_value()) {
+            continue;
+        }
+        const qreal x = axis.pixelForTime(*time);
+        const QString text = QString::number(index);
+        const qreal textWidth = metrics.horizontalAdvance(text);
+        labels.push_back(
+            {index, QRectF(x + kTickLabelInsetPixels, 0.0, textWidth, labelAreaHeight)});
+    }
+    return labels;
+}
 
 } // namespace
 
@@ -164,8 +258,11 @@ class TimelineKeyframeRow final : public QWidget {
     void paintEvent(QPaintEvent* event) override {
         Q_UNUSED(event)
         QPainter painter(this);
-        painter.fillRect(rect(), palette().color(QPalette::AlternateBase));
-        painter.setPen(QPen(palette().color(QPalette::Mid), 1.0));
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        // One step up the surface ladder from the ruler's own Surface (decision 1's "row striping
+        // via surface ladder" carried down into the lane rows, which sit directly beneath it).
+        painter.fillRect(rect(), kit::color(kit::surfaceStep(kit::Color::Surface, 1)));
+        kit::applyHairlinePen(painter, kit::color(kit::Color::Border));
         painter.drawLine(QPointF(0.0, height() - 0.5), QPointF(width(), height() - 0.5));
 
         const auto* composition = session_.composition();
@@ -177,8 +274,10 @@ class TimelineKeyframeRow final : public QWidget {
             return;
         }
 
+        // Decision 4: the SAME Accent 2px line the ruler paints, continuing this row's own segment
+        // of it (no head marker here -- that lives once, in the ruler).
         const qreal playheadX = axis->pixelForTime(session_.currentTime());
-        painter.setPen(QPen(palette().color(QPalette::Highlight).lighter(150), 1.0));
+        painter.setPen(QPen(kit::color(kit::Color::Accent), kPlayheadLineWidth));
         painter.drawLine(QPointF(playheadX, 0.0), QPointF(playheadX, height()));
 
         const auto* keySelection = std::get_if<KeyframeSelection>(&session_.selection().primary);
@@ -187,8 +286,11 @@ class TimelineKeyframeRow final : public QWidget {
             const qreal x = axis->pixelForTime(key.time);
             const bool selected = keySelection != nullptr && keySelection->curveId == curveId_ &&
                                   keySelection->keyframeId == key.id;
-            const QColor fill = selected ? palette().color(QPalette::Highlight)
-                                         : palette().color(QPalette::ButtonText);
+            // Decision 2: "gold diamonds, Accent selection" -- Keyframe is the token every other
+            // keyframe indicator in the interface already uses (PropertiesEditor's own
+            // updateKeyframeIndicator()) for exactly this "gold" meaning.
+            const QColor fill =
+                selected ? kit::color(kit::Color::Accent) : kit::color(kit::Color::Keyframe);
             painter.setPen(QPen(fill.darker(140), 1.0));
             painter.setBrush(fill);
             QPolygonF diamond;
@@ -202,7 +304,7 @@ class TimelineKeyframeRow final : public QWidget {
         if (dragging_ && ghostTime_.has_value()) {
             // Presentation-only: paint the snapped drag target, never mutate the document mid-drag.
             const qreal x = axis->pixelForTime(*ghostTime_);
-            QColor ghostColor = palette().color(QPalette::Highlight);
+            QColor ghostColor = kit::color(kit::Color::Accent);
             ghostColor.setAlpha(150);
             painter.setPen(QPen(ghostColor.darker(120), 1.5, Qt::DashLine));
             painter.setBrush(Qt::NoBrush);
@@ -214,14 +316,14 @@ class TimelineKeyframeRow final : public QWidget {
             painter.drawPolygon(diamond);
         }
 
+        painter.setFont(kit::font(kit::TypeRole::UiSmall));
         const QFontMetrics metrics = painter.fontMetrics();
-        const QRectF chip(2.0, 2.0, metrics.horizontalAdvance(label_) + 10.0, height() - 4.0);
-        QColor chipColor = palette().color(QPalette::Window);
-        chipColor.setAlpha(212);
-        painter.setPen(Qt::NoPen);
-        painter.setBrush(chipColor);
-        painter.drawRoundedRect(chip, 3.0, 3.0);
-        painter.setPen(palette().color(QPalette::WindowText));
+        const QRectF chip(kit::px(kit::Spacing::XXS), kit::px(kit::Spacing::XXS),
+                          metrics.horizontalAdvance(label_) + kit::px(kit::Spacing::S),
+                          height() - 2.0 * kit::px(kit::Spacing::XXS));
+        kit::fillRoundedSurface(painter, chip, kit::color(kit::Color::SurfaceRaised), QColor(),
+                                kit::Radius::Small);
+        painter.setPen(kit::color(kit::Color::Muted));
         painter.drawText(chip, Qt::AlignCenter, label_);
     }
 
@@ -480,8 +582,9 @@ TimelineRuler::TimelineRuler(CompositionSession& session,
 void TimelineRuler::paintEvent(QPaintEvent* event) {
     Q_UNUSED(event)
     QPainter painter(this);
-    painter.fillRect(rect(), palette().color(QPalette::Base));
-    painter.setPen(QPen(palette().color(QPalette::Mid), 1.0));
+    // Decision 3: "Surface bg, hairline base."
+    painter.fillRect(rect(), kit::color(kit::Color::Surface));
+    kit::applyHairlinePen(painter, kit::color(kit::Color::Border));
     painter.drawLine(QPointF(0.0, height() - 0.5), QPointF(width(), height() - 0.5));
 
     const auto* composition = session_.composition();
@@ -493,26 +596,46 @@ void TimelineRuler::paintEvent(QPaintEvent* event) {
         return;
     }
 
-    painter.setPen(palette().color(QPalette::WindowText));
-    QFont tickFont = painter.font();
-    tickFont.setPointSizeF(tickFont.pointSizeF() * 0.85);
-    painter.setFont(tickFont);
+    painter.setFont(tickFont());
+    const auto labelAreaHeight = static_cast<qreal>(height()) - kMajorTickHeight;
+    const auto majorLabels = computeMajorTickLabels(*axis, labelAreaHeight);
+    const auto minorStep = minorTickStepFrames(*axis);
 
-    const auto step = tickStepFrames(*axis);
-    for (std::uint64_t index = 0; index <= axis->maxIndex; index += step) {
+    // Minor grid first (decision 3: "minors as subtle ticks"), so a coincident major tick paints
+    // on top of it below rather than the other way around.
+    kit::applyHairlinePen(painter, kit::color(kit::Color::Faint));
+    for (std::uint64_t index = 0; index <= axis->maxIndex; index += minorStep) {
         const auto time = frameTimeForIndex(axis->frameRate, axis->duration, index);
         if (!time.has_value()) {
             continue;
         }
         const qreal x = axis->pixelForTime(*time);
-        painter.drawLine(QPointF(x, height() - 8.0), QPointF(x, height() - 1.0));
-        painter.drawText(QRectF(x + 2.0, 0.0, 60.0, height() - 9.0),
-                         Qt::AlignLeft | Qt::AlignVCenter, QString::number(index));
+        painter.drawLine(QPointF(x, static_cast<qreal>(height()) - kMinorTickHeight),
+                         QPointF(x, static_cast<qreal>(height()) - 1.0));
     }
 
+    // Major grid: taller ticks plus a Geist Mono label (decision 3), density-adaptive so labels
+    // never collide -- see computeMajorTickLabels()/majorTickStepFrames().
+    for (const auto& label : majorLabels) {
+        const auto time = frameTimeForIndex(axis->frameRate, axis->duration, label.index);
+        if (!time.has_value()) {
+            continue;
+        }
+        const qreal x = axis->pixelForTime(*time);
+        kit::applyHairlinePen(painter, kit::color(kit::Color::Muted));
+        painter.drawLine(QPointF(x, static_cast<qreal>(height()) - kMajorTickHeight),
+                         QPointF(x, static_cast<qreal>(height()) - 1.0));
+        painter.setPen(kit::color(kit::Color::Muted));
+        painter.drawText(label.rect, Qt::AlignLeft | Qt::AlignVCenter,
+                         QString::number(label.index));
+    }
+
+    // Playhead (decision 4): an Accent 2px line with a head marker, shared visually with every
+    // keyframe lane row's own playhead segment below (TimelineKeyframeRow::paintEvent) so the line
+    // reads as one continuous stroke down through the whole panel.
     const qreal playheadX = axis->pixelForTime(session_.currentTime());
-    const QColor playheadColor = palette().color(QPalette::Highlight);
-    painter.setPen(QPen(playheadColor, 2.0));
+    const QColor playheadColor = kit::color(kit::Color::Accent);
+    painter.setPen(QPen(playheadColor, kPlayheadLineWidth));
     painter.drawLine(QPointF(playheadX, 0.0), QPointF(playheadX, height()));
     painter.setPen(Qt::NoPen);
     painter.setBrush(playheadColor);
@@ -520,6 +643,23 @@ void TimelineRuler::paintEvent(QPaintEvent* event) {
     marker << QPointF(playheadX - 5.0, 0.0) << QPointF(playheadX + 5.0, 0.0)
            << QPointF(playheadX, 6.0);
     painter.drawPolygon(marker);
+}
+
+std::vector<QRectF> TimelineRuler::majorTickLabelRectsForTest() const {
+    std::vector<QRectF> rects;
+    const auto* composition = session_.composition();
+    if (composition == nullptr) {
+        return rects;
+    }
+    const auto axis = TimelineAxis::create(*composition, width());
+    if (!axis.has_value()) {
+        return rects;
+    }
+    const auto labelAreaHeight = static_cast<qreal>(height()) - kMajorTickHeight;
+    for (const auto& label : computeMajorTickLabels(*axis, labelAreaHeight)) {
+        rects.push_back(label.rect);
+    }
+    return rects;
 }
 
 void TimelineRuler::mousePressEvent(QMouseEvent* event) {
@@ -565,6 +705,36 @@ void TimelineRuler::scrubToPixel(const int pixelX) {
         return;
     }
     (void)session_.setCurrentTime(*exactTime);
+}
+
+TimelineWorkAreaStrip::TimelineWorkAreaStrip(CompositionSession& session, QWidget* parent)
+    : QWidget(parent), session_(session) {
+    setObjectName("timelineWorkAreaStrip");
+    setAccessibleName(tr("Work area"));
+    setFixedHeight(kWorkAreaStripHeight);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    connect(&session_, &CompositionSession::compositionChanged, this,
+            qOverload<>(&TimelineWorkAreaStrip::update));
+    connect(&session_, &CompositionSession::snapshotChanged, this,
+            qOverload<>(&TimelineWorkAreaStrip::update));
+}
+
+void TimelineWorkAreaStrip::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event)
+    QPainter painter(this);
+    // Background chrome (Surface) shows through when no composition is active -- an honest empty
+    // strip, not a stale/leftover band.
+    painter.fillRect(rect(), kit::color(kit::Color::Surface));
+    if (session_.composition() == nullptr) {
+        return;
+    }
+    // The honest current work area is the WHOLE [0, duration) range (decision 3: no range-editing
+    // feature exists, so there is no separate in/out point to visualize) -- the band therefore
+    // always spans this widget's full width by construction, never a fake partial trim. Reuses
+    // kDisabledOpacity as the "dim" fraction (the same "dimmed ink and disabled ink are the same
+    // fade recipe" precedent PropertiesEditor's updateKeyframeIndicator() already uses) rather than
+    // inventing a new opacity literal.
+    painter.fillRect(rect(), kit::withOpacity(kit::color(kit::Color::Accent), kit::kDisabledOpacity));
 }
 
 TimelineKeyframePanel::TimelineKeyframePanel(CompositionSession& session, QWidget* parent)


### PR DESCRIPTION
The timeline slice of #116 — presentation redesign with interaction semantics byte-equivalent (every existing scrub, keyframe, playback, and projection test passes unmodified):

- **Track rows**: 34px rows with surface-ladder striping and a 2px accent selection edge; name/kind columns keep their exact test contract; new columns added honestly — the visibility eye renders inert with a truthful tooltip (verified: no visibility command exists anywhere in the command layer), blending and parenting are single-value disabled dropdowns naming their missing features, and audio-mute/solo/lock are omitted entirely rather than shipped as dead ghosts.
- **Lanes**: rounded full-width layer bars colored as authored-composition content (the data palette's external-media entries would misrepresent generated layers — reasoning recorded at the mapping site); keyframe rows restyled to gold diamonds with accent selection.
- **Ruler**: density-adaptive labeled majors derived from the font's own widest-label metrics so labels provably never collide (pinned at two widths), subtle minors, mono labels; a non-interactive work-area band spanning the honest full duration; a prominent accent playhead with head marker continuing through the lanes.
- **Transport**: play/pause icon swap on the untouched button contract, step buttons wired to the existing actions, and looping presented as an indicator rather than a control — playback always loops and a toggle would be a lie.
- One column removed: the old free-text opacity summary (not in the design; opacity lives in Properties).

Desktop 121/121 and native 88/88. The report's note about the value-field shortcut gap was stale — the fix merged with the properties slice and is present in this branch.

Closes #122.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.