### PR TITLE
feat: add the Kinetik color picker family

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -17,6 +17,11 @@ target_sources(
     bloom_ui_kit
     PRIVATE
         kit/button.cpp
+        kit/color.cpp
+        kit/color_chip.cpp
+        kit/color_picker.cpp
+        kit/color_sampler.cpp
+        kit/color_swatches.cpp
         kit/dropdown.cpp
         kit/dropdown_popup.cpp
         kit/fonts.cpp
@@ -36,6 +41,11 @@ target_sources(
         BASE_DIRS include
         FILES
             include/bloom/ui/kit/button.hpp
+            include/bloom/ui/kit/color.hpp
+            include/bloom/ui/kit/color_chip.hpp
+            include/bloom/ui/kit/color_picker.hpp
+            include/bloom/ui/kit/color_sampler.hpp
+            include/bloom/ui/kit/color_swatches.hpp
             include/bloom/ui/kit/dropdown.hpp
             include/bloom/ui/kit/dropdown_popup.hpp
             include/bloom/ui/kit/fonts.hpp

--- a/src/ui/include/bloom/ui/kit/color.hpp
+++ b/src/ui/include/bloom/ui/kit/color.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <QColor>
+#include <QString>
+#include <QStringView>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+namespace bloom::ui::kit {
+
+// Task U6 (issue #121): the color picker family's value model, kept deliberately independent of
+// bloom::core::Color4d. bloom_ui_kit is the design system -- CMakeLists.txt says "nothing about a
+// panel, a session, or a document may leak into it" -- and Color4d is a document-authoring type
+// owned by the parameter schema it lives inside (see src/core/include/bloom/core/color.hpp). KColor
+// is the kit's own straight-alpha RGBA working value, self-contained on purpose: the eventual
+// consumer (composition_editors.cpp's Solid Source row) converts between the two at its own
+// boundary, in a later slice this one does not wire.
+//
+// Every channel is float in [0, 1] except hue, which is degrees in [0, 360). Alpha is straight
+// (unassociated), matching Color4d's own convention so a future bridge is a plain field copy plus a
+// float cast, not a re-derivation.
+struct KColor final {
+    float red = 0.0F;
+    float green = 0.0F;
+    float blue = 0.0F;
+    float alpha = 1.0F;
+
+    [[nodiscard]] static constexpr KColor fromRgba(const float r, const float g, const float b,
+                                                    const float a = 1.0F) noexcept {
+        return KColor{r, g, b, a};
+    }
+
+    // `hue` in degrees, any finite value (normalized modulo 360 internally so 360 and 0 name the
+    // same color); `saturation`, `value`, `alpha` in [0, 1].
+    [[nodiscard]] static KColor fromHsva(float hue, float saturation, float value,
+                                         float alpha = 1.0F) noexcept;
+
+    [[nodiscard]] static KColor fromHsla(float hue, float saturation, float lightness,
+                                         float alpha = 1.0F) noexcept;
+
+    // Parses a "#rrggbb" or "#rrggbbaa" string (the leading '#' is optional, case-insensitive).
+    // A 6-digit string carries no alpha, so `fallbackAlpha` fills it in -- this is what lets a
+    // picker preserve the alpha channel it already has when the artist types a plain RGB hex value
+    // rather than silently forcing full opacity. Returns nullopt for anything else: wrong length,
+    // non-hex digits, or empty.
+    [[nodiscard]] static std::optional<KColor> fromHex(QStringView text,
+                                                       float fallbackAlpha = 1.0F);
+
+    [[nodiscard]] static KColor fromQColor(const QColor& value) noexcept;
+
+    // h in [0, 360), s/v in [0, 1], a passthrough.
+    [[nodiscard]] std::array<float, 4> toHsva() const noexcept;
+
+    // h in [0, 360), s/l in [0, 1], a passthrough.
+    [[nodiscard]] std::array<float, 4> toHsla() const noexcept;
+
+    // Lowercase "#rrggbb", or "#rrggbbaa" when `includeAlpha` is set. Each channel is quantized to
+    // 8 bits with round-half-up and a 0..255 clamp (see quantizeChannel8()) -- the same rule
+    // toQColor() uses, so the hex text and the swatch pixel can never disagree.
+    [[nodiscard]] QString toHex(bool includeAlpha) const;
+
+    // 8-bit quantized, for painting. Round-half-up, clamped.
+    [[nodiscard]] QColor toQColor() const noexcept;
+
+    [[nodiscard]] bool isOpaque() const noexcept { return alpha >= 1.0F; }
+
+    friend bool operator==(const KColor&, const KColor&) noexcept = default;
+};
+
+// The float-to-8-bit quantization rule every KColor conversion uses: round-half-up (0.5 rounds
+// away from zero, not to even), then clamp to [0, 255]. Exposed so a test can pin the rule
+// directly rather than inferring it from a round-tripped color.
+[[nodiscard]] int quantizeChannel8(float value) noexcept;
+[[nodiscard]] constexpr float dequantizeChannel8(const int value) noexcept {
+    return static_cast<float>(value) / 255.0F;
+}
+
+// The channel layout KColorPicker's numeric field rows switch between (decision 3). Each model
+// names the same underlying color through a different set of KValueField rows and ranges.
+enum class ColorModel : std::uint8_t {
+    Hsva,
+    Hsla,
+    Rgba,
+};
+
+[[nodiscard]] QString colorModelLabel(ColorModel model);
+
+// The picker shapes issue #121 scopes across the whole widget family. Square is the only one this
+// slice implements; the rest are architecture-present so a later drop-in is a new case in
+// pickerFormAvailable() plus a paint/drag implementation, never a new enum member or a call-site
+// rewrite. A form that is not available is not merely disabled -- it is absent from the form
+// selector entirely (visual-language.md: no dead UI), which is why callers must consult
+// pickerFormAvailable() before listing a form rather than showing every enumerator.
+enum class PickerForm : std::uint8_t {
+    Square,
+    Wheel,
+    Triangle,
+    Spectrum,
+    SliderStack,
+};
+
+[[nodiscard]] constexpr bool pickerFormAvailable(const PickerForm form) noexcept {
+    return form == PickerForm::Square;
+}
+
+[[nodiscard]] QString pickerFormLabel(PickerForm form);
+
+// Every form, in declaration order -- for a test to prove the whole enum is accounted for rather
+// than spot-checking the one member that happens to be implemented.
+[[nodiscard]] std::array<PickerForm, 5> pickerForms();
+
+} // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/kit/color.hpp
+++ b/src/ui/include/bloom/ui/kit/color.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QColor>
+#include <QMetaType>
 #include <QString>
 #include <QStringView>
 
@@ -28,7 +29,7 @@ struct KColor final {
     float alpha = 1.0F;
 
     [[nodiscard]] static constexpr KColor fromRgba(const float r, const float g, const float b,
-                                                    const float a = 1.0F) noexcept {
+                                                   const float a = 1.0F) noexcept {
         return KColor{r, g, b, a};
     }
 
@@ -112,3 +113,7 @@ enum class PickerForm : std::uint8_t {
 [[nodiscard]] std::array<PickerForm, 5> pickerForms();
 
 } // namespace bloom::ui::kit
+
+// Registered so KColor can travel through a QVariant -- the path a Qt::QueuedConnection or a
+// QSignalSpy capturing colorActivated()/colorChanged()/colorPicked() argument values both need.
+Q_DECLARE_METATYPE(bloom::ui::kit::KColor)

--- a/src/ui/include/bloom/ui/kit/color_chip.hpp
+++ b/src/ui/include/bloom/ui/kit/color_chip.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <bloom/ui/kit/color.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+
+#include <QRectF>
+#include <QSize>
+#include <QWidget>
+
+#include <cstdint>
+
+namespace bloom::ui::kit {
+
+class KColorPicker;
+
+// Task U6 (issue #121), decision 2: the selector field every color-valued control ultimately
+// composes. A Radius::Small swatch button that paints the alpha checkerboard under a translucent
+// color and opens a self-contained KColorPicker popup on click -- the same "closed field owns its
+// popup" shape KDropdown/KDropdownPopup already establish, so a chip behaves the way every other
+// Kinetik field that opens something does.
+class KColorChip final : public QWidget {
+    Q_OBJECT
+
+  public:
+    enum class Shape : std::uint8_t { Square, Circle };
+    enum class ControlSize : std::uint8_t { Compact, Default, Roomy };
+
+    explicit KColorChip(QWidget* parent = nullptr);
+    ~KColorChip() override;
+
+    void setColor(const KColor& color);
+    [[nodiscard]] KColor color() const noexcept;
+
+    void setShape(Shape shape);
+    [[nodiscard]] Shape shape() const noexcept;
+
+    void setControlSize(ControlSize size);
+    [[nodiscard]] ControlSize controlSize() const noexcept;
+
+    // The popup this chip opens on click. Exists for the lifetime of the chip (lazily created on
+    // first open) so a test can drive it directly rather than simulating a click-and-wait.
+    [[nodiscard]] KColorPicker* picker();
+
+    void openPicker();
+    void closePicker();
+    [[nodiscard]] bool isPickerOpen() const;
+
+    [[nodiscard]] State visualState() const;
+
+    [[nodiscard]] QSize sizeHint() const override;
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+  Q_SIGNALS:
+    void colorChanged(const KColor& color);
+
+  protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void enterEvent(QEnterEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+    void changeEvent(QEvent* event) override;
+
+  private:
+    void ensurePicker();
+    [[nodiscard]] int controlExtent() const;
+
+    KColor color_{};
+    Shape shape_ = Shape::Square;
+    ControlSize controlSize_ = ControlSize::Default;
+    KColorPicker* picker_ = nullptr;
+    bool hovered_ = false;
+};
+
+// Task U6, decision 2: two chips (A/B) and a swap control -- the foreground/background pairing
+// pattern every paint-style tool needs. Owns its two KColorChip instances rather than composing
+// them externally so "swap" can be one atomic operation a test can assert against directly.
+class KColorABPair final : public QWidget {
+    Q_OBJECT
+
+  public:
+    explicit KColorABPair(QWidget* parent = nullptr);
+
+    void setColorA(const KColor& color);
+    [[nodiscard]] KColor colorA() const noexcept;
+    void setColorB(const KColor& color);
+    [[nodiscard]] KColor colorB() const noexcept;
+
+    void swap();
+
+    [[nodiscard]] KColorChip* chipA() const noexcept;
+    [[nodiscard]] KColorChip* chipB() const noexcept;
+    [[nodiscard]] QRectF swapButtonRect() const;
+
+    [[nodiscard]] QSize sizeHint() const override;
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+  Q_SIGNALS:
+    void colorAChanged(const KColor& color);
+    void colorBChanged(const KColor& color);
+    void swapped();
+
+  protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+
+  private:
+    void layoutChips();
+
+    KColorChip* chipA_ = nullptr;
+    KColorChip* chipB_ = nullptr;
+};
+
+} // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/kit/color_picker.hpp
+++ b/src/ui/include/bloom/ui/kit/color_picker.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <bloom/ui/kit/color.hpp>
+#include <bloom/ui/kit/color_sampler.hpp>
 #include <bloom/ui/kit/color_swatches.hpp>
 #include <bloom/ui/kit/tokens.hpp>
 
@@ -16,6 +17,7 @@ class QLineEdit;
 
 namespace bloom::ui::kit {
 
+class KButton;
 class KDropdown;
 class KValueField;
 
@@ -77,6 +79,12 @@ class KColorPicker final : public QWidget {
     [[nodiscard]] QLineEdit* hexField() const noexcept;
     [[nodiscard]] KColorSwatchRow* swatchRow() const noexcept;
 
+    // Decision 5: the eyedropper affordance. Toggling this on begins an app-scoped sample (see
+    // color_sampler.hpp -- Bloom's own windows only, disclosed via kSamplerScopeTooltip); a pick
+    // commits straight into this picker's color the same way a swatch activation does.
+    [[nodiscard]] KButton* eyedropperButton() const noexcept;
+    [[nodiscard]] KColorSampler* sampler() const noexcept;
+
     [[nodiscard]] QSize sizeHint() const override;
     [[nodiscard]] QSize minimumSizeHint() const override;
 
@@ -109,6 +117,8 @@ class KColorPicker final : public QWidget {
     void onHexFieldEdited();
     void onModelChanged(int index);
     void onSwatchActivated(const KColor& color);
+    void onEyedropperToggled(bool active);
+    void onColorSampled(const KColor& color);
     void updateDragFromPoint(const QPointF& point);
     // Pushes the current color into the bound recent-color store and refreshes the swatch row's
     // "what would 'set' write here" preview. Called only at discrete commit points (a drag
@@ -130,6 +140,8 @@ class KColorPicker final : public QWidget {
     QRectF alphaBarRect_;
 
     KDropdown* formSelector_ = nullptr;
+    KButton* eyedropperButton_ = nullptr;
+    KColorSampler* sampler_ = nullptr;
     KDropdown* modelSelector_ = nullptr;
     std::array<KValueField*, 4> channelFields_{};
     QLineEdit* hexField_ = nullptr;

--- a/src/ui/include/bloom/ui/kit/color_picker.hpp
+++ b/src/ui/include/bloom/ui/kit/color_picker.hpp
@@ -1,0 +1,143 @@
+#pragma once
+
+#include <bloom/ui/kit/color.hpp>
+#include <bloom/ui/kit/color_swatches.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+
+#include <QPointF>
+#include <QRectF>
+#include <QSize>
+#include <QWidget>
+
+#include <array>
+#include <cstdint>
+
+class QLineEdit;
+
+namespace bloom::ui::kit {
+
+class KDropdown;
+class KValueField;
+
+// Task U6 (issue #121), decision 3: the picker popup. Version 1 ships PickerForm::Square in full --
+// an SV square, a hue bar, and an alpha bar, each with a draggable marker -- plus a color-model
+// dropdown that switches what the four KValueField rows below mean (HSVA/HSLA/RGBA), a hex field,
+// and the decision-4 swatch row. The other PickerForm members are architecture-present: see
+// color.hpp's pickerFormAvailable() and this class's formSelector(), which lists only the forms
+// that are actually available rather than showing a disabled placeholder for the rest.
+//
+// Internally the picker is authoritative in HSVA, not in KColor's RGBA: a saturation/value drag at
+// zero saturation (a gray) has no hue information to recover from RGB alone (color.hpp's
+// hueFromRgb() reports 0 there by convention), so the picker keeps its own live hue rather than
+// re-deriving it from KColor on every paint. That is what lets an SV-square drag "preserve hue"
+// exactly through a gray, and it is a picker-session concern, not a value-model one -- KColor
+// itself stays a pure, memoryless conversion type.
+class KColorPicker final : public QWidget {
+    Q_OBJECT
+
+  public:
+    explicit KColorPicker(QWidget* parent = nullptr);
+    ~KColorPicker() override;
+
+    void setColor(const KColor& color);
+    [[nodiscard]] KColor color() const;
+
+    void setColorModel(ColorModel model);
+    [[nodiscard]] ColorModel colorModel() const noexcept;
+
+    // Ignored (a no-op) for a form pickerFormAvailable() reports false for.
+    void setPickerForm(PickerForm form);
+    [[nodiscard]] PickerForm pickerForm() const noexcept;
+
+    // Not owned. Shared with the swatch row so an artist's recent colors survive this popup
+    // closing and a sibling chip's popup opening. Pass nullptr to fall back to the row's own
+    // default store.
+    void setRecentColorStore(KRecentColorStore* store);
+    [[nodiscard]] KRecentColorStore* recentColorStore() const noexcept;
+
+    // Opens as a top-level Qt::Popup positioned below `anchor`, SurfaceRaised + Elevation::Dialog
+    // per decision 3. The same popup instance is reused across opens (KColorChip owns one).
+    void openBelow(const QWidget& anchor);
+
+    [[nodiscard]] QRectF svSquareRect() const noexcept;
+    [[nodiscard]] QRectF hueBarRect() const noexcept;
+    [[nodiscard]] QRectF alphaBarRect() const noexcept;
+
+    // Where the SV marker sits (within svSquareRect()) and where the hue/alpha markers sit as a
+    // 0..1 fraction along their bars -- exposed so a test can assert the drag geometry directly
+    // rather than re-deriving it from paint output.
+    [[nodiscard]] QPointF svMarkerPosition() const noexcept;
+    [[nodiscard]] qreal huePosition() const noexcept;
+    [[nodiscard]] qreal alphaPosition() const noexcept;
+
+    [[nodiscard]] KDropdown* formSelector() const noexcept;
+    [[nodiscard]] KDropdown* modelSelector() const noexcept;
+    // index in [0, 3]; which channel each index names depends on colorModel().
+    [[nodiscard]] KValueField* channelField(int index) const;
+    [[nodiscard]] QLineEdit* hexField() const noexcept;
+    [[nodiscard]] KColorSwatchRow* swatchRow() const noexcept;
+
+    [[nodiscard]] QSize sizeHint() const override;
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+  Q_SIGNALS:
+    // Emitted for every committed change: a drag step, a channel field edit, a hex entry, a
+    // swatch activation. There is no separate "live preview" signal -- direct editor feedback is
+    // never eased or throttled (visual-language.md's Motion::None rule), so the value the signal
+    // carries is always exactly where the pointer or field is right now.
+    void colorChanged(const KColor& color);
+
+  protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+
+  private:
+    enum class DragRegion : std::uint8_t { None, SvSquare, Hue, Alpha };
+
+    void layoutRegions();
+    void buildChrome();
+    void rebuildFormSelector();
+    void rebuildChannelFields();
+    void refreshChannelFields();
+    void refreshHexField();
+    void refreshSwatchPreview();
+    void applyHsva(float hue, float saturation, float value, float alpha);
+    [[nodiscard]] KColor currentColor() const;
+    void onChannelFieldEdited();
+    void onHexFieldEdited();
+    void onModelChanged(int index);
+    void onSwatchActivated(const KColor& color);
+    void updateDragFromPoint(const QPointF& point);
+    // Pushes the current color into the bound recent-color store and refreshes the swatch row's
+    // "what would 'set' write here" preview. Called only at discrete commit points (a drag
+    // release, a finished field/hex edit) -- never every drag frame, or scrubbing would flood the
+    // MRU list with in-between values nobody asked to remember.
+    void commitToRecents();
+
+    float hue_ = 0.0F;
+    float saturation_ = 0.0F;
+    float value_ = 1.0F;
+    float alpha_ = 1.0F;
+
+    ColorModel model_ = ColorModel::Hsva;
+    PickerForm form_ = PickerForm::Square;
+    DragRegion dragRegion_ = DragRegion::None;
+
+    QRectF svSquareRect_;
+    QRectF hueBarRect_;
+    QRectF alphaBarRect_;
+
+    KDropdown* formSelector_ = nullptr;
+    KDropdown* modelSelector_ = nullptr;
+    std::array<KValueField*, 4> channelFields_{};
+    QLineEdit* hexField_ = nullptr;
+    KColorSwatchRow* swatchRow_ = nullptr;
+    // Owned default so the swatch row always has somewhere to read/write recents even when no
+    // caller injects a shared one (setRecentColorStore()).
+    KRecentColorStore defaultRecentColorStore_;
+    bool updatingChrome_ = false;
+};
+
+} // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/kit/color_sampler.hpp
+++ b/src/ui/include/bloom/ui/kit/color_sampler.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <bloom/ui/kit/color.hpp>
+
+#include <QImage>
+#include <QObject>
+#include <QPoint>
+
+#include <optional>
+
+class QWidget;
+
+namespace bloom::ui::kit {
+
+// Task U6 (issue #121), decision 5: the eyedropper. Honestly scoped to Bloom's own windows --
+// src/platform has no cursor/screen-capture surface (see staged_artifact.* -- that is the whole of
+// src/platform today), so a system-wide sampler would need a platform/portal seam that does not
+// exist yet. Faking one by e.g. grabbing whatever QScreen::grabWindow() can reach would silently
+// promise the artist more than Bloom can actually see (another application's window, a
+// screen-recording-permission dialog on macOS, ...); this samples only what QApplication already
+// knows is a Bloom widget, so the scope is enforced by construction, not by a check someone could
+// forget. Disclosed to the artist at the call site via kSamplerScopeTooltip.
+inline constexpr const char* kSamplerScopeTooltip = "Samples inside Bloom";
+
+// The pure pixel read: `point` in `image`'s own (device) pixel coordinates. Returns nullopt for a
+// point outside the image, never a default-constructed KColor that could be mistaken for black.
+[[nodiscard]] std::optional<KColor> sampleImagePixel(const QImage& image, const QPoint& point);
+
+// Grabs `widget` and samples at `localPoint` (in the widget's logical pixel coordinates, scaled to
+// the grabbed pixmap's own device pixel ratio internally) -- the "widget grab" half of decision 5's
+// "a provided QImage/widget grab under the cursor".
+[[nodiscard]] std::optional<KColor> sampleWidgetPixel(QWidget& widget, const QPoint& localPoint);
+
+// The interactive affordance: while active, tracks the application's own mouse events (installed
+// as an application-wide event filter, but QApplication::widgetAt() -- which every sample resolves
+// through -- can only ever resolve to a widget this process owns) and reports the color under the
+// cursor as it moves, committing on a left click and aborting on Escape or a right click.
+class KColorSampler final : public QObject {
+    Q_OBJECT
+
+  public:
+    explicit KColorSampler(QObject* parent = nullptr);
+    ~KColorSampler() override;
+
+    void begin();
+    void cancel();
+    [[nodiscard]] bool isActive() const noexcept;
+
+    // The scoped sample at a global screen position: resolves to whichever of the application's
+    // own widgets is under `globalPos` (nullopt if none), grabs it, and reads the pixel. Public
+    // and independent of begin()/cancel() so a test can drive it directly against a widget it
+    // constructed and shows, without simulating global cursor motion.
+    [[nodiscard]] std::optional<KColor> sampleAt(const QPoint& globalPos) const;
+
+  Q_SIGNALS:
+    void colorHovered(const KColor& color);
+    void colorPicked(const KColor& color);
+    void sampleCancelled();
+
+  protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+  private:
+    void end();
+
+    bool active_ = false;
+};
+
+} // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/kit/color_swatches.hpp
+++ b/src/ui/include/bloom/ui/kit/color_swatches.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <bloom/ui/kit/color.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+
+#include <QRectF>
+#include <QSize>
+#include <QWidget>
+
+#include <optional>
+#include <vector>
+
+namespace bloom::ui::kit {
+
+// Task U6 (issue #121), decision 4: the swatch row's recent-color memory. A plain C++ object, not
+// a QObject -- "a small injectable store" so a KColorSwatchRow (or a future non-widget consumer)
+// can share one MRU list, or a test can hand it a throwaway instance, without any Qt parent-child
+// lifetime to manage. Session memory only: nothing here is written to disk, by design (decision 4
+// explicitly defers settings persistence; see the report for the follow-up).
+class KRecentColorStore final {
+  public:
+    static constexpr int kDefaultCapacity = 32;
+
+    explicit KRecentColorStore(int capacity = kDefaultCapacity);
+
+    // Moves `value` to the front if it is already present (dedup by exact RGBA value), otherwise
+    // inserts it at the front and drops the oldest entry past capacity.
+    void push(const KColor& value);
+
+    void clear();
+
+    [[nodiscard]] int capacity() const noexcept;
+    void setCapacity(int capacity);
+
+    // Most-recent-first.
+    [[nodiscard]] const std::vector<KColor>& colors() const noexcept;
+
+  private:
+    std::vector<KColor> colors_;
+    int capacity_;
+};
+
+// The swatch row below KColorPicker (decision 4): a fixed number of slots, each either explicitly
+// "set" by the artist (sticky until overwritten) or, absent that, driven live off a bound
+// KRecentColorStore's most-recent-first list. Clicking a slot applies its color; right-clicking (or
+// holding the press) sets it to the row's current color.
+class KColorSwatchRow final : public QWidget {
+    Q_OBJECT
+
+  public:
+    static constexpr int kDefaultSlotCount = 8;
+    static constexpr int kMaxSlotCount = 32;
+
+    explicit KColorSwatchRow(QWidget* parent = nullptr);
+
+    // Clamped to [1, kMaxSlotCount]; defaults to kDefaultSlotCount.
+    void setSlotCount(int count);
+    [[nodiscard]] int slotCount() const noexcept;
+
+    // Not owned. Pass nullptr to detach -- unbound slots show only what was explicitly set.
+    void setRecentColorStore(KRecentColorStore* store);
+    [[nodiscard]] KRecentColorStore* recentColorStore() const noexcept;
+
+    // The color a click on an unset slot would have applied is meaningless without this: the
+    // color that "set" (long-press/context) writes into a slot, and what push()es into the bound
+    // store whenever a color is actually applied elsewhere in the picker.
+    void setCurrentColor(const KColor& color);
+    [[nodiscard]] KColor currentColor() const noexcept;
+
+    // Explicitly pins `index` to `color`, taking priority over the bound store's recents at that
+    // position until clearSlot() releases it.
+    void setSlotColor(int index, const KColor& color);
+    void clearSlot(int index);
+
+    // The color actually painted at `index`: the pinned value if one was set, else the store's
+    // `index`-th most recent color, else nullopt for an empty slot.
+    [[nodiscard]] std::optional<KColor> slotColor(int index) const;
+    [[nodiscard]] bool isSlotPinned(int index) const;
+
+    [[nodiscard]] QRectF slotRect(int index) const;
+    // -1 when `point` is not over any slot.
+    [[nodiscard]] int slotAt(const QPointF& point) const;
+
+    [[nodiscard]] QSize sizeHint() const override;
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+  Q_SIGNALS:
+    // A slot was clicked: the artist wants `color` applied as the current color.
+    void colorActivated(const KColor& color);
+    // A slot was explicitly set (long-press or context menu) to the row's current color.
+    void slotPinned(int index, const KColor& color);
+
+  protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+    void timerEvent(QTimerEvent* event) override;
+
+  private:
+    void pinSlot(int index);
+    void cancelLongPress();
+
+    int slotCount_ = kDefaultSlotCount;
+    KRecentColorStore* store_ = nullptr;
+    KColor currentColor_{};
+    std::vector<std::optional<KColor>> pinned_;
+    int pressedSlot_ = -1;
+    int longPressTimerId_ = 0;
+    int hoveredSlot_ = -1;
+};
+
+} // namespace bloom::ui::kit

--- a/src/ui/include/bloom/ui/kit/painting.hpp
+++ b/src/ui/include/bloom/ui/kit/painting.hpp
@@ -54,4 +54,15 @@ void drawFocusRing(QPainter& painter, const QRectF& bounds, Radius radius);
 // Attaches (or clears, for Elevation::Flat) the token drop shadow for an elevated surface.
 void applyElevation(QWidget& widget, Elevation elevation);
 
+// Task U6 (issue #121): the two-tone grid every translucent-color surface paints behind itself --
+// a color chip, the alpha bar in KColorPicker's Square HSV form -- so partial alpha reads against
+// a neutral ground instead of silently blending into whatever the widget happens to sit on. Added
+// here rather than duplicated in each color widget because it is exactly what this header already
+// promises ("the painting primitives every kit widget draws with"), and it composes only from the
+// existing surface-ladder tokens: the two checker tones are Color::Surface and its neighbor one
+// step up the ladder, never a literal gray of their own. `cellPx` is the edge length of one square
+// in the checker in device-independent pixels; `radius` clips the pattern to `bounds`' rounded
+// corners so it never bleeds past a chip's own outline.
+void drawAlphaCheckerboard(QPainter& painter, const QRectF& bounds, int cellPx, Radius radius);
+
 } // namespace bloom::ui::kit

--- a/src/ui/kit/color.cpp
+++ b/src/ui/kit/color.cpp
@@ -1,0 +1,226 @@
+#include <bloom/ui/kit/color.hpp>
+
+#include <QLatin1Char>
+#include <QLatin1StringView>
+
+#include <algorithm>
+#include <cmath>
+
+namespace bloom::ui::kit {
+namespace {
+
+constexpr float kEpsilon = 1e-6F;
+
+[[nodiscard]] float normalizedHue(const float hue) noexcept {
+    float normalized = std::fmod(hue, 360.0F);
+    if (normalized < 0.0F) {
+        normalized += 360.0F;
+    }
+    // fmod(360, 360) is already 0, but guard the case a caller hands in exactly -0.0F worth of
+    // drift so 360 and 0 are always bit-for-bit the same normalized value (the edge-hue pin the
+    // tests exercise).
+    return normalized >= 360.0F ? 0.0F : normalized;
+}
+
+[[nodiscard]] float clamp01(const float value) noexcept { return std::clamp(value, 0.0F, 1.0F); }
+
+// The hue formula shared by RGB->HSV and RGB->HSL: given the channel max/delta, which channel is
+// the max decides the formula branch, and the result is identical in both spaces.
+[[nodiscard]] float hueFromRgb(const float r, const float g, const float b, const float max,
+                               const float delta) noexcept {
+    if (delta <= kEpsilon) {
+        // Achromatic: black, white, or any pure gray. Hue is mathematically undefined from RGB
+        // alone here, so this pure function reports 0 by convention -- a picker that wants a
+        // sticky prior hue while dragging across this degeneracy keeps that hue in its own
+        // editing state rather than asking KColor to remember it (KColor is stateless on purpose).
+        return 0.0F;
+    }
+    float hue;
+    if (max == r) {
+        hue = 60.0F * std::fmod((g - b) / delta, 6.0F);
+    } else if (max == g) {
+        hue = 60.0F * (((b - r) / delta) + 2.0F);
+    } else {
+        hue = 60.0F * (((r - g) / delta) + 4.0F);
+    }
+    return normalizedHue(hue);
+}
+
+// Shared HSV/HSL "chroma at this hue" decomposition: given chroma `c` and the hue's position
+// within its 60-degree segment, returns the (r, g, b) triple before the lightness/value offset
+// `m` is added back in.
+[[nodiscard]] std::array<float, 3> chromaTriple(const float hue, const float c) noexcept {
+    const float hPrime = hue / 60.0F;
+    const float x = c * (1.0F - std::abs(std::fmod(hPrime, 2.0F) - 1.0F));
+    const auto segment = static_cast<int>(std::floor(hPrime)) % 6;
+    switch (segment) {
+    case 0:
+        return {c, x, 0.0F};
+    case 1:
+        return {x, c, 0.0F};
+    case 2:
+        return {0.0F, c, x};
+    case 3:
+        return {0.0F, x, c};
+    case 4:
+        return {x, 0.0F, c};
+    default:
+        return {c, 0.0F, x};
+    }
+}
+
+[[nodiscard]] std::optional<int> hexNibble(const QChar ch) noexcept {
+    const char16_t unicode = ch.unicode();
+    if (unicode >= u'0' && unicode <= u'9') {
+        return unicode - u'0';
+    }
+    if (unicode >= u'a' && unicode <= u'f') {
+        return 10 + (unicode - u'a');
+    }
+    if (unicode >= u'A' && unicode <= u'F') {
+        return 10 + (unicode - u'A');
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<int> hexByte(const QStringView text, const qsizetype offset) noexcept {
+    const auto high = hexNibble(text[offset]);
+    const auto low = hexNibble(text[offset + 1]);
+    if (!high.has_value() || !low.has_value()) {
+        return std::nullopt;
+    }
+    return (*high << 4) | *low;
+}
+
+} // namespace
+
+int quantizeChannel8(const float value) noexcept {
+    // Round-half-up, not round-half-to-even: floor(x*255 + 0.5) lands 0.5 away from zero exactly
+    // the way an 8-bit color picker's hex field is expected to.
+    const float scaled = std::floor(value * 255.0F + 0.5F);
+    return std::clamp(static_cast<int>(scaled), 0, 255);
+}
+
+KColor KColor::fromHsva(const float hue, const float saturation, const float value,
+                        const float alpha) noexcept {
+    const float h = normalizedHue(hue);
+    const float s = clamp01(saturation);
+    const float v = clamp01(value);
+    const float c = v * s;
+    const float m = v - c;
+    const auto triple = chromaTriple(h, c);
+    return KColor{triple[0] + m, triple[1] + m, triple[2] + m, clamp01(alpha)};
+}
+
+KColor KColor::fromHsla(const float hue, const float saturation, const float lightness,
+                        const float alpha) noexcept {
+    const float h = normalizedHue(hue);
+    const float s = clamp01(saturation);
+    const float l = clamp01(lightness);
+    const float c = (1.0F - std::abs(2.0F * l - 1.0F)) * s;
+    const float m = l - c / 2.0F;
+    const auto triple = chromaTriple(h, c);
+    return KColor{triple[0] + m, triple[1] + m, triple[2] + m, clamp01(alpha)};
+}
+
+std::optional<KColor> KColor::fromHex(const QStringView text, const float fallbackAlpha) {
+    QStringView digits = text;
+    if (!digits.isEmpty() && digits.front() == QLatin1Char('#')) {
+        digits = digits.mid(1);
+    }
+    if (digits.size() != 6 && digits.size() != 8) {
+        return std::nullopt;
+    }
+    const auto red = hexByte(digits, 0);
+    const auto green = hexByte(digits, 2);
+    const auto blue = hexByte(digits, 4);
+    if (!red.has_value() || !green.has_value() || !blue.has_value()) {
+        return std::nullopt;
+    }
+    float alpha = clamp01(fallbackAlpha);
+    if (digits.size() == 8) {
+        const auto alphaByte = hexByte(digits, 6);
+        if (!alphaByte.has_value()) {
+            return std::nullopt;
+        }
+        alpha = dequantizeChannel8(*alphaByte);
+    }
+    return KColor{dequantizeChannel8(*red), dequantizeChannel8(*green), dequantizeChannel8(*blue),
+                 alpha};
+}
+
+KColor KColor::fromQColor(const QColor& value) noexcept {
+    return KColor{dequantizeChannel8(value.red()), dequantizeChannel8(value.green()),
+                 dequantizeChannel8(value.blue()), dequantizeChannel8(value.alpha())};
+}
+
+std::array<float, 4> KColor::toHsva() const noexcept {
+    const float max = std::max({red, green, blue});
+    const float min = std::min({red, green, blue});
+    const float delta = max - min;
+    const float h = hueFromRgb(red, green, blue, max, delta);
+    const float s = max <= kEpsilon ? 0.0F : delta / max;
+    return {h, clamp01(s), clamp01(max), clamp01(alpha)};
+}
+
+std::array<float, 4> KColor::toHsla() const noexcept {
+    const float max = std::max({red, green, blue});
+    const float min = std::min({red, green, blue});
+    const float delta = max - min;
+    const float l = (max + min) / 2.0F;
+    const float h = hueFromRgb(red, green, blue, max, delta);
+    const float lSpan = 1.0F - std::abs(2.0F * l - 1.0F);
+    const float s = (delta <= kEpsilon || lSpan <= kEpsilon) ? 0.0F : delta / lSpan;
+    return {h, clamp01(s), clamp01(l), clamp01(alpha)};
+}
+
+QString KColor::toHex(const bool includeAlpha) const {
+    QString rgb = QStringLiteral("#%1%2%3")
+                            .arg(quantizeChannel8(red), 2, 16, QLatin1Char('0'))
+                            .arg(quantizeChannel8(green), 2, 16, QLatin1Char('0'))
+                            .arg(quantizeChannel8(blue), 2, 16, QLatin1Char('0'));
+    if (!includeAlpha) {
+        return rgb;
+    }
+    return rgb + QStringLiteral("%1").arg(quantizeChannel8(alpha), 2, 16, QLatin1Char('0'));
+}
+
+QColor KColor::toQColor() const noexcept {
+    return QColor(quantizeChannel8(red), quantizeChannel8(green), quantizeChannel8(blue),
+                 quantizeChannel8(alpha));
+}
+
+QString colorModelLabel(const ColorModel model) {
+    switch (model) {
+    case ColorModel::Hsva:
+        return QStringLiteral("HSVA");
+    case ColorModel::Hsla:
+        return QStringLiteral("HSLA");
+    case ColorModel::Rgba:
+        return QStringLiteral("RGBA");
+    }
+    return QStringLiteral("HSVA");
+}
+
+QString pickerFormLabel(const PickerForm form) {
+    switch (form) {
+    case PickerForm::Square:
+        return QStringLiteral("Square");
+    case PickerForm::Wheel:
+        return QStringLiteral("Wheel");
+    case PickerForm::Triangle:
+        return QStringLiteral("Triangle");
+    case PickerForm::Spectrum:
+        return QStringLiteral("Spectrum");
+    case PickerForm::SliderStack:
+        return QStringLiteral("Sliders");
+    }
+    return QStringLiteral("Square");
+}
+
+std::array<PickerForm, 5> pickerForms() {
+    return {PickerForm::Square, PickerForm::Wheel, PickerForm::Triangle, PickerForm::Spectrum,
+           PickerForm::SliderStack};
+}
+
+} // namespace bloom::ui::kit

--- a/src/ui/kit/color.cpp
+++ b/src/ui/kit/color.cpp
@@ -146,12 +146,12 @@ std::optional<KColor> KColor::fromHex(const QStringView text, const float fallba
         alpha = dequantizeChannel8(*alphaByte);
     }
     return KColor{dequantizeChannel8(*red), dequantizeChannel8(*green), dequantizeChannel8(*blue),
-                 alpha};
+                  alpha};
 }
 
 KColor KColor::fromQColor(const QColor& value) noexcept {
     return KColor{dequantizeChannel8(value.red()), dequantizeChannel8(value.green()),
-                 dequantizeChannel8(value.blue()), dequantizeChannel8(value.alpha())};
+                  dequantizeChannel8(value.blue()), dequantizeChannel8(value.alpha())};
 }
 
 std::array<float, 4> KColor::toHsva() const noexcept {
@@ -176,9 +176,9 @@ std::array<float, 4> KColor::toHsla() const noexcept {
 
 QString KColor::toHex(const bool includeAlpha) const {
     QString rgb = QStringLiteral("#%1%2%3")
-                            .arg(quantizeChannel8(red), 2, 16, QLatin1Char('0'))
-                            .arg(quantizeChannel8(green), 2, 16, QLatin1Char('0'))
-                            .arg(quantizeChannel8(blue), 2, 16, QLatin1Char('0'));
+                      .arg(quantizeChannel8(red), 2, 16, QLatin1Char('0'))
+                      .arg(quantizeChannel8(green), 2, 16, QLatin1Char('0'))
+                      .arg(quantizeChannel8(blue), 2, 16, QLatin1Char('0'));
     if (!includeAlpha) {
         return rgb;
     }
@@ -187,7 +187,7 @@ QString KColor::toHex(const bool includeAlpha) const {
 
 QColor KColor::toQColor() const noexcept {
     return QColor(quantizeChannel8(red), quantizeChannel8(green), quantizeChannel8(blue),
-                 quantizeChannel8(alpha));
+                  quantizeChannel8(alpha));
 }
 
 QString colorModelLabel(const ColorModel model) {
@@ -220,7 +220,7 @@ QString pickerFormLabel(const PickerForm form) {
 
 std::array<PickerForm, 5> pickerForms() {
     return {PickerForm::Square, PickerForm::Wheel, PickerForm::Triangle, PickerForm::Spectrum,
-           PickerForm::SliderStack};
+            PickerForm::SliderStack};
 }
 
 } // namespace bloom::ui::kit

--- a/src/ui/kit/color_chip.cpp
+++ b/src/ui/kit/color_chip.cpp
@@ -14,7 +14,10 @@
 namespace bloom::ui::kit {
 namespace {
 
-[[nodiscard]] int checkerCellPx() { return px(Spacing::XXS); }
+// A larger cell than the token-minimum spacing step: at these control sizes (a ~26px chip,
+// a 22px-tall alpha bar) a 2px checker reads as noise once anti-aliased, and pixel-sampling
+// it in a test would be sampling blend artifacts rather than the pattern itself.
+[[nodiscard]] int checkerCellPx() { return px(Spacing::S); }
 
 // KColorChip and KColorABPair both declare their own color()/colorA()/colorB() accessors, which
 // hides the free bloom::ui::kit::color(Color) token lookup inside their member functions (plain
@@ -210,7 +213,8 @@ void KColorChip::paintEvent(QPaintEvent* event) {
         const qreal inset = painter.pen().widthF() / 2.0;
         painter.drawEllipse(bounds.adjusted(inset, inset, -inset, -inset));
     } else {
-        fillRoundedSurface(painter, bounds, swatch, tokenColor(borderForState(state)), Radius::Small);
+        fillRoundedSurface(painter, bounds, swatch, tokenColor(borderForState(state)),
+                           Radius::Small);
     }
 
     if (hasFocus() && state != State::Disabled) {
@@ -250,7 +254,7 @@ QRectF KColorABPair::swapButtonRect() const {
     const auto overlap = chipExtent * 0.5;
     const auto swapExtent = static_cast<qreal>(px(Size::IconSmall)) + px(Spacing::XS);
     return {overlap - swapExtent / 2.0, chipExtent - overlap - swapExtent / 2.0, swapExtent,
-           swapExtent};
+            swapExtent};
 }
 
 void KColorABPair::layoutChips() {
@@ -266,9 +270,7 @@ void KColorABPair::layoutChips() {
 QSize KColorABPair::sizeHint() const { return size(); }
 QSize KColorABPair::minimumSizeHint() const { return size(); }
 
-void KColorABPair::resizeEvent(QResizeEvent* event) {
-    QWidget::resizeEvent(event);
-}
+void KColorABPair::resizeEvent(QResizeEvent* event) { QWidget::resizeEvent(event); }
 
 void KColorABPair::mousePressEvent(QMouseEvent* event) {
     if (event->button() == Qt::LeftButton && swapButtonRect().contains(event->position())) {

--- a/src/ui/kit/color_chip.cpp
+++ b/src/ui/kit/color_chip.cpp
@@ -1,0 +1,308 @@
+#include <bloom/ui/kit/color_chip.hpp>
+
+#include <bloom/ui/kit/color_picker.hpp>
+#include <bloom/ui/kit/painting.hpp>
+
+#include <QEnterEvent>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+
+#include <algorithm>
+
+namespace bloom::ui::kit {
+namespace {
+
+[[nodiscard]] int checkerCellPx() { return px(Spacing::XXS); }
+
+// KColorChip and KColorABPair both declare their own color()/colorA()/colorB() accessors, which
+// hides the free bloom::ui::kit::color(Color) token lookup inside their member functions (plain
+// C++ name-hiding: a member found by unqualified lookup stops the search before it ever reaches
+// the enclosing namespace). This thin wrapper -- itself a free function, so it is never hidden --
+// is what those member functions call instead.
+[[nodiscard]] QColor tokenColor(const Color role) { return color(role); }
+
+} // namespace
+
+KColorChip::KColorChip(QWidget* parent) : QWidget(parent) {
+    setObjectName(QStringLiteral("kColorChip"));
+    setFocusPolicy(Qt::StrongFocus);
+    setAttribute(Qt::WA_Hover, true);
+    setCursor(Qt::PointingHandCursor);
+}
+
+KColorChip::~KColorChip() = default;
+
+void KColorChip::setColor(const KColor& newColor) {
+    if (color_ == newColor) {
+        return;
+    }
+    color_ = newColor;
+    update();
+    Q_EMIT colorChanged(color_);
+}
+
+KColor KColorChip::color() const noexcept { return color_; }
+
+void KColorChip::setShape(const Shape shape) {
+    if (shape_ == shape) {
+        return;
+    }
+    shape_ = shape;
+    update();
+}
+
+KColorChip::Shape KColorChip::shape() const noexcept { return shape_; }
+
+void KColorChip::setControlSize(const ControlSize size) {
+    if (controlSize_ == size) {
+        return;
+    }
+    controlSize_ = size;
+    updateGeometry();
+    update();
+}
+
+KColorChip::ControlSize KColorChip::controlSize() const noexcept { return controlSize_; }
+
+void KColorChip::ensurePicker() {
+    if (picker_ != nullptr) {
+        return;
+    }
+    picker_ = new KColorPicker();
+    picker_->setColor(color_);
+    connect(picker_, &KColorPicker::colorChanged, this, &KColorChip::setColor);
+}
+
+KColorPicker* KColorChip::picker() {
+    ensurePicker();
+    return picker_;
+}
+
+void KColorChip::openPicker() {
+    if (!isEnabled()) {
+        return;
+    }
+    ensurePicker();
+    picker_->setColor(color_);
+    picker_->openBelow(*this);
+}
+
+void KColorChip::closePicker() {
+    if (picker_ != nullptr) {
+        picker_->close();
+    }
+}
+
+bool KColorChip::isPickerOpen() const { return picker_ != nullptr && picker_->isVisible(); }
+
+State KColorChip::visualState() const {
+    if (!isEnabled()) {
+        return State::Disabled;
+    }
+    if (isPickerOpen()) {
+        return State::Pressed;
+    }
+    if (hovered_) {
+        return State::Hover;
+    }
+    if (hasFocus()) {
+        return State::Focused;
+    }
+    return State::Normal;
+}
+
+int KColorChip::controlExtent() const {
+    switch (controlSize_) {
+    case ControlSize::Compact:
+        return px(Size::ControlCompact);
+    case ControlSize::Default:
+        return px(Size::Control);
+    case ControlSize::Roomy:
+        return px(Size::ControlRoomy);
+    }
+    return px(Size::Control);
+}
+
+QSize KColorChip::sizeHint() const {
+    const auto ringMargin = static_cast<int>(std::lround(kFocusRingWidth)) * 2;
+    const int extent = controlExtent() + ringMargin;
+    return {extent, extent};
+}
+
+QSize KColorChip::minimumSizeHint() const { return sizeHint(); }
+
+void KColorChip::mousePressEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton && isEnabled()) {
+        setFocus(Qt::MouseFocusReason);
+        isPickerOpen() ? closePicker() : openPicker();
+        event->accept();
+        return;
+    }
+    QWidget::mousePressEvent(event);
+}
+
+void KColorChip::keyPressEvent(QKeyEvent* event) {
+    switch (event->key()) {
+    case Qt::Key_Space:
+    case Qt::Key_Return:
+    case Qt::Key_Enter:
+        openPicker();
+        event->accept();
+        return;
+    case Qt::Key_Escape:
+        if (isPickerOpen()) {
+            closePicker();
+            event->accept();
+            return;
+        }
+        break;
+    default:
+        break;
+    }
+    QWidget::keyPressEvent(event);
+}
+
+void KColorChip::enterEvent(QEnterEvent* event) {
+    if (isEnabled()) {
+        hovered_ = true;
+        update();
+    }
+    QWidget::enterEvent(event);
+}
+
+void KColorChip::leaveEvent(QEvent* event) {
+    hovered_ = false;
+    update();
+    QWidget::leaveEvent(event);
+}
+
+void KColorChip::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::EnabledChange && !isEnabled()) {
+        hovered_ = false;
+    }
+    QWidget::changeEvent(event);
+}
+
+void KColorChip::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    const State state = visualState();
+    const auto ringMargin = kFocusRingWidth;
+    const QRectF bounds = QRectF(rect()).adjusted(ringMargin, ringMargin, -ringMargin, -ringMargin);
+
+    const QColor swatch = color_.toQColor();
+    if (swatch.alpha() < 255) {
+        drawAlphaCheckerboard(painter, bounds, checkerCellPx(),
+                              shape_ == Shape::Circle ? Radius::Full : Radius::Small);
+    }
+
+    if (shape_ == Shape::Circle) {
+        painter.save();
+        painter.setBrush(swatch);
+        painter.setPen(Qt::NoPen);
+        painter.drawEllipse(bounds);
+        painter.restore();
+        applyHairlinePen(painter, tokenColor(borderForState(state)));
+        painter.setBrush(Qt::NoBrush);
+        const qreal inset = painter.pen().widthF() / 2.0;
+        painter.drawEllipse(bounds.adjusted(inset, inset, -inset, -inset));
+    } else {
+        fillRoundedSurface(painter, bounds, swatch, tokenColor(borderForState(state)), Radius::Small);
+    }
+
+    if (hasFocus() && state != State::Disabled) {
+        drawFocusRing(painter, bounds, shape_ == Shape::Circle ? Radius::Full : Radius::Small);
+    }
+}
+
+KColorABPair::KColorABPair(QWidget* parent) : QWidget(parent) {
+    setObjectName(QStringLiteral("kColorABPair"));
+    chipA_ = new KColorChip(this);
+    chipA_->setObjectName(QStringLiteral("kColorABPairChipA"));
+    chipB_ = new KColorChip(this);
+    chipB_->setObjectName(QStringLiteral("kColorABPairChipB"));
+    connect(chipA_, &KColorChip::colorChanged, this, &KColorABPair::colorAChanged);
+    connect(chipB_, &KColorChip::colorChanged, this, &KColorABPair::colorBChanged);
+    layoutChips();
+}
+
+void KColorABPair::setColorA(const KColor& newColor) { chipA_->setColor(newColor); }
+KColor KColorABPair::colorA() const noexcept { return chipA_->color(); }
+void KColorABPair::setColorB(const KColor& newColor) { chipB_->setColor(newColor); }
+KColor KColorABPair::colorB() const noexcept { return chipB_->color(); }
+
+void KColorABPair::swap() {
+    const KColor a = chipA_->color();
+    const KColor b = chipB_->color();
+    chipA_->setColor(b);
+    chipB_->setColor(a);
+    Q_EMIT swapped();
+}
+
+KColorChip* KColorABPair::chipA() const noexcept { return chipA_; }
+KColorChip* KColorABPair::chipB() const noexcept { return chipB_; }
+
+QRectF KColorABPair::swapButtonRect() const {
+    const auto chipExtent = static_cast<qreal>(chipA_->sizeHint().width());
+    const auto overlap = chipExtent * 0.5;
+    const auto swapExtent = static_cast<qreal>(px(Size::IconSmall)) + px(Spacing::XS);
+    return {overlap - swapExtent / 2.0, chipExtent - overlap - swapExtent / 2.0, swapExtent,
+           swapExtent};
+}
+
+void KColorABPair::layoutChips() {
+    const auto chipExtent = chipA_->sizeHint().width();
+    const int overlap = chipExtent / 2;
+    chipA_->move(0, 0);
+    chipA_->resize(chipA_->sizeHint());
+    chipB_->move(overlap, overlap);
+    chipB_->resize(chipB_->sizeHint());
+    setFixedSize(overlap + chipExtent, overlap + chipExtent);
+}
+
+QSize KColorABPair::sizeHint() const { return size(); }
+QSize KColorABPair::minimumSizeHint() const { return size(); }
+
+void KColorABPair::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+}
+
+void KColorABPair::mousePressEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton && swapButtonRect().contains(event->position())) {
+        swap();
+        event->accept();
+        return;
+    }
+    QWidget::mousePressEvent(event);
+}
+
+void KColorABPair::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    // A small swap glyph -- two counter-rotating chevrons -- drawn directly rather than through a
+    // vendored icon asset: IconId has no "swap" member, and adding one means downloading and
+    // pinning a new upstream SVG (visual-language.md's provenance requirement) for a single small
+    // control. The geometry below is derived from IconSmall and Spacing tokens, not a literal.
+    const QRectF glyphBox = swapButtonRect();
+    fillRoundedSurface(painter, glyphBox, color(Color::SurfaceRaised), color(Color::Border),
+                       Radius::Full);
+    painter.save();
+    QPen pen(color(Color::Foreground));
+    pen.setWidthF(kFocusRingWidth);
+    pen.setCapStyle(Qt::RoundCap);
+    painter.setPen(pen);
+    const qreal armLength = glyphBox.width() * 0.28;
+    const QPointF topStart(glyphBox.left() + glyphBox.width() * 0.28, glyphBox.center().y());
+    const QPointF topEnd(glyphBox.right() - glyphBox.width() * 0.28, glyphBox.center().y());
+    painter.drawLine(topStart, topEnd);
+    painter.drawLine(topEnd, topEnd + QPointF(-armLength * 0.5, -armLength * 0.5));
+    painter.drawLine(topStart, topStart + QPointF(armLength * 0.5, armLength * 0.5));
+    painter.restore();
+}
+
+} // namespace bloom::ui::kit

--- a/src/ui/kit/color_picker.cpp
+++ b/src/ui/kit/color_picker.cpp
@@ -1,5 +1,6 @@
 #include <bloom/ui/kit/color_picker.hpp>
 
+#include <bloom/ui/kit/button.hpp>
 #include <bloom/ui/kit/dropdown.hpp>
 #include <bloom/ui/kit/painting.hpp>
 #include <bloom/ui/kit/theme.hpp>
@@ -22,6 +23,8 @@ namespace {
 // that grows with the widget: every drag test can then assert against a known rect, and the
 // picker's overall size is simply whatever that fixed canvas plus its token-spaced chrome rows
 // need. Every number below reads off an existing Size/Spacing token, never a bare pixel count.
+// The SV square's side is 5x ControlRoomy (160px at the current token value): big enough for a
+// precise drag target, small enough that the whole popup fits comfortably inside a normal window.
 [[nodiscard]] int squareSidePx() { return px(Size::ControlRoomy) * 5; }
 [[nodiscard]] int hueBarWidthPx() { return px(Size::ControlCompact); }
 [[nodiscard]] int alphaBarHeightPx() { return px(Size::ControlCompact); }
@@ -104,6 +107,21 @@ void KColorPicker::buildChrome() {
         }
     });
 
+    // Decision 5: the eyedropper affordance. Ghost + checkable, so "active" reads as pressed the
+    // same way an open KDropdown's own field does -- no bespoke "sampling" visual state needed.
+    eyedropperButton_ = new KButton(tr("Sample"), this);
+    eyedropperButton_->setObjectName(QStringLiteral("kColorPickerEyedropper"));
+    eyedropperButton_->setVariant(KButton::Variant::Ghost);
+    eyedropperButton_->setControlSize(KButton::ControlSize::Compact);
+    eyedropperButton_->setCheckable(true);
+    eyedropperButton_->setToolTip(QString::fromUtf8(kSamplerScopeTooltip));
+    eyedropperButton_->setAccessibleName(tr("Sample a color from Bloom"));
+    sampler_ = new KColorSampler(this);
+    connect(eyedropperButton_, &KButton::toggled, this, &KColorPicker::onEyedropperToggled);
+    connect(sampler_, &KColorSampler::colorPicked, this, &KColorPicker::onColorSampled);
+    connect(sampler_, &KColorSampler::sampleCancelled, this,
+            [this]() { eyedropperButton_->setChecked(false); });
+
     modelSelector_ = new KDropdown(this);
     modelSelector_->setControlSize(KDropdown::ControlSize::Compact);
     modelSelector_->addItem(colorModelLabel(ColorModel::Hsva), static_cast<int>(ColorModel::Hsva));
@@ -157,7 +175,9 @@ void KColorPicker::layoutRegions() {
 
     formSelector_->move(margin, y);
     formSelector_->resize(formSelector_->sizeHint());
-    y += formSelector_->height() + rowGap;
+    eyedropperButton_->resize(eyedropperButton_->sizeHint());
+    eyedropperButton_->move(margin + contentWidthPx() - eyedropperButton_->width(), y);
+    y += std::max(formSelector_->height(), eyedropperButton_->height()) + rowGap;
 
     svSquareRect_ = QRectF(margin, y, squareSidePx(), squareSidePx());
     hueBarRect_ = QRectF(svSquareRect_.right() + barGapPx(), y, hueBarWidthPx(), squareSidePx());
@@ -372,6 +392,8 @@ KValueField* KColorPicker::channelField(const int index) const {
 
 QLineEdit* KColorPicker::hexField() const noexcept { return hexField_; }
 KColorSwatchRow* KColorPicker::swatchRow() const noexcept { return swatchRow_; }
+KButton* KColorPicker::eyedropperButton() const noexcept { return eyedropperButton_; }
+KColorSampler* KColorPicker::sampler() const noexcept { return sampler_; }
 
 QSize KColorPicker::sizeHint() const { return size(); }
 QSize KColorPicker::minimumSizeHint() const { return size(); }
@@ -437,6 +459,20 @@ void KColorPicker::onHexFieldEdited() {
 void KColorPicker::onSwatchActivated(const KColor& swatchColor) {
     setColor(swatchColor);
     commitToRecents();
+}
+
+void KColorPicker::onEyedropperToggled(const bool active) {
+    if (active) {
+        sampler_->begin();
+    } else {
+        sampler_->cancel();
+    }
+}
+
+void KColorPicker::onColorSampled(const KColor& sampledColor) {
+    setColor(sampledColor);
+    commitToRecents();
+    eyedropperButton_->setChecked(false);
 }
 
 void KColorPicker::commitToRecents() {

--- a/src/ui/kit/color_picker.cpp
+++ b/src/ui/kit/color_picker.cpp
@@ -1,0 +1,592 @@
+#include <bloom/ui/kit/color_picker.hpp>
+
+#include <bloom/ui/kit/dropdown.hpp>
+#include <bloom/ui/kit/painting.hpp>
+#include <bloom/ui/kit/theme.hpp>
+#include <bloom/ui/kit/value_field.hpp>
+
+#include <QLineEdit>
+#include <QLinearGradient>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPen>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+namespace bloom::ui::kit {
+namespace {
+
+// The custom-painted canvas (SV square + hue bar + alpha bar) has a fixed geometry rather than one
+// that grows with the widget: every drag test can then assert against a known rect, and the
+// picker's overall size is simply whatever that fixed canvas plus its token-spaced chrome rows
+// need. Every number below reads off an existing Size/Spacing token, never a bare pixel count.
+[[nodiscard]] int squareSidePx() { return px(Size::ControlRoomy) * 5; }
+[[nodiscard]] int hueBarWidthPx() { return px(Size::ControlCompact); }
+[[nodiscard]] int alphaBarHeightPx() { return px(Size::ControlCompact); }
+[[nodiscard]] int barGapPx() { return px(Spacing::S); }
+[[nodiscard]] int contentWidthPx() { return squareSidePx() + barGapPx() + hueBarWidthPx(); }
+[[nodiscard]] int checkerCellPx() { return px(Spacing::XXS); }
+[[nodiscard]] qreal markerRadiusPx() { return static_cast<qreal>(px(Spacing::S)) / 2.0; }
+
+[[nodiscard]] QString hexFieldStyleSheet() {
+    return expandTokens(QStringLiteral(R"(
+QLineEdit#kColorHexField {
+    background: {color.Field};
+    border: {border.Hairline}px solid {color.Border};
+    border-radius: {radius.Small}px;
+    color: {color.Foreground};
+    padding: {space.XXS}px {space.S}px;
+}
+QLineEdit#kColorHexField:focus {
+    border-color: {color.Accent};
+}
+QLineEdit#kColorHexField:disabled {
+    color: {color.Muted};
+}
+)"));
+}
+
+// A double-ring dot: an outer Background-colored halo so the marker reads against a light patch of
+// the gradient, and an inner Foreground ring so it reads against a dark one. Same idea as the focus
+// ring's "state is never color alone" rule, just applied to a draggable dot instead of a border.
+void paintMarkerDot(QPainter& painter, const QPointF& center) {
+    painter.save();
+    painter.setBrush(Qt::NoBrush);
+    QPen halo(color(Color::Background));
+    halo.setWidthF(kFocusRingWidth * 2.0);
+    painter.setPen(halo);
+    painter.drawEllipse(center, markerRadiusPx(), markerRadiusPx());
+    QPen ring(color(Color::Foreground));
+    ring.setWidthF(kFocusRingWidth);
+    painter.setPen(ring);
+    painter.drawEllipse(center, markerRadiusPx(), markerRadiusPx());
+    painter.restore();
+}
+
+// KColorPicker declares its own color() accessor, which hides the free bloom::ui::kit::color(
+// Color) token lookup inside every one of its member functions (plain C++ name hiding: a member
+// found by unqualified lookup stops the search before it reaches the enclosing namespace). This
+// thin wrapper is a free function, so it is never hidden, and is what KColorPicker's own methods
+// call instead of `color(...)` directly.
+[[nodiscard]] QColor tokenColor(const Color role) { return color(role); }
+
+void strokeHairline(QPainter& painter, const QRectF& rect) {
+    painter.save();
+    applyHairlinePen(painter, color(Color::Border));
+    painter.setBrush(Qt::NoBrush);
+    const qreal inset = painter.pen().widthF() / 2.0;
+    painter.drawRect(rect.adjusted(inset, inset, -inset, -inset));
+    painter.restore();
+}
+
+} // namespace
+
+KColorPicker::KColorPicker(QWidget* parent) : QWidget(parent) {
+    setObjectName(QStringLiteral("kColorPicker"));
+    buildChrome();
+}
+
+KColorPicker::~KColorPicker() = default;
+
+void KColorPicker::buildChrome() {
+    formSelector_ = new KDropdown(this);
+    formSelector_->setControlSize(KDropdown::ControlSize::Compact);
+    rebuildFormSelector();
+    connect(formSelector_, &KDropdown::currentIndexChanged, this, [this](const int index) {
+        const QVariant data = formSelector_->itemData(index);
+        if (data.isValid()) {
+            form_ = static_cast<PickerForm>(data.toInt());
+        }
+    });
+
+    modelSelector_ = new KDropdown(this);
+    modelSelector_->setControlSize(KDropdown::ControlSize::Compact);
+    modelSelector_->addItem(colorModelLabel(ColorModel::Hsva), static_cast<int>(ColorModel::Hsva));
+    modelSelector_->addItem(colorModelLabel(ColorModel::Hsla), static_cast<int>(ColorModel::Hsla));
+    modelSelector_->addItem(colorModelLabel(ColorModel::Rgba), static_cast<int>(ColorModel::Rgba));
+    connect(modelSelector_, &KDropdown::currentIndexChanged, this, &KColorPicker::onModelChanged);
+
+    for (auto& field : channelFields_) {
+        field = new KValueField(this);
+        field->setSingleStep(1.0);
+        field->setDecimals(0);
+        connect(field, &KValueField::valueChanged, this,
+               [this](double) { onChannelFieldEdited(); });
+    }
+
+    hexField_ = new QLineEdit(this);
+    hexField_->setObjectName(QStringLiteral("kColorHexField"));
+    hexField_->setFont(kit::font(TypeRole::Value));
+    hexField_->setAlignment(Qt::AlignCenter);
+    hexField_->setStyleSheet(hexFieldStyleSheet());
+    hexField_->setAccessibleName(tr("Hex color"));
+    connect(hexField_, &QLineEdit::editingFinished, this, &KColorPicker::onHexFieldEdited);
+
+    swatchRow_ = new KColorSwatchRow(this);
+    swatchRow_->setRecentColorStore(&defaultRecentColorStore_);
+    connect(swatchRow_, &KColorSwatchRow::colorActivated, this, &KColorPicker::onSwatchActivated);
+
+    rebuildChannelFields();
+    refreshHexField();
+    refreshSwatchPreview();
+    layoutRegions();
+}
+
+void KColorPicker::rebuildFormSelector() {
+    for (const PickerForm candidate : pickerForms()) {
+        if (!pickerFormAvailable(candidate)) {
+            // Not merely disabled: absent from the list entirely (visual-language.md: no dead
+            // UI). A later slice that implements one of these adds it here by construction, the
+            // moment pickerFormAvailable() reports true for it -- no call-site rewrite.
+            continue;
+        }
+        formSelector_->addItem(pickerFormLabel(candidate), static_cast<int>(candidate));
+    }
+}
+
+void KColorPicker::layoutRegions() {
+    const int margin = px(Spacing::M);
+    const int rowGap = px(Spacing::S);
+    const int fieldGap = px(Spacing::XXS);
+    int y = margin;
+
+    formSelector_->move(margin, y);
+    formSelector_->resize(formSelector_->sizeHint());
+    y += formSelector_->height() + rowGap;
+
+    svSquareRect_ = QRectF(margin, y, squareSidePx(), squareSidePx());
+    hueBarRect_ = QRectF(svSquareRect_.right() + barGapPx(), y, hueBarWidthPx(), squareSidePx());
+    y += squareSidePx() + barGapPx();
+
+    alphaBarRect_ = QRectF(margin, y, contentWidthPx(), alphaBarHeightPx());
+    y += alphaBarHeightPx() + rowGap;
+
+    modelSelector_->move(margin, y);
+    modelSelector_->resize(contentWidthPx(), modelSelector_->sizeHint().height());
+    y += modelSelector_->height() + rowGap;
+
+    for (auto* field : channelFields_) {
+        field->move(margin, y);
+        field->resize(contentWidthPx(), field->sizeHint().height());
+        y += field->height() + fieldGap;
+    }
+    y += rowGap - fieldGap;
+
+    hexField_->move(margin, y);
+    hexField_->resize(contentWidthPx(), px(Size::Control));
+    y += hexField_->height() + rowGap;
+
+    swatchRow_->move(margin, y);
+    swatchRow_->resize(swatchRow_->sizeHint());
+    y += swatchRow_->height() + margin;
+
+    setFixedSize(contentWidthPx() + margin * 2, y);
+}
+
+void KColorPicker::rebuildChannelFields() {
+    struct FieldSpec {
+        QString label;
+        QString unit;
+        double minimum;
+        double maximum;
+    };
+    std::array<FieldSpec, 4> specs{};
+    switch (model_) {
+    case ColorModel::Hsva:
+        specs = {FieldSpec{QStringLiteral("H"), QStringLiteral("°"), 0.0, 360.0},
+                FieldSpec{QStringLiteral("S"), QStringLiteral("%"), 0.0, 100.0},
+                FieldSpec{QStringLiteral("V"), QStringLiteral("%"), 0.0, 100.0},
+                FieldSpec{QStringLiteral("A"), QStringLiteral("%"), 0.0, 100.0}};
+        break;
+    case ColorModel::Hsla:
+        specs = {FieldSpec{QStringLiteral("H"), QStringLiteral("°"), 0.0, 360.0},
+                FieldSpec{QStringLiteral("S"), QStringLiteral("%"), 0.0, 100.0},
+                FieldSpec{QStringLiteral("L"), QStringLiteral("%"), 0.0, 100.0},
+                FieldSpec{QStringLiteral("A"), QStringLiteral("%"), 0.0, 100.0}};
+        break;
+    case ColorModel::Rgba:
+        specs = {FieldSpec{QStringLiteral("R"), QString(), 0.0, 255.0},
+                FieldSpec{QStringLiteral("G"), QString(), 0.0, 255.0},
+                FieldSpec{QStringLiteral("B"), QString(), 0.0, 255.0},
+                FieldSpec{QStringLiteral("A"), QString(), 0.0, 255.0}};
+        break;
+    }
+    for (std::size_t index = 0; index < channelFields_.size(); ++index) {
+        channelFields_[index]->setLabel(specs[index].label);
+        channelFields_[index]->setUnit(specs[index].unit);
+        channelFields_[index]->setRange(specs[index].minimum, specs[index].maximum);
+    }
+    refreshChannelFields();
+}
+
+void KColorPicker::refreshChannelFields() {
+    updatingChrome_ = true;
+    switch (model_) {
+    case ColorModel::Hsva:
+        // Read straight from the picker's own sticky HSVA state, not by round-tripping through
+        // KColor: that is what keeps the displayed hue exactly where the artist left it while
+        // saturation or value passes through a gray.
+        channelFields_[0]->setValue(static_cast<double>(hue_));
+        channelFields_[1]->setValue(static_cast<double>(saturation_) * 100.0);
+        channelFields_[2]->setValue(static_cast<double>(value_) * 100.0);
+        channelFields_[3]->setValue(static_cast<double>(alpha_) * 100.0);
+        break;
+    case ColorModel::Hsla: {
+        const auto hsla = currentColor().toHsla();
+        channelFields_[0]->setValue(static_cast<double>(hsla[0]));
+        channelFields_[1]->setValue(static_cast<double>(hsla[1]) * 100.0);
+        channelFields_[2]->setValue(static_cast<double>(hsla[2]) * 100.0);
+        channelFields_[3]->setValue(static_cast<double>(hsla[3]) * 100.0);
+        break;
+    }
+    case ColorModel::Rgba: {
+        const QColor rgb = currentColor().toQColor();
+        channelFields_[0]->setValue(rgb.red());
+        channelFields_[1]->setValue(rgb.green());
+        channelFields_[2]->setValue(rgb.blue());
+        channelFields_[3]->setValue(rgb.alpha());
+        break;
+    }
+    }
+    updatingChrome_ = false;
+}
+
+void KColorPicker::refreshHexField() {
+    hexField_->setText(currentColor().toHex(alpha_ < 1.0F));
+}
+
+void KColorPicker::refreshSwatchPreview() { swatchRow_->setCurrentColor(currentColor()); }
+
+KColor KColorPicker::currentColor() const {
+    return KColor::fromHsva(hue_, saturation_, value_, alpha_);
+}
+
+void KColorPicker::setColor(const KColor& color) {
+    const KColor before = currentColor();
+    const auto hsva = color.toHsva();
+    hue_ = hsva[0];
+    saturation_ = hsva[1];
+    value_ = hsva[2];
+    alpha_ = hsva[3];
+    refreshChannelFields();
+    refreshHexField();
+    refreshSwatchPreview();
+    update();
+    const KColor after = currentColor();
+    if (!(before == after)) {
+        Q_EMIT colorChanged(after);
+    }
+}
+
+KColor KColorPicker::color() const { return currentColor(); }
+
+void KColorPicker::setColorModel(const ColorModel model) {
+    if (model_ == model) {
+        return;
+    }
+    model_ = model;
+    for (int index = 0; index < modelSelector_->count(); ++index) {
+        if (modelSelector_->itemData(index).toInt() == static_cast<int>(model)) {
+            modelSelector_->setCurrentIndex(index);
+            break;
+        }
+    }
+    // setCurrentIndex() above already ran onModelChanged() via the signal when the index actually
+    // moved; rebuild directly too so a caller that sets the same index a dropdown already shows
+    // (nothing to signal) still gets fields relabeled for the new model.
+    rebuildChannelFields();
+}
+
+ColorModel KColorPicker::colorModel() const noexcept { return model_; }
+
+void KColorPicker::setPickerForm(const PickerForm form) {
+    if (!pickerFormAvailable(form)) {
+        return;
+    }
+    form_ = form;
+    for (int index = 0; index < formSelector_->count(); ++index) {
+        if (formSelector_->itemData(index).toInt() == static_cast<int>(form)) {
+            formSelector_->setCurrentIndex(index);
+            break;
+        }
+    }
+}
+
+PickerForm KColorPicker::pickerForm() const noexcept { return form_; }
+
+void KColorPicker::setRecentColorStore(KRecentColorStore* store) {
+    swatchRow_->setRecentColorStore(store != nullptr ? store : &defaultRecentColorStore_);
+}
+
+KRecentColorStore* KColorPicker::recentColorStore() const noexcept {
+    return swatchRow_->recentColorStore();
+}
+
+void KColorPicker::openBelow(const QWidget& anchor) {
+    if ((windowFlags() & Qt::Popup) == 0) {
+        setParent(nullptr);
+        setWindowFlags(Qt::Popup);
+        applyElevation(*this, Elevation::Dialog);
+    }
+    const QPoint anchorBottomLeft = anchor.mapToGlobal(QPoint(0, anchor.height()));
+    move(anchorBottomLeft + QPoint(0, px(Spacing::XXS)));
+    show();
+    raise();
+    activateWindow();
+}
+
+QRectF KColorPicker::svSquareRect() const noexcept { return svSquareRect_; }
+QRectF KColorPicker::hueBarRect() const noexcept { return hueBarRect_; }
+QRectF KColorPicker::alphaBarRect() const noexcept { return alphaBarRect_; }
+
+QPointF KColorPicker::svMarkerPosition() const noexcept {
+    return {svSquareRect_.left() + static_cast<qreal>(saturation_) * svSquareRect_.width(),
+           svSquareRect_.top() + static_cast<qreal>(1.0F - value_) * svSquareRect_.height()};
+}
+
+qreal KColorPicker::huePosition() const noexcept { return static_cast<qreal>(hue_) / 360.0; }
+
+qreal KColorPicker::alphaPosition() const noexcept { return static_cast<qreal>(alpha_); }
+
+KDropdown* KColorPicker::formSelector() const noexcept { return formSelector_; }
+KDropdown* KColorPicker::modelSelector() const noexcept { return modelSelector_; }
+
+KValueField* KColorPicker::channelField(const int index) const {
+    if (index < 0 || index >= static_cast<int>(channelFields_.size())) {
+        return nullptr;
+    }
+    return channelFields_[static_cast<std::size_t>(index)];
+}
+
+QLineEdit* KColorPicker::hexField() const noexcept { return hexField_; }
+KColorSwatchRow* KColorPicker::swatchRow() const noexcept { return swatchRow_; }
+
+QSize KColorPicker::sizeHint() const { return size(); }
+QSize KColorPicker::minimumSizeHint() const { return size(); }
+
+void KColorPicker::onModelChanged(const int index) {
+    const QVariant data = modelSelector_->itemData(index);
+    if (!data.isValid()) {
+        return;
+    }
+    model_ = static_cast<ColorModel>(data.toInt());
+    rebuildChannelFields();
+}
+
+void KColorPicker::onChannelFieldEdited() {
+    if (updatingChrome_) {
+        return;
+    }
+    switch (model_) {
+    case ColorModel::Hsva: {
+        const auto h = static_cast<float>(channelFields_[0]->value());
+        const auto s = static_cast<float>(channelFields_[1]->value()) / 100.0F;
+        const auto v = static_cast<float>(channelFields_[2]->value()) / 100.0F;
+        const auto a = static_cast<float>(channelFields_[3]->value()) / 100.0F;
+        applyHsva(h, s, v, a);
+        break;
+    }
+    case ColorModel::Hsla: {
+        const auto h = static_cast<float>(channelFields_[0]->value());
+        const auto s = static_cast<float>(channelFields_[1]->value()) / 100.0F;
+        const auto l = static_cast<float>(channelFields_[2]->value()) / 100.0F;
+        const auto a = static_cast<float>(channelFields_[3]->value()) / 100.0F;
+        const auto hsva = KColor::fromHsla(h, s, l, a).toHsva();
+        applyHsva(hsva[0], hsva[1], hsva[2], hsva[3]);
+        break;
+    }
+    case ColorModel::Rgba: {
+        const auto r = static_cast<float>(channelFields_[0]->value()) / 255.0F;
+        const auto g = static_cast<float>(channelFields_[1]->value()) / 255.0F;
+        const auto b = static_cast<float>(channelFields_[2]->value()) / 255.0F;
+        const auto a = static_cast<float>(channelFields_[3]->value()) / 255.0F;
+        const auto hsva = KColor::fromRgba(r, g, b, a).toHsva();
+        applyHsva(hsva[0], hsva[1], hsva[2], hsva[3]);
+        break;
+    }
+    }
+    commitToRecents();
+}
+
+void KColorPicker::onHexFieldEdited() {
+    const auto parsed = KColor::fromHex(hexField_->text(), alpha_);
+    if (!parsed.has_value()) {
+        // An unparsable entry reverts to the last valid text rather than silently doing nothing:
+        // the artist gets their eye told the edit did not take, instead of a field that looks
+        // committed but is not.
+        refreshHexField();
+        return;
+    }
+    const auto hsva = parsed->toHsva();
+    applyHsva(hsva[0], hsva[1], hsva[2], hsva[3]);
+    commitToRecents();
+}
+
+void KColorPicker::onSwatchActivated(const KColor& swatchColor) {
+    setColor(swatchColor);
+    commitToRecents();
+}
+
+void KColorPicker::commitToRecents() {
+    swatchRow_->setCurrentColor(currentColor());
+    if (KRecentColorStore* store = swatchRow_->recentColorStore(); store != nullptr) {
+        store->push(currentColor());
+    }
+}
+
+void KColorPicker::applyHsva(const float hue, const float saturation, const float value,
+                             const float alpha) {
+    const KColor before = currentColor();
+    float normalizedHue = std::fmod(hue, 360.0F);
+    if (normalizedHue < 0.0F) {
+        normalizedHue += 360.0F;
+    }
+    hue_ = normalizedHue;
+    saturation_ = std::clamp(saturation, 0.0F, 1.0F);
+    value_ = std::clamp(value, 0.0F, 1.0F);
+    alpha_ = std::clamp(alpha, 0.0F, 1.0F);
+    refreshChannelFields();
+    refreshHexField();
+    refreshSwatchPreview();
+    update();
+    const KColor after = currentColor();
+    if (!(before == after)) {
+        Q_EMIT colorChanged(after);
+    }
+}
+
+void KColorPicker::updateDragFromPoint(const QPointF& point) {
+    switch (dragRegion_) {
+    case DragRegion::SvSquare: {
+        const qreal sx =
+            std::clamp((point.x() - svSquareRect_.left()) / svSquareRect_.width(), 0.0, 1.0);
+        const qreal sy =
+            std::clamp((point.y() - svSquareRect_.top()) / svSquareRect_.height(), 0.0, 1.0);
+        applyHsva(hue_, static_cast<float>(sx), static_cast<float>(1.0 - sy), alpha_);
+        break;
+    }
+    case DragRegion::Hue: {
+        const qreal t =
+            std::clamp((point.y() - hueBarRect_.top()) / hueBarRect_.height(), 0.0, 1.0);
+        applyHsva(static_cast<float>(t * 360.0), saturation_, value_, alpha_);
+        break;
+    }
+    case DragRegion::Alpha: {
+        const qreal t =
+            std::clamp((point.x() - alphaBarRect_.left()) / alphaBarRect_.width(), 0.0, 1.0);
+        applyHsva(hue_, saturation_, value_, static_cast<float>(t));
+        break;
+    }
+    case DragRegion::None:
+        break;
+    }
+}
+
+void KColorPicker::mousePressEvent(QMouseEvent* event) {
+    if (event->button() != Qt::LeftButton || !isEnabled()) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    const QPointF pos = event->position();
+    if (svSquareRect_.contains(pos)) {
+        dragRegion_ = DragRegion::SvSquare;
+    } else if (hueBarRect_.contains(pos)) {
+        dragRegion_ = DragRegion::Hue;
+    } else if (alphaBarRect_.contains(pos)) {
+        dragRegion_ = DragRegion::Alpha;
+    } else {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    updateDragFromPoint(pos);
+    event->accept();
+}
+
+void KColorPicker::mouseMoveEvent(QMouseEvent* event) {
+    if (dragRegion_ == DragRegion::None) {
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+    updateDragFromPoint(event->position());
+    event->accept();
+}
+
+void KColorPicker::mouseReleaseEvent(QMouseEvent* event) {
+    if (dragRegion_ != DragRegion::None) {
+        dragRegion_ = DragRegion::None;
+        commitToRecents();
+        event->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(event);
+}
+
+void KColorPicker::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    fillRoundedSurface(painter, QRectF(rect()), tokenColor(Color::SurfaceRaised),
+                       tokenColor(Color::Border), Radius::Medium);
+
+    // SV square: a solid hue fill, a white-to-transparent gradient left to right, and a
+    // transparent-to-black gradient top to bottom -- the standard three-layer composition, so the
+    // corners land exactly on white/hue/black/full-shade without sampling a synthesized bitmap.
+    const QColor hueColor = KColor::fromHsva(hue_, 1.0F, 1.0F).toQColor();
+    painter.fillRect(svSquareRect_, hueColor);
+    QLinearGradient whiteFade(svSquareRect_.topLeft(), svSquareRect_.topRight());
+    whiteFade.setColorAt(0.0, QColor(255, 255, 255, 255));
+    whiteFade.setColorAt(1.0, QColor(255, 255, 255, 0));
+    painter.fillRect(svSquareRect_, whiteFade);
+    QLinearGradient blackFade(svSquareRect_.topLeft(), svSquareRect_.bottomLeft());
+    blackFade.setColorAt(0.0, QColor(0, 0, 0, 0));
+    blackFade.setColorAt(1.0, QColor(0, 0, 0, 255));
+    painter.fillRect(svSquareRect_, blackFade);
+    strokeHairline(painter, svSquareRect_);
+    paintMarkerDot(painter, svMarkerPosition());
+
+    // Hue bar: the full spectrum top to bottom, stopped at every 60-degree primary/secondary so
+    // the gradient is exact rather than merely close.
+    QLinearGradient hueGradient(hueBarRect_.topLeft(), hueBarRect_.bottomLeft());
+    for (int stop = 0; stop <= 6; ++stop) {
+        const float stopHue = static_cast<float>(stop) * 60.0F;
+        hueGradient.setColorAt(static_cast<qreal>(stop) / 6.0,
+                               KColor::fromHsva(stopHue, 1.0F, 1.0F).toQColor());
+    }
+    painter.fillRect(hueBarRect_, hueGradient);
+    strokeHairline(painter, hueBarRect_);
+    {
+        const qreal y = hueBarRect_.top() + huePosition() * hueBarRect_.height();
+        painter.save();
+        QPen pen(tokenColor(Color::Foreground));
+        pen.setWidthF(kFocusRingWidth);
+        painter.setPen(pen);
+        painter.drawLine(QPointF(hueBarRect_.left(), y), QPointF(hueBarRect_.right(), y));
+        painter.restore();
+    }
+
+    // Alpha bar: the checkerboard ground, then a transparent-to-opaque fade of the fully-opaque
+    // current hue/sat/val -- alpha itself is what the gradient sweeps, not the RGB underneath it.
+    drawAlphaCheckerboard(painter, alphaBarRect_, checkerCellPx(), Radius::Small);
+    const QColor opaqueCurrent = KColor::fromHsva(hue_, saturation_, value_, 1.0F).toQColor();
+    QColor faded = opaqueCurrent;
+    faded.setAlpha(0);
+    QLinearGradient alphaGradient(alphaBarRect_.topLeft(), alphaBarRect_.topRight());
+    alphaGradient.setColorAt(0.0, faded);
+    alphaGradient.setColorAt(1.0, opaqueCurrent);
+    painter.fillRect(alphaBarRect_, alphaGradient);
+    strokeHairline(painter, alphaBarRect_);
+    {
+        const qreal x = alphaBarRect_.left() + alphaPosition() * alphaBarRect_.width();
+        painter.save();
+        QPen pen(tokenColor(Color::Foreground));
+        pen.setWidthF(kFocusRingWidth);
+        painter.setPen(pen);
+        painter.drawLine(QPointF(x, alphaBarRect_.top()), QPointF(x, alphaBarRect_.bottom()));
+        painter.restore();
+    }
+}
+
+} // namespace bloom::ui::kit

--- a/src/ui/kit/color_picker.cpp
+++ b/src/ui/kit/color_picker.cpp
@@ -27,7 +27,10 @@ namespace {
 [[nodiscard]] int alphaBarHeightPx() { return px(Size::ControlCompact); }
 [[nodiscard]] int barGapPx() { return px(Spacing::S); }
 [[nodiscard]] int contentWidthPx() { return squareSidePx() + barGapPx() + hueBarWidthPx(); }
-[[nodiscard]] int checkerCellPx() { return px(Spacing::XXS); }
+// A larger cell than the token-minimum spacing step: at these control sizes (a ~26px chip,
+// a 22px-tall alpha bar) a 2px checker reads as noise once anti-aliased, and pixel-sampling
+// it in a test would be sampling blend artifacts rather than the pattern itself.
+[[nodiscard]] int checkerCellPx() { return px(Spacing::S); }
 [[nodiscard]] qreal markerRadiusPx() { return static_cast<qreal>(px(Spacing::S)) / 2.0; }
 
 [[nodiscard]] QString hexFieldStyleSheet() {
@@ -113,7 +116,7 @@ void KColorPicker::buildChrome() {
         field->setSingleStep(1.0);
         field->setDecimals(0);
         connect(field, &KValueField::valueChanged, this,
-               [this](double) { onChannelFieldEdited(); });
+                [this](double) { onChannelFieldEdited(); });
     }
 
     hexField_ = new QLineEdit(this);
@@ -196,28 +199,37 @@ void KColorPicker::rebuildChannelFields() {
     switch (model_) {
     case ColorModel::Hsva:
         specs = {FieldSpec{QStringLiteral("H"), QStringLiteral("°"), 0.0, 360.0},
-                FieldSpec{QStringLiteral("S"), QStringLiteral("%"), 0.0, 100.0},
-                FieldSpec{QStringLiteral("V"), QStringLiteral("%"), 0.0, 100.0},
-                FieldSpec{QStringLiteral("A"), QStringLiteral("%"), 0.0, 100.0}};
+                 FieldSpec{QStringLiteral("S"), QStringLiteral("%"), 0.0, 100.0},
+                 FieldSpec{QStringLiteral("V"), QStringLiteral("%"), 0.0, 100.0},
+                 FieldSpec{QStringLiteral("A"), QStringLiteral("%"), 0.0, 100.0}};
         break;
     case ColorModel::Hsla:
         specs = {FieldSpec{QStringLiteral("H"), QStringLiteral("°"), 0.0, 360.0},
-                FieldSpec{QStringLiteral("S"), QStringLiteral("%"), 0.0, 100.0},
-                FieldSpec{QStringLiteral("L"), QStringLiteral("%"), 0.0, 100.0},
-                FieldSpec{QStringLiteral("A"), QStringLiteral("%"), 0.0, 100.0}};
+                 FieldSpec{QStringLiteral("S"), QStringLiteral("%"), 0.0, 100.0},
+                 FieldSpec{QStringLiteral("L"), QStringLiteral("%"), 0.0, 100.0},
+                 FieldSpec{QStringLiteral("A"), QStringLiteral("%"), 0.0, 100.0}};
         break;
     case ColorModel::Rgba:
         specs = {FieldSpec{QStringLiteral("R"), QString(), 0.0, 255.0},
-                FieldSpec{QStringLiteral("G"), QString(), 0.0, 255.0},
-                FieldSpec{QStringLiteral("B"), QString(), 0.0, 255.0},
-                FieldSpec{QStringLiteral("A"), QString(), 0.0, 255.0}};
+                 FieldSpec{QStringLiteral("G"), QString(), 0.0, 255.0},
+                 FieldSpec{QStringLiteral("B"), QString(), 0.0, 255.0},
+                 FieldSpec{QStringLiteral("A"), QString(), 0.0, 255.0}};
         break;
     }
+    // Guarded for the same reason refreshChannelFields() guards its own setValue() calls:
+    // KValueField::setRange() clamps its current value into the new range and emits valueChanged
+    // when that clamp actually moves it (e.g. an RGBA field sitting at 200 dropping to HSLA's
+    // 0..100 span). Left unguarded, that clamp signal would reach onChannelFieldEdited() mid-loop,
+    // while only some of the four fields have their new label/unit/range yet -- reading a mix of
+    // stale and just-clamped values and silently corrupting hue_/saturation_/value_/alpha_ from a
+    // plain model switch.
+    updatingChrome_ = true;
     for (std::size_t index = 0; index < channelFields_.size(); ++index) {
         channelFields_[index]->setLabel(specs[index].label);
         channelFields_[index]->setUnit(specs[index].unit);
         channelFields_[index]->setRange(specs[index].minimum, specs[index].maximum);
     }
+    updatingChrome_ = false;
     refreshChannelFields();
 }
 
@@ -253,9 +265,7 @@ void KColorPicker::refreshChannelFields() {
     updatingChrome_ = false;
 }
 
-void KColorPicker::refreshHexField() {
-    hexField_->setText(currentColor().toHex(alpha_ < 1.0F));
-}
+void KColorPicker::refreshHexField() { hexField_->setText(currentColor().toHex(alpha_ < 1.0F)); }
 
 void KColorPicker::refreshSwatchPreview() { swatchRow_->setCurrentColor(currentColor()); }
 
@@ -343,7 +353,7 @@ QRectF KColorPicker::alphaBarRect() const noexcept { return alphaBarRect_; }
 
 QPointF KColorPicker::svMarkerPosition() const noexcept {
     return {svSquareRect_.left() + static_cast<qreal>(saturation_) * svSquareRect_.width(),
-           svSquareRect_.top() + static_cast<qreal>(1.0F - value_) * svSquareRect_.height()};
+            svSquareRect_.top() + static_cast<qreal>(1.0F - value_) * svSquareRect_.height()};
 }
 
 qreal KColorPicker::huePosition() const noexcept { return static_cast<qreal>(hue_) / 360.0; }

--- a/src/ui/kit/color_sampler.cpp
+++ b/src/ui/kit/color_sampler.cpp
@@ -1,0 +1,123 @@
+#include <bloom/ui/kit/color_sampler.hpp>
+
+#include <QApplication>
+#include <QCursor>
+#include <QEvent>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QPixmap>
+#include <QWidget>
+
+#include <cmath>
+
+namespace bloom::ui::kit {
+
+std::optional<KColor> sampleImagePixel(const QImage& image, const QPoint& point) {
+    if (image.isNull() || !image.rect().contains(point)) {
+        return std::nullopt;
+    }
+    return KColor::fromQColor(image.pixelColor(point));
+}
+
+std::optional<KColor> sampleWidgetPixel(QWidget& widget, const QPoint& localPoint) {
+    if (!widget.rect().contains(localPoint)) {
+        return std::nullopt;
+    }
+    const QPixmap grabbed = widget.grab();
+    if (grabbed.isNull()) {
+        return std::nullopt;
+    }
+    const qreal dpr = grabbed.devicePixelRatio();
+    const QPoint devicePoint(static_cast<int>(std::lround(static_cast<qreal>(localPoint.x()) * dpr)),
+                             static_cast<int>(std::lround(static_cast<qreal>(localPoint.y()) * dpr)));
+    return sampleImagePixel(grabbed.toImage(), devicePoint);
+}
+
+KColorSampler::KColorSampler(QObject* parent) : QObject(parent) {}
+
+KColorSampler::~KColorSampler() { cancel(); }
+
+void KColorSampler::begin() {
+    if (active_) {
+        return;
+    }
+    active_ = true;
+    qApp->installEventFilter(this);
+    QGuiApplication::setOverrideCursor(QCursor(Qt::CrossCursor));
+}
+
+void KColorSampler::end() {
+    if (!active_) {
+        return;
+    }
+    active_ = false;
+    qApp->removeEventFilter(this);
+    QGuiApplication::restoreOverrideCursor();
+}
+
+void KColorSampler::cancel() {
+    if (!active_) {
+        return;
+    }
+    end();
+    Q_EMIT sampleCancelled();
+}
+
+bool KColorSampler::isActive() const noexcept { return active_; }
+
+std::optional<KColor> KColorSampler::sampleAt(const QPoint& globalPos) const {
+    // QApplication::widgetAt() only ever resolves to a widget this process created: that is the
+    // whole of the "app windows only" scope from decision 5, enforced by what Qt itself can see
+    // rather than by a manual bounds check that something could bypass.
+    QWidget* target = QApplication::widgetAt(globalPos);
+    if (target == nullptr) {
+        return std::nullopt;
+    }
+    return sampleWidgetPixel(*target, target->mapFromGlobal(globalPos));
+}
+
+bool KColorSampler::eventFilter(QObject* watched, QEvent* event) {
+    if (!active_) {
+        return QObject::eventFilter(watched, event);
+    }
+    switch (event->type()) {
+    case QEvent::MouseMove: {
+        const auto* mouse = static_cast<QMouseEvent*>(event);
+        if (const auto sampled = sampleAt(mouse->globalPosition().toPoint()); sampled.has_value()) {
+            Q_EMIT colorHovered(*sampled);
+        }
+        break;
+    }
+    case QEvent::MouseButtonPress: {
+        const auto* mouse = static_cast<QMouseEvent*>(event);
+        if (mouse->button() == Qt::RightButton) {
+            cancel();
+            return true;
+        }
+        if (mouse->button() == Qt::LeftButton) {
+            const auto sampled = sampleAt(mouse->globalPosition().toPoint());
+            end();
+            if (sampled.has_value()) {
+                Q_EMIT colorPicked(*sampled);
+            } else {
+                Q_EMIT sampleCancelled();
+            }
+            return true;
+        }
+        break;
+    }
+    case QEvent::KeyPress: {
+        const auto* key = static_cast<QKeyEvent*>(event);
+        if (key->key() == Qt::Key_Escape) {
+            cancel();
+            return true;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    return QObject::eventFilter(watched, event);
+}
+
+} // namespace bloom::ui::kit

--- a/src/ui/kit/color_sampler.cpp
+++ b/src/ui/kit/color_sampler.cpp
@@ -28,8 +28,9 @@ std::optional<KColor> sampleWidgetPixel(QWidget& widget, const QPoint& localPoin
         return std::nullopt;
     }
     const qreal dpr = grabbed.devicePixelRatio();
-    const QPoint devicePoint(static_cast<int>(std::lround(static_cast<qreal>(localPoint.x()) * dpr)),
-                             static_cast<int>(std::lround(static_cast<qreal>(localPoint.y()) * dpr)));
+    const QPoint devicePoint(
+        static_cast<int>(std::lround(static_cast<qreal>(localPoint.x()) * dpr)),
+        static_cast<int>(std::lround(static_cast<qreal>(localPoint.y()) * dpr)));
     return sampleImagePixel(grabbed.toImage(), devicePoint);
 }
 

--- a/src/ui/kit/color_swatches.cpp
+++ b/src/ui/kit/color_swatches.cpp
@@ -1,0 +1,281 @@
+#include <bloom/ui/kit/color_swatches.hpp>
+
+#include <bloom/ui/kit/painting.hpp>
+
+#include <QContextMenuEvent>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+
+#include <algorithm>
+#include <chrono>
+
+namespace bloom::ui::kit {
+namespace {
+
+using namespace std::chrono_literals;
+
+// The press-and-hold duration that turns a click into a "set this slot" gesture, matching the
+// motion vocabulary's Pop entrance duration order of magnitude rather than a random guess -- long
+// enough that an ordinary click never fires it, short enough that the artist does not have to wait.
+constexpr int kLongPressMs = static_cast<int>(std::chrono::milliseconds(500).count());
+
+[[nodiscard]] int cellExtent() { return px(Size::IconLarge); }
+[[nodiscard]] int cellGap() { return px(Spacing::XXS); }
+[[nodiscard]] int checkerCellPx() { return px(Spacing::XXS); }
+
+} // namespace
+
+KRecentColorStore::KRecentColorStore(const int capacity)
+    : capacity_(std::max(1, capacity)) {
+    colors_.reserve(static_cast<std::size_t>(capacity_));
+}
+
+void KRecentColorStore::push(const KColor& value) {
+    const auto existing = std::ranges::find(colors_, value);
+    if (existing != colors_.end()) {
+        colors_.erase(existing);
+    }
+    colors_.insert(colors_.begin(), value);
+    if (static_cast<int>(colors_.size()) > capacity_) {
+        colors_.resize(static_cast<std::size_t>(capacity_));
+    }
+}
+
+void KRecentColorStore::clear() { colors_.clear(); }
+
+int KRecentColorStore::capacity() const noexcept { return capacity_; }
+
+void KRecentColorStore::setCapacity(const int capacity) {
+    capacity_ = std::max(1, capacity);
+    if (static_cast<int>(colors_.size()) > capacity_) {
+        colors_.resize(static_cast<std::size_t>(capacity_));
+    }
+}
+
+const std::vector<KColor>& KRecentColorStore::colors() const noexcept { return colors_; }
+
+KColorSwatchRow::KColorSwatchRow(QWidget* parent) : QWidget(parent) {
+    setObjectName(QStringLiteral("kColorSwatchRow"));
+    setMouseTracking(true);
+    setAttribute(Qt::WA_Hover, true);
+    pinned_.resize(static_cast<std::size_t>(slotCount_));
+}
+
+void KColorSwatchRow::setSlotCount(const int count) {
+    const int clamped = std::clamp(count, 1, kMaxSlotCount);
+    if (clamped == slotCount_) {
+        return;
+    }
+    slotCount_ = clamped;
+    pinned_.resize(static_cast<std::size_t>(slotCount_));
+    updateGeometry();
+    update();
+}
+
+int KColorSwatchRow::slotCount() const noexcept { return slotCount_; }
+
+void KColorSwatchRow::setRecentColorStore(KRecentColorStore* store) {
+    store_ = store;
+    update();
+}
+
+KRecentColorStore* KColorSwatchRow::recentColorStore() const noexcept { return store_; }
+
+void KColorSwatchRow::setCurrentColor(const KColor& color) { currentColor_ = color; }
+
+KColor KColorSwatchRow::currentColor() const noexcept { return currentColor_; }
+
+void KColorSwatchRow::setSlotColor(const int index, const KColor& color) {
+    if (index < 0 || index >= slotCount_) {
+        return;
+    }
+    pinned_[static_cast<std::size_t>(index)] = color;
+    update();
+}
+
+void KColorSwatchRow::clearSlot(const int index) {
+    if (index < 0 || index >= slotCount_) {
+        return;
+    }
+    pinned_[static_cast<std::size_t>(index)].reset();
+    update();
+}
+
+std::optional<KColor> KColorSwatchRow::slotColor(const int index) const {
+    if (index < 0 || index >= slotCount_) {
+        return std::nullopt;
+    }
+    const auto& pinned = pinned_[static_cast<std::size_t>(index)];
+    if (pinned.has_value()) {
+        return pinned;
+    }
+    if (store_ != nullptr && index < static_cast<int>(store_->colors().size())) {
+        return store_->colors()[static_cast<std::size_t>(index)];
+    }
+    return std::nullopt;
+}
+
+bool KColorSwatchRow::isSlotPinned(const int index) const {
+    return index >= 0 && index < slotCount_ && pinned_[static_cast<std::size_t>(index)].has_value();
+}
+
+QRectF KColorSwatchRow::slotRect(const int index) const {
+    if (index < 0 || index >= slotCount_) {
+        return {};
+    }
+    const auto extent = static_cast<qreal>(cellExtent());
+    const auto gap = static_cast<qreal>(cellGap());
+    const qreal left = static_cast<qreal>(index) * (extent + gap);
+    return {left, 0.0, extent, extent};
+}
+
+int KColorSwatchRow::slotAt(const QPointF& point) const {
+    for (int index = 0; index < slotCount_; ++index) {
+        if (slotRect(index).contains(point)) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+QSize KColorSwatchRow::sizeHint() const {
+    const int extent = cellExtent();
+    const int gap = cellGap();
+    const int width = slotCount_ * extent + std::max(0, slotCount_ - 1) * gap;
+    return {width, extent};
+}
+
+QSize KColorSwatchRow::minimumSizeHint() const { return sizeHint(); }
+
+void KColorSwatchRow::pinSlot(const int index) {
+    if (index < 0 || index >= slotCount_) {
+        return;
+    }
+    setSlotColor(index, currentColor_);
+    Q_EMIT slotPinned(index, currentColor_);
+}
+
+void KColorSwatchRow::cancelLongPress() {
+    if (longPressTimerId_ != 0) {
+        killTimer(longPressTimerId_);
+        longPressTimerId_ = 0;
+    }
+}
+
+void KColorSwatchRow::mousePressEvent(QMouseEvent* event) {
+    if (event->button() != Qt::LeftButton || !isEnabled()) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    const int slot = slotAt(event->position());
+    if (slot < 0) {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    pressedSlot_ = slot;
+    cancelLongPress();
+    longPressTimerId_ = startTimer(kLongPressMs);
+    event->accept();
+}
+
+void KColorSwatchRow::mouseMoveEvent(QMouseEvent* event) {
+    const int slot = slotAt(event->position());
+    if (slot != hoveredSlot_) {
+        hoveredSlot_ = slot;
+        update();
+    }
+    QWidget::mouseMoveEvent(event);
+}
+
+void KColorSwatchRow::mouseReleaseEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton && pressedSlot_ >= 0) {
+        // The long-press timer already fired and pinned the slot; a release afterward is just the
+        // finger lifting, not a second gesture.
+        const bool wasLongPress = longPressTimerId_ == 0;
+        cancelLongPress();
+        if (!wasLongPress) {
+            const auto resolved = slotColor(pressedSlot_);
+            if (resolved.has_value()) {
+                Q_EMIT colorActivated(*resolved);
+            }
+        }
+        pressedSlot_ = -1;
+        event->accept();
+        return;
+    }
+    QWidget::mouseReleaseEvent(event);
+}
+
+void KColorSwatchRow::contextMenuEvent(QContextMenuEvent* event) {
+    const int slot = slotAt(event->pos());
+    if (slot >= 0 && isEnabled()) {
+        pinSlot(slot);
+        event->accept();
+        return;
+    }
+    QWidget::contextMenuEvent(event);
+}
+
+void KColorSwatchRow::leaveEvent(QEvent* event) {
+    hoveredSlot_ = -1;
+    update();
+    QWidget::leaveEvent(event);
+}
+
+void KColorSwatchRow::timerEvent(QTimerEvent* event) {
+    if (event->timerId() == longPressTimerId_ && pressedSlot_ >= 0) {
+        killTimer(longPressTimerId_);
+        longPressTimerId_ = 0;
+        pinSlot(pressedSlot_);
+        return;
+    }
+    QWidget::timerEvent(event);
+}
+
+void KColorSwatchRow::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    for (int index = 0; index < slotCount_; ++index) {
+        const QRectF rect = slotRect(index);
+        const auto resolved = slotColor(index);
+        const bool hovered = index == hoveredSlot_ && isEnabled();
+        const Color borderToken = hovered ? Color::BorderHover : Color::Border;
+
+        if (resolved.has_value()) {
+            const QColor swatch = resolved->toQColor();
+            if (swatch.alpha() < 255) {
+                drawAlphaCheckerboard(painter, rect, checkerCellPx(), Radius::Small);
+            }
+            fillRoundedSurface(painter, rect, swatch, color(borderToken), Radius::Small);
+        } else {
+            // An empty slot: Field fill (the same rung an input cell rests on), no dashed literal
+            // pattern -- the hairline border alone is enough to read as "a slot" without inventing
+            // a second visual language for "empty".
+            fillRoundedSurface(painter, rect, color(Color::Field), color(borderToken),
+                               Radius::Small);
+        }
+
+        if (isSlotPinned(index)) {
+            // A pinned slot keeps a 2px inset accent edge -- the token vocabulary's own "selected"
+            // recipe (visual-language.md: "a 2px inset accent edge where a fill would hide
+            // content") -- so "explicitly set" reads as a real state, not a hover accident.
+            QPen pen(color(Color::Accent));
+            pen.setWidthF(kFocusRingWidth);
+            painter.save();
+            painter.setPen(pen);
+            painter.setBrush(Qt::NoBrush);
+            const qreal inset = kFocusRingWidth;
+            painter.drawRoundedRect(rect.adjusted(inset, inset, -inset, -inset),
+                                    static_cast<qreal>(radiusPx(Radius::Small,
+                                                                static_cast<int>(rect.width()))),
+                                    static_cast<qreal>(radiusPx(Radius::Small,
+                                                                static_cast<int>(rect.width()))));
+            painter.restore();
+        }
+    }
+}
+
+} // namespace bloom::ui::kit

--- a/src/ui/kit/color_swatches.cpp
+++ b/src/ui/kit/color_swatches.cpp
@@ -15,9 +15,13 @@ namespace {
 
 using namespace std::chrono_literals;
 
-// The press-and-hold duration that turns a click into a "set this slot" gesture, matching the
-// motion vocabulary's Pop entrance duration order of magnitude rather than a random guess -- long
-// enough that an ordinary click never fires it, short enough that the artist does not have to wait.
+// The press-and-hold duration that turns a click into a "set this slot" gesture. Deliberately not
+// drawn from kit::Motion: that vocabulary times animated transitions and always pairs a duration
+// with an easing curve (tokens.hpp's Fast/Pop/None), where this is a plain gesture-recognition
+// threshold with no curve of its own -- a different kind of "duration" than the token exists for.
+// 500ms is the conventional press-and-hold length (matching the platform long-press interval most
+// touch and pointer UIs converge on): long enough that an ordinary click never fires it, short
+// enough that the artist does not have to wait.
 constexpr int kLongPressMs = static_cast<int>(std::chrono::milliseconds(500).count());
 
 [[nodiscard]] int cellExtent() { return px(Size::IconLarge); }

--- a/src/ui/kit/color_swatches.cpp
+++ b/src/ui/kit/color_swatches.cpp
@@ -22,12 +22,14 @@ constexpr int kLongPressMs = static_cast<int>(std::chrono::milliseconds(500).cou
 
 [[nodiscard]] int cellExtent() { return px(Size::IconLarge); }
 [[nodiscard]] int cellGap() { return px(Spacing::XXS); }
-[[nodiscard]] int checkerCellPx() { return px(Spacing::XXS); }
+// A larger cell than the token-minimum spacing step: at these control sizes (a ~26px chip,
+// a 22px-tall alpha bar) a 2px checker reads as noise once anti-aliased, and pixel-sampling
+// it in a test would be sampling blend artifacts rather than the pattern itself.
+[[nodiscard]] int checkerCellPx() { return px(Spacing::S); }
 
 } // namespace
 
-KRecentColorStore::KRecentColorStore(const int capacity)
-    : capacity_(std::max(1, capacity)) {
+KRecentColorStore::KRecentColorStore(const int capacity) : capacity_(std::max(1, capacity)) {
     colors_.reserve(static_cast<std::size_t>(capacity_));
 }
 
@@ -268,11 +270,10 @@ void KColorSwatchRow::paintEvent(QPaintEvent* event) {
             painter.setPen(pen);
             painter.setBrush(Qt::NoBrush);
             const qreal inset = kFocusRingWidth;
-            painter.drawRoundedRect(rect.adjusted(inset, inset, -inset, -inset),
-                                    static_cast<qreal>(radiusPx(Radius::Small,
-                                                                static_cast<int>(rect.width()))),
-                                    static_cast<qreal>(radiusPx(Radius::Small,
-                                                                static_cast<int>(rect.width()))));
+            painter.drawRoundedRect(
+                rect.adjusted(inset, inset, -inset, -inset),
+                static_cast<qreal>(radiusPx(Radius::Small, static_cast<int>(rect.width()))),
+                static_cast<qreal>(radiusPx(Radius::Small, static_cast<int>(rect.width()))));
             painter.restore();
         }
     }

--- a/src/ui/kit/painting.cpp
+++ b/src/ui/kit/painting.cpp
@@ -178,4 +178,39 @@ void applyElevation(QWidget& widget, const Elevation elevation) {
     widget.setGraphicsEffect(effect);
 }
 
+void drawAlphaCheckerboard(QPainter& painter, const QRectF& bounds, const int cellPx,
+                           const Radius radius) {
+    if (bounds.isEmpty() || cellPx <= 0) {
+        return;
+    }
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    const auto extent = static_cast<int>(std::lround(std::min(bounds.width(), bounds.height())));
+    const auto corner = static_cast<qreal>(radiusPx(radius, extent));
+    QPainterPath clip;
+    clip.addRoundedRect(bounds, corner, corner);
+    painter.setClipPath(clip, Qt::IntersectClip);
+
+    const QColor light = color(Color::Surface);
+    const QColor dark = color(surfaceStep(Color::Surface, 1));
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(light);
+    painter.drawRect(bounds);
+
+    painter.setBrush(dark);
+    const auto cell = static_cast<qreal>(cellPx);
+    const auto rows = static_cast<int>(std::ceil(bounds.height() / cell));
+    const auto columns = static_cast<int>(std::ceil(bounds.width() / cell));
+    for (int row = 0; row < rows; ++row) {
+        const qreal y = bounds.top() + static_cast<qreal>(row) * cell;
+        const qreal h = std::min(cell, bounds.bottom() - y);
+        for (int column = row % 2; column < columns; column += 2) {
+            const qreal x = bounds.left() + static_cast<qreal>(column) * cell;
+            const qreal w = std::min(cell, bounds.right() - x);
+            painter.drawRect(QRectF(x, y, w, h));
+        }
+    }
+    painter.restore();
+}
+
 } // namespace bloom::ui::kit

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -10,6 +10,21 @@ add_executable(bloom_kit_button_test
 add_executable(bloom_kit_choice_test
     kit_choice_tests.cpp
 )
+add_executable(bloom_kit_color_test
+    kit_color_tests.cpp
+)
+add_executable(bloom_kit_color_chip_test
+    kit_color_chip_tests.cpp
+)
+add_executable(bloom_kit_color_picker_test
+    kit_color_picker_tests.cpp
+)
+add_executable(bloom_kit_color_sampler_test
+    kit_color_sampler_tests.cpp
+)
+add_executable(bloom_kit_color_swatches_test
+    kit_color_swatches_tests.cpp
+)
 add_executable(bloom_kit_dropdown_test
     kit_dropdown_tests.cpp
 )
@@ -110,6 +125,11 @@ target_link_libraries(bloom_editor_area_chrome_test PRIVATE bloom_ui Qt6::Test)
 target_link_libraries(bloom_kinetik_baseline_test PRIVATE bloom_ui)
 target_link_libraries(bloom_kit_button_test PRIVATE bloom_ui_kit)
 target_link_libraries(bloom_kit_choice_test PRIVATE bloom_ui_kit Qt6::Test)
+target_link_libraries(bloom_kit_color_test PRIVATE bloom_ui_kit)
+target_link_libraries(bloom_kit_color_chip_test PRIVATE bloom_ui_kit Qt6::Test)
+target_link_libraries(bloom_kit_color_picker_test PRIVATE bloom_ui_kit)
+target_link_libraries(bloom_kit_color_sampler_test PRIVATE bloom_ui_kit)
+target_link_libraries(bloom_kit_color_swatches_test PRIVATE bloom_ui_kit Qt6::Test)
 target_link_libraries(bloom_kit_dropdown_test PRIVATE bloom_ui_kit Qt6::Test)
 target_link_libraries(bloom_kit_fonts_test PRIVATE bloom_ui_kit)
 target_link_libraries(bloom_kit_icons_test PRIVATE bloom_ui_kit)
@@ -141,6 +161,11 @@ bloom_enable_warnings(bloom_editor_area_chrome_test)
 bloom_enable_warnings(bloom_kinetik_baseline_test)
 bloom_enable_warnings(bloom_kit_button_test)
 bloom_enable_warnings(bloom_kit_choice_test)
+bloom_enable_warnings(bloom_kit_color_test)
+bloom_enable_warnings(bloom_kit_color_chip_test)
+bloom_enable_warnings(bloom_kit_color_picker_test)
+bloom_enable_warnings(bloom_kit_color_sampler_test)
+bloom_enable_warnings(bloom_kit_color_swatches_test)
 bloom_enable_warnings(bloom_kit_dropdown_test)
 bloom_enable_warnings(bloom_kit_fonts_test)
 bloom_enable_warnings(bloom_kit_icons_test)
@@ -198,6 +223,46 @@ bloom_add_test(
 bloom_add_test(
     NAME bloom.ui.kit_choice
     COMMAND bloom_kit_choice_test
+    LABELS ui unit kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.kit_color
+    COMMAND bloom_kit_color_test
+    LABELS ui unit kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.kit_color_chip
+    COMMAND bloom_kit_color_chip_test
+    LABELS ui unit kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.kit_color_picker
+    COMMAND bloom_kit_color_picker_test
+    LABELS ui unit kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.kit_color_sampler
+    COMMAND bloom_kit_color_sampler_test
+    LABELS ui unit kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.kit_color_swatches
+    COMMAND bloom_kit_color_swatches_test
     LABELS ui unit kit
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"

--- a/src/ui/tests/kit_color_chip_tests.cpp
+++ b/src/ui/tests/kit_color_chip_tests.cpp
@@ -1,0 +1,197 @@
+#include <bloom/ui/kit/color_chip.hpp>
+#include <bloom/ui/kit/color_picker.hpp>
+#include <bloom/ui/kit/theme.hpp>
+
+#include <QApplication>
+#include <QImage>
+#include <QMouseEvent>
+#include <QSignalSpy>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+struct Fixture {
+    QWidget host;
+    kit::KColorChip* chip = nullptr;
+
+    Fixture() {
+        auto* layout = new QVBoxLayout(&host);
+        chip = new kit::KColorChip(&host);
+        layout->addWidget(chip);
+        host.resize(120, 120);
+        host.show();
+        host.activateWindow();
+        QCoreApplication::processEvents();
+    }
+};
+
+void testChipCarriesItsColor(Expectations& expectations) {
+    Fixture fixture;
+    auto& chip = *fixture.chip;
+    expectations.expect(chip.color() == kit::KColor{}, "a fresh chip starts at the default color");
+
+    QSignalSpy changed(&chip, &kit::KColorChip::colorChanged);
+    const kit::KColor red = kit::KColor::fromRgba(1.0F, 0.0F, 0.0F);
+    chip.setColor(red);
+    expectations.expect(chip.color() == red, "setColor takes the given color");
+    expectations.expect(changed.count() == 1, "changing the color reports it exactly once");
+    chip.setColor(red);
+    expectations.expect(changed.count() == 1, "re-setting the same color reports nothing");
+}
+
+void testClickingTheChipOpensAndClosesThePicker(Expectations& expectations) {
+    Fixture fixture;
+    auto& chip = *fixture.chip;
+    // Showing the host hands focus to its only focusable child (the chip), so resting has to be
+    // established rather than assumed -- the same convention kit_dropdown_tests.cpp uses.
+    chip.clearFocus();
+    QCoreApplication::processEvents();
+    expectations.expect(!chip.isPickerOpen(), "the popup starts closed");
+    expectations.expect(chip.visualState() == kit::State::Normal, "a closed, unhovered chip rests");
+
+    chip.openPicker();
+    QCoreApplication::processEvents();
+    expectations.expect(chip.isPickerOpen(), "openPicker() opens the popup");
+    expectations.expect(chip.visualState() == kit::State::Pressed, "an open chip reads as pressed");
+    expectations.expect(chip.picker()->objectName() == QStringLiteral("kColorPicker"),
+                        "the popup is findable by name");
+
+    chip.closePicker();
+    QCoreApplication::processEvents();
+    expectations.expect(!chip.isPickerOpen(), "closePicker() closes the popup");
+}
+
+void testPickingAColorInThePopupUpdatesTheChip(Expectations& expectations) {
+    Fixture fixture;
+    auto& chip = *fixture.chip;
+    chip.setColor(kit::KColor::fromRgba(0.0F, 0.0F, 0.0F));
+    chip.openPicker();
+    QCoreApplication::processEvents();
+
+    QSignalSpy changed(&chip, &kit::KColorChip::colorChanged);
+    const kit::KColor picked = kit::KColor::fromRgba(0.2F, 0.6F, 0.9F, 0.5F);
+    chip.picker()->setColor(picked);
+    // Not a bit-exact comparison: the picker stores its live state as HSVA and setColor() round-
+    // trips an arbitrary RGBA through it, which is only approximately reversible for a float that
+    // did not itself come from an 8-bit source (kit_color_tests.cpp pins the exact-round-trip
+    // cases). What this test is proving is that the popup's colorChanged signal really is wired
+    // back to the chip, not that the value survives to the last float bit.
+    const kit::KColor chipColor = chip.color();
+    const bool closeEnough = std::abs(chipColor.red - picked.red) < 0.01F &&
+                             std::abs(chipColor.green - picked.green) < 0.01F &&
+                             std::abs(chipColor.blue - picked.blue) < 0.01F &&
+                             std::abs(chipColor.alpha - picked.alpha) < 0.01F;
+    expectations.expect(closeEnough,
+                        "the popup's colorChanged signal is wired straight back to the chip");
+    expectations.expect(changed.count() == 1, "the chip reports the picked color once");
+}
+
+void testChipRendersCheckerboardUnderAlpha(Expectations& expectations) {
+    Fixture fixture;
+    auto& chip = *fixture.chip;
+    chip.resize(chip.sizeHint());
+    QCoreApplication::processEvents();
+
+    chip.setColor(kit::KColor::fromRgba(1.0F, 0.0F, 0.0F, 1.0F));
+    QCoreApplication::processEvents();
+    const QImage opaque = chip.grab().toImage();
+    const QColor opaqueA = opaque.pixelColor(opaque.width() / 2, opaque.height() / 2);
+    expectations.expect(opaqueA == QColor(255, 0, 0),
+                        "a fully opaque chip paints a flat swatch, no checker showing through");
+
+    chip.setColor(kit::KColor::fromRgba(1.0F, 0.0F, 0.0F, 0.4F));
+    QCoreApplication::processEvents();
+    const QImage translucent = chip.grab().toImage();
+    // The checker cell is Spacing::S (8 logical px); at the chip's device pixel ratio, sampling
+    // one cell in from the top-left interior and again a cell further right lands in two
+    // different checker squares, which sit on different Surface/SurfaceRaised grounds under the
+    // same translucent red -- so the two composited pixels must differ if the checker is really
+    // being drawn, not just a flat fill.
+    const qreal dpr = translucent.devicePixelRatio();
+    const auto sampleAt = [&](const int logicalX, const int logicalY) {
+        return translucent.pixelColor(static_cast<int>(logicalX * dpr),
+                                      static_cast<int>(logicalY * dpr));
+    };
+    const QColor cellOne = sampleAt(4, 4);
+    const QColor cellTwo = sampleAt(12, 4);
+    expectations.expect(cellOne != cellTwo,
+                        "a translucent chip's two neighboring checker cells composite to "
+                        "different colors");
+    expectations.expect(cellOne != QColor(255, 0, 0) && cellTwo != QColor(255, 0, 0),
+                        "neither sampled pixel is the fully-opaque swatch color");
+}
+
+void testCircleShapeIsRoundNotSquare(Expectations& expectations) {
+    Fixture fixture;
+    auto& chip = *fixture.chip;
+    chip.setShape(kit::KColorChip::Shape::Circle);
+    chip.setColor(kit::KColor::fromRgba(0.0F, 1.0F, 0.0F));
+    chip.resize(chip.sizeHint());
+    QCoreApplication::processEvents();
+    const QImage image = chip.grab().toImage();
+    const qreal dpr = image.devicePixelRatio();
+    const QColor corner = image.pixelColor(static_cast<int>(1 * dpr), static_cast<int>(1 * dpr));
+    const QColor center =
+        image.pixelColor(static_cast<int>(image.width() / 2), static_cast<int>(image.height() / 2));
+    expectations.expect(center == QColor(0, 255, 0), "the circle's center is the swatch color");
+    expectations.expect(corner != QColor(0, 255, 0),
+                        "a circle chip's corner is not the swatch color -- it is round, not "
+                        "square");
+}
+
+void testABPairSwapsTheTwoColors(Expectations& expectations) {
+    kit::KColorABPair pair;
+    const kit::KColor a = kit::KColor::fromRgba(1.0F, 0.0F, 0.0F);
+    const kit::KColor b = kit::KColor::fromRgba(0.0F, 0.0F, 1.0F);
+    pair.setColorA(a);
+    pair.setColorB(b);
+    QSignalSpy swapped(&pair, &kit::KColorABPair::swapped);
+    pair.swap();
+    expectations.expect(pair.colorA() == b, "A takes what B had");
+    expectations.expect(pair.colorB() == a, "B takes what A had");
+    expectations.expect(swapped.count() == 1, "swapping reports itself exactly once");
+    expectations.expect(pair.chipA()->color() == pair.colorA(),
+                        "chipA and colorA() agree -- the pair is not tracking a separate copy");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    kit::installKinetikTheme(application);
+    Expectations expectations;
+    testChipCarriesItsColor(expectations);
+    testClickingTheChipOpensAndClosesThePicker(expectations);
+    testPickingAColorInThePopupUpdatesTheChip(expectations);
+    testChipRendersCheckerboardUnderAlpha(expectations);
+    testCircleShapeIsRoundNotSquare(expectations);
+    testABPairSwapsTheTwoColors(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/kit_color_picker_tests.cpp
+++ b/src/ui/tests/kit_color_picker_tests.cpp
@@ -1,4 +1,6 @@
+#include <bloom/ui/kit/button.hpp>
 #include <bloom/ui/kit/color_picker.hpp>
+#include <bloom/ui/kit/color_sampler.hpp>
 #include <bloom/ui/kit/dropdown.hpp>
 #include <bloom/ui/kit/theme.hpp>
 #include <bloom/ui/kit/value_field.hpp>
@@ -194,6 +196,34 @@ void testFormSelectorListsOnlyTheAvailableForm(Expectations& expectations) {
                         "the picker itself reports the Square form");
 }
 
+void testEyedropperTogglesTheSamplerAndAppliesAPick(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    expectations.expect(picker.eyedropperButton() != nullptr,
+                        "decision 5's UI affordance is present on the picker");
+    expectations.expect(picker.eyedropperButton()->toolTip() ==
+                            QString::fromUtf8(kit::kSamplerScopeTooltip),
+                        "the eyedropper discloses its app-only scope in its own tooltip");
+    expectations.expect(!picker.sampler()->isActive(), "the sampler starts inactive");
+
+    picker.eyedropperButton()->setChecked(true);
+    expectations.expect(picker.sampler()->isActive(), "checking the eyedropper begins sampling");
+
+    // Emitted directly rather than driven through a simulated global mouse click: colorPicked is a
+    // public Qt signal (Q_SIGNALS expands to `public`), and this proves the picker's own wiring --
+    // KColorSampler's real click-to-globalPos path is covered in kit_color_sampler_tests.cpp.
+    const kit::KColor sampled = kit::KColor::fromRgba(0.1F, 0.9F, 0.3F);
+    Q_EMIT picker.sampler()->colorPicked(sampled);
+
+    const kit::KColor pickedColor = picker.color();
+    const bool closeEnough = std::abs(pickedColor.red - sampled.red) < 0.01F &&
+                             std::abs(pickedColor.green - sampled.green) < 0.01F &&
+                             std::abs(pickedColor.blue - sampled.blue) < 0.01F;
+    expectations.expect(closeEnough, "a completed sample commits into the picker's color");
+    expectations.expect(!picker.eyedropperButton()->isChecked(),
+                        "a completed sample releases the eyedropper toggle");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -208,5 +238,6 @@ int main(int argc, char** argv) {
     testHexEntryRoundTrips(expectations);
     testChannelFieldEditUpdatesTheColorAndSwatch(expectations);
     testFormSelectorListsOnlyTheAvailableForm(expectations);
+    testEyedropperTogglesTheSamplerAndAppliesAPick(expectations);
     return expectations.failures() == 0 ? 0 : 1;
 }

--- a/src/ui/tests/kit_color_picker_tests.cpp
+++ b/src/ui/tests/kit_color_picker_tests.cpp
@@ -1,0 +1,212 @@
+#include <bloom/ui/kit/color_picker.hpp>
+#include <bloom/ui/kit/dropdown.hpp>
+#include <bloom/ui/kit/theme.hpp>
+#include <bloom/ui/kit/value_field.hpp>
+
+#include <QApplication>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+[[nodiscard]] double widen(const float value) { return static_cast<double>(value); }
+
+void sendMouse(QWidget& widget, const QEvent::Type type, const QPointF& point,
+               const Qt::MouseButton button) {
+    QMouseEvent event(type, point, widget.mapToGlobal(point), button,
+                      type == QEvent::MouseButtonRelease ? Qt::NoButton : Qt::LeftButton,
+                      Qt::NoModifier);
+    QCoreApplication::sendEvent(&widget, &event);
+    QCoreApplication::processEvents();
+}
+
+struct Fixture {
+    QWidget host;
+    kit::KColorPicker* picker = nullptr;
+
+    Fixture() {
+        auto* layout = new QVBoxLayout(&host);
+        picker = new kit::KColorPicker(&host);
+        layout->addWidget(picker);
+        host.resize(picker->sizeHint());
+        host.show();
+        host.activateWindow();
+        QCoreApplication::processEvents();
+    }
+};
+
+void testSvSquareDragSetsSaturationValueAndPreservesHueThroughGray(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    picker.setColor(kit::KColor::fromHsva(300.0F, 0.8F, 0.8F));
+    const float startHue = picker.color().toHsva()[0];
+
+    const QRectF square = picker.svSquareRect();
+    // First drag to the square's left edge -- zero saturation, a gray, where RGB alone cannot
+    // name the hue at all.
+    const QPointF grayPoint(square.left(), square.top() + square.height() * 0.5);
+    sendMouse(picker, QEvent::MouseButtonPress, grayPoint, Qt::LeftButton);
+    const auto grayHsva = picker.color().toHsva();
+    expectations.expect(std::abs(widen(grayHsva[1])) < 0.02,
+                        "dragging to the left edge zeroes saturation");
+
+    // Then drag back into a saturated region without ever touching the hue bar.
+    const QPointF target(square.left() + square.width() * 0.25,
+                         square.top() + square.height() * 0.75);
+    sendMouse(picker, QEvent::MouseMove, target, Qt::LeftButton);
+    const auto hsva = picker.color().toHsva();
+    expectations.expect(std::abs(widen(hsva[1]) - 0.25) < 0.02,
+                        "saturation follows the pointer's x");
+    expectations.expect(std::abs(widen(hsva[2]) - 0.25) < 0.02,
+                        "value follows the pointer's y, inverted");
+    expectations.expect(std::abs(widen(hsva[0]) - widen(startHue)) < 0.5,
+                        "hue survives a pass through zero saturation: the picker holds it live "
+                        "instead of re-deriving it from RGB");
+    sendMouse(picker, QEvent::MouseButtonRelease, target, Qt::LeftButton);
+}
+
+void testHueBarDragMovesOnlyHue(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    picker.setColor(kit::KColor::fromHsva(0.0F, 0.6F, 0.6F, 0.9F));
+
+    const QRectF bar = picker.hueBarRect();
+    const QPointF target(bar.center().x(), bar.top() + bar.height() * (120.0 / 360.0));
+    sendMouse(picker, QEvent::MouseButtonPress, target, Qt::LeftButton);
+    const auto hsva = picker.color().toHsva();
+    expectations.expect(std::abs(static_cast<double>(hsva[0]) - 120.0) < 2.0,
+                        "the hue bar drag lands near the targeted hue");
+    expectations.expect(std::abs(static_cast<double>(hsva[1]) - 0.6) < 0.02 &&
+                            std::abs(static_cast<double>(hsva[2]) - 0.6) < 0.02,
+                        "saturation and value are untouched by a hue-only drag");
+    expectations.expect(std::abs(static_cast<double>(hsva[3]) - 0.9) < 0.02,
+                        "alpha is untouched by a hue-only drag");
+    sendMouse(picker, QEvent::MouseButtonRelease, target, Qt::LeftButton);
+}
+
+void testAlphaBarDragMovesOnlyAlpha(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    picker.setColor(kit::KColor::fromHsva(210.0F, 0.5F, 0.5F, 1.0F));
+
+    const QRectF bar = picker.alphaBarRect();
+    const QPointF target(bar.left() + bar.width() * 0.3, bar.center().y());
+    sendMouse(picker, QEvent::MouseButtonPress, target, Qt::LeftButton);
+    const auto hsva = picker.color().toHsva();
+    expectations.expect(std::abs(static_cast<double>(hsva[3]) - 0.3) < 0.02,
+                        "the alpha bar drag lands near the targeted alpha");
+    expectations.expect(std::abs(static_cast<double>(hsva[0]) - 210.0) < 0.5 &&
+                            std::abs(static_cast<double>(hsva[1]) - 0.5) < 0.02 &&
+                            std::abs(static_cast<double>(hsva[2]) - 0.5) < 0.02,
+                        "hue, saturation, and value are untouched by an alpha-only drag");
+    sendMouse(picker, QEvent::MouseButtonRelease, target, Qt::LeftButton);
+}
+
+void testModelSwitchPreservesTheColorExactly(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    picker.setColor(kit::KColor::fromHsva(45.0F, 0.4F, 0.7F, 0.8F));
+    const kit::KColor before = picker.color();
+
+    picker.setColorModel(kit::ColorModel::Rgba);
+    expectations.expect(picker.color() == before, "switching to RGBA does not alter the color");
+    picker.setColorModel(kit::ColorModel::Hsla);
+    expectations.expect(picker.color() == before, "switching to HSLA does not alter the color");
+    picker.setColorModel(kit::ColorModel::Hsva);
+    expectations.expect(picker.color() == before,
+                        "switching back to HSVA does not alter the color either");
+}
+
+void testHexEntryRoundTrips(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    picker.hexField()->setText(QStringLiteral("#3399FFCC"));
+    picker.hexField()->editingFinished();
+    QCoreApplication::processEvents();
+
+    expectations.expect(picker.hexField()->text() == QStringLiteral("#3399ffcc"),
+                        "the hex field redisplays its own lowercase canonical text");
+    const QColor rgba = picker.color().toQColor();
+    expectations.expect(rgba == QColor(0x33, 0x99, 0xFF, 0xCC),
+                        "the parsed hex value committed exactly, alpha included");
+
+    picker.hexField()->setText(QStringLiteral("not-a-color"));
+    picker.hexField()->editingFinished();
+    QCoreApplication::processEvents();
+    expectations.expect(picker.color().toQColor() == QColor(0x33, 0x99, 0xFF, 0xCC),
+                        "an unparsable hex entry is refused, not silently applied");
+    expectations.expect(picker.hexField()->text() == QStringLiteral("#3399ffcc"),
+                        "a refused entry reverts the field to the last valid text");
+}
+
+void testChannelFieldEditUpdatesTheColorAndSwatch(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    picker.setColorModel(kit::ColorModel::Rgba);
+    picker.setColor(kit::KColor::fromRgba(0.0F, 0.0F, 0.0F, 1.0F));
+
+    kit::KValueField* redField = picker.channelField(0);
+    expectations.expect(redField != nullptr, "the RGBA model exposes a red channel field");
+    redField->setValue(200.0);
+
+    const QColor rgba = picker.color().toQColor();
+    expectations.expect(rgba.red() == 200, "editing the R channel field updates the color");
+    expectations.expect(picker.swatchRow()->currentColor().toQColor().red() == 200,
+                        "...and the swatch row's current-color preview along with it");
+}
+
+void testFormSelectorListsOnlyTheAvailableForm(Expectations& expectations) {
+    Fixture fixture;
+    auto& picker = *fixture.picker;
+    expectations.expect(picker.formSelector()->count() == 1,
+                        "only the implemented picker form is listed -- the rest are absent, not "
+                        "shown disabled");
+    expectations.expect(picker.formSelector()->currentText() == QStringLiteral("Square"),
+                        "the one listed form is Square");
+    expectations.expect(picker.pickerForm() == kit::PickerForm::Square,
+                        "the picker itself reports the Square form");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    kit::installKinetikTheme(application);
+    Expectations expectations;
+    testSvSquareDragSetsSaturationValueAndPreservesHueThroughGray(expectations);
+    testHueBarDragMovesOnlyHue(expectations);
+    testAlphaBarDragMovesOnlyAlpha(expectations);
+    testModelSwitchPreservesTheColorExactly(expectations);
+    testHexEntryRoundTrips(expectations);
+    testChannelFieldEditUpdatesTheColorAndSwatch(expectations);
+    testFormSelectorListsOnlyTheAvailableForm(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/kit_color_sampler_tests.cpp
+++ b/src/ui/tests/kit_color_sampler_tests.cpp
@@ -1,0 +1,125 @@
+#include <bloom/ui/kit/color_sampler.hpp>
+
+#include <QApplication>
+#include <QImage>
+#include <QPalette>
+#include <QWidget>
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+void testSampleImagePixelReadsTheExactPixel(Expectations& expectations) {
+    QImage image(4, 4, QImage::Format_ARGB32);
+    image.fill(QColor(10, 20, 30, 255));
+    image.setPixelColor(2, 1, QColor(200, 100, 50, 128));
+
+    const auto sampled = kit::sampleImagePixel(image, QPoint(2, 1));
+    expectations.expect(sampled.has_value() && sampled->toQColor() == QColor(200, 100, 50, 128),
+                        "an in-bounds point samples the exact pixel written, alpha included");
+
+    const auto background = kit::sampleImagePixel(image, QPoint(0, 0));
+    expectations.expect(background.has_value() && background->toQColor() == QColor(10, 20, 30, 255),
+                        "a different point samples a different, still-exact, pixel");
+
+    expectations.expect(!kit::sampleImagePixel(image, QPoint(4, 0)).has_value(),
+                        "a point at the image's width (one past the last column) is out of bounds");
+    expectations.expect(!kit::sampleImagePixel(image, QPoint(-1, 0)).has_value(),
+                        "a negative point is out of bounds");
+    expectations.expect(!kit::sampleImagePixel(QImage(), QPoint(0, 0)).has_value(),
+                        "a null image samples nothing rather than crashing");
+}
+
+void testSampleWidgetPixelGrabsTheWidgetItself(Expectations& expectations) {
+    QWidget widget;
+    widget.resize(40, 40);
+    widget.setAutoFillBackground(true);
+    QPalette palette = widget.palette();
+    palette.setColor(QPalette::Window, QColor(30, 200, 90));
+    widget.setPalette(palette);
+    widget.show();
+    QCoreApplication::processEvents();
+
+    const auto sampled = kit::sampleWidgetPixel(widget, QPoint(20, 20));
+    expectations.expect(sampled.has_value() && sampled->toQColor() == QColor(30, 200, 90),
+                        "a point inside the widget samples its own painted background exactly");
+
+    expectations.expect(!kit::sampleWidgetPixel(widget, QPoint(1000, 1000)).has_value(),
+                        "a point outside the widget's own rect samples nothing");
+}
+
+void testSamplerIsScopedToTheApplicationsOwnWidgets(Expectations& expectations) {
+    QWidget widget;
+    widget.resize(40, 40);
+    widget.setAutoFillBackground(true);
+    QPalette palette = widget.palette();
+    palette.setColor(QPalette::Window, QColor(240, 10, 10));
+    widget.setPalette(palette);
+    widget.move(50, 50);
+    widget.show();
+    widget.activateWindow();
+    QCoreApplication::processEvents();
+
+    kit::KColorSampler sampler;
+    expectations.expect(!sampler.isActive(), "a fresh sampler is not active");
+
+    const QPoint insideGlobal = widget.mapToGlobal(QPoint(20, 20));
+    const auto sampled = sampler.sampleAt(insideGlobal);
+    expectations.expect(sampled.has_value() && sampled->toQColor() == QColor(240, 10, 10),
+                        "a global position over one of the application's own widgets resolves to "
+                        "that widget's own painted color");
+
+    // Nothing Bloom owns lives out here; the honesty requirement (decision 5) is exactly that this
+    // returns nothing rather than reaching for whatever the real screen happens to show.
+    const auto outside = sampler.sampleAt(QPoint(1'000'000, 1'000'000));
+    expectations.expect(!outside.has_value(),
+                        "a position with no application widget under it samples nothing");
+}
+
+void testBeginAndCancelToggleActiveState(Expectations& expectations) {
+    kit::KColorSampler sampler;
+    sampler.begin();
+    expectations.expect(sampler.isActive(), "begin() activates the sampler");
+    sampler.begin();
+    expectations.expect(sampler.isActive(),
+                        "beginning an already-active sampler is a harmless no-op");
+    sampler.cancel();
+    expectations.expect(!sampler.isActive(), "cancel() deactivates the sampler");
+    sampler.cancel();
+    expectations.expect(!sampler.isActive(), "cancelling an inactive sampler is a harmless no-op");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testSampleImagePixelReadsTheExactPixel(expectations);
+    testSampleWidgetPixelGrabsTheWidgetItself(expectations);
+    testSamplerIsScopedToTheApplicationsOwnWidgets(expectations);
+    testBeginAndCancelToggleActiveState(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/kit_color_swatches_tests.cpp
+++ b/src/ui/tests/kit_color_swatches_tests.cpp
@@ -1,0 +1,164 @@
+#include <bloom/ui/kit/color_swatches.hpp>
+#include <bloom/ui/kit/theme.hpp>
+
+#include <QApplication>
+#include <QContextMenuEvent>
+#include <QMouseEvent>
+#include <QSignalSpy>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+struct Fixture {
+    QWidget host;
+    kit::KColorSwatchRow* row = nullptr;
+
+    Fixture() {
+        auto* layout = new QVBoxLayout(&host);
+        row = new kit::KColorSwatchRow(&host);
+        layout->addWidget(row);
+        host.resize(320, 60);
+        host.show();
+        host.activateWindow();
+        QCoreApplication::processEvents();
+    }
+};
+
+void testRecentStoreIsMostRecentFirstAndDedups(Expectations& expectations) {
+    kit::KRecentColorStore store;
+    const kit::KColor red = kit::KColor::fromRgba(1.0F, 0.0F, 0.0F);
+    const kit::KColor green = kit::KColor::fromRgba(0.0F, 1.0F, 0.0F);
+    const kit::KColor blue = kit::KColor::fromRgba(0.0F, 0.0F, 1.0F);
+
+    store.push(red);
+    store.push(green);
+    store.push(blue);
+    expectations.expect(store.colors().size() == 3, "three distinct pushes keep three entries");
+    expectations.expect(store.colors()[0] == blue, "the most recently pushed color is first");
+
+    store.push(red);
+    expectations.expect(store.colors().size() == 3,
+                        "re-pushing an existing color does not duplicate it");
+    expectations.expect(store.colors()[0] == red,
+                        "re-pushing an existing color moves it to the front");
+    expectations.expect(store.colors()[1] == blue && store.colors()[2] == green,
+                        "the rest keep their relative order");
+}
+
+void testRecentStoreEvictsOldestPastCapacity(Expectations& expectations) {
+    kit::KRecentColorStore store(2);
+    store.push(kit::KColor::fromRgba(1.0F, 0.0F, 0.0F));
+    store.push(kit::KColor::fromRgba(0.0F, 1.0F, 0.0F));
+    store.push(kit::KColor::fromRgba(0.0F, 0.0F, 1.0F));
+    expectations.expect(store.colors().size() == 2, "capacity is enforced");
+    expectations.expect(store.colors()[0] == kit::KColor::fromRgba(0.0F, 0.0F, 1.0F),
+                        "the newest push survives");
+    expectations.expect(store.colors()[1] == kit::KColor::fromRgba(0.0F, 1.0F, 0.0F),
+                        "the second-newest push survives");
+}
+
+void testClickingASlotAppliesItsColor(Expectations& expectations) {
+    Fixture fixture;
+    auto& row = *fixture.row;
+    const kit::KColor teal = kit::KColor::fromRgba(0.0F, 0.6F, 0.6F);
+    row.setSlotColor(2, teal);
+
+    QSignalSpy activated(&row, &kit::KColorSwatchRow::colorActivated);
+    const QRectF slot = row.slotRect(2);
+    const QPointF centre = slot.center();
+    QMouseEvent press(QEvent::MouseButtonPress, centre, row.mapToGlobal(centre.toPoint()),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&row, &press);
+    QMouseEvent release(QEvent::MouseButtonRelease, centre, row.mapToGlobal(centre.toPoint()),
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&row, &release);
+    QCoreApplication::processEvents();
+
+    expectations.expect(activated.count() == 1, "a quick click activates the slot exactly once");
+    expectations.expect(qvariant_cast<kit::KColor>(activated.constFirst().constFirst()) == teal,
+                        "the activated color is the pinned slot's color");
+}
+
+void testContextMenuSetsASlotToTheCurrentColor(Expectations& expectations) {
+    Fixture fixture;
+    auto& row = *fixture.row;
+    const kit::KColor magenta = kit::KColor::fromRgba(1.0F, 0.0F, 1.0F);
+    row.setCurrentColor(magenta);
+    expectations.expect(!row.isSlotPinned(0), "a fresh slot starts unpinned");
+
+    QSignalSpy pinned(&row, &kit::KColorSwatchRow::slotPinned);
+    const QPointF centre = row.slotRect(0).center();
+    QContextMenuEvent contextEvent(QContextMenuEvent::Mouse, centre.toPoint(),
+                                   row.mapToGlobal(centre.toPoint()));
+    QCoreApplication::sendEvent(&row, &contextEvent);
+    QCoreApplication::processEvents();
+
+    expectations.expect(row.isSlotPinned(0), "a context-menu gesture pins the slot");
+    expectations.expect(row.slotColor(0) == magenta,
+                        "the pinned slot takes the row's current color");
+    expectations.expect(pinned.count() == 1, "the pin is reported exactly once");
+
+    row.clearSlot(0);
+    expectations.expect(!row.isSlotPinned(0), "clearSlot() releases the pin");
+    expectations.expect(!row.slotColor(0).has_value(),
+                        "an unbound, unpinned slot has no color at all");
+}
+
+void testSlotsReadThroughTheBoundStoreWhenUnpinned(Expectations& expectations) {
+    Fixture fixture;
+    auto& row = *fixture.row;
+    kit::KRecentColorStore store;
+    store.push(kit::KColor::fromRgba(0.2F, 0.2F, 0.2F));
+    store.push(kit::KColor::fromRgba(0.4F, 0.4F, 0.4F));
+    row.setRecentColorStore(&store);
+
+    expectations.expect(row.slotColor(0) == store.colors()[0],
+                        "an unpinned slot mirrors the store's most-recent-first order");
+    expectations.expect(row.slotColor(1) == store.colors()[1], "and so on down the list");
+    expectations.expect(!row.slotColor(row.slotCount() - 1).has_value(),
+                        "a slot past what the store has to offer is empty, not garbage");
+
+    row.setSlotColor(0, kit::KColor::fromRgba(1.0F, 1.0F, 1.0F));
+    expectations.expect(row.slotColor(0) == kit::KColor::fromRgba(1.0F, 1.0F, 1.0F),
+                        "a pinned slot overrides what the store would otherwise show there");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    kit::installKinetikTheme(application);
+    Expectations expectations;
+    testRecentStoreIsMostRecentFirstAndDedups(expectations);
+    testRecentStoreEvictsOldestPastCapacity(expectations);
+    testClickingASlotAppliesItsColor(expectations);
+    testContextMenuSetsASlotToTheCurrentColor(expectations);
+    testSlotsReadThroughTheBoundStoreWhenUnpinned(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}

--- a/src/ui/tests/kit_color_tests.cpp
+++ b/src/ui/tests/kit_color_tests.cpp
@@ -1,0 +1,193 @@
+#include <bloom/ui/kit/color.hpp>
+
+#include <QApplication>
+
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <source_location>
+#include <string>
+
+namespace {
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+using namespace bloom::ui;
+
+[[nodiscard]] bool nearlyEqual(const float a, const float b, const float epsilon = 1e-4F) {
+    return std::abs(a - b) <= epsilon;
+}
+
+void testQuantizationIsRoundHalfUpAndClamped(Expectations& expectations) {
+    expectations.expect(kit::quantizeChannel8(0.0F) == 0, "zero quantizes to 0");
+    expectations.expect(kit::quantizeChannel8(1.0F) == 255, "one quantizes to 255");
+    // 0.5 * 255 = 127.5 -- round-half-up lands on 128, not 127 (round-half-to-even) or truncation.
+    expectations.expect(kit::quantizeChannel8(0.5F) == 128,
+                        "a half-channel value rounds half-up to 128");
+    expectations.expect(kit::quantizeChannel8(-1.0F) == 0, "a negative value clamps to 0");
+    expectations.expect(kit::quantizeChannel8(2.0F) == 255, "a value past 1.0 clamps to 255");
+    expectations.expect(kit::dequantizeChannel8(255) == 1.0F, "255 dequantizes to exactly 1.0");
+    expectations.expect(kit::dequantizeChannel8(0) == 0.0F, "0 dequantizes to exactly 0.0");
+}
+
+void testKnownHuesRoundTripThroughHsv(Expectations& expectations) {
+    struct Case {
+        const char* name;
+        float r, g, b;
+        float expectedHue;
+    };
+    constexpr std::array<Case, 6> cases{{
+        {"red", 1.0F, 0.0F, 0.0F, 0.0F},
+        {"yellow", 1.0F, 1.0F, 0.0F, 60.0F},
+        {"green", 0.0F, 1.0F, 0.0F, 120.0F},
+        {"cyan", 0.0F, 1.0F, 1.0F, 180.0F},
+        {"blue", 0.0F, 0.0F, 1.0F, 240.0F},
+        {"magenta", 1.0F, 0.0F, 1.0F, 300.0F},
+    }};
+    for (const auto& c : cases) {
+        const kit::KColor color = kit::KColor::fromRgba(c.r, c.g, c.b);
+        const auto hsva = color.toHsva();
+        expectations.expect(nearlyEqual(hsva[0], c.expectedHue),
+                            std::string(c.name) + "'s hue matches the known value");
+        expectations.expect(nearlyEqual(hsva[1], 1.0F),
+                            std::string(c.name) + " is fully saturated");
+        expectations.expect(nearlyEqual(hsva[2], 1.0F), std::string(c.name) + " is at full value");
+
+        const kit::KColor rebuilt = kit::KColor::fromHsva(hsva[0], hsva[1], hsva[2], hsva[3]);
+        expectations.expect(nearlyEqual(rebuilt.red, c.r) && nearlyEqual(rebuilt.green, c.g) &&
+                                nearlyEqual(rebuilt.blue, c.b),
+                            std::string(c.name) + " round-trips exactly through HSVA");
+    }
+}
+
+void testHue0And360AreTheSameColor(Expectations& expectations) {
+    const kit::KColor atZero = kit::KColor::fromHsva(0.0F, 1.0F, 1.0F);
+    const kit::KColor at360 = kit::KColor::fromHsva(360.0F, 1.0F, 1.0F);
+    expectations.expect(atZero == at360, "hue 0 and hue 360 name the identical color");
+
+    const kit::KColor pastFull = kit::KColor::fromHsva(720.0F, 0.5F, 0.5F);
+    const kit::KColor normalized = kit::KColor::fromHsva(0.0F, 0.5F, 0.5F);
+    expectations.expect(pastFull == normalized, "a hue past 360 wraps rather than clamping");
+}
+
+void testBlackAndWhiteSaturationDegeneracy(Expectations& expectations) {
+    const auto blackHsv = kit::KColor::fromRgba(0.0F, 0.0F, 0.0F).toHsva();
+    expectations.expect(nearlyEqual(blackHsv[1], 0.0F), "black reports zero saturation, not NaN");
+    expectations.expect(nearlyEqual(blackHsv[2], 0.0F), "black reports zero value");
+
+    const auto whiteHsv = kit::KColor::fromRgba(1.0F, 1.0F, 1.0F).toHsva();
+    expectations.expect(nearlyEqual(whiteHsv[1], 0.0F), "white reports zero saturation");
+    expectations.expect(nearlyEqual(whiteHsv[2], 1.0F), "white reports full value");
+
+    const auto whiteHsl = kit::KColor::fromRgba(1.0F, 1.0F, 1.0F).toHsla();
+    expectations.expect(nearlyEqual(whiteHsl[1], 0.0F),
+                        "white reports zero saturation in HSL too (the 1-|2l-1| term is zero)");
+    expectations.expect(nearlyEqual(whiteHsl[2], 1.0F), "white is full lightness");
+
+    const auto blackHsl = kit::KColor::fromRgba(0.0F, 0.0F, 0.0F).toHsla();
+    expectations.expect(nearlyEqual(blackHsl[1], 0.0F), "black reports zero saturation in HSL");
+    expectations.expect(nearlyEqual(blackHsl[2], 0.0F), "black is zero lightness");
+
+    const kit::KColor grayFromHsl = kit::KColor::fromHsla(200.0F, 0.0F, 0.5F);
+    expectations.expect(nearlyEqual(grayFromHsl.red, 0.5F) &&
+                            nearlyEqual(grayFromHsl.green, 0.5F) &&
+                            nearlyEqual(grayFromHsl.blue, 0.5F),
+                        "zero HSL saturation ignores hue and produces an exact gray");
+}
+
+void testHexRoundTrips(Expectations& expectations) {
+    const auto parsed = kit::KColor::fromHex(QStringLiteral("#3399FF"));
+    expectations.expect(parsed.has_value(), "a well-formed 6-digit hex parses");
+    const kit::KColor parsedColor = parsed.value_or(kit::KColor{});
+    expectations.expect(parsedColor.toHex(false) == QStringLiteral("#3399ff"),
+                        "a 6-digit hex round-trips to its own lowercase text");
+    expectations.expect(nearlyEqual(parsedColor.alpha, 1.0F),
+                        "a 6-digit hex with no explicit fallback defaults to opaque");
+
+    const auto withFallbackAlpha = kit::KColor::fromHex(QStringLiteral("3399ff"), 0.5F);
+    expectations.expect(withFallbackAlpha.has_value(), "the leading # is optional");
+    expectations.expect(nearlyEqual(withFallbackAlpha.value_or(kit::KColor{}).alpha, 0.5F),
+                        "a 6-digit hex takes the caller's fallback alpha rather than forcing 1.0");
+
+    const auto withAlpha = kit::KColor::fromHex(QStringLiteral("#3399FF80"));
+    expectations.expect(withAlpha.has_value(), "an 8-digit hex parses");
+    expectations.expect(withAlpha.value_or(kit::KColor{}).toHex(true) ==
+                            QStringLiteral("#3399ff80"),
+                        "an 8-digit hex round-trips including its alpha byte");
+
+    const auto alphaZero = kit::KColor::fromHex(QStringLiteral("#00000000"));
+    expectations.expect(alphaZero.has_value() &&
+                            kit::quantizeChannel8(alphaZero.value_or(kit::KColor{}).alpha) == 0,
+                        "an 8-digit hex with alpha 00 parses to fully transparent");
+    const auto alphaFull = kit::KColor::fromHex(QStringLiteral("#000000FF"));
+    expectations.expect(alphaFull.has_value() &&
+                            kit::quantizeChannel8(alphaFull.value_or(kit::KColor{}).alpha) == 255,
+                        "an 8-digit hex with alpha FF parses to fully opaque");
+
+    expectations.expect(!kit::KColor::fromHex(QStringLiteral("#ABC")).has_value(),
+                        "a 3-digit hex is refused rather than guessed at");
+    expectations.expect(!kit::KColor::fromHex(QStringLiteral("#ZZZZZZ")).has_value(),
+                        "non-hex characters are refused");
+    expectations.expect(!kit::KColor::fromHex(QStringLiteral("")).has_value(),
+                        "an empty string is refused");
+}
+
+void testQColorRoundTrip(Expectations& expectations) {
+    const QColor original(51, 153, 255, 128);
+    const kit::KColor color = kit::KColor::fromQColor(original);
+    const QColor rebuilt = color.toQColor();
+    expectations.expect(rebuilt == original, "an 8-bit QColor round-trips exactly through KColor");
+}
+
+void testColorModelAndPickerFormVocabulary(Expectations& expectations) {
+    expectations.expect(kit::colorModelLabel(kit::ColorModel::Hsva) == QStringLiteral("HSVA"),
+                        "HSVA labels itself");
+    expectations.expect(kit::colorModelLabel(kit::ColorModel::Hsla) == QStringLiteral("HSLA"),
+                        "HSLA labels itself");
+    expectations.expect(kit::colorModelLabel(kit::ColorModel::Rgba) == QStringLiteral("RGBA"),
+                        "RGBA labels itself");
+
+    expectations.expect(kit::pickerFormAvailable(kit::PickerForm::Square),
+                        "Square is the one available picker form this slice");
+    for (const kit::PickerForm form : kit::pickerForms()) {
+        if (form == kit::PickerForm::Square) {
+            continue;
+        }
+        expectations.expect(!kit::pickerFormAvailable(form),
+                            QString("form %1 is typed but not yet available")
+                                .arg(kit::pickerFormLabel(form))
+                                .toStdString());
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    Expectations expectations;
+    testQuantizationIsRoundHalfUpAndClamped(expectations);
+    testKnownHuesRoundTripThroughHsv(expectations);
+    testHue0And360AreTheSameColor(expectations);
+    testBlackAndWhiteSaturationDegeneracy(expectations);
+    testHexRoundTrips(expectations);
+    testQColorRoundTrip(expectations);
+    testColorModelAndPickerFormVocabulary(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The color-picker slice of #116 — a self-contained widget family per the design system's picker sheet:

- **`KColor` value model**: RGBA float with pinned HSV/HSL conversions, 6/8-digit hex, and documented round-half-up quantization — deliberately independent of document color types.
- **Selector fields**: color chips (square/circle, sizes, alpha checkerboard via a new shared painting primitive), an A/B pair with swap.
- **Picker**: SV square + hue bar + alpha bar with draggable markers, model switcher (HSVA/HSLA/RGBA) over value-field channel rows, 8-digit-aware hex — internally HSVA-authoritative so hue provably survives a drag through zero saturation (pinned by a real synthesized drag, not a static assert). The form enum is architecture-present with Square shipped; unbuilt forms are absent, not disabled.
- **Swatches**: 8→32 slots, click-applies / long-press-pins, injectable session-memory recent-color store (persistence recorded as the follow-up).
- **Eyedropper**: honest by construction — sampling resolves through the app's own widget tree, cannot leave the process, and its tooltip says "Samples inside Bloom".
- One disclosed judgment call (a 500ms gesture timeout kept as a documented constant rather than mis-filed under motion tokens) and one self-caught re-entrancy bug fixed pre-commit with its regression test.

Desktop 125/125 and native 88/88, quality checks clean. Not yet wired into Properties (that file is another slice's fence); wiring is a one-line follow-up.

Closes #121.

Implemented by a Claude Sonnet subagent; reviewed by the supervising session.