### PR TITLE
feat: make the node editor a first-class canvas

### DIFF
--- a/src/ui/composition_editors.cpp
+++ b/src/ui/composition_editors.cpp
@@ -78,16 +78,6 @@ const document::LayerOutputBoundary* layerBoundary(const document::Composition& 
     return found == boundaries.end() ? nullptr : &*found;
 }
 
-QString sourceDescription(const document::ParameterRecord& parameter) {
-    if (std::holds_alternative<document::AnimationCurveSource>(parameter.source)) {
-        return QStringLiteral("Animated");
-    }
-    if (std::holds_alternative<document::DriverBindingSource>(parameter.source)) {
-        return QStringLiteral("Driven by graph");
-    }
-    return QStringLiteral("Constant");
-}
-
 QString layerName(const document::Composition& composition, const document::LayerId layerId) {
     const auto* boundary = layerBoundary(composition, layerId);
     if (boundary == nullptr || boundary->name.empty()) {
@@ -169,12 +159,6 @@ QString exactNumber(const double value) {
         return QString::number(value, 'g', std::numeric_limits<double>::max_digits10);
     }
     return QString::fromLatin1(buffer.data(), static_cast<qsizetype>(result.ptr - buffer.data()));
-}
-
-QString exactColor(const core::Color4d color) {
-    return QStringLiteral("R %1  G %2  B %3  A %4")
-        .arg(exactNumber(color.red), exactNumber(color.green), exactNumber(color.blue),
-             exactNumber(color.alpha));
 }
 
 QString selectionName(const CompositionSession& session) {
@@ -544,8 +528,8 @@ void addSectionHeader(QVBoxLayout* section, QWidget* parent, const QString& titl
 
 // True when `parameter` carries an animation curve source (issue #120, decision 2: "truth from
 // the session snapshot, no new session API") -- the same std::holds_alternative check
-// sourceDescription() above already uses to report "Animated", read directly rather than by
-// string-comparing that tooltip text.
+// parameterSourceDescription() below already uses to report "Animated", read directly rather than
+// by string-comparing that tooltip text.
 bool isAnimatedParameter(const document::ParameterRecord* parameter) {
     return parameter != nullptr &&
            std::holds_alternative<document::AnimationCurveSource>(parameter->source);
@@ -600,6 +584,46 @@ QString formatDuration(const TimelineFrameContext& context) {
 }
 
 } // namespace
+
+// --- Shared authoring/presentation truth (task U4, issue #123) ---------------------------------
+//
+// Declared in composition_editors.hpp; defined here, beside the anonymous-namespace helpers they
+// already used, so the Nodes canvas calls exactly what the Properties panel and the Timeline's Add
+// menu call rather than re-deriving it. Every one of these is a verbatim lift of code that already
+// lived in this file -- the wording, the numbering rule, the palette, and the command labels are
+// byte-identical to what shipped before, so no existing pinned expectation moves.
+
+QString parameterSourceDescription(const document::ParameterRecord& parameter) {
+    if (std::holds_alternative<document::AnimationCurveSource>(parameter.source)) {
+        return QStringLiteral("Animated");
+    }
+    if (std::holds_alternative<document::DriverBindingSource>(parameter.source)) {
+        return QStringLiteral("Driven by graph");
+    }
+    return QStringLiteral("Constant");
+}
+
+QString exactColorText(const core::Color4d color) {
+    return QStringLiteral("R %1  G %2  B %3  A %4")
+        .arg(exactNumber(color.red), exactNumber(color.green), exactNumber(color.blue),
+             exactNumber(color.alpha));
+}
+
+bool addDefaultSolidLayer(CompositionSession& session) {
+    const auto layerNumber = nextLayerNumber(session, document::kSolidSourceNodeType,
+                                             document::kSolidSourceNodeSchemaVersion);
+    const auto paletteIndex =
+        static_cast<std::size_t>(layerNumber - 1) % kDefaultSolidPalette.size();
+    return session.addSolidLayer(TimelineEditor::tr("Solid %1").arg(layerNumber),
+                                 kDefaultSolidPalette[paletteIndex]);
+}
+
+bool addDefaultTextLayer(CompositionSession& session) {
+    const auto layerNumber = nextLayerNumber(session, document::kTextSourceNodeType,
+                                             document::kTextSourceNodeSchemaVersion);
+    return session.addTextLayer(TimelineEditor::tr("Text %1").arg(layerNumber),
+                                TimelineEditor::tr("Text"));
+}
 
 TimelineEditor::TimelineEditor(CompositionSession& session,
                                CompositionPreviewController& previewController, QWidget* parent)
@@ -730,19 +754,12 @@ TimelineEditor::TimelineEditor(CompositionSession& session,
     layout->addWidget(keyframes_);
     layout->addWidget(layers_, 1);
 
-    connect(addSolidAction, &QAction::triggered, this, [this] {
-        const auto layerNumber = nextLayerNumber(session_, document::kSolidSourceNodeType,
-                                                 document::kSolidSourceNodeSchemaVersion);
-        const auto paletteIndex =
-            static_cast<std::size_t>(layerNumber - 1) % kDefaultSolidPalette.size();
-        (void)session_.addSolidLayer(tr("Solid %1").arg(layerNumber),
-                                     kDefaultSolidPalette[paletteIndex]);
-    });
-    connect(addTextAction, &QAction::triggered, this, [this] {
-        const auto layerNumber = nextLayerNumber(session_, document::kTextSourceNodeType,
-                                                 document::kTextSourceNodeSchemaVersion);
-        (void)session_.addTextLayer(tr("Text %1").arg(layerNumber), tr("Text"));
-    });
+    // One definition of the "Add Solid"/"Add Text" default name and proof color, shared with the
+    // Nodes canvas context menu (task U4, issue #123) -- see composition_editors.hpp.
+    connect(addSolidAction, &QAction::triggered, this,
+            [this] { (void)addDefaultSolidLayer(session_); });
+    connect(addTextAction, &QAction::triggered, this,
+            [this] { (void)addDefaultTextLayer(session_); });
     connect(undoButton_, &QToolButton::clicked, &session_, &CompositionSession::undo);
     connect(redoButton_, &QToolButton::clicked, &session_, &CompositionSession::redo);
     connect(playPauseButton_, &QToolButton::clicked, playback_, &PlaybackController::toggle);
@@ -1279,7 +1296,7 @@ void PropertiesEditor::configurePosition() {
     }
     const QString positionTip = position == nullptr
                                     ? tr("Position is not exposed by this selection")
-                                    : sourceDescription(*position);
+                                    : parameterSourceDescription(*position);
     positionX_->setToolTip(positionTip);
     positionY_->setToolTip(positionTip);
     updateKeyframeIndicator(positionKeyframe_, position);
@@ -1292,7 +1309,7 @@ void PropertiesEditor::configureOpacity() {
     const QSignalBlocker blocker(opacity_);
     opacity_->setValue(value.has_value() ? *value * 100.0 : 100.0);
     opacity_->setToolTip(parameter == nullptr ? tr("Opacity is not exposed by this selection")
-                                              : sourceDescription(*parameter));
+                                              : parameterSourceDescription(*parameter));
     updateKeyframeIndicator(opacityKeyframe_, parameter);
 }
 
@@ -1310,8 +1327,8 @@ void PropertiesEditor::configureSolidColor() {
 
     updateKeyframeIndicator(solidColorKeyframe_, parameter);
     const auto value = session_.constantColorValue(parameter->id);
-    solidColorValue_->setText(value.has_value() ? exactColor(*value)
-                                                : sourceDescription(*parameter));
+    solidColorValue_->setText(value.has_value() ? exactColorText(*value)
+                                                : parameterSourceDescription(*parameter));
     solidColorValue_->setToolTip(
         tr("Straight scene-linear authoring values; negative and HDR RGB are not clipped"));
     solidAlphaAssociation_->setText(tr("Straight (unassociated)"));

--- a/src/ui/include/bloom/ui/composition_editors.hpp
+++ b/src/ui/include/bloom/ui/composition_editors.hpp
@@ -2,6 +2,7 @@
 
 #include <bloom/ui/playback_controller.hpp>
 
+#include <QString>
 #include <QWidget>
 
 class QAction;
@@ -9,6 +10,14 @@ class QLabel;
 class QListWidget;
 class QToolButton;
 class QTreeWidget;
+
+namespace bloom::core {
+struct Color4d;
+} // namespace bloom::core
+
+namespace bloom::document {
+struct ParameterRecord;
+} // namespace bloom::document
 
 namespace bloom::ui {
 
@@ -21,6 +30,36 @@ class TimelineWorkAreaStrip;
 namespace kit {
 class KValueField;
 } // namespace kit
+
+// --- Shared authoring/presentation truth (task U4, issue #123) ---------------------------------
+//
+// Three decisions the Properties panel and the Timeline's Add menu already owned, now CALLED by the
+// Nodes canvas rather than copied into it. Task U4's decision 4 requires the node editor's Add menu
+// to offer "exactly the layer kinds the command layer offers today (mirror the timeline's Add menu
+// contents)", and its decision 5 requires in-node fields to read and commit through "the EXACT same
+// session/command paths Properties uses". Copying the default-name rule, the built-in proof
+// palette, or the source wording into node_editor.cpp would have duplicated four raw color literals
+// and three user-visible strings, and would let the two surfaces silently drift. These declarations
+// exist so there is exactly one definition of each; every one of them is defined in
+// composition_editors.cpp, beside the anonymous-namespace helpers it already used.
+
+// "Constant" / "Animated" / "Driven by graph" -- the one wording for a parameter's source, shown by
+// the Properties rows' tooltips and by the node card's own field tooltips.
+[[nodiscard]] QString parameterSourceDescription(const document::ParameterRecord& parameter);
+
+// The exact, never-rounded and never-clipped "R r  G g  B b  A a" rendering of an authoring color
+// (negative and HDR channels included -- docs/architecture/evaluation-primitives.md's straight
+// Color4d authoring values). The Properties Solid Source row shows it as its value text; the node
+// card's read-only color chip carries it in its tooltip, because a quantized 8-bit swatch cannot
+// show an out-of-range channel honestly on its own.
+[[nodiscard]] QString exactColorText(core::Color4d color);
+
+// One "Add Solid"/"Add Text" gesture, two entry points (the Timeline's Add menu, the Nodes canvas
+// context menu): same default numbered name derived from the composition's own existing layers,
+// same next built-in reference-linear-sRGB proof color, same single command transaction. Returns
+// what CompositionSession::addSolidLayer()/addTextLayer() returned.
+[[nodiscard]] bool addDefaultSolidLayer(CompositionSession& session);
+[[nodiscard]] bool addDefaultTextLayer(CompositionSession& session);
 
 class TimelineEditor final : public QWidget {
     Q_OBJECT

--- a/src/ui/include/bloom/ui/node_editor.hpp
+++ b/src/ui/include/bloom/ui/node_editor.hpp
@@ -18,6 +18,7 @@ class QKeyEvent;
 class QMenu;
 class QMouseEvent;
 class QPainter;
+class QResizeEvent;
 class QShowEvent;
 class QWheelEvent;
 
@@ -161,6 +162,7 @@ class NodeGraphicsView final : public QGraphicsView {
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
     void showEvent(QShowEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
   private:
     void updatePanCursor();

--- a/src/ui/include/bloom/ui/node_editor.hpp
+++ b/src/ui/include/bloom/ui/node_editor.hpp
@@ -2,11 +2,23 @@
 
 #include <bloom/document/document.hpp>
 #include <bloom/document/ids.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/ui/kit/tokens.hpp>
 
 #include <QGraphicsScene>
 #include <QGraphicsView>
+#include <QPoint>
+#include <QPointF>
+#include <QString>
+#include <QTransform>
 #include <QWidget>
 
+class QContextMenuEvent;
+class QKeyEvent;
+class QMenu;
+class QMouseEvent;
+class QPainter;
+class QShowEvent;
 class QWheelEvent;
 
 namespace bloom::ui {
@@ -16,27 +28,141 @@ class CompositionSession;
 inline constexpr int kNodeItemKindRole = Qt::UserRole + 1;
 inline constexpr int kNodeStableIdRole = Qt::UserRole + 2;
 
+// The typed-connector color mapping (task U4, issue #123, decision 3), keyed by the runtime's own
+// socket kind rather than by a node-editor-local guess at what a wire carries.
+//
+// `runtime::SocketValueKind` has exactly ONE enumerator today -- `Image` -- and
+// docs/architecture/evaluation-primitives.md says so in as many words: "The current `Image` socket
+// is only the first transport kind; semantic role constraints must exist before masks, depth,
+// normals, motion, UV, ID, or arbitrary data images can use it safely." Every port constant in
+// src/document is literally named "image" (kSolidSourceOutputPort, kTextSourceOutputPort,
+// kLayerOutputContentInputPort, kLayerOutputOutputPort, kLayerStackOutputPort,
+// kCompositionOutputInputPort, kCompositionOutputOutputPort), and every edge in a
+// document::CanonicalGraph -- whether its destination is a NodeInputRef or a LayerStackInputRef
+// slot -- carries that one transport.
+//
+// So this is deliberately a ONE-ENTRY mapping, not a speculative palette. Image transport takes
+// `Color::DataImage`, the data-type palette's own image role (docs/ux/visual-language.md). The
+// second transport kind gets its own token the day `SocketValueKind` gains its second enumerator,
+// and this switch is what will refuse to compile until someone makes that decision explicitly.
+//
+// Parameter/object links are NOT colored here because they do not exist as connectors: a
+// document::ParameterRecord binds to a node through a ParameterBinding (a role plus a stable
+// ParameterId), never through a graph edge, and the one "graph-driven value" source the model
+// declares -- document::DriverBindingSource -- is rejected outright by both the project format
+// (project::CanonicalDocumentError::UnsupportedDriverBindingSource) and the runtime snapshot
+// compiler. Drawing a second connector color for a link kind no document can currently contain
+// would be exactly the speculative palette this decision forbids.
+[[nodiscard]] kit::Color socketColorToken(runtime::SocketValueKind kind) noexcept;
+
 class NodeGraphicsScene final : public QGraphicsScene {
     Q_OBJECT
 
   public:
     explicit NodeGraphicsScene(QObject* parent = nullptr);
 
+    // The session in-node field rows read and commit through (decision 5). Null leaves the scene a
+    // pure read-only projection with no editable rows at all -- the shape
+    // kinetik_baseline_tests.cpp constructs directly to assert the canvas background token.
+    void setSession(CompositionSession* session);
+
+    // Reconciles the scene against `snapshot`'s composition IN PLACE: node cards are matched by
+    // their stable NodeId and updated, never dropped and rebuilt, so an in-node kit field keeps its
+    // identity (and its keyboard focus) across the snapshot change that its own edit produced.
+    // Cards for nodes that left the graph are removed; edges, which carry no widget state, are
+    // rebuilt outright each time.
     void setProjection(const document::Snapshot& snapshot, document::CompositionId compositionId);
     [[nodiscard]] QGraphicsItem* findNodeItem(document::NodeId nodeId) const;
 
+    // Test/diagnostic surface only, mirroring ViewerEditor's own *ForTest precedent: an in-node kit
+    // field lives inside a QGraphicsProxyWidget, so it is not a QWidget child of the view and
+    // findChild() cannot reach it.
+    [[nodiscard]] QWidget* nodeFieldForTest(document::NodeId nodeId,
+                                            const QString& fieldObjectName) const;
+
+  protected:
+    void drawBackground(QPainter* painter, const QRectF& rect) override;
+
   private:
     void rebuildEdges(const document::Composition& composition);
+
+    CompositionSession* session_ = nullptr;
 };
 
+// The graph canvas. Its navigation conventions are the Viewer's, deliberately and structurally:
+// the wheel step factor and the zoom bounds are the SAME named constants viewer_editor.hpp
+// publishes (kZoomStepFactor, ViewTransform::kMinZoom/kMaxZoom), so the two canvases cannot drift
+// apart by someone re-spelling a number. Wheel zooms about the cursor, Space-hold + left drag or a
+// middle drag pans, F frames the graph, Z returns to 100% -- one app, one feel (decision 1).
+//
+// QGraphicsView's own transform is what carries zoom and pan underneath, but its SCROLLING is
+// switched off entirely -- both scroll bar policies AlwaysOff, top-left alignment, and a fixed
+// oversized view scene rectangle (see kCanvasHalfExtent in node_editor.cpp) that keeps
+// QGraphicsView's alignment indents and scroll values pinned at zero. The view transform is then
+// the whole mapping: viewportTransform() is exactly it, which is what makes the zoom-about-cursor
+// invariant exact and testable rather than dependent on a scroll bar's clamping behavior.
 class NodeGraphicsView final : public QGraphicsView {
     Q_OBJECT
 
   public:
     explicit NodeGraphicsView(QWidget* parent = nullptr);
 
+    // The current uniform scale: 1.0 is 100%, clamped by construction into the Viewer's own
+    // [ViewTransform::kMinZoom, ViewTransform::kMaxZoom].
+    [[nodiscard]] double zoomFactor() const noexcept;
+
+    // False until the artist zooms or pans; the editor re-frames the graph on a projection rebuild
+    // only while it is false, so a freshly opened panel frames its content and a deliberately
+    // positioned view is never yanked out from under the artist. Fit (F) puts it back to false --
+    // "keep framing everything" -- while 100% (Z), a wheel step, and a pan set it.
+    [[nodiscard]] bool viewAdjusted() const noexcept;
+
+    // The scene point under a viewport point, exactly (no integer rounding): the mapping the
+    // zoom-about-cursor invariant is stated in terms of.
+    [[nodiscard]] QPointF sceneFromViewport(QPointF viewportPoint) const;
+
+    // Scales by `factor` (clamped into the shared zoom bounds) while holding the scene point under
+    // `viewportPoint` fixed.
+    void zoomAboutViewportPoint(QPointF viewportPoint, double factor);
+    // `notches` wheel detents' worth of zoom about the viewport's own center -- the menu's Zoom
+    // In/Out and the keyboard both land here.
+    void zoomStep(int notches);
+    // F: scales and centers so every item fits, clamped into the shared zoom bounds.
+    void frameGraph();
+    // Z: exactly 100%, with the graph's bounding rectangle centered -- the same "actual size,
+    // centered" the Viewer's 100% means.
+    void zoomToActualSize();
+
+  Q_SIGNALS:
+    // Emitted instead of QGraphicsView's default "forward a context menu event into the scene"
+    // behavior, which no item here consumes. `viewportPosition` is in viewport coordinates, so it
+    // feeds itemAt()/mapToGlobal() directly.
+    void contextMenuRequested(const QPoint& viewportPosition);
+
   protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+
+  private:
+    void updatePanCursor();
+    [[nodiscard]] QRectF graphBounds() const;
+    void applyCenteredScale(double scale);
+
+    bool spaceHeld_ = false;
+    bool panActive_ = false;
+    Qt::MouseButton panButton_ = Qt::NoButton;
+    QPointF panOrigin_;
+    // The transform frozen at pan begin: every move applies the TOTAL displacement from the press
+    // point to it, never a chain of already-rounded per-move deltas -- the Viewer's own pan rule.
+    QTransform panBaseTransform_;
+    bool viewAdjusted_ = false;
+    bool framedOnce_ = false;
 };
 
 class NodeGraphEditor final : public QWidget {
@@ -49,10 +175,17 @@ class NodeGraphEditor final : public QWidget {
     [[nodiscard]] NodeGraphicsScene* graphScene() const noexcept;
     [[nodiscard]] NodeGraphicsView* graphView() const noexcept;
 
+    // Test/diagnostic surface only: the exact menu a right-click builds, parented to this widget
+    // and never shown. Lets a test enumerate what the canvas offers -- and, just as importantly,
+    // what it honestly does not.
+    [[nodiscard]] QMenu* contextMenuForTest();
+
   private:
     void rebuild();
     void updateSelection();
     void sceneSelectionChanged();
+    void showContextMenu(const QPoint& viewportPosition);
+    [[nodiscard]] QMenu* buildContextMenu(QWidget* parent);
 
     CompositionSession& session_;
     NodeGraphicsScene* scene_ = nullptr;

--- a/src/ui/include/bloom/ui/node_editor.hpp
+++ b/src/ui/include/bloom/ui/node_editor.hpp
@@ -55,6 +55,16 @@ inline constexpr int kNodeStableIdRole = Qt::UserRole + 2;
 // would be exactly the speculative palette this decision forbids.
 [[nodiscard]] kit::Color socketColorToken(runtime::SocketValueKind kind) noexcept;
 
+// Which ends of a card's header line carry a port dot: an input on the left, an output on the
+// right. Both accumulate from the edges that actually touch the node, so a card in the middle of
+// the chain carries both.
+struct NodeSockets final {
+    bool hasInput = false;
+    bool hasOutput = false;
+
+    friend bool operator==(const NodeSockets&, const NodeSockets&) = default;
+};
+
 class NodeGraphicsScene final : public QGraphicsScene {
     Q_OBJECT
 
@@ -79,6 +89,9 @@ class NodeGraphicsScene final : public QGraphicsScene {
     // findChild() cannot reach it.
     [[nodiscard]] QWidget* nodeFieldForTest(document::NodeId nodeId,
                                             const QString& fieldObjectName) const;
+    // Likewise: the port dots are painted, not separate items, so this is the only way to assert
+    // that a mid-chain card carries BOTH ends rather than only whichever edge was visited last.
+    [[nodiscard]] NodeSockets nodeSocketsForTest(document::NodeId nodeId) const;
 
   protected:
     void drawBackground(QPainter* painter, const QRectF& rect) override;

--- a/src/ui/include/bloom/ui/node_editor.hpp
+++ b/src/ui/include/bloom/ui/node_editor.hpp
@@ -167,7 +167,9 @@ class NodeGraphicsView final : public QGraphicsView {
   private:
     void updatePanCursor();
     [[nodiscard]] QRectF graphBounds() const;
-    void applyCenteredScale(double scale);
+    // False when there is nothing to frame -- an empty graph, or a viewport with no area --
+    // in which case the caller must not latch any "the artist moved the view" state.
+    [[nodiscard]] bool applyCenteredScale(double scale);
 
     bool spaceHeld_ = false;
     bool panActive_ = false;

--- a/src/ui/include/bloom/ui/viewer_editor.hpp
+++ b/src/ui/include/bloom/ui/viewer_editor.hpp
@@ -50,6 +50,13 @@ class CompositionPreviewController;
 // actualPixelRect() about its own center and `pan` translates the result in screen pixels. `pan` is
 // meaningless while `fitToWindow` is true and is always {0, 0} there by construction (see
 // setFit()/materializeZoom() in viewer_editor.cpp).
+// One wheel notch, or one Zoom In/Out menu action: the current effective zoom multiplied by this
+// factor and clamped into [ViewTransform::kMinZoom, ViewTransform::kMaxZoom]. Published here rather
+// than kept file-local to viewer_editor.cpp (task U4, issue #123, decision 1) because the Nodes
+// canvas must step by exactly the same amount for an artist to feel one application; sharing the
+// constant makes that structurally true instead of a number two files happen to agree on.
+inline constexpr double kZoomStepFactor = 1.1;
+
 struct ViewTransform final {
     static constexpr double kMinZoom = 1.0 / 16.0;
     static constexpr double kMaxZoom = 16.0;

--- a/src/ui/node_editor.cpp
+++ b/src/ui/node_editor.cpp
@@ -426,9 +426,20 @@ class NodeItem final : public QGraphicsObject {
         if (fieldsBuilt_ && roles == builtRoles_) {
             return;
         }
+        // Detached from the card, taken out of the scene (an item whose parent is cleared stays in
+        // the scene as a top-level item and would keep painting), then deferred-deleted: this can
+        // in principle run while one of these very widgets is emitting, so nothing is destroyed
+        // under a live stack frame.
         for (auto* child : childItems()) {
             child->setParentItem(nullptr);
-            delete child;
+            if (scene() != nullptr) {
+                scene()->removeItem(child);
+            }
+            if (auto* object = child->toGraphicsObject()) {
+                object->deleteLater();
+            } else {
+                delete child;
+            }
         }
         valueRows_.clear();
         readOnlyRows_.clear();

--- a/src/ui/node_editor.cpp
+++ b/src/ui/node_editor.cpp
@@ -33,6 +33,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QPen>
+#include <QResizeEvent>
 #include <QShowEvent>
 #include <QSignalBlocker>
 #include <QStyleOptionGraphicsItem>
@@ -1082,6 +1083,17 @@ void NodeGraphicsView::zoomToActualSize() {
 void NodeGraphicsView::showEvent(QShowEvent* event) {
     QGraphicsView::showEvent(event);
     if (!framedOnce_ && !viewAdjusted_) {
+        frameGraph();
+    }
+}
+
+void NodeGraphicsView::resizeEvent(QResizeEvent* event) {
+    QGraphicsView::resizeEvent(event);
+    // The Viewer's Fit recomputes its rectangle from the available area on every paint, so a
+    // resized Viewer stays fitted. This canvas keeps that behavior for the same state: while the
+    // artist has not moved the view, a resize re-frames the graph. Once they have, the view is
+    // theirs and a resize leaves it exactly where they put it.
+    if (!viewAdjusted_) {
         frameGraph();
     }
 }

--- a/src/ui/node_editor.cpp
+++ b/src/ui/node_editor.cpp
@@ -326,7 +326,16 @@ class NodeItem final : public QGraphicsObject {
         return nullptr;
     }
 
-    [[nodiscard]] QRectF boundingRect() const override { return {0.0, 0.0, width_, height_}; }
+    // The card's own rectangle. The port dots are centered ON its left and right edges, so half of
+    // each dot lies outside it -- boundingRect() below adds that overhang, because a QGraphicsItem
+    // that paints outside its bounding rectangle leaves trails behind it and gets clipped out of
+    // itemsBoundingRect() (which is what Fit frames against).
+    [[nodiscard]] QRectF cardRect() const { return {0.0, 0.0, width_, height_}; }
+
+    [[nodiscard]] QRectF boundingRect() const override {
+        const qreal overhang = kSocketDiameter / 2.0 + kit::kHairlineWidth;
+        return cardRect().adjusted(-overhang, 0.0, overhang, 0.0);
+    }
 
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget*) override;
 
@@ -584,10 +593,12 @@ class NodeItem final : public QGraphicsObject {
         const qreal width =
             std::max({kCardMinimumWidth, 2.0 * kCardPadding + contentWidth,
                       2.0 * kCardPadding + headerMetrics.horizontalAdvance(title_)});
+        // A card with no parameter rows is exactly its header: no empty body lip below it, which
+        // would read as a clipped row rather than as a node that simply has nothing to edit.
         const qreal height =
             kCardHeaderHeight +
             (rowCount > 0.0 ? rowCount * (rowHeight + kCardRowGap) - kCardRowGap + kCardPadding
-                            : kCardPadding);
+                            : 0.0);
 
         if (!qFuzzyCompare(width, width_) || !qFuzzyCompare(height, height_)) {
             prepareGeometryChange();
@@ -704,7 +715,7 @@ class NodeEdgeItem final : public QGraphicsPathItem {
 };
 
 void NodeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget*) {
-    const QRectF bounds = boundingRect();
+    const QRectF bounds = cardRect();
     const bool selected = option->state.testFlag(QStyle::State_Selected);
     painter->setRenderHint(QPainter::Antialiasing, true);
 
@@ -723,6 +734,11 @@ void NodeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, 
     // The header strip: one step down the surface ladder from the card so it reads as chrome, with
     // its own hairline foot rather than a second rounded rectangle.
     QPainterPath header;
+    // Winding, not QPainterPath's default odd-even rule: the header is a rounded rectangle UNION a
+    // square strip that squares off its bottom corners, and the two subpaths overlap. Under
+    // odd-even the overlap cancels and the strip is left unpainted -- a dark band across the bottom
+    // of every header, which is exactly what the pre-U4 projection drew.
+    header.setFillRule(Qt::WindingFill);
     const auto headerRadius = static_cast<qreal>(
         kit::radiusPx(kCardRadius, static_cast<int>(std::min(bounds.width(), kCardHeaderHeight))));
     header.addRoundedRect(QRectF(0.0, 0.0, bounds.width(), kCardHeaderHeight), headerRadius,

--- a/src/ui/node_editor.cpp
+++ b/src/ui/node_editor.cpp
@@ -276,13 +276,34 @@ class NodeItem final : public QGraphicsObject {
         relayout();
     }
 
-    void setSockets(const bool hasInput, const bool hasOutput) {
-        if (hasInput != hasInputSocket_ || hasOutput != hasOutputSocket_) {
-            hasInputSocket_ = hasInput;
-            hasOutputSocket_ = hasOutput;
+    // Sockets ACCUMULATE across the edges that touch this card, and are cleared once per
+    // projection. A node in the middle of the chain -- a layer output, the layer stack -- is both
+    // an edge source and an edge destination, so a setter that assigned both flags at once would
+    // let whichever edge happened to be visited last erase the other end's dot.
+    void clearSockets() {
+        if (hasInputSocket_ || hasOutputSocket_) {
+            hasInputSocket_ = false;
+            hasOutputSocket_ = false;
             update();
         }
     }
+
+    void markInputSocket() {
+        if (!hasInputSocket_) {
+            hasInputSocket_ = true;
+            update();
+        }
+    }
+
+    void markOutputSocket() {
+        if (!hasOutputSocket_) {
+            hasOutputSocket_ = true;
+            update();
+        }
+    }
+
+    [[nodiscard]] bool hasInputSocket() const noexcept { return hasInputSocket_; }
+    [[nodiscard]] bool hasOutputSocket() const noexcept { return hasOutputSocket_; }
 
     [[nodiscard]] QPointF inputAnchor() const {
         return mapToScene(QPointF(0.0, kCardHeaderHeight / 2.0));
@@ -866,7 +887,7 @@ void NodeGraphicsScene::setProjection(const document::Snapshot& snapshot,
     }
     for (const auto& [id, item] : existing) {
         item->clearEdges();
-        item->setSockets(false, false);
+        item->clearSockets();
     }
 
     std::array<int, 4> rows{};
@@ -924,6 +945,12 @@ QWidget* NodeGraphicsScene::nodeFieldForTest(const document::NodeId nodeId,
     return item == nullptr ? nullptr : item->fieldWidget(fieldObjectName);
 }
 
+NodeSockets NodeGraphicsScene::nodeSocketsForTest(const document::NodeId nodeId) const {
+    const auto* item = dynamic_cast<const NodeItem*>(findNodeItem(nodeId));
+    return item == nullptr ? NodeSockets{}
+                           : NodeSockets{item->hasInputSocket(), item->hasOutputSocket()};
+}
+
 void NodeGraphicsScene::rebuildEdges(const document::Composition& composition) {
     for (const auto& edge : composition.graph().edges()) {
         auto* source = dynamic_cast<NodeItem*>(findNodeItem(edge.source.nodeId));
@@ -931,8 +958,8 @@ void NodeGraphicsScene::rebuildEdges(const document::Composition& composition) {
             dynamic_cast<NodeItem*>(findNodeItem(destinationNodeId(edge.destination)));
         if (source != nullptr && destination != nullptr) {
             addItem(new NodeEdgeItem(*source, *destination));
-            source->setSockets(false, true);
-            destination->setSockets(true, false);
+            source->markOutputSocket();
+            destination->markInputSocket();
         }
     }
 }

--- a/src/ui/node_editor.cpp
+++ b/src/ui/node_editor.cpp
@@ -33,6 +33,7 @@
 #include <QPainter>
 #include <QPainterPath>
 #include <QPen>
+#include <QPointer>
 #include <QResizeEvent>
 #include <QShowEvent>
 #include <QSignalBlocker>
@@ -1059,17 +1060,18 @@ QRectF NodeGraphicsView::graphBounds() const {
     return scene() == nullptr ? QRectF() : scene()->itemsBoundingRect();
 }
 
-void NodeGraphicsView::applyCenteredScale(const double scale) {
+bool NodeGraphicsView::applyCenteredScale(const double scale) {
     const QRectF bounds = graphBounds();
     const QRectF view = QRectF(viewport()->rect());
     if (bounds.isEmpty() || view.isEmpty()) {
-        return;
+        return false;
     }
     const double clamped = std::clamp(scale, ViewTransform::kMinZoom, ViewTransform::kMaxZoom);
     QTransform framed = QTransform::fromTranslate(-bounds.center().x(), -bounds.center().y());
     framed *= QTransform::fromScale(clamped, clamped);
     framed *= QTransform::fromTranslate(view.center().x(), view.center().y());
     setTransform(framed);
+    return true;
 }
 
 void NodeGraphicsView::frameGraph() {
@@ -1078,7 +1080,10 @@ void NodeGraphicsView::frameGraph() {
     if (bounds.isEmpty() || view.isEmpty()) {
         return;
     }
-    applyCenteredScale(std::min(view.width() / bounds.width(), view.height() / bounds.height()));
+    if (!applyCenteredScale(
+            std::min(view.width() / bounds.width(), view.height() / bounds.height()))) {
+        return;
+    }
     // Fit means "keep framing everything": a later projection rebuild re-frames until the artist
     // moves the view themselves.
     viewAdjusted_ = false;
@@ -1086,7 +1091,13 @@ void NodeGraphicsView::frameGraph() {
 }
 
 void NodeGraphicsView::zoomToActualSize() {
-    applyCenteredScale(1.0);
+    // A gesture that could not move the view does not count as the artist having taken the view
+    // over. Latching the flag on an empty canvas -- no composition, or a collapsed panel -- would
+    // permanently stop the auto-framing that a rebuild and a resize depend on, and the canvas would
+    // never frame the content that arrived afterwards.
+    if (!applyCenteredScale(1.0)) {
+        return;
+    }
     viewAdjusted_ = true;
     framedOnce_ = true;
 }
@@ -1119,6 +1130,12 @@ void NodeGraphicsView::wheelEvent(QWheelEvent* event) {
         event->ignore();
         return;
     }
+    // The wheel ALWAYS zooms the canvas, including over an in-node field. The canvas's
+    // zoom-about-cursor rule is decision 1's contract and an artist reaching for the wheel over a
+    // dense graph means "zoom" every time; a field that silently ate the gesture because it
+    // happened to hold focus would make the canvas feel broken in exactly the places it is densest.
+    // The field loses nothing it needs: its own steppers, and Up/Down/PageUp/PageDown while
+    // focused (kit/value_field.cpp), still step it.
     const int notches = event->angleDelta().y() / kWheelDetent;
     if (notches == 0) {
         QGraphicsView::wheelEvent(event);
@@ -1356,9 +1373,15 @@ void NodeGraphEditor::showContextMenu(const QPoint& viewportPosition) {
     if (auto* node = nodeItemAncestor(view_->itemAt(viewportPosition))) {
         session_.selectNode(node->id());
     }
-    auto* menu = buildContextMenu(view_);
+    // QPointer, because exec() runs a nested event loop: anything that closed this panel from
+    // inside the menu would take the menu (its child) with it, and the cleanup below would then be
+    // touching freed memory. Nothing the menu currently offers can do that; the guard is what keeps
+    // that true when something later can.
+    const QPointer<QMenu> menu = buildContextMenu(view_);
     menu->exec(view_->viewport()->mapToGlobal(viewportPosition));
-    menu->deleteLater();
+    if (!menu.isNull()) {
+        menu->deleteLater();
+    }
 }
 
 } // namespace bloom::ui

--- a/src/ui/node_editor.cpp
+++ b/src/ui/node_editor.cpp
@@ -1,21 +1,40 @@
 #include <bloom/ui/node_editor.hpp>
 
+#include <bloom/ui/composition_editors.hpp>
 #include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/viewer_editor.hpp>
+
+#include <bloom/ui/kit/color.hpp>
+#include <bloom/ui/kit/color_chip.hpp>
+#include <bloom/ui/kit/painting.hpp>
 #include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/kit/value_field.hpp>
 
 #include <bloom/core/color.hpp>
 #include <bloom/document/graph.hpp>
 #include <bloom/document/parameter.hpp>
 #include <bloom/document/project.hpp>
 
+#include <QAction>
 #include <QBrush>
 #include <QColor>
+#include <QContextMenuEvent>
+#include <QFontMetricsF>
+#include <QGraphicsDropShadowEffect>
 #include <QGraphicsObject>
 #include <QGraphicsPathItem>
+#include <QGraphicsProxyWidget>
+#include <QGraphicsSceneHoverEvent>
+#include <QGraphicsSceneMouseEvent>
 #include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPen>
+#include <QShowEvent>
+#include <QSignalBlocker>
 #include <QStyleOptionGraphicsItem>
 #include <QVariant>
 #include <QWheelEvent>
@@ -24,8 +43,9 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
-#include <limits>
 #include <map>
+#include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <variant>
@@ -34,12 +54,63 @@
 namespace bloom::ui {
 namespace {
 
-constexpr qreal kNodeWidth = 190.0;
-constexpr qreal kNodeHeaderHeight = 30.0;
-constexpr qreal kNodeRowHeight = 22.0;
-// The node card's corner, in the graph's own coordinates: Radius::Medium in design pixels, applied
-// at 1x -- the view's zoom scales it along with everything else.
-constexpr auto kNodeCornerRadius = static_cast<qreal>(kit::Radius::Medium);
+// --- Card geometry, entirely from tokens -------------------------------------------------------
+//
+// These are graph-space lengths in design pixels applied at 1x; the view's own zoom scales the
+// whole card along with everything else, so a token spelled here reads exactly as it would in a
+// widget at 100%.
+constexpr qreal kCardPadding = kit::px(kit::Spacing::S);
+constexpr qreal kCardLabelGap = kit::px(kit::Spacing::S);
+constexpr qreal kCardRowGap = kit::px(kit::Spacing::XXS);
+constexpr qreal kCardHeaderHeight = kit::px(kit::Size::PanelHeader);
+constexpr auto kCardRadius = kit::Radius::Medium;
+// The narrowest a card is ever drawn: four roomy controls' worth, so a parameterless node still
+// reads as a card rather than as a label with a border.
+constexpr qreal kCardMinimumWidth = kit::px(kit::Size::ControlRoomy) * 4;
+// The port dot's diameter; its center sits on the header's own mid-line, at the card's left edge
+// for an input and its right edge for an output.
+constexpr qreal kSocketDiameter = kit::px(kit::Spacing::S);
+// Dot-grid pitch, and the smallest on-screen pitch worth drawing at: below it the grid stops being
+// a texture and starts being noise (and a pointless number of ellipses).
+constexpr qreal kGridSpacing = kit::px(kit::Spacing::XXL);
+constexpr qreal kGridMinimumDeviceSpacing = kit::px(kit::Spacing::M);
+constexpr qreal kGridDotRadius = kit::kHairlineWidth;
+// Selection is the 2px inset Accent edge docs/ux/visual-language.md's States table specifies for
+// the case where a full Accent fill would hide content -- the same edge the timeline's track rows
+// and the previous node projection already used.
+constexpr qreal kSelectionEdgeWidth = 2.0;
+
+// Default placement for a card the artist has never moved: four columns (source, layer output,
+// layer stack, composition output), each pitch wide enough that a widest-case card still leaves a
+// visible gutter, and a row pitch taller than the tallest card a layer boundary can produce. A card
+// the artist HAS moved keeps its own position across every projection rebuild.
+constexpr qreal kNodeColumnOrigin = kit::px(kit::Spacing::XXL);
+constexpr qreal kNodeColumnPitch = kCardMinimumWidth + kit::px(kit::Spacing::XXL) * 4;
+constexpr qreal kNodeRowPitch = kit::px(kit::Size::PanelHeader) * 6;
+constexpr qreal kNodeSceneMargin = kit::px(kit::Spacing::XXL) * 2;
+
+// The VIEW's own scrolling area, fixed and deliberately far larger than any graph or any display.
+//
+// This exists to make the canvas's mapping exact. QGraphicsView derives its viewport transform from
+// the view transform PLUS a scroll offset, and that offset is not always zero: when the scene
+// rectangle maps to something smaller than the viewport, QGraphicsView silently "indents" it to
+// honor the view's alignment, which would quietly override a centered Fit and break the
+// zoom-about-cursor invariant. Pinning the view's scene rectangle to a region that always maps
+// LARGER than any viewport removes that branch entirely: the indents are always zero, the scroll
+// bar values stay inside their range at 0, and viewportTransform() is exactly the view transform.
+//
+// "Always larger" is a real quantity, not a guess: at the smallest zoom the shared bounds allow
+// (ViewTransform::kMinZoom), this half-extent still maps to kNodeColumnPitch * 1024 / 16 = more
+// than twenty thousand device pixels on each side of the origin -- larger than any display, and
+// larger than any graph the four-column default layout can produce.
+constexpr qreal kCanvasHalfExtent = kNodeColumnPitch * 1024;
+
+// A wheel detent, in QWheelEvent::angleDelta() eighth-of-a-degree units. Exactly the divisor
+// ViewerEditor::wheelEvent() uses, so one notch means one step on both canvases.
+constexpr int kWheelDetent = 120;
+
+class NodeEdgeItem;
+class NodeItem;
 
 QString displayTypeName(const std::string_view typeId) {
     QString name = QString::fromUtf8(typeId.data(), static_cast<qsizetype>(typeId.size()));
@@ -53,12 +124,34 @@ QString displayTypeName(const std::string_view typeId) {
     return name;
 }
 
+// A layer boundary node's display name is the layer's own durable name (the exact string the
+// timeline row shows); every other node is named by its type. Both are the node's real name, read
+// from document truth -- neither is invented here.
+QString nodeDisplayName(const document::Composition& composition,
+                        const document::NodeRecord& node) {
+    for (const auto& boundary : composition.graph().layerOutputs()) {
+        if (boundary.nodeId == node.id && !boundary.name.empty()) {
+            return QString::fromStdString(boundary.name);
+        }
+    }
+    return displayTypeName(node.typeId);
+}
+
+const document::ParameterRecord* parameterForRole(const document::NodeRecord& node,
+                                                  const document::Composition& composition,
+                                                  const std::string_view role) {
+    const auto binding = std::ranges::find_if(
+        node.parameters, [role](const auto& candidate) { return candidate.role == role; });
+    return binding == node.parameters.end() ? nullptr
+                                            : composition.parameters().find(binding->parameterId);
+}
+
+// The read-only rendering for a bound parameter that has no editable kit primitive behind it (see
+// NodeItem::ensureFields()). Unchanged from the pre-U4 projection.
 QString parameterText(const document::ParameterRecord& parameter) {
     const auto* constant = std::get_if<document::ConstantValueSource>(&parameter.source);
     if (constant == nullptr) {
-        return std::holds_alternative<document::AnimationCurveSource>(parameter.source)
-                   ? QStringLiteral("Animated")
-                   : QStringLiteral("Driven");
+        return parameterSourceDescription(parameter);
     }
 
     return std::visit(
@@ -73,14 +166,7 @@ QString parameterText(const document::ParameterRecord& parameter) {
             } else if constexpr (std::is_same_v<Value, document::Vec2d>) {
                 return QStringLiteral("%1, %2").arg(value.x, 0, 'f', 1).arg(value.y, 0, 'f', 1);
             } else if constexpr (std::is_same_v<Value, core::Color4d>) {
-                return QStringLiteral("RGBA %1, %2, %3, %4")
-                    .arg(QString::number(value.red, 'g', std::numeric_limits<double>::max_digits10))
-                    .arg(QString::number(value.green, 'g',
-                                         std::numeric_limits<double>::max_digits10))
-                    .arg(
-                        QString::number(value.blue, 'g', std::numeric_limits<double>::max_digits10))
-                    .arg(QString::number(value.alpha, 'g',
-                                         std::numeric_limits<double>::max_digits10));
+                return exactColorText(value);
             } else if constexpr (std::is_same_v<Value, std::string>) {
                 return QString::fromStdString(value).left(24);
             } else {
@@ -88,142 +174,6 @@ QString parameterText(const document::ParameterRecord& parameter) {
             }
         },
         constant->value);
-}
-
-class NodeEdgeItem;
-
-class NodeItem final : public QGraphicsObject {
-  public:
-    NodeItem(const document::NodeRecord& node, const document::ParameterStore& parameters)
-        : id_(node.id), title_(displayTypeName(node.typeId)) {
-        setData(kNodeItemKindRole, QStringLiteral("node"));
-        setData(kNodeStableIdRole, QVariant::fromValue<qulonglong>(node.id.value()));
-        setFlags(ItemIsMovable | ItemIsSelectable | ItemSendsGeometryChanges);
-        setCursor(Qt::OpenHandCursor);
-        setToolTip(QStringLiteral("%1\nNode %2").arg(title_).arg(node.id.value()));
-
-        parameterRows_.reserve(node.parameters.size());
-        for (const auto& binding : node.parameters) {
-            const auto* parameter = parameters.find(binding.parameterId);
-            if (parameter != nullptr) {
-                parameterRows_.push_back(
-                    {QString::fromStdString(binding.role), parameterText(*parameter)});
-            }
-        }
-    }
-
-    [[nodiscard]] QRectF boundingRect() const override {
-        const auto rowCount = std::max<std::size_t>(parameterRows_.size(), 1);
-        return {0.0, 0.0, kNodeWidth,
-                kNodeHeaderHeight + kNodeRowHeight * static_cast<qreal>(rowCount) + 10.0};
-    }
-
-    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget*) override {
-        const QRectF bounds = boundingRect();
-        const bool selected = option->state.testFlag(QStyle::State_Selected);
-        // Selection is a 2px inset accent edge, exactly as the States token says; unselected nodes
-        // carry the hover-weight border because a hairline Border on Background would vanish at
-        // graph zoom levels.
-        const QColor border =
-            selected ? kit::color(kit::Color::Accent) : kit::color(kit::Color::BorderHover);
-        painter->setRenderHint(QPainter::Antialiasing);
-        painter->setPen(QPen(border, selected ? 2.0 : 1.0));
-        painter->setBrush(kit::color(kit::Color::SurfaceRaised));
-        painter->drawRoundedRect(bounds, kNodeCornerRadius, kNodeCornerRadius);
-
-        QPainterPath header;
-        header.addRoundedRect(QRectF(0.0, 0.0, bounds.width(), kNodeHeaderHeight),
-                              kNodeCornerRadius, kNodeCornerRadius);
-        header.addRect(
-            QRectF(0.0, kNodeHeaderHeight - kNodeCornerRadius, bounds.width(), kNodeCornerRadius));
-        painter->fillPath(header, kit::color(kit::Color::Field));
-
-        painter->setPen(kit::color(kit::Color::Foreground));
-        painter->drawText(QRectF(12.0, 0.0, bounds.width() - 24.0, kNodeHeaderHeight),
-                          Qt::AlignVCenter | Qt::AlignLeft, title_);
-
-        if (parameterRows_.empty()) {
-            painter->setPen(kit::color(kit::Color::Faint));
-            painter->drawText(
-                QRectF(12.0, kNodeHeaderHeight, bounds.width() - 24.0, kNodeRowHeight + 10.0),
-                Qt::AlignCenter, QStringLiteral("No exposed parameters"));
-            return;
-        }
-
-        qreal y = kNodeHeaderHeight + 5.0;
-        for (const auto& [role, value] : parameterRows_) {
-            painter->setPen(kit::color(kit::Color::Muted));
-            painter->drawText(QRectF(12.0, y, bounds.width() * 0.54, kNodeRowHeight),
-                              Qt::AlignVCenter | Qt::AlignLeft, role);
-            painter->setPen(kit::color(kit::Color::Foreground));
-            painter->drawText(
-                QRectF(bounds.width() * 0.52, y, bounds.width() * 0.42 - 12.0, kNodeRowHeight),
-                Qt::AlignVCenter | Qt::AlignRight, value);
-            y += kNodeRowHeight;
-        }
-    }
-
-    [[nodiscard]] document::NodeId id() const noexcept { return id_; }
-    void addEdge(NodeEdgeItem& edge) { edges_.push_back(&edge); }
-
-  protected:
-    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
-
-  private:
-    document::NodeId id_;
-    QString title_;
-    std::vector<std::pair<QString, QString>> parameterRows_;
-    std::vector<NodeEdgeItem*> edges_;
-};
-
-class NodeEdgeItem final : public QGraphicsPathItem {
-  public:
-    NodeEdgeItem(NodeItem& source, NodeItem& destination)
-        : source_(source), destination_(destination) {
-        setZValue(-1.0);
-        setPen(
-            QPen(kit::color(kit::Color::Accent), 2.0, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-        source_.addEdge(*this);
-        destination_.addEdge(*this);
-        updatePath();
-    }
-
-    void updatePath() {
-        const QPointF sourcePoint = source_.mapToScene(source_.boundingRect().center());
-        const QPointF destinationPoint =
-            destination_.mapToScene(destination_.boundingRect().center());
-        const QPointF start(source_.mapToScene(source_.boundingRect().topRight()).x(),
-                            sourcePoint.y());
-        const QPointF end(destination_.mapToScene(destination_.boundingRect().topLeft()).x(),
-                          destinationPoint.y());
-        const qreal handle = std::max<qreal>(60.0, std::abs(end.x() - start.x()) * 0.48);
-
-        QPainterPath curve(start);
-        curve.cubicTo(start + QPointF(handle, 0.0), end - QPointF(handle, 0.0), end);
-        setPath(curve);
-    }
-
-  private:
-    NodeItem& source_;
-    NodeItem& destination_;
-};
-
-QVariant NodeItem::itemChange(const GraphicsItemChange change, const QVariant& value) {
-    if (change == ItemPositionHasChanged) {
-        for (auto* edge : edges_) {
-            edge->updatePath();
-        }
-    }
-    return QGraphicsObject::itemChange(change, value);
-}
-
-NodeItem* nodeItem(const QList<QGraphicsItem*>& items) {
-    for (auto* item : items) {
-        if (auto* node = dynamic_cast<NodeItem*>(item)) {
-            return node;
-        }
-    }
-    return nullptr;
 }
 
 document::NodeId destinationNodeId(const document::InputPortRef& input) {
@@ -252,7 +202,603 @@ std::size_t layoutColumn(const document::NodeRecord& node) {
     return 0;
 }
 
+// A kit numeric cell sized for a node card: no internal label column (KValueField's own is a fixed
+// 72px meant for a Properties-style row), because the card paints the row's name itself in a column
+// shared by every row.
+kit::KValueField* makeCardField(const QString& objectName, const QString& accessibleName,
+                                const double minimum, const double maximum, const int decimals,
+                                const QString& unit) {
+    auto* field = new kit::KValueField;
+    field->setObjectName(objectName);
+    field->setAccessibleName(accessibleName);
+    field->setRange(minimum, maximum);
+    field->setDecimals(decimals);
+    field->setSingleStep(1.0);
+    field->setUnit(unit);
+    field->resize(field->sizeHint());
+    return field;
+}
+
 } // namespace
+
+kit::Color socketColorToken(const runtime::SocketValueKind kind) noexcept {
+    switch (kind) {
+    case runtime::SocketValueKind::Image:
+        return kit::Color::DataImage;
+    }
+    return kit::Color::DataImage;
+}
+
+namespace {
+
+// The one transport kind any edge in a document::CanonicalGraph can carry today; see
+// socketColorToken()'s own comment in node_editor.hpp for why there is exactly one.
+constexpr auto kGraphTransportKind = runtime::SocketValueKind::Image;
+
+class NodeItem final : public QGraphicsObject {
+  public:
+    NodeItem(const document::NodeId id, CompositionSession* session) : id_(id), session_(session) {
+        setData(kNodeItemKindRole, QStringLiteral("node"));
+        setData(kNodeStableIdRole, QVariant::fromValue<qulonglong>(id.value()));
+        setFlags(ItemIsMovable | ItemIsSelectable | ItemSendsGeometryChanges);
+        setCursor(Qt::OpenHandCursor);
+
+        // Elevation on drag (decision 2). kit::applyElevation() takes a QWidget, and a node card is
+        // a QGraphicsItem, so the token's own offset/blur/color are read here and handed to the
+        // same QGraphicsDropShadowEffect that helper installs -- no literal shadow of its own. The
+        // effect exists for the item's lifetime and is only ENABLED while a drag is in flight, so a
+        // resting card pays nothing for it.
+        const kit::Shadow token = kit::shadow(kit::Elevation::Drag);
+        if (!token.isFlat()) {
+            auto* shadow = new QGraphicsDropShadowEffect;
+            shadow->setOffset(token.offsetX, token.offsetY);
+            shadow->setBlurRadius(token.blurRadius);
+            shadow->setColor(token.color);
+            shadow->setEnabled(false);
+            setGraphicsEffect(shadow);
+            dragShadow_ = shadow;
+        }
+    }
+
+    [[nodiscard]] document::NodeId id() const noexcept { return id_; }
+
+    // Reconciles this card against the node record IN PLACE. Field widgets are created once, on the
+    // first refresh that sees a given set of parameter roles, and afterwards only reconfigured --
+    // exactly the discipline PropertiesEditor::rebuild() already follows, and what lets a card's
+    // own field survive the snapshot change its edit produced.
+    void refresh(const document::NodeRecord& node, const document::Composition& composition) {
+        title_ = nodeDisplayName(composition, node);
+        setToolTip(QStringLiteral("%1\n%2\nNode %3")
+                       .arg(title_, displayTypeName(node.typeId))
+                       .arg(id_.value()));
+        ensureFields(node);
+        refreshValues(node, composition);
+        relayout();
+    }
+
+    void setSockets(const bool hasInput, const bool hasOutput) {
+        if (hasInput != hasInputSocket_ || hasOutput != hasOutputSocket_) {
+            hasInputSocket_ = hasInput;
+            hasOutputSocket_ = hasOutput;
+            update();
+        }
+    }
+
+    [[nodiscard]] QPointF inputAnchor() const {
+        return mapToScene(QPointF(0.0, kCardHeaderHeight / 2.0));
+    }
+    [[nodiscard]] QPointF outputAnchor() const {
+        return mapToScene(QPointF(width_, kCardHeaderHeight / 2.0));
+    }
+
+    void addEdge(NodeEdgeItem& edge) { edges_.push_back(&edge); }
+    void clearEdges() { edges_.clear(); }
+
+    [[nodiscard]] QWidget* fieldWidget(const QString& objectName) const {
+        for (const auto* child : childItems()) {
+            const auto* proxy = qgraphicsitem_cast<const QGraphicsProxyWidget*>(child);
+            if (proxy != nullptr && proxy->widget() != nullptr &&
+                proxy->widget()->objectName() == objectName) {
+                return proxy->widget();
+            }
+        }
+        return nullptr;
+    }
+
+    [[nodiscard]] QRectF boundingRect() const override { return {0.0, 0.0, width_, height_}; }
+
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget*) override;
+
+  protected:
+    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
+
+    void mousePressEvent(QGraphicsSceneMouseEvent* event) override {
+        if (dragShadow_ != nullptr) {
+            dragShadow_->setEnabled(true);
+        }
+        QGraphicsObject::mousePressEvent(event);
+    }
+
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override {
+        if (dragShadow_ != nullptr) {
+            dragShadow_->setEnabled(false);
+        }
+        QGraphicsObject::mouseReleaseEvent(event);
+    }
+
+  private:
+    struct ValueRow final {
+        QString label;
+        kit::KValueField* field = nullptr;
+    };
+
+    // Selects THIS node through the session's one selection truth before any edit, because every
+    // session write path this card uses (setSelectedPosition/setSelectedOpacity) targets the
+    // session's current selection -- the same functions, on the same parameters, that
+    // PropertiesEditor calls. Returns false if the node is no longer selectable, in which case no
+    // command is issued at all.
+    [[nodiscard]] bool selectSelf() {
+        if (session_ == nullptr) {
+            return false;
+        }
+        session_->selectNode(id_);
+        const auto* selected = std::get_if<document::NodeId>(&session_->selection().primary);
+        return selected != nullptr && *selected == id_;
+    }
+
+    void commitPosition() {
+        if (refreshing_ || positionX_ == nullptr || positionY_ == nullptr || !selectSelf()) {
+            return;
+        }
+        // Both components in one call, exactly as PropertiesEditor's own commitPosition lambda
+        // does: one gesture is one SetParameterSource/SetKeyframeAtTime transaction, so it is one
+        // undo step.
+        (void)session_->setSelectedPosition(positionX_->value(), positionY_->value());
+    }
+
+    void commitOpacity() {
+        if (refreshing_ || opacity_ == nullptr || !selectSelf()) {
+            return;
+        }
+        (void)session_->setSelectedOpacity(opacity_->value() / 100.0);
+    }
+
+    void addProxy(QWidget* widget) {
+        auto* proxy = new QGraphicsProxyWidget(this);
+        proxy->setWidget(widget);
+    }
+
+    // Builds the card's rows once per role set. Editable rows exist only for roles that have BOTH a
+    // kit primitive able to carry the value AND an existing session/command path able to write it
+    // (decision 5's honesty rule):
+    //
+    //   position -> two KValueFields (X, Y), committed through
+    //               CompositionSession::setSelectedPosition()
+    //   opacity  -> one KValueField, committed through CompositionSession::setSelectedOpacity()
+    //   color    -> a READ-ONLY KColorChip. There is no color write path anywhere: the whole
+    //               command layer is AddSolidLayer, AddTextLayer, SetProjectName,
+    //               SetCompositionName, SetCompositionDuration, SetCompositionFormat,
+    //               SetParameterSource, MoveLayerBefore plus the animation operations, and
+    //               CompositionSession exposes no color mutator at all -- PropertiesEditor's own
+    //               Solid Source row is read-only text for exactly this reason. An enabled chip
+    //               would open a picker whose result nothing could commit.
+    //   anything else (text today) -> a painted read-only value row, because KValueField cannot
+    //               carry a string and no command sets one after layer creation.
+    void ensureFields(const document::NodeRecord& node) {
+        std::vector<std::string> roles;
+        roles.reserve(node.parameters.size());
+        for (const auto& binding : node.parameters) {
+            roles.push_back(binding.role);
+        }
+        if (fieldsBuilt_ && roles == builtRoles_) {
+            return;
+        }
+        for (auto* child : childItems()) {
+            child->setParentItem(nullptr);
+            delete child;
+        }
+        valueRows_.clear();
+        readOnlyRows_.clear();
+        positionX_ = nullptr;
+        positionY_ = nullptr;
+        opacity_ = nullptr;
+        colorChip_ = nullptr;
+        colorRowLabel_.clear();
+
+        for (const auto& role : roles) {
+            if (role == document::kPositionParameterRole) {
+                // Range/decimals/step/unit mirror PropertiesEditor's Position editors verbatim, so
+                // the same gesture in either surface produces the same value.
+                positionX_ = makeCardField(QStringLiteral("nodePositionXEditor"), tr("Position X"),
+                                           -1'000'000.0, 1'000'000.0, 2, QStringLiteral("px"));
+                positionY_ = makeCardField(QStringLiteral("nodePositionYEditor"), tr("Position Y"),
+                                           -1'000'000.0, 1'000'000.0, 2, QStringLiteral("px"));
+                addProxy(positionX_);
+                addProxy(positionY_);
+                connect(positionX_, &kit::KValueField::valueChanged, this,
+                        [this] { commitPosition(); });
+                connect(positionY_, &kit::KValueField::valueChanged, this,
+                        [this] { commitPosition(); });
+                valueRows_.push_back({QStringLiteral("X"), positionX_});
+                valueRows_.push_back({QStringLiteral("Y"), positionY_});
+            } else if (role == document::kOpacityParameterRole) {
+                opacity_ = makeCardField(QStringLiteral("nodeOpacityEditor"), tr("Opacity"), 0.0,
+                                         100.0, 1, QStringLiteral("%"));
+                addProxy(opacity_);
+                connect(opacity_, &kit::KValueField::valueChanged, this,
+                        [this] { commitOpacity(); });
+                valueRows_.push_back({tr("Opacity"), opacity_});
+            } else if (role == document::kSolidColorParameterRole) {
+                colorChip_ = new kit::KColorChip;
+                colorChip_->setObjectName(QStringLiteral("nodeColorChip"));
+                colorChip_->setAccessibleName(tr("Solid color"));
+                colorChip_->setControlSize(kit::KColorChip::ControlSize::Compact);
+                colorChip_->setEnabled(false);
+                colorChip_->resize(colorChip_->sizeHint());
+                addProxy(colorChip_);
+                colorRowLabel_ = tr("Color");
+            } else {
+                readOnlyRows_.push_back({displayTypeName(role), QString{}});
+            }
+        }
+        builtRoles_ = std::move(roles);
+        fieldsBuilt_ = true;
+    }
+
+    void refreshValues(const document::NodeRecord& node, const document::Composition& composition) {
+        refreshing_ = true;
+        const auto describe = [](const document::ParameterRecord* parameter,
+                                 const QString& absent) {
+            return parameter == nullptr ? absent : parameterSourceDescription(*parameter);
+        };
+
+        if (positionX_ != nullptr && positionY_ != nullptr) {
+            const auto* parameter =
+                parameterForRole(node, composition, document::kPositionParameterRole);
+            const auto value = parameter == nullptr || session_ == nullptr
+                                   ? std::nullopt
+                                   : session_->constantVec2Value(parameter->id);
+            const QString tip = describe(parameter, tr("Position is not exposed by this node"));
+            for (auto* field : {positionX_, positionY_}) {
+                field->setEnabled(value.has_value());
+                field->setToolTip(tip);
+            }
+            if (value.has_value()) {
+                const QSignalBlocker blockX(positionX_);
+                const QSignalBlocker blockY(positionY_);
+                positionX_->setValue(value->x);
+                positionY_->setValue(value->y);
+            }
+        }
+
+        if (opacity_ != nullptr) {
+            const auto* parameter =
+                parameterForRole(node, composition, document::kOpacityParameterRole);
+            const auto value = parameter == nullptr || session_ == nullptr
+                                   ? std::nullopt
+                                   : session_->constantValue(parameter->id);
+            opacity_->setEnabled(value.has_value());
+            opacity_->setToolTip(describe(parameter, tr("Opacity is not exposed by this node")));
+            const QSignalBlocker blocker(opacity_);
+            opacity_->setValue(value.has_value() ? *value * 100.0 : 100.0);
+        }
+
+        if (colorChip_ != nullptr) {
+            const auto* parameter =
+                parameterForRole(node, composition, document::kSolidColorParameterRole);
+            const auto value = parameter == nullptr || session_ == nullptr
+                                   ? std::nullopt
+                                   : session_->constantColorValue(parameter->id);
+            if (value.has_value()) {
+                colorChip_->setColor(kit::KColor::fromRgba(
+                    static_cast<float>(value->red), static_cast<float>(value->green),
+                    static_cast<float>(value->blue), static_cast<float>(value->alpha)));
+            }
+            // The swatch quantizes to 8 bits and clamps, so an HDR or negative authoring channel
+            // cannot be shown in it honestly; the exact, unclipped value travels in the tooltip
+            // alongside the reason the chip does not open a picker.
+            const QString exact =
+                value.has_value() ? exactColorText(*value) : describe(parameter, tr("No color"));
+            colorChip_->setToolTip(tr("%1\nRead-only: no command sets a color yet").arg(exact));
+        }
+
+        std::size_t readOnlyIndex = 0;
+        for (const auto& binding : node.parameters) {
+            if (binding.role == document::kPositionParameterRole ||
+                binding.role == document::kOpacityParameterRole ||
+                binding.role == document::kSolidColorParameterRole) {
+                continue;
+            }
+            const auto* parameter = composition.parameters().find(binding.parameterId);
+            if (readOnlyIndex < readOnlyRows_.size()) {
+                readOnlyRows_[readOnlyIndex].second =
+                    parameter == nullptr ? QString{} : parameterText(*parameter);
+            }
+            ++readOnlyIndex;
+        }
+        refreshing_ = false;
+    }
+
+    // Recomputes the card's own extent from what it actually carries -- the header text, the widest
+    // row label, and the widest control -- rather than from a spelled card width, then positions
+    // each proxy inside it.
+    void relayout() {
+        const QFontMetricsF headerMetrics(kit::font(kit::TypeRole::UiSmall));
+        const QFontMetricsF rowMetrics(kit::font(kit::TypeRole::UiSmall));
+        const QFontMetricsF valueMetrics(kit::font(kit::TypeRole::Value));
+
+        qreal labelColumn = 0.0;
+        qreal controlColumn = 0.0;
+        qreal rowHeight = 0.0;
+        // sizeHint(), never the CURRENT width: a control is stretched to the card's own control
+        // column below, so measuring its live width here would feed the card's width back into
+        // itself and make the layout depend on how many times it had been run.
+        for (const auto& row : valueRows_) {
+            labelColumn = std::max(labelColumn, rowMetrics.horizontalAdvance(row.label));
+            controlColumn =
+                std::max(controlColumn, static_cast<qreal>(row.field->sizeHint().width()));
+            rowHeight = std::max(rowHeight, static_cast<qreal>(row.field->sizeHint().height()));
+        }
+        if (colorChip_ != nullptr) {
+            labelColumn = std::max(labelColumn, rowMetrics.horizontalAdvance(colorRowLabel_));
+            controlColumn =
+                std::max(controlColumn, static_cast<qreal>(colorChip_->sizeHint().width()));
+            rowHeight = std::max(rowHeight, static_cast<qreal>(colorChip_->sizeHint().height()));
+        }
+        for (const auto& [label, value] : readOnlyRows_) {
+            labelColumn = std::max(labelColumn, rowMetrics.horizontalAdvance(label));
+            controlColumn = std::max(controlColumn, valueMetrics.horizontalAdvance(value));
+            rowHeight = std::max(rowHeight, valueMetrics.height());
+        }
+        if (rowHeight <= 0.0) {
+            rowHeight = kit::px(kit::Size::Control);
+        }
+
+        const auto rowCount = static_cast<qreal>(valueRows_.size() + readOnlyRows_.size() +
+                                                 (colorChip_ != nullptr ? 1 : 0));
+        const qreal contentWidth =
+            rowCount > 0.0 ? labelColumn + kCardLabelGap + controlColumn : 0.0;
+        const qreal width =
+            std::max({kCardMinimumWidth, 2.0 * kCardPadding + contentWidth,
+                      2.0 * kCardPadding + headerMetrics.horizontalAdvance(title_)});
+        const qreal height =
+            kCardHeaderHeight +
+            (rowCount > 0.0 ? rowCount * (rowHeight + kCardRowGap) - kCardRowGap + kCardPadding
+                            : kCardPadding);
+
+        if (!qFuzzyCompare(width, width_) || !qFuzzyCompare(height, height_)) {
+            prepareGeometryChange();
+            width_ = width;
+            height_ = height;
+        }
+        labelColumnWidth_ = labelColumn;
+        rowHeight_ = rowHeight;
+
+        const qreal controlLeft = kCardPadding + labelColumn + kCardLabelGap;
+        const qreal controlSpan = width_ - kCardPadding - controlLeft;
+        qreal y = kCardHeaderHeight;
+        for (const auto& row : valueRows_) {
+            row.field->resize(static_cast<int>(controlSpan), row.field->sizeHint().height());
+            positionProxy(row.field, controlLeft, y + (rowHeight - row.field->height()) / 2.0);
+            y += rowHeight + kCardRowGap;
+        }
+        if (colorChip_ != nullptr) {
+            colorChip_->resize(colorChip_->sizeHint());
+            // The color row is the last row carrying a real widget -- read-only rows below it are
+            // painted, not positioned -- so `y` is deliberately not advanced again here.
+            positionProxy(colorChip_, controlLeft, y + (rowHeight - colorChip_->height()) / 2.0);
+        }
+        update();
+    }
+
+    void positionProxy(const QWidget* widget, const qreal x, const qreal y) {
+        for (auto* child : childItems()) {
+            auto* proxy = qgraphicsitem_cast<QGraphicsProxyWidget*>(child);
+            if (proxy != nullptr && proxy->widget() == widget) {
+                proxy->setPos(x, y);
+                return;
+            }
+        }
+    }
+
+    document::NodeId id_;
+    CompositionSession* session_ = nullptr;
+    QString title_;
+    qreal width_ = kCardMinimumWidth;
+    qreal height_ = kCardHeaderHeight + kCardPadding;
+    qreal labelColumnWidth_ = 0.0;
+    qreal rowHeight_ = kit::px(kit::Size::Control);
+    bool hasInputSocket_ = false;
+    bool hasOutputSocket_ = false;
+    bool fieldsBuilt_ = false;
+    bool refreshing_ = false;
+    std::vector<std::string> builtRoles_;
+    std::vector<ValueRow> valueRows_;
+    std::vector<std::pair<QString, QString>> readOnlyRows_;
+    kit::KValueField* positionX_ = nullptr;
+    kit::KValueField* positionY_ = nullptr;
+    kit::KValueField* opacity_ = nullptr;
+    kit::KColorChip* colorChip_ = nullptr;
+    QString colorRowLabel_;
+    QGraphicsDropShadowEffect* dragShadow_ = nullptr;
+    std::vector<NodeEdgeItem*> edges_;
+};
+
+// A typed wire. Hairline by default, brightened while hovered or while either endpoint card is
+// selected -- the same "one surface step brighter" idea the kit's own hover recipe states, applied
+// to ink instead of a fill (kit::hoverFillFor() is that recipe, and is reused verbatim rather than
+// picking a second highlight color).
+class NodeEdgeItem final : public QGraphicsPathItem {
+  public:
+    NodeEdgeItem(NodeItem& source, NodeItem& destination)
+        : source_(source), destination_(destination) {
+        setZValue(-1.0);
+        setAcceptHoverEvents(true);
+        source_.addEdge(*this);
+        destination_.addEdge(*this);
+        updatePath();
+    }
+
+    void updatePath() {
+        const QPointF start = source_.outputAnchor();
+        const QPointF end = destination_.inputAnchor();
+        // A horizontal-tangent cubic: the handles reach along x only, so a wire always leaves an
+        // output and enters an input horizontally no matter where the two cards sit.
+        const qreal handle =
+            std::max<qreal>(kCardMinimumWidth / 2.0, std::abs(end.x() - start.x()) / 2.0);
+        QPainterPath curve(start);
+        curve.cubicTo(start + QPointF(handle, 0.0), end - QPointF(handle, 0.0), end);
+        setPath(curve);
+    }
+
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*) override {
+        const QColor base = kit::color(socketColorToken(kGraphTransportKind));
+        const bool emphasized = hovered_ || source_.isSelected() || destination_.isSelected();
+        painter->setRenderHint(QPainter::Antialiasing, true);
+        painter->setBrush(Qt::NoBrush);
+        painter->setPen(QPen(emphasized ? kit::hoverFillFor(base) : base, kit::kHairlineWidth,
+                             Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+        painter->drawPath(path());
+    }
+
+  protected:
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override {
+        hovered_ = true;
+        update();
+        QGraphicsPathItem::hoverEnterEvent(event);
+    }
+
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override {
+        hovered_ = false;
+        update();
+        QGraphicsPathItem::hoverLeaveEvent(event);
+    }
+
+  private:
+    NodeItem& source_;
+    NodeItem& destination_;
+    bool hovered_ = false;
+};
+
+void NodeItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget*) {
+    const QRectF bounds = boundingRect();
+    const bool selected = option->state.testFlag(QStyle::State_Selected);
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    // SurfaceRaised card + hairline Border, then the Accent inset edge when selected.
+    kit::fillRoundedSurface(*painter, bounds, kit::color(kit::Color::SurfaceRaised),
+                            kit::color(kit::Color::Border), kCardRadius);
+    if (selected) {
+        const qreal inset = kSelectionEdgeWidth / 2.0;
+        painter->setBrush(Qt::NoBrush);
+        painter->setPen(QPen(kit::color(kit::Color::Accent), kSelectionEdgeWidth));
+        const auto radius = static_cast<qreal>(kit::radiusPx(
+            kCardRadius, static_cast<int>(std::min(bounds.width(), bounds.height()))));
+        painter->drawRoundedRect(bounds.adjusted(inset, inset, -inset, -inset), radius, radius);
+    }
+
+    // The header strip: one step down the surface ladder from the card so it reads as chrome, with
+    // its own hairline foot rather than a second rounded rectangle.
+    QPainterPath header;
+    const auto headerRadius = static_cast<qreal>(
+        kit::radiusPx(kCardRadius, static_cast<int>(std::min(bounds.width(), kCardHeaderHeight))));
+    header.addRoundedRect(QRectF(0.0, 0.0, bounds.width(), kCardHeaderHeight), headerRadius,
+                          headerRadius);
+    header.addRect(QRectF(0.0, kCardHeaderHeight - headerRadius, bounds.width(), headerRadius));
+    painter->setPen(Qt::NoPen);
+    painter->fillPath(header, kit::color(kit::Color::Surface));
+    kit::applyHairlinePen(*painter, kit::color(kit::Color::Border));
+    painter->drawLine(QPointF(0.0, kCardHeaderHeight), QPointF(bounds.width(), kCardHeaderHeight));
+
+    painter->setFont(kit::font(kit::TypeRole::UiSmall));
+    painter->setPen(kit::color(kit::Color::Foreground));
+    const QRectF titleRect(kCardPadding, 0.0, bounds.width() - 2.0 * kCardPadding,
+                           kCardHeaderHeight);
+    painter->drawText(
+        titleRect, Qt::AlignVCenter | Qt::AlignLeft,
+        QFontMetricsF(painter->font()).elidedText(title_, Qt::ElideRight, titleRect.width()));
+
+    // Port dots, in the transport's own token color, centered on the header's mid-line. A dot is
+    // drawn only where the graph actually connects: nothing in src/document exposes a node's
+    // declared-but-unconnected ports to src/ui, so drawing a socket that no edge reaches would be a
+    // guess rather than a projection.
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(kit::color(socketColorToken(kGraphTransportKind)));
+    const qreal socketY = kCardHeaderHeight / 2.0;
+    const qreal socketRadius = kSocketDiameter / 2.0;
+    if (hasInputSocket_) {
+        painter->drawEllipse(QPointF(0.0, socketY), socketRadius, socketRadius);
+    }
+    if (hasOutputSocket_) {
+        painter->drawEllipse(QPointF(bounds.width(), socketY), socketRadius, socketRadius);
+    }
+
+    // Row labels. The controls themselves are real kit widgets in proxies; only their names are
+    // painted here, in the shared right-aligned label column.
+    painter->setFont(kit::font(kit::TypeRole::UiSmall));
+    qreal y = kCardHeaderHeight;
+    const QRectF labelColumn(kCardPadding, 0.0, labelColumnWidth_, rowHeight_);
+    const auto drawLabel = [&](const QString& text, const qreal top) {
+        painter->setPen(kit::color(kit::Color::Muted));
+        painter->drawText(labelColumn.translated(0.0, top), Qt::AlignVCenter | Qt::AlignRight,
+                          text);
+    };
+    for (const auto& row : valueRows_) {
+        drawLabel(row.label, y);
+        y += rowHeight_ + kCardRowGap;
+    }
+    if (colorChip_ != nullptr) {
+        drawLabel(colorRowLabel_, y);
+        y += rowHeight_ + kCardRowGap;
+    }
+    for (const auto& [label, value] : readOnlyRows_) {
+        drawLabel(label, y);
+        painter->setFont(kit::font(kit::TypeRole::Value));
+        painter->setPen(kit::color(kit::Color::Foreground));
+        const QRectF valueRect(
+            kCardPadding + labelColumnWidth_ + kCardLabelGap, y,
+            bounds.width() - kCardPadding * 2.0 - labelColumnWidth_ - kCardLabelGap, rowHeight_);
+        painter->drawText(
+            valueRect, Qt::AlignVCenter | Qt::AlignLeft,
+            QFontMetricsF(painter->font()).elidedText(value, Qt::ElideRight, valueRect.width()));
+        painter->setFont(kit::font(kit::TypeRole::UiSmall));
+        y += rowHeight_ + kCardRowGap;
+    }
+}
+
+QVariant NodeItem::itemChange(const GraphicsItemChange change, const QVariant& value) {
+    if (change == ItemPositionHasChanged || change == ItemSelectedHasChanged) {
+        for (auto* edge : edges_) {
+            if (change == ItemPositionHasChanged) {
+                edge->updatePath();
+            }
+            edge->update();
+        }
+    }
+    return QGraphicsObject::itemChange(change, value);
+}
+
+NodeItem* nodeItemAncestor(QGraphicsItem* item) {
+    for (auto* candidate = item; candidate != nullptr; candidate = candidate->parentItem()) {
+        if (auto* node = dynamic_cast<NodeItem*>(candidate)) {
+            return node;
+        }
+    }
+    return nullptr;
+}
+
+NodeItem* firstNodeItem(const QList<QGraphicsItem*>& items) {
+    for (auto* item : items) {
+        if (auto* node = nodeItemAncestor(item)) {
+            return node;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+// --- NodeGraphicsScene -------------------------------------------------------------------------
 
 NodeGraphicsScene::NodeGraphicsScene(QObject* parent) : QGraphicsScene(parent) {
     setObjectName("nodeGraphicsScene");
@@ -260,40 +806,105 @@ NodeGraphicsScene::NodeGraphicsScene(QObject* parent) : QGraphicsScene(parent) {
     setItemIndexMethod(QGraphicsScene::BspTreeIndex);
 }
 
-void NodeGraphicsScene::setProjection(const document::Snapshot& snapshot,
-                                      const document::CompositionId compositionId) {
-    std::map<std::uint64_t, QPointF> positions;
-    for (auto* item : items()) {
-        if (item->data(kNodeItemKindRole).toString() == QStringLiteral("node")) {
-            positions.emplace(item->data(kNodeStableIdRole).toULongLong(), item->pos());
+void NodeGraphicsScene::setSession(CompositionSession* session) { session_ = session; }
+
+void NodeGraphicsScene::drawBackground(QPainter* painter, const QRectF& rect) {
+    // The canvas surface itself stays the scene's own Background brush; the grid is drawn on top of
+    // it, one step up the surface ladder, so it reads as texture rather than as a second color.
+    QGraphicsScene::drawBackground(painter, rect);
+
+    const qreal scale = painter->worldTransform().m11();
+    if (!(scale > 0.0) || kGridSpacing * scale < kGridMinimumDeviceSpacing) {
+        return;
+    }
+    // Integer step counts, not a floating-point loop variable: repeatedly adding a pitch to a
+    // double accumulates error across a wide exposed rectangle, and the dots would slowly drift off
+    // the lattice the far side of the canvas is drawn on.
+    const qreal first = std::floor(rect.left() / kGridSpacing) * kGridSpacing;
+    const qreal top = std::floor(rect.top() / kGridSpacing) * kGridSpacing;
+    const auto columns = static_cast<int>(std::floor((rect.right() - first) / kGridSpacing)) + 1;
+    const auto lines = static_cast<int>(std::floor((rect.bottom() - top) / kGridSpacing)) + 1;
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(kit::color(kit::surfaceStep(kit::Color::Background, 2)));
+    for (int column = 0; column < columns; ++column) {
+        const qreal x = first + static_cast<qreal>(column) * kGridSpacing;
+        for (int line = 0; line < lines; ++line) {
+            const qreal y = top + static_cast<qreal>(line) * kGridSpacing;
+            painter->drawEllipse(QPointF(x, y), kGridDotRadius, kGridDotRadius);
         }
     }
-    clear();
+    painter->restore();
+}
 
+void NodeGraphicsScene::setProjection(const document::Snapshot& snapshot,
+                                      const document::CompositionId compositionId) {
     const auto* composition = snapshot.project().findComposition(compositionId);
     if (composition == nullptr) {
+        clear();
         setSceneRect({});
         return;
     }
 
+    std::map<std::uint64_t, NodeItem*> existing;
+    std::vector<QGraphicsItem*> staleEdges;
+    for (auto* item : items()) {
+        if (auto* node = dynamic_cast<NodeItem*>(item)) {
+            existing.emplace(node->id().value(), node);
+        } else if (dynamic_cast<NodeEdgeItem*>(item) != nullptr) {
+            staleEdges.push_back(item);
+        }
+    }
+    // Edges carry no widget state and no artist-owned position, so they are always rebuilt; node
+    // cards are not, because theirs is exactly the state this reconciliation exists to preserve.
+    for (auto* edge : staleEdges) {
+        removeItem(edge);
+        delete edge;
+    }
+    for (const auto& [id, item] : existing) {
+        item->clearEdges();
+        item->setSockets(false, false);
+    }
+
     std::array<int, 4> rows{};
+    std::vector<std::uint64_t> present;
+    present.reserve(composition->graph().nodes().size());
     for (const auto& node : composition->graph().nodes()) {
-        auto* item = new NodeItem(node, composition->parameters());
-        addItem(item);
-        const auto saved = positions.find(node.id.value());
-        if (saved != positions.end()) {
-            item->setPos(saved->second);
+        const std::size_t column = layoutColumn(node);
+        const auto found = existing.find(node.id.value());
+        NodeItem* item = nullptr;
+        if (found != existing.end()) {
+            item = found->second;
         } else {
-            const std::size_t column = layoutColumn(node);
-            item->setPos(40.0 + static_cast<qreal>(column) * 270.0,
-                         40.0 + static_cast<qreal>(rows.at(column)++) * 150.0);
+            item = new NodeItem(node.id, session_);
+            addItem(item);
+            item->setPos(kNodeColumnOrigin + static_cast<qreal>(column) * kNodeColumnPitch,
+                         kNodeColumnOrigin + static_cast<qreal>(rows.at(column)) * kNodeRowPitch);
+        }
+        // Counted for reused cards too, so a node added later lands BELOW the column's existing
+        // cards instead of on top of the first one.
+        ++rows.at(column);
+        item->refresh(node, *composition);
+        present.push_back(node.id.value());
+    }
+
+    for (const auto& [id, item] : existing) {
+        if (std::ranges::find(present, id) == present.end()) {
+            removeItem(item);
+            // deleteLater(), not delete: a card can be dropped from inside one of its own field
+            // widgets' signal emission (an edit that removes the node), and unwinding through a
+            // freed widget is not something a projection may risk.
+            item->deleteLater();
         }
     }
 
     rebuildEdges(*composition);
     const QRectF bounds = itemsBoundingRect();
-    setSceneRect(bounds.isEmpty() ? QRectF(-100.0, -100.0, 200.0, 200.0)
-                                  : bounds.adjusted(-120.0, -120.0, 120.0, 120.0));
+    setSceneRect(bounds.isEmpty() ? QRectF(-kNodeSceneMargin, -kNodeSceneMargin,
+                                           kNodeSceneMargin * 2.0, kNodeSceneMargin * 2.0)
+                                  : bounds.adjusted(-kNodeSceneMargin, -kNodeSceneMargin,
+                                                    kNodeSceneMargin, kNodeSceneMargin));
 }
 
 QGraphicsItem* NodeGraphicsScene::findNodeItem(const document::NodeId nodeId) const {
@@ -305,6 +916,12 @@ QGraphicsItem* NodeGraphicsScene::findNodeItem(const document::NodeId nodeId) co
     return found == matching.end() ? nullptr : *found;
 }
 
+QWidget* NodeGraphicsScene::nodeFieldForTest(const document::NodeId nodeId,
+                                             const QString& fieldObjectName) const {
+    auto* item = dynamic_cast<NodeItem*>(findNodeItem(nodeId));
+    return item == nullptr ? nullptr : item->fieldWidget(fieldObjectName);
+}
+
 void NodeGraphicsScene::rebuildEdges(const document::Composition& composition) {
     for (const auto& edge : composition.graph().edges()) {
         auto* source = dynamic_cast<NodeItem*>(findNodeItem(edge.source.nodeId));
@@ -312,29 +929,221 @@ void NodeGraphicsScene::rebuildEdges(const document::Composition& composition) {
             dynamic_cast<NodeItem*>(findNodeItem(destinationNodeId(edge.destination)));
         if (source != nullptr && destination != nullptr) {
             addItem(new NodeEdgeItem(*source, *destination));
+            source->setSockets(false, true);
+            destination->setSockets(true, false);
         }
     }
 }
+
+// --- NodeGraphicsView --------------------------------------------------------------------------
 
 NodeGraphicsView::NodeGraphicsView(QWidget* parent) : QGraphicsView(parent) {
     setObjectName("nodeGraphicsView");
     setAccessibleName(tr("Composition node graph"));
     setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
     setDragMode(QGraphicsView::RubberBandDrag);
-    setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
-    setResizeAnchor(QGraphicsView::AnchorViewCenter);
     setViewportUpdateMode(QGraphicsView::MinimalViewportUpdate);
     setFrameShape(QFrame::NoFrame);
+    // Zoom/pan live entirely in the view transform (see the class comment): with scrolling off and
+    // a top-left alignment, viewportTransform() has no scroll offset folded into it, so
+    // sceneFromViewport() is an exact inverse and a zoom step's cursor invariant is exact.
+    setTransformationAnchor(QGraphicsView::NoAnchor);
+    setResizeAnchor(QGraphicsView::NoAnchor);
+    setAlignment(Qt::AlignLeft | Qt::AlignTop);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    // The view's OWN scene rectangle, which overrides the scene's for scrolling purposes -- see
+    // kCanvasHalfExtent for why it is fixed and oversized rather than tracking the graph.
+    setSceneRect(-kCanvasHalfExtent, -kCanvasHalfExtent, kCanvasHalfExtent * 2.0,
+                 kCanvasHalfExtent * 2.0);
+    // StrongFocus so Space/F/Z reach the canvas without a prior click -- the Viewer's own rule.
+    setFocusPolicy(Qt::StrongFocus);
+}
+
+double NodeGraphicsView::zoomFactor() const noexcept { return transform().m11(); }
+
+bool NodeGraphicsView::viewAdjusted() const noexcept { return viewAdjusted_; }
+
+QPointF NodeGraphicsView::sceneFromViewport(const QPointF viewportPoint) const {
+    return viewportTransform().inverted().map(viewportPoint);
+}
+
+void NodeGraphicsView::zoomAboutViewportPoint(const QPointF viewportPoint, const double factor) {
+    const double current = zoomFactor();
+    if (!(current > 0.0) || !(factor > 0.0)) {
+        return;
+    }
+    const double target =
+        std::clamp(current * factor, ViewTransform::kMinZoom, ViewTransform::kMaxZoom);
+    const double applied = target / current;
+    if (qFuzzyCompare(applied, 1.0)) {
+        viewAdjusted_ = true;
+        return;
+    }
+    // Scale about `viewportPoint` in VIEWPORT space, composed after the current transform: shift
+    // the point to the origin, scale, shift back. Qt maps row vectors (p * M), so "apply A then B"
+    // is A * B -- the composition order below is exactly that, and nothing about it depends on a
+    // scroll bar's value or range.
+    QTransform about = QTransform::fromTranslate(-viewportPoint.x(), -viewportPoint.y());
+    about *= QTransform::fromScale(applied, applied);
+    about *= QTransform::fromTranslate(viewportPoint.x(), viewportPoint.y());
+    setTransform(transform() * about);
+    viewAdjusted_ = true;
+}
+
+void NodeGraphicsView::zoomStep(const int notches) {
+    if (notches == 0) {
+        return;
+    }
+    zoomAboutViewportPoint(QRectF(viewport()->rect()).center(), std::pow(kZoomStepFactor, notches));
+}
+
+QRectF NodeGraphicsView::graphBounds() const {
+    return scene() == nullptr ? QRectF() : scene()->itemsBoundingRect();
+}
+
+void NodeGraphicsView::applyCenteredScale(const double scale) {
+    const QRectF bounds = graphBounds();
+    const QRectF view = QRectF(viewport()->rect());
+    if (bounds.isEmpty() || view.isEmpty()) {
+        return;
+    }
+    const double clamped = std::clamp(scale, ViewTransform::kMinZoom, ViewTransform::kMaxZoom);
+    QTransform framed = QTransform::fromTranslate(-bounds.center().x(), -bounds.center().y());
+    framed *= QTransform::fromScale(clamped, clamped);
+    framed *= QTransform::fromTranslate(view.center().x(), view.center().y());
+    setTransform(framed);
+}
+
+void NodeGraphicsView::frameGraph() {
+    const QRectF bounds = graphBounds();
+    const QRectF view = QRectF(viewport()->rect());
+    if (bounds.isEmpty() || view.isEmpty()) {
+        return;
+    }
+    applyCenteredScale(std::min(view.width() / bounds.width(), view.height() / bounds.height()));
+    // Fit means "keep framing everything": a later projection rebuild re-frames until the artist
+    // moves the view themselves.
+    viewAdjusted_ = false;
+    framedOnce_ = true;
+}
+
+void NodeGraphicsView::zoomToActualSize() {
+    applyCenteredScale(1.0);
+    viewAdjusted_ = true;
+    framedOnce_ = true;
+}
+
+void NodeGraphicsView::showEvent(QShowEvent* event) {
+    QGraphicsView::showEvent(event);
+    if (!framedOnce_ && !viewAdjusted_) {
+        frameGraph();
+    }
+}
+
+void NodeGraphicsView::contextMenuEvent(QContextMenuEvent* event) {
+    emit contextMenuRequested(event->pos());
+    event->accept();
 }
 
 void NodeGraphicsView::wheelEvent(QWheelEvent* event) {
-    const qreal currentScale = transform().m11();
-    const qreal requested = std::pow(1.0015, event->angleDelta().y());
-    const qreal nextScale = std::clamp(currentScale * requested, 0.2, 3.0);
-    const qreal applied = nextScale / currentScale;
-    scale(applied, applied);
+    if (panActive_) {
+        event->ignore();
+        return;
+    }
+    const int notches = event->angleDelta().y() / kWheelDetent;
+    if (notches == 0) {
+        QGraphicsView::wheelEvent(event);
+        return;
+    }
+    zoomAboutViewportPoint(event->position(), std::pow(kZoomStepFactor, notches));
     event->accept();
 }
+
+void NodeGraphicsView::mousePressEvent(QMouseEvent* event) {
+    if (!panActive_ && (event->button() == Qt::MiddleButton ||
+                        (event->button() == Qt::LeftButton && spaceHeld_))) {
+        panActive_ = true;
+        panButton_ = event->button();
+        panOrigin_ = event->position();
+        panBaseTransform_ = transform();
+        setDragMode(QGraphicsView::NoDrag);
+        setFocus(Qt::MouseFocusReason);
+        updatePanCursor();
+        event->accept();
+        return;
+    }
+    QGraphicsView::mousePressEvent(event);
+}
+
+void NodeGraphicsView::mouseMoveEvent(QMouseEvent* event) {
+    if (!panActive_) {
+        QGraphicsView::mouseMoveEvent(event);
+        return;
+    }
+    // TOTAL displacement from the press point applied to the transform frozen there -- never a
+    // chain of per-move deltas (the Viewer's own pan rule).
+    const QPointF delta = event->position() - panOrigin_;
+    setTransform(panBaseTransform_ * QTransform::fromTranslate(delta.x(), delta.y()));
+    viewAdjusted_ = true;
+    event->accept();
+}
+
+void NodeGraphicsView::mouseReleaseEvent(QMouseEvent* event) {
+    if (panActive_ && event->button() == panButton_) {
+        panActive_ = false;
+        panButton_ = Qt::NoButton;
+        setDragMode(QGraphicsView::RubberBandDrag);
+        updatePanCursor();
+        event->accept();
+        return;
+    }
+    QGraphicsView::mouseReleaseEvent(event);
+}
+
+void NodeGraphicsView::keyPressEvent(QKeyEvent* event) {
+    if (!panActive_) {
+        if (!event->isAutoRepeat() && event->key() == Qt::Key_Space) {
+            spaceHeld_ = true;
+            updatePanCursor();
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_Z) {
+            zoomToActualSize();
+            event->accept();
+            return;
+        }
+        if (event->key() == Qt::Key_F) {
+            frameGraph();
+            event->accept();
+            return;
+        }
+    }
+    QGraphicsView::keyPressEvent(event);
+}
+
+void NodeGraphicsView::keyReleaseEvent(QKeyEvent* event) {
+    if (!event->isAutoRepeat() && event->key() == Qt::Key_Space) {
+        spaceHeld_ = false;
+        updatePanCursor();
+        event->accept();
+        return;
+    }
+    QGraphicsView::keyReleaseEvent(event);
+}
+
+void NodeGraphicsView::updatePanCursor() {
+    if (panActive_) {
+        viewport()->setCursor(Qt::ClosedHandCursor);
+    } else if (spaceHeld_) {
+        viewport()->setCursor(Qt::OpenHandCursor);
+    } else {
+        viewport()->unsetCursor();
+    }
+}
+
+// --- NodeGraphEditor ---------------------------------------------------------------------------
 
 NodeGraphEditor::NodeGraphEditor(CompositionSession& session, QWidget* parent)
     : QWidget(parent), session_(session) {
@@ -346,6 +1155,7 @@ NodeGraphEditor::NodeGraphEditor(CompositionSession& session, QWidget* parent)
     layout->setSpacing(0);
 
     scene_ = new NodeGraphicsScene(this);
+    scene_->setSession(&session_);
     view_ = new NodeGraphicsView(this);
     view_->setScene(scene_);
     layout->addWidget(view_);
@@ -356,6 +1166,8 @@ NodeGraphEditor::NodeGraphEditor(CompositionSession& session, QWidget* parent)
             &NodeGraphEditor::updateSelection);
     connect(scene_, &QGraphicsScene::selectionChanged, this,
             &NodeGraphEditor::sceneSelectionChanged);
+    connect(view_, &NodeGraphicsView::contextMenuRequested, this,
+            &NodeGraphEditor::showContextMenu);
 
     rebuild();
 }
@@ -371,9 +1183,13 @@ void NodeGraphEditor::rebuild() {
     scene_->setProjection(session_.snapshot(), session_.compositionId());
     updateSelection();
     rebuilding_ = false;
+    if (!view_->viewAdjusted()) {
+        view_->frameGraph();
+    }
 }
 
 void NodeGraphEditor::updateSelection() {
+    const bool wasRebuilding = rebuilding_;
     rebuilding_ = true;
     scene_->clearSelection();
 
@@ -389,19 +1205,80 @@ void NodeGraphEditor::updateSelection() {
             item->setSelected(true);
         }
     }
-    rebuilding_ = false;
+    rebuilding_ = wasRebuilding;
 }
 
 void NodeGraphEditor::sceneSelectionChanged() {
     if (rebuilding_) {
         return;
     }
-    auto* item = nodeItem(scene_->selectedItems());
+    auto* item = firstNodeItem(scene_->selectedItems());
     if (item == nullptr) {
         session_.clearSelection();
         return;
     }
     session_.selectNode(item->id());
+}
+
+QMenu* NodeGraphEditor::buildContextMenu(QWidget* parent) {
+    // Kit-styled through the application-wide QMenu stylesheet rule every other Bloom menu already
+    // picks up (the Timeline's Add menu, the Viewer's canvas menu) -- no per-menu styling here.
+    auto* menu = new QMenu(parent);
+    menu->setObjectName(QStringLiteral("nodeCanvasMenu"));
+    menu->setAccessibleName(tr("Node graph menu"));
+
+    auto* addMenu = menu->addMenu(tr("Add"));
+    addMenu->setObjectName(QStringLiteral("nodeAddMenu"));
+    addMenu->setAccessibleName(tr("Add layer menu"));
+    addMenu->setEnabled(session_.composition() != nullptr);
+
+    auto* addSolidAction = addMenu->addAction(tr("Solid"));
+    addSolidAction->setObjectName(QStringLiteral("nodeAddSolidLayerAction"));
+    addSolidAction->setToolTip(
+        tr("Add a solid using the next built-in reference-linear-sRGB proof color"));
+    connect(addSolidAction, &QAction::triggered, this,
+            [this] { (void)addDefaultSolidLayer(session_); });
+
+    auto* addTextAction = addMenu->addAction(tr("Text"));
+    addTextAction->setObjectName(QStringLiteral("nodeAddTextLayerAction"));
+    addTextAction->setToolTip(tr("Add a text layer"));
+    connect(addTextAction, &QAction::triggered, this,
+            [this] { (void)addDefaultTextLayer(session_); });
+
+    // No Remove/Delete, and no Duplicate. Verified against the WHOLE command layer, not inferred:
+    // src/commands/include/bloom/commands/operations.hpp declares AddSolidLayer, AddTextLayer,
+    // SetProjectName, SetCompositionName, SetCompositionDuration, SetCompositionFormat,
+    // SetParameterSource and MoveLayerBefore, and animation_operations.hpp declares the keyframe/
+    // curve operations -- there is no delete-layer, remove-node, duplicate or rename-layer command
+    // anywhere, and CompositionSession exposes no such entry point either. The honesty rule says an
+    // item that cannot do anything must not appear at all, so neither is drawn (not even disabled),
+    // and both are reported as command-layer gaps rather than faked here. Edge dragging/rewiring is
+    // absent for the same reason: no connect/disconnect command exists.
+    menu->addSeparator();
+
+    auto* fitAction = menu->addAction(tr("Fit"));
+    fitAction->setObjectName(QStringLiteral("nodeFitAction"));
+    connect(fitAction, &QAction::triggered, view_, &NodeGraphicsView::frameGraph);
+
+    auto* actualSizeAction = menu->addAction(tr("100%"));
+    actualSizeAction->setObjectName(QStringLiteral("nodeActualSizeAction"));
+    connect(actualSizeAction, &QAction::triggered, view_, &NodeGraphicsView::zoomToActualSize);
+
+    return menu;
+}
+
+QMenu* NodeGraphEditor::contextMenuForTest() { return buildContextMenu(this); }
+
+void NodeGraphEditor::showContextMenu(const QPoint& viewportPosition) {
+    // A right-click ON a card selects it first, through the same session selection a left-click
+    // routes through -- never a menu-local "context target" that could disagree with what the rest
+    // of the application thinks is selected.
+    if (auto* node = nodeItemAncestor(view_->itemAt(viewportPosition))) {
+        session_.selectNode(node->id());
+    }
+    auto* menu = buildContextMenu(view_);
+    menu->exec(view_->viewport()->mapToGlobal(viewportPosition));
+    menu->deleteLater();
 }
 
 } // namespace bloom::ui

--- a/src/ui/node_editor.cpp
+++ b/src/ui/node_editor.cpp
@@ -312,11 +312,13 @@ class NodeItem final : public QGraphicsObject {
   protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
 
-    void mousePressEvent(QGraphicsSceneMouseEvent* event) override {
+    // The elevation is raised on the first MOVE, not on the press: a click that only selects a card
+    // is not a drag, and lifting the card for it would read as a flash rather than as depth.
+    void mouseMoveEvent(QGraphicsSceneMouseEvent* event) override {
         if (dragShadow_ != nullptr) {
             dragShadow_->setEnabled(true);
         }
-        QGraphicsObject::mousePressEvent(event);
+        QGraphicsObject::mouseMoveEvent(event);
     }
 
     void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override {
@@ -1263,6 +1265,18 @@ QMenu* NodeGraphEditor::buildContextMenu(QWidget* parent) {
     auto* actualSizeAction = menu->addAction(tr("100%"));
     actualSizeAction->setObjectName(QStringLiteral("nodeActualSizeAction"));
     connect(actualSizeAction, &QAction::triggered, view_, &NodeGraphicsView::zoomToActualSize);
+
+    // The same Fit / 100% / Zoom In / Zoom Out set, in the same order and with the same separator,
+    // that ViewerEditor::contextMenuEvent() offers -- one application, one canvas menu.
+    menu->addSeparator();
+
+    auto* zoomInAction = menu->addAction(tr("Zoom In"));
+    zoomInAction->setObjectName(QStringLiteral("nodeZoomInAction"));
+    connect(zoomInAction, &QAction::triggered, view_, [this] { view_->zoomStep(1); });
+
+    auto* zoomOutAction = menu->addAction(tr("Zoom Out"));
+    zoomOutAction->setObjectName(QStringLiteral("nodeZoomOutAction"));
+    connect(zoomOutAction, &QAction::triggered, view_, [this] { view_->zoomStep(-1); });
 
     return menu;
 }

--- a/src/ui/tests/CMakeLists.txt
+++ b/src/ui/tests/CMakeLists.txt
@@ -128,6 +128,14 @@ add_executable(bloom_timeline_editor_style_test
     timeline_editor_style_tests.cpp
 )
 
+# Task U4 (issue #123): the node editor's navigation, selection, typed connector, context menu and
+# in-node editing contracts. Its own executable rather than more cases inside
+# composition_projection_test.cpp, which owns the cross-editor projection/selection contract this
+# task keeps byte-equivalent.
+add_executable(bloom_node_editor_test
+    node_editor_tests.cpp
+)
+
 target_link_libraries(bloom_editor_area_chrome_test PRIVATE bloom_ui Qt6::Test)
 target_link_libraries(bloom_kinetik_baseline_test PRIVATE bloom_ui)
 target_link_libraries(bloom_kit_button_test PRIVATE bloom_ui_kit)
@@ -165,6 +173,7 @@ target_link_libraries(bloom_frame_export_controller_test PRIVATE bloom_ui)
 target_link_libraries(bloom_main_window_readonly_placeholder_test PRIVATE bloom_ui ZLIB::ZLIB)
 target_link_libraries(bloom_playback_controller_test PRIVATE bloom_ui Qt6::Test)
 target_link_libraries(bloom_timeline_editor_style_test PRIVATE bloom_ui)
+target_link_libraries(bloom_node_editor_test PRIVATE bloom_ui)
 bloom_enable_warnings(bloom_editor_area_chrome_test)
 bloom_enable_warnings(bloom_kinetik_baseline_test)
 bloom_enable_warnings(bloom_kit_button_test)
@@ -202,6 +211,7 @@ bloom_enable_warnings(bloom_frame_export_controller_test)
 bloom_enable_warnings(bloom_main_window_readonly_placeholder_test)
 bloom_enable_warnings(bloom_playback_controller_test)
 bloom_enable_warnings(bloom_timeline_editor_style_test)
+bloom_enable_warnings(bloom_node_editor_test)
 
 include(BloomTesting)
 
@@ -496,6 +506,14 @@ bloom_add_test(
 bloom_add_test(
     NAME bloom.ui.timeline_editor_style
     COMMAND bloom_timeline_editor_style_test
+    LABELS ui integration kit
+    TIMEOUT 30
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)
+
+bloom_add_test(
+    NAME bloom.ui.node_editor
+    COMMAND bloom_node_editor_test
     LABELS ui integration kit
     TIMEOUT 30
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen"

--- a/src/ui/tests/node_editor_tests.cpp
+++ b/src/ui/tests/node_editor_tests.cpp
@@ -218,6 +218,21 @@ void testFitFramesTheGraphAndActualSizeIsExactlyOneHundredPercent(Expectations& 
     sendKey(fixture.view(), QEvent::KeyPress, Qt::Key_F);
     expectations.expect(!fixture.view()->viewAdjusted() && !near(fixture.view()->zoomFactor(), 1.0),
                         "F re-frames the graph");
+
+    // While the artist has not moved the view, a resize re-frames -- the same way the Viewer's Fit
+    // recomputes its rectangle from the available area. Once they HAVE moved it, a resize leaves
+    // the view exactly where they put it.
+    const double fittedZoom = fixture.view()->zoomFactor();
+    fixture.editor.resize(400, 300);
+    QCoreApplication::processEvents();
+    expectations.expect(!near(fixture.view()->zoomFactor(), fittedZoom),
+                        "a resize re-frames the graph while the view is still following it");
+
+    sendKey(fixture.view(), QEvent::KeyPress, Qt::Key_Z);
+    fixture.editor.resize(800, 600);
+    QCoreApplication::processEvents();
+    expectations.expect(near(fixture.view()->zoomFactor(), 1.0),
+                        "but a resize never moves a view the artist has taken over");
 }
 
 void testSpaceHoldAndMiddleDragBothPan(Expectations& expectations) {

--- a/src/ui/tests/node_editor_tests.cpp
+++ b/src/ui/tests/node_editor_tests.cpp
@@ -373,8 +373,11 @@ void testContextMenuOffersOnlyRealCommands(Expectations& expectations) {
                         "Add offers exactly the two layer kinds the command layer has: Solid and "
                         "Text -- the same pair the timeline's Add menu offers");
     expectations.expect(named(QStringLiteral("nodeFitAction")) != nullptr &&
-                            named(QStringLiteral("nodeActualSizeAction")) != nullptr,
-                        "and the canvas view items Fit and 100%");
+                            named(QStringLiteral("nodeActualSizeAction")) != nullptr &&
+                            named(QStringLiteral("nodeZoomInAction")) != nullptr &&
+                            named(QStringLiteral("nodeZoomOutAction")) != nullptr,
+                        "and the same canvas view items the Viewer's own menu offers: Fit, 100%, "
+                        "Zoom In, Zoom Out");
 
     // The honesty rule, pinned: no delete-layer, remove-node or duplicate command exists anywhere
     // in src/commands, so no such item may appear -- not even a disabled one.
@@ -472,9 +475,15 @@ void testInNodeValueFieldsCommitThroughThePropertiesPath(Expectations& expectati
     }
     const document::Vec2d editedPosition{24.0, originalPosition.value().y};
 
-    // One gesture on the card: one command, one undo step, on the SAME ParameterId the Properties
-    // panel writes.
+    // One gesture on the card: one command, one undo step, one snapshot signal, on the SAME
+    // ParameterId the Properties panel writes.
+    int snapshotSignals = 0;
+    QObject::connect(&fixture.session, &ui::CompositionSession::snapshotChanged, &fixture.session,
+                     [&snapshotSignals] { ++snapshotSignals; });
     positionX->setValue(24.0);
+    expectations.expect(snapshotSignals == 1,
+                        "one field gesture produces exactly one committed snapshot -- the session "
+                        "signal flow is intact and the edit is not split across commands");
     expectations.expect(fixture.session.constantVec2Value(positionId) == editedPosition,
                         "an in-node X edit writes the canonical position parameter");
     expectations.expect(fixture.session.undoLabel() == QStringLiteral("Set Position"),

--- a/src/ui/tests/node_editor_tests.cpp
+++ b/src/ui/tests/node_editor_tests.cpp
@@ -348,6 +348,37 @@ void testEveryProjectedEdgeIsAPathItemBetweenTwoCards(Expectations& expectations
                         "and exactly one wire per graph edge");
 }
 
+// A card in the middle of the chain is BOTH an edge source and an edge destination, so it carries
+// both port dots. Sockets accumulate across the edges that touch a node; assigning both flags from
+// each edge in turn would let whichever edge was visited last erase the other end.
+void testMidChainCardsCarryBothPortDots(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Socket Test"));
+    const auto layerId = addSolid(fixture.session);
+    if (!layerId.has_value()) {
+        expectations.expect(false, "the fixture can add a solid layer");
+        return;
+    }
+    const auto boundaryNodeId = fixture.session.boundaryNodeForLayer(*layerId);
+    const auto sourceNodeId = fixture.session.directSourceNodeForLayer(*layerId);
+    const auto* composition = fixture.session.composition();
+    if (!boundaryNodeId.has_value() || !sourceNodeId.has_value() || composition == nullptr) {
+        expectations.expect(false, "the solid layer resolves its boundary and source nodes");
+        return;
+    }
+
+    expectations.expect(fixture.scene()->nodeSocketsForTest(*sourceNodeId) ==
+                            ui::NodeSockets{false, true},
+                        "a source card carries only an output dot: nothing feeds into it");
+    expectations.expect(fixture.scene()->nodeSocketsForTest(*boundaryNodeId) ==
+                            ui::NodeSockets{true, true},
+                        "the layer boundary card carries both: it consumes the source and feeds "
+                        "the stack");
+    expectations.expect(
+        fixture.scene()->nodeSocketsForTest(composition->graph().layerStack().nodeId()) ==
+            ui::NodeSockets{true, true},
+        "and so does the layer stack");
+}
+
 // --- Decision 4: context menu offers only what the command layer can do -------------------------
 
 void testContextMenuOffersOnlyRealCommands(Expectations& expectations) {
@@ -564,6 +595,7 @@ int runAll() {
     testSelectionFollowsTheSessionInBothDirections(expectations);
     testConnectorTypingIsPinnedPerSocketKind(expectations);
     testEveryProjectedEdgeIsAPathItemBetweenTwoCards(expectations);
+    testMidChainCardsCarryBothPortDots(expectations);
     testContextMenuOffersOnlyRealCommands(expectations);
     testAddFromTheCanvasIsOneUndoableCommand(expectations);
     testInNodeValueFieldsCommitThroughThePropertiesPath(expectations);

--- a/src/ui/tests/node_editor_tests.cpp
+++ b/src/ui/tests/node_editor_tests.cpp
@@ -276,6 +276,32 @@ void testSpaceHoldAndMiddleDragBothPan(Expectations& expectations) {
               Qt::NoButton);
 }
 
+// A zoom gesture that cannot move the view must not count as the artist taking the view over.
+// Latching that state on an empty canvas would permanently stop the auto-framing that a projection
+// rebuild and a resize both depend on, and the canvas would never frame content that arrived later.
+void testEmptyCanvasZoomDoesNotLatchTheViewAway(Expectations& expectations) {
+    // A project with no composition at all -- the only way session.composition() is legitimately
+    // null (CompositionSession's constructor falls back to the lowest id whenever one exists).
+    document::Project emptyProject(document::ProjectId::fromRaw(1), "Empty Node Project");
+    document::Document document(std::move(emptyProject));
+    commands::CommandStack commands(document);
+    ui::CompositionSession session(document, commands, document::CompositionId::fromRaw(1));
+    ui::NodeGraphEditor editor(session);
+    editor.resize(800, 600);
+    editor.show();
+    QCoreApplication::processEvents();
+
+    expectations.expect(session.composition() == nullptr,
+                        "the fixture genuinely has no composition -- this is the empty canvas");
+    expectations.expect(editor.graphScene()->items().isEmpty(), "so the canvas projects nothing");
+
+    sendKey(editor.graphView(), QEvent::KeyPress, Qt::Key_Z);
+    expectations.expect(!editor.graphView()->viewAdjusted(),
+                        "100% on an empty canvas changes nothing, so it does not claim the view");
+    sendKey(editor.graphView(), QEvent::KeyPress, Qt::Key_F);
+    expectations.expect(!editor.graphView()->viewAdjusted(), "and neither does Fit");
+}
+
 // --- Decision 2: selection stays the session's one truth ---------------------------------------
 
 void testSelectionFollowsTheSessionInBothDirections(Expectations& expectations) {
@@ -607,6 +633,7 @@ int runAll() {
     testZoomClampsToTheViewersOwnBounds(expectations);
     testFitFramesTheGraphAndActualSizeIsExactlyOneHundredPercent(expectations);
     testSpaceHoldAndMiddleDragBothPan(expectations);
+    testEmptyCanvasZoomDoesNotLatchTheViewAway(expectations);
     testSelectionFollowsTheSessionInBothDirections(expectations);
     testConnectorTypingIsPinnedPerSocketKind(expectations);
     testEveryProjectedEdgeIsAPathItemBetweenTwoCards(expectations);

--- a/src/ui/tests/node_editor_tests.cpp
+++ b/src/ui/tests/node_editor_tests.cpp
@@ -1,0 +1,576 @@
+// Task U4 (issue #123): the Kinetik node editor's navigation, selection, typed connectors,
+// context menu and in-node editing contracts. Appended as its own executable rather than folded
+// into composition_projection_test.cpp, which owns the cross-editor projection/selection contract
+// this task must keep byte-equivalent.
+
+#include <bloom/ui/node_editor.hpp>
+
+#include <bloom/commands/command_stack.hpp>
+#include <bloom/core/color.hpp>
+#include <bloom/core/rational_time.hpp>
+#include <bloom/document/document.hpp>
+#include <bloom/document/graph.hpp>
+#include <bloom/document/new_project.hpp>
+#include <bloom/document/parameter.hpp>
+#include <bloom/document/project.hpp>
+#include <bloom/runtime/node_definition_registry.hpp>
+#include <bloom/ui/composition_session.hpp>
+#include <bloom/ui/kit/color_chip.hpp>
+#include <bloom/ui/kit/tokens.hpp>
+#include <bloom/ui/kit/value_field.hpp>
+#include <bloom/ui/viewer_editor.hpp>
+
+#include <QAction>
+#include <QApplication>
+#include <QGraphicsItem>
+#include <QKeyEvent>
+#include <QList>
+#include <QMenu>
+#include <QMouseEvent>
+#include <QPoint>
+#include <QPointF>
+#include <QRectF>
+#include <QString>
+#include <QWheelEvent>
+
+#include <cmath>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <optional>
+#include <source_location>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace {
+
+using namespace bloom;
+
+class Expectations final {
+  public:
+    void expect(const bool condition, const std::string& message,
+                const std::source_location location = std::source_location::current()) {
+        if (condition) {
+            return;
+        }
+        ++failures_;
+        std::cerr << location.file_name() << ':' << location.line() << ": " << message << '\n';
+    }
+
+    [[nodiscard]] int failures() const noexcept { return failures_; }
+
+  private:
+    int failures_ = 0;
+};
+
+[[nodiscard]] bool near(const double lhs, const double rhs, const double tolerance = 0.0001) {
+    return std::abs(lhs - rhs) <= tolerance;
+}
+
+// One solid layer is enough to exercise every contract here: it produces a solid-source node (a
+// color parameter), a layer-output boundary node (position and opacity parameters), the layer
+// stack, and the composition output -- plus the edges between them.
+struct GraphFixture final {
+    document::Document document;
+    commands::CommandStack commands;
+    ui::CompositionSession session;
+    ui::NodeGraphEditor editor;
+
+    explicit GraphFixture(document::NewProject newProject)
+        : document(std::move(newProject.project)), commands(document),
+          session(document, commands, newProject.initialCompositionId), editor(session) {
+        editor.resize(800, 600);
+        editor.show();
+        QCoreApplication::processEvents();
+    }
+
+    [[nodiscard]] ui::NodeGraphicsView* view() const { return editor.graphView(); }
+    [[nodiscard]] ui::NodeGraphicsScene* scene() const { return editor.graphScene(); }
+};
+
+document::NewProject makeProject(std::string name) {
+    return document::makeNewProject(std::move(name), "Main", core::RationalTime::fromInteger(10));
+}
+
+// Pointer events go to the VIEWPORT, which is where QAbstractScrollArea expects them and the only
+// route by which QGraphicsView's own mouse/wheel handlers run (QAbstractScrollArea::event()
+// deliberately ignores pointer events delivered to the scroll area itself). Key events go to the
+// view, which is what holds focus. The canvas has no frame and no scroll bars, so viewport and view
+// coordinates coincide.
+void sendWheel(ui::NodeGraphicsView* view, const QPointF position, const int notches) {
+    QWheelEvent event(position, view->viewport()->mapToGlobal(position.toPoint()), QPoint(),
+                      QPoint(0, notches * 120), Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase,
+                      false);
+    QCoreApplication::sendEvent(view->viewport(), &event);
+}
+
+void sendKey(ui::NodeGraphicsView* view, const QEvent::Type type, const int key) {
+    QKeyEvent event(type, key, Qt::NoModifier);
+    QCoreApplication::sendEvent(view, &event);
+}
+
+void sendMouse(ui::NodeGraphicsView* view, const QEvent::Type type, const QPointF position,
+               const Qt::MouseButton button, const Qt::MouseButtons buttons) {
+    QMouseEvent event(type, position, view->viewport()->mapToGlobal(position.toPoint()), button,
+                      buttons, Qt::NoModifier);
+    QCoreApplication::sendEvent(view->viewport(), &event);
+}
+
+[[nodiscard]] std::optional<document::LayerId> addSolid(ui::CompositionSession& session) {
+    if (!session.addSolidLayer(QStringLiteral("Solid 1"), core::Color4d{0.62, 0.08, 0.04, 1.0})) {
+        return std::nullopt;
+    }
+    const auto* layerId = std::get_if<document::LayerId>(&session.selection().primary);
+    return layerId == nullptr ? std::nullopt : std::optional<document::LayerId>(*layerId);
+}
+
+const document::ParameterRecord* parameterForRole(const ui::CompositionSession& session,
+                                                  const document::NodeId nodeId,
+                                                  const std::string_view role) {
+    const auto* composition = session.composition();
+    const auto* node = composition == nullptr ? nullptr : composition->graph().findNode(nodeId);
+    if (node == nullptr) {
+        return nullptr;
+    }
+    for (const auto& binding : node->parameters) {
+        if (binding.role == role) {
+            return composition->parameters().find(binding.parameterId);
+        }
+    }
+    return nullptr;
+}
+
+// --- Decision 1: navigation matches the Viewer's conventions -----------------------------------
+
+// The invariant the whole zoom design exists to guarantee, stated exactly as the Viewer's own test
+// states it: the DOCUMENT point under the cursor does not move across a zoom step.
+void testZoomAboutCursorHoldsTheScenePointUnderTheCursor(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Zoom Cursor Test"));
+    fixture.view()->zoomToActualSize();
+
+    const QPointF cursor(517.0, 233.0); // arbitrary, and not the viewport's own center
+    const QPointF before = fixture.view()->sceneFromViewport(cursor);
+    sendWheel(fixture.view(), cursor, 1);
+    const QPointF after = fixture.view()->sceneFromViewport(cursor);
+
+    expectations.expect(near(fixture.view()->zoomFactor(), ui::kZoomStepFactor),
+                        "one wheel notch multiplies the zoom by the Viewer's own step factor");
+    expectations.expect(near(before.x(), after.x(), 0.0005) && near(before.y(), after.y(), 0.0005),
+                        "the scene point under the cursor is fixed across the zoom step");
+
+    // Stepping back by the same notch about the same cursor restores the original mapping -- the
+    // stronger form of the same pin.
+    sendWheel(fixture.view(), cursor, -1);
+    const QPointF restored = fixture.view()->sceneFromViewport(cursor);
+    expectations.expect(near(fixture.view()->zoomFactor(), 1.0, 0.0005) &&
+                            near(before.x(), restored.x(), 0.01) &&
+                            near(before.y(), restored.y(), 0.01),
+                        "zooming in then out about the same cursor restores the view exactly");
+}
+
+void testZoomClampsToTheViewersOwnBounds(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Zoom Bounds Test"));
+    const QPointF center = QRectF(fixture.view()->viewport()->rect()).center();
+
+    for (int step = 0; step < 200; ++step) {
+        sendWheel(fixture.view(), center, 1);
+    }
+    expectations.expect(near(fixture.view()->zoomFactor(), ui::ViewTransform::kMaxZoom),
+                        "zooming in clamps at the Viewer's kMaxZoom, never above");
+
+    for (int step = 0; step < 400; ++step) {
+        sendWheel(fixture.view(), center, -1);
+    }
+    expectations.expect(near(fixture.view()->zoomFactor(), ui::ViewTransform::kMinZoom),
+                        "zooming out clamps at the Viewer's kMinZoom, never below");
+}
+
+void testFitFramesTheGraphAndActualSizeIsExactlyOneHundredPercent(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Fit Test"));
+    expectations.expect(addSolid(fixture.session).has_value(), "the fixture can add a solid layer");
+
+    fixture.view()->frameGraph();
+    const QRectF bounds = fixture.scene()->itemsBoundingRect();
+    const QRectF framed = fixture.view()->viewportTransform().mapRect(bounds);
+    const QRectF viewport = QRectF(fixture.view()->viewport()->rect());
+    expectations.expect(framed.width() <= viewport.width() + 1.0 &&
+                            framed.height() <= viewport.height() + 1.0,
+                        "Fit scales the whole graph to fit inside the viewport");
+    expectations.expect(near(framed.center().x(), viewport.center().x(), 0.5) &&
+                            near(framed.center().y(), viewport.center().y(), 0.5),
+                        "Fit centers the graph, exactly as the Viewer's Fit centers its frame");
+    expectations.expect(!fixture.view()->viewAdjusted(),
+                        "Fit leaves the canvas following the graph until the artist moves it");
+
+    // Z, through the real key event, not the method.
+    sendKey(fixture.view(), QEvent::KeyPress, Qt::Key_Z);
+    expectations.expect(near(fixture.view()->zoomFactor(), 1.0),
+                        "Z is exactly 100%, one scene unit per screen pixel");
+    const QRectF actual = fixture.view()->viewportTransform().mapRect(bounds);
+    expectations.expect(near(actual.center().x(), viewport.center().x(), 0.5) &&
+                            near(actual.center().y(), viewport.center().y(), 0.5),
+                        "100% centers the graph rather than jumping to its corner");
+    expectations.expect(fixture.view()->viewAdjusted(),
+                        "an explicit 100% counts as the artist having moved the view");
+
+    // F, through the real key event.
+    sendKey(fixture.view(), QEvent::KeyPress, Qt::Key_F);
+    expectations.expect(!fixture.view()->viewAdjusted() && !near(fixture.view()->zoomFactor(), 1.0),
+                        "F re-frames the graph");
+}
+
+void testSpaceHoldAndMiddleDragBothPan(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Pan Test"));
+    fixture.view()->zoomToActualSize();
+
+    const QPointF press(300.0, 220.0);
+    const QPointF move(360.0, 190.0);
+    const QPointF anchorBefore = fixture.view()->sceneFromViewport(press);
+
+    sendKey(fixture.view(), QEvent::KeyPress, Qt::Key_Space);
+    sendMouse(fixture.view(), QEvent::MouseButtonPress, press, Qt::LeftButton, Qt::LeftButton);
+    sendMouse(fixture.view(), QEvent::MouseMove, move, Qt::NoButton, Qt::LeftButton);
+
+    const QPointF anchorAfter = fixture.view()->sceneFromViewport(move);
+    expectations.expect(near(anchorBefore.x(), anchorAfter.x(), 0.01) &&
+                            near(anchorBefore.y(), anchorAfter.y(), 0.01),
+                        "a space-hold left drag pans by the TOTAL displacement from the press "
+                        "point: the grabbed scene point stays under the pointer");
+    expectations.expect(near(fixture.view()->zoomFactor(), 1.0), "panning never changes the zoom");
+
+    sendMouse(fixture.view(), QEvent::MouseButtonRelease, move, Qt::LeftButton, Qt::NoButton);
+    sendKey(fixture.view(), QEvent::KeyRelease, Qt::Key_Space);
+    const QPointF afterRelease = fixture.view()->sceneFromViewport(move);
+    expectations.expect(near(afterRelease.x(), anchorAfter.x()) &&
+                            near(afterRelease.y(), anchorAfter.y()),
+                        "releasing ends the pan without resetting the accumulated pan");
+
+    // The middle button pans with no modifier at all -- the Viewer's second pan entry point.
+    const QPointF middlePress(200.0, 200.0);
+    const QPointF middleMove(140.0, 260.0);
+    const QPointF middleAnchor = fixture.view()->sceneFromViewport(middlePress);
+    sendMouse(fixture.view(), QEvent::MouseButtonPress, middlePress, Qt::MiddleButton,
+              Qt::MiddleButton);
+    sendMouse(fixture.view(), QEvent::MouseMove, middleMove, Qt::NoButton, Qt::MiddleButton);
+    const QPointF middleAfter = fixture.view()->sceneFromViewport(middleMove);
+    expectations.expect(near(middleAnchor.x(), middleAfter.x(), 0.01) &&
+                            near(middleAnchor.y(), middleAfter.y(), 0.01),
+                        "a middle drag pans exactly like the space-hold drag");
+    sendMouse(fixture.view(), QEvent::MouseButtonRelease, middleMove, Qt::MiddleButton,
+              Qt::NoButton);
+}
+
+// --- Decision 2: selection stays the session's one truth ---------------------------------------
+
+void testSelectionFollowsTheSessionInBothDirections(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Selection Test"));
+    const auto layerId = addSolid(fixture.session);
+    expectations.expect(layerId.has_value(), "the fixture can add a solid layer");
+    if (!layerId.has_value()) {
+        return;
+    }
+    const auto boundaryNodeId = fixture.session.boundaryNodeForLayer(*layerId);
+    const auto sourceNodeId = fixture.session.directSourceNodeForLayer(*layerId);
+    expectations.expect(boundaryNodeId.has_value() && sourceNodeId.has_value(),
+                        "the solid layer resolves both its boundary and its source node");
+    if (!boundaryNodeId.has_value() || !sourceNodeId.has_value()) {
+        return;
+    }
+
+    // Scene -> session: selecting a card makes that NodeId the session's primary selection.
+    auto* sourceItem = fixture.scene()->findNodeItem(*sourceNodeId);
+    expectations.expect(sourceItem != nullptr, "the scene projects the solid source node");
+    if (sourceItem == nullptr) {
+        return;
+    }
+    fixture.scene()->clearSelection();
+    sourceItem->setSelected(true);
+    expectations.expect(fixture.session.selection().primary == ui::SelectionTarget{*sourceNodeId},
+                        "selecting a card in the scene selects that node in the session");
+    expectations.expect(fixture.session.selection().contextualLayer == layerId,
+                        "and carries the node's own contextual layer, unchanged");
+
+    // Session -> scene: selecting the LAYER elsewhere highlights its boundary card, and nothing
+    // else stays selected.
+    fixture.session.selectLayer(*layerId);
+    auto* boundaryItem = fixture.scene()->findNodeItem(*boundaryNodeId);
+    expectations.expect(boundaryItem != nullptr && boundaryItem->isSelected(),
+                        "selecting the layer elsewhere highlights its boundary card");
+    expectations.expect(!sourceItem->isSelected(),
+                        "and the previously selected card is no longer highlighted");
+    expectations.expect(fixture.scene()->selectedItems().size() == 1,
+                        "exactly one card carries the selection edge -- there is no scene-local "
+                        "second selection truth");
+
+    fixture.session.clearSelection();
+    expectations.expect(fixture.scene()->selectedItems().isEmpty(),
+                        "clearing the session's selection clears the scene's");
+}
+
+// --- Decision 3: typed connectors, only for the types that exist -------------------------------
+
+void testConnectorTypingIsPinnedPerSocketKind(Expectations& expectations) {
+    // Image is the ONE transport kind runtime::SocketValueKind declares, and the only one any edge
+    // in a document::CanonicalGraph can carry today (see socketColorToken()'s comment in
+    // node_editor.hpp). Pinning the mapping here is what makes adding a second kind a deliberate
+    // decision rather than an accident: socketColorToken()'s switch stops being exhaustive.
+    expectations.expect(ui::socketColorToken(runtime::SocketValueKind::Image) ==
+                            ui::kit::Color::DataImage,
+                        "an Image socket takes the data palette's own Image token");
+    expectations.expect(ui::kit::color(ui::socketColorToken(runtime::SocketValueKind::Image)) ==
+                            ui::kit::color(ui::kit::Color::DataImage),
+                        "and resolves to exactly that token's color, not a look-alike");
+}
+
+void testEveryProjectedEdgeIsAPathItemBetweenTwoCards(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Connector Test"));
+    expectations.expect(addSolid(fixture.session).has_value(), "the fixture can add a solid layer");
+    const auto* composition = fixture.session.composition();
+    expectations.expect(composition != nullptr, "the fixture has a live composition");
+    if (composition == nullptr) {
+        return;
+    }
+
+    int cards = 0;
+    int wires = 0;
+    for (const auto* item : fixture.scene()->items()) {
+        if (item->data(ui::kNodeItemKindRole).toString() == QStringLiteral("node")) {
+            ++cards;
+        } else if (item->type() == QGraphicsPathItem::Type) {
+            ++wires;
+        }
+    }
+    expectations.expect(
+        cards == static_cast<int>(composition->graph().nodes().size()),
+        "the scene projects exactly one card per graph node -- no more, and none invented");
+    expectations.expect(wires == static_cast<int>(composition->graph().edges().size()),
+                        "and exactly one wire per graph edge");
+}
+
+// --- Decision 4: context menu offers only what the command layer can do -------------------------
+
+void testContextMenuOffersOnlyRealCommands(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Menu Test"));
+    auto* menu = fixture.editor.contextMenuForTest();
+    expectations.expect(menu != nullptr, "the canvas builds a context menu");
+    if (menu == nullptr) {
+        return;
+    }
+
+    const auto actions = menu->findChildren<QAction*>();
+    const auto named = [&actions](const QString& objectName) -> QAction* {
+        for (auto* action : actions) {
+            if (action->objectName() == objectName) {
+                return action;
+            }
+        }
+        return nullptr;
+    };
+
+    expectations.expect(named(QStringLiteral("nodeAddSolidLayerAction")) != nullptr &&
+                            named(QStringLiteral("nodeAddTextLayerAction")) != nullptr,
+                        "Add offers exactly the two layer kinds the command layer has: Solid and "
+                        "Text -- the same pair the timeline's Add menu offers");
+    expectations.expect(named(QStringLiteral("nodeFitAction")) != nullptr &&
+                            named(QStringLiteral("nodeActualSizeAction")) != nullptr,
+                        "and the canvas view items Fit and 100%");
+
+    // The honesty rule, pinned: no delete-layer, remove-node or duplicate command exists anywhere
+    // in src/commands, so no such item may appear -- not even a disabled one.
+    for (const auto* action : actions) {
+        const QString text = action->text();
+        expectations.expect(!text.contains(QStringLiteral("Duplicate"), Qt::CaseInsensitive) &&
+                                !text.contains(QStringLiteral("Delete"), Qt::CaseInsensitive) &&
+                                !text.contains(QStringLiteral("Remove"), Qt::CaseInsensitive),
+                            "no menu item claims an operation the command layer cannot perform: " +
+                                text.toStdString());
+    }
+    menu->deleteLater();
+}
+
+void testAddFromTheCanvasIsOneUndoableCommand(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Menu Add Test"));
+    auto* menu = fixture.editor.contextMenuForTest();
+    if (menu == nullptr) {
+        expectations.expect(false, "the canvas builds a context menu");
+        return;
+    }
+    QAction* addSolidAction = nullptr;
+    for (auto* action : menu->findChildren<QAction*>()) {
+        if (action->objectName() == QStringLiteral("nodeAddSolidLayerAction")) {
+            addSolidAction = action;
+        }
+    }
+    if (addSolidAction == nullptr) {
+        expectations.expect(false, "the canvas menu offers Add > Solid");
+        return;
+    }
+
+    const auto nodesBefore = fixture.session.composition()->graph().nodes().size();
+    addSolidAction->trigger();
+    expectations.expect(fixture.session.composition()->graph().layerStack().entries().size() == 1,
+                        "Add > Solid on the canvas creates one layer through the command layer");
+    expectations.expect(fixture.session.composition()->graph().nodes().size() > nodesBefore,
+                        "and the projection grows with the new nodes");
+    expectations.expect(fixture.session.undoLabel() == QStringLiteral("Add Solid Layer"),
+                        "through the exact command the timeline's own Add menu uses");
+
+    expectations.expect(fixture.session.undo(), "the canvas Add is undoable");
+    expectations.expect(fixture.session.composition()->graph().layerStack().entries().empty() &&
+                            fixture.session.composition()->graph().nodes().size() == nodesBefore,
+                        "ONE undo step removes the whole layer the gesture created");
+    menu->deleteLater();
+}
+
+// --- Decision 5: in-node edits take the Properties panel's own path -----------------------------
+
+void testInNodeValueFieldsCommitThroughThePropertiesPath(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Field Edit Test"));
+    const auto layerId = addSolid(fixture.session);
+    expectations.expect(layerId.has_value(), "the fixture can add a solid layer");
+    if (!layerId.has_value()) {
+        return;
+    }
+    const auto boundaryNodeId = fixture.session.boundaryNodeForLayer(*layerId);
+    if (!boundaryNodeId.has_value()) {
+        expectations.expect(false, "the solid layer resolves its boundary node");
+        return;
+    }
+
+    auto* positionX = qobject_cast<ui::kit::KValueField*>(
+        fixture.scene()->nodeFieldForTest(*boundaryNodeId, QStringLiteral("nodePositionXEditor")));
+    auto* positionY = qobject_cast<ui::kit::KValueField*>(
+        fixture.scene()->nodeFieldForTest(*boundaryNodeId, QStringLiteral("nodePositionYEditor")));
+    auto* opacity = qobject_cast<ui::kit::KValueField*>(
+        fixture.scene()->nodeFieldForTest(*boundaryNodeId, QStringLiteral("nodeOpacityEditor")));
+    expectations.expect(positionX != nullptr && positionY != nullptr && opacity != nullptr,
+                        "the layer boundary card carries live kit fields for the parameters it "
+                        "actually binds");
+    if (positionX == nullptr || positionY == nullptr || opacity == nullptr) {
+        return;
+    }
+    expectations.expect(positionX->isEnabled() && positionY->isEnabled() && opacity->isEnabled(),
+                        "constant parameters are editable in the card, exactly as in Properties");
+
+    const auto* positionParameter =
+        parameterForRole(fixture.session, *boundaryNodeId, document::kPositionParameterRole);
+    const auto* opacityParameter =
+        parameterForRole(fixture.session, *boundaryNodeId, document::kOpacityParameterRole);
+    if (positionParameter == nullptr || opacityParameter == nullptr) {
+        expectations.expect(false, "the boundary node binds position and opacity");
+        return;
+    }
+    const auto positionId = positionParameter->id;
+    const auto opacityId = opacityParameter->id;
+    const auto originalPosition = fixture.session.constantVec2Value(positionId);
+    const auto originalOpacity = fixture.session.constantValue(opacityId);
+    expectations.expect(originalPosition.has_value() && originalOpacity.has_value(),
+                        "the fixture starts from constant position and opacity values");
+    if (!originalPosition.has_value() || !originalOpacity.has_value()) {
+        return;
+    }
+    const document::Vec2d editedPosition{24.0, originalPosition.value().y};
+
+    // One gesture on the card: one command, one undo step, on the SAME ParameterId the Properties
+    // panel writes.
+    positionX->setValue(24.0);
+    expectations.expect(fixture.session.constantVec2Value(positionId) == editedPosition,
+                        "an in-node X edit writes the canonical position parameter");
+    expectations.expect(fixture.session.undoLabel() == QStringLiteral("Set Position"),
+                        "through PropertiesEditor's own \"Set Position\" command path");
+    expectations.expect(fixture.session.selection().primary == ui::SelectionTarget{*boundaryNodeId},
+                        "and the edit routed through the session's one selection truth first");
+    expectations.expect(fixture.session.undo() &&
+                            fixture.session.constantVec2Value(positionId) == originalPosition,
+                        "ONE undo step reverts the whole in-node edit");
+
+    // The field survived the snapshot change its own edit produced -- the reconciliation contract
+    // that makes an in-node field usable at all (a rebuilt card would delete the widget mid-signal
+    // and lose keyboard focus on every step).
+    expectations.expect(fixture.scene()->nodeFieldForTest(
+                            *boundaryNodeId, QStringLiteral("nodePositionXEditor")) == positionX,
+                        "the card is reconciled in place, so the field keeps its identity");
+
+    opacity->setValue(50.0);
+    const auto editedOpacity = fixture.session.constantValue(opacityId);
+    expectations.expect(editedOpacity.has_value() && near(editedOpacity.value(), 0.5),
+                        "an in-node opacity edit writes the canonical 0..1 opacity parameter");
+    expectations.expect(fixture.session.undoLabel() == QStringLiteral("Set Opacity"),
+                        "through PropertiesEditor's own \"Set Opacity\" command path");
+    expectations.expect(fixture.session.undo() &&
+                            fixture.session.constantValue(opacityId) == originalOpacity,
+                        "and one undo step reverts it");
+}
+
+void testColorIsAReadOnlyChipAndParameterlessNodesStayClean(Expectations& expectations) {
+    GraphFixture fixture(makeProject("Node Color Chip Test"));
+    const auto layerId = addSolid(fixture.session);
+    if (!layerId.has_value()) {
+        expectations.expect(false, "the fixture can add a solid layer");
+        return;
+    }
+    const auto sourceNodeId = fixture.session.directSourceNodeForLayer(*layerId);
+    if (!sourceNodeId.has_value()) {
+        expectations.expect(false, "the solid layer resolves its source node");
+        return;
+    }
+
+    auto* chip = qobject_cast<ui::kit::KColorChip*>(
+        fixture.scene()->nodeFieldForTest(*sourceNodeId, QStringLiteral("nodeColorChip")));
+    expectations.expect(chip != nullptr, "the solid source card carries a kit color chip");
+    if (chip == nullptr) {
+        return;
+    }
+    // No command anywhere sets a color, so the chip must not offer a picker whose result nothing
+    // could commit -- the honesty rule, pinned.
+    expectations.expect(!chip->isEnabled(),
+                        "the chip is read-only: no command in src/commands sets a color");
+    expectations.expect(!chip->isPickerOpen(), "and it never opens its picker");
+    expectations.expect(chip->toolTip().contains(QStringLiteral("R 0.62")),
+                        "the exact, unclipped authoring value travels in the tooltip, because an "
+                        "8-bit swatch cannot show one honestly");
+    expectations.expect(chip->toolTip().contains(QStringLiteral("Read-only")),
+                        "and the tooltip says why the chip does not open");
+
+    // A node that binds no parameters carries no rows at all.
+    const auto stackNodeId = fixture.session.composition()->graph().layerStack().nodeId();
+    expectations.expect(fixture.scene()->nodeFieldForTest(
+                            stackNodeId, QStringLiteral("nodePositionXEditor")) == nullptr &&
+                            fixture.scene()->nodeFieldForTest(
+                                stackNodeId, QStringLiteral("nodeColorChip")) == nullptr,
+                        "a node with no parameter bindings stays clean -- no placeholder rows");
+}
+
+} // namespace
+
+namespace {
+
+int runAll() {
+    Expectations expectations;
+    testZoomAboutCursorHoldsTheScenePointUnderTheCursor(expectations);
+    testZoomClampsToTheViewersOwnBounds(expectations);
+    testFitFramesTheGraphAndActualSizeIsExactlyOneHundredPercent(expectations);
+    testSpaceHoldAndMiddleDragBothPan(expectations);
+    testSelectionFollowsTheSessionInBothDirections(expectations);
+    testConnectorTypingIsPinnedPerSocketKind(expectations);
+    testEveryProjectedEdgeIsAPathItemBetweenTwoCards(expectations);
+    testContextMenuOffersOnlyRealCommands(expectations);
+    testAddFromTheCanvasIsOneUndoableCommand(expectations);
+    testInNodeValueFieldsCommitThroughThePropertiesPath(expectations);
+    testColorIsAReadOnlyChipAndParameterlessNodesStayClean(expectations);
+    return expectations.failures() == 0 ? 0 : 1;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    qputenv("QT_QPA_PLATFORM", "offscreen");
+    QApplication application(argc, argv);
+    try {
+        return runAll();
+    } catch (const std::exception& error) {
+        std::cerr << "node editor test failed with an exception: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/src/ui/viewer_editor.cpp
+++ b/src/ui/viewer_editor.cpp
@@ -39,8 +39,9 @@ namespace bloom::ui {
 namespace {
 
 // Wheel/menu zoom step (decision 2): each wheel notch or Zoom In/Out menu action multiplies the
-// current effective zoom by this factor (clamped into ViewTransform's [kMinZoom, kMaxZoom]).
-constexpr double kZoomStepFactor = 1.1;
+// current effective zoom by this factor (clamped into ViewTransform's [kMinZoom, kMaxZoom]). The
+// value itself moved to viewer_editor.hpp for task U4 (issue #123) so the Nodes canvas steps by
+// exactly the same amount; nothing about this file's behavior changed.
 
 // The Fit item plus the fixed percentage presets a real gesture never removes (decision 3). A
 // zoom that lands off this ladder (e.g. from a wheel step) gets ONE additional trailing item --


### PR DESCRIPTION
The final slice of #116 — the node editor becomes a navigable, editable Kinetik surface:

- **One app, one feel**: the canvas shares the Viewer's zoom step constant structurally (moved to the shared header, consumed by both), the same bounds, wheel-about-cursor with an exact invariant, space/middle drag, F/Z — with QGraphicsView's scroll machinery disabled outright because its alignment indentation silently broke centered fits and the cursor invariant.
- **Kinetik cards**: raised surfaces, header strips carrying the layer's own durable name (the same string the timeline shows), accent selection edges, drag elevation — with selection remaining session-one-truth in both directions and zero scene-local state.
- **Honest connectors**: one transport type exists, so one connector color exists — mapped from the runtime's own socket enum with the reasoning at the definition; parameter links draw no edges because they are not edges.
- **Command-verified menus**: Add Solid/Text through the same shared helper the timeline uses; Fit/100%/zoom items matching the Viewer's set; Delete, Duplicate, and rename absent entirely because no such commands exist — each gap reported, none faked.
- **In-node editing**: X/Y/Opacity value fields configured verbatim as Properties configures them, committing through the identical session calls — one edit, one undo step, one snapshot signal, pinned.
- **Nine defects found and fixed en route** (two pre-existing since the original projection: an odd-even fill band across every card header, and stacking new-card placement), several caught by rendering the canvas offscreen and reading the pixels. One real merged-module gap documented for the backlog: the shared space-hold pan state survives focus loss in both canvases.
- The report's stale note about value-field shortcut overrides is superseded — that fix merged with the properties slice and is in this branch.

Desktop 127/127 and native 88/88, all quality gates run against the final commit's exact tree.

Closes #123.

Implemented by a Claude Opus subagent; reviewed by the supervising session.